### PR TITLE
Improve error message when `chromedriver` is not installed

### DIFF
--- a/scripts/gentest/src/main.rs
+++ b/scripts/gentest/src/main.rs
@@ -34,7 +34,10 @@ async fn main() {
 
     info!("starting webdriver instance");
     let webdriver_url = "http://localhost:4444";
-    let mut webdriver_handle = Command::new("chromedriver").arg("--port=4444").spawn().unwrap();
+    let mut webdriver_handle = Command::new("chromedriver")
+        .arg("--port=4444")
+        .spawn()
+        .expect("ChromeDriver not found: Make sure you have it installed and added to your PATH.");
 
     // this is silly, but it works
     std::thread::sleep(std::time::Duration::from_secs(1));


### PR DESCRIPTION
# Objective

Fixes #45 

This fixes the error message, but I'm not able to get the gentest to run correctly from only installing this. Do we have other dependencies that needs to be installed?

@mockersf Was there other things you did to get it to produce an output?