### PR TITLE
Stop leaking internal types in public interface

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 0.2.0 Removed
+
+- various internal types are no longer public
+  - if you needed one of these, please file an issue!
+
 ## 0.1.0
 
 ### 0.1.0 Changed

--- a/src/flexbox.rs
+++ b/src/flexbox.rs
@@ -16,9 +16,9 @@ use crate::sys::{abs, round, ChildrenVec, Vec};
 
 /// The computed results of a [`flexbox`](crate::flexbox) calculation
 #[derive(Debug, Clone)]
-pub struct ComputeResult {
+pub(crate) struct ComputeResult {
     /// The computed size
-    pub size: Size<f32>,
+    pub(crate) size: Size<f32>,
 }
 
 /// The intermediate results of a flexbox calculation for a single item

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -2,33 +2,33 @@
 
 // When std is enabled, prefer those types
 #[cfg(feature = "std")]
-pub use self::std::*;
+pub(crate) use self::std::*;
 
 // When alloc but not std is enabled, use those types
 #[cfg(all(feature = "alloc", not(feature = "std")))]
-pub use self::alloc::*;
+pub(crate) use self::alloc::*;
 
 // When neither alloc or std is enabled, use a heapless fallback
 #[cfg(all(not(feature = "alloc"), not(feature = "std")))]
-pub use self::core::*;
+pub(crate) use self::core::*;
 
 /// For when `std` is enabled
 #[cfg(feature = "std")]
 mod std {
     /// An allocation-backend agnostic [`Box`] type
-    pub type Box<A> = std::boxed::Box<A>;
+    pub(crate) type Box<A> = std::boxed::Box<A>;
     /// An allocation-backend agnostic map type
-    pub type Map<K, V> = std::collections::HashMap<K, V>;
+    pub(crate) type Map<K, V> = std::collections::HashMap<K, V>;
     /// An allocation-backend agnostic vector type
-    pub type Vec<A> = std::vec::Vec<A>;
+    pub(crate) type Vec<A> = std::vec::Vec<A>;
     /// A vector of child nodes
-    pub type ChildrenVec<A> = std::vec::Vec<A>;
+    pub(crate) type ChildrenVec<A> = std::vec::Vec<A>;
     /// A vector of parent nodes
-    pub type ParentsVec<A> = std::vec::Vec<A>;
+    pub(crate) type ParentsVec<A> = std::vec::Vec<A>;
 
     /// Creates a new map with the capacity for the specified number of items before it must be resized
     #[must_use]
-    pub fn new_map_with_capacity<K, V>(capacity: usize) -> Map<K, V>
+    pub(crate) fn new_map_with_capacity<K, V>(capacity: usize) -> Map<K, V>
     where
         K: Eq + std::hash::Hash,
     {
@@ -37,19 +37,19 @@ mod std {
 
     /// Creates a new vector with the capacity for the specified number of items before it must be resized    
     #[must_use]
-    pub fn new_vec_with_capacity<A>(capacity: usize) -> Vec<A> {
+    pub(crate) fn new_vec_with_capacity<A>(capacity: usize) -> Vec<A> {
         Vec::with_capacity(capacity)
     }
 
     /// Rounds to the nearest whole number
     #[must_use]
-    pub fn round(value: f32) -> f32 {
+    pub(crate) fn round(value: f32) -> f32 {
         value.round()
     }
 
     /// Computes the absolute value
     #[must_use]
-    pub fn abs(value: f32) -> f32 {
+    pub(crate) fn abs(value: f32) -> f32 {
         value.abs()
     }
 }
@@ -60,37 +60,37 @@ mod alloc {
     extern crate alloc;
 
     /// An allocation-backend agnostic `Box` type
-    pub type Box<A> = alloc::boxed::Box<A>;
+    pub(crate) type Box<A> = alloc::boxed::Box<A>;
     /// An allocation-backend agnostic map type
-    pub type Map<K, V> = hashbrown::HashMap<K, V>;
+    pub(crate) type Map<K, V> = hashbrown::HashMap<K, V>;
     /// An allocation-backend agnostic vector type
-    pub type Vec<A> = alloc::vec::Vec<A>;
+    pub(crate) type Vec<A> = alloc::vec::Vec<A>;
     /// A vector of child nodes
-    pub type ChildrenVec<A> = alloc::vec::Vec<A>;
+    pub(crate) type ChildrenVec<A> = alloc::vec::Vec<A>;
     /// A vector of parent nodes
-    pub type ParentsVec<A> = alloc::vec::Vec<A>;
+    pub(crate) type ParentsVec<A> = alloc::vec::Vec<A>;
 
     /// Creates a new map with the capacity for the specified number of items before it must be resized
     #[must_use]
-    pub fn new_map_with_capacity<K, V>(capacity: usize) -> Map<K, V> {
+    pub(crate) fn new_map_with_capacity<K, V>(capacity: usize) -> Map<K, V> {
         Map::with_capacity(capacity)
     }
 
     /// Creates a new vector with the capacity for the specified number of items before it must be resized
     #[must_use]
-    pub fn new_vec_with_capacity<A>(capacity: usize) -> Vec<A> {
+    pub(crate) fn new_vec_with_capacity<A>(capacity: usize) -> Vec<A> {
         Vec::with_capacity(capacity)
     }
 
     /// Rounds to the nearest whole number
     #[must_use]
-    pub fn round(value: f32) -> f32 {
+    pub(crate) fn round(value: f32) -> f32 {
         num_traits::float::FloatCore::round(value)
     }
 
     /// Computes the absolute value
     #[must_use]
-    pub fn abs(value: f32) -> f32 {
+    pub(crate) fn abs(value: f32) -> f32 {
         num_traits::float::FloatCore::abs(value)
     }
 }
@@ -106,19 +106,19 @@ mod core {
     pub const MAX_PARENTS_COUNT: usize = 1;
 
     /// An allocation-backend agnostic map type
-    pub type Map<K, V> = crate::indexmap::FnvIndexMap<K, V, MAX_NODE_COUNT>;
+    pub(crate) type Map<K, V> = crate::indexmap::FnvIndexMap<K, V, MAX_NODE_COUNT>;
     /// An allocation-backend agnostic vector type
-    pub type Vec<A> = arrayvec::ArrayVec<A, MAX_NODE_COUNT>;
+    pub(crate) type Vec<A> = arrayvec::ArrayVec<A, MAX_NODE_COUNT>;
     /// A vector of child nodes, whose length cannot exceed [`MAX_CHILD_COUNT`]
-    pub type ChildrenVec<A> = arrayvec::ArrayVec<A, MAX_CHILD_COUNT>;
+    pub(crate) type ChildrenVec<A> = arrayvec::ArrayVec<A, MAX_CHILD_COUNT>;
     /// A vector of parent nodes, whose length cannot exceed [`MAX_PARENTS_COUNT`]
-    pub type ParentsVec<A> = arrayvec::ArrayVec<A, MAX_PARENTS_COUNT>;
+    pub(crate) type ParentsVec<A> = arrayvec::ArrayVec<A, MAX_PARENTS_COUNT>;
 
     /// Creates a new map with the capacity for the specified number of items
     ///
     /// This map cannot be resized.
     #[must_use]
-    pub fn new_map_with_capacity<K, V>(_capacity: usize) -> Map<K, V>
+    pub(crate) fn new_map_with_capacity<K, V>(_capacity: usize) -> Map<K, V>
     where
         K: Eq + ::hash32::Hash,
     {
@@ -129,21 +129,21 @@ mod core {
     ///
     /// This vector cannot be resized.
     #[must_use]
-    pub fn new_vec_with_capacity<A, const CAP: usize>(_capacity: usize) -> arrayvec::ArrayVec<A, CAP> {
+    pub(crate) fn new_vec_with_capacity<A, const CAP: usize>(_capacity: usize) -> arrayvec::ArrayVec<A, CAP> {
         arrayvec::ArrayVec::new()
     }
 
     /// Rounds to the nearest whole number
     #[inline]
     #[must_use]
-    pub fn round(value: f32) -> f32 {
+    pub(crate) fn round(value: f32) -> f32 {
         num_traits::float::FloatCore::round(value)
     }
 
     /// Computes the absolute value
     #[inline]
     #[must_use]
-    pub fn abs(value: f32) -> f32 {
+    pub(crate) fn abs(value: f32) -> f32 {
         num_traits::float::FloatCore::abs(value)
     }
 }


### PR DESCRIPTION
# Objective

Several internal types were publicly exposed. This is confusing and noisy, and limits our ability to make changes to implementation details in minor releases.

They are now pub(crate) instead.