### PR TITLE
Mark generated files as lunguist-generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+tests/generated linguist-generated=true
+benches/generated linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-tests/generated linguist-generated=true
-benches/generated linguist-generated=true
+/tests/generated/** linguist-generated=true
+/benches/generated/** linguist-generated=true


### PR DESCRIPTION
# Objective

The generated tests and benchmarks add a lot of noise when reviewing PRs.
Their diffs should be hidden by default.

## Solution

This PR adds a `.gitattribute` file that marks the folders `tests/generated` and `benches/generated` as `linguist-generated=true`. This will a) exclude them from the GitHub language stats and b) hide their diffs by default ([Docs](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github)).

## Context

We first discussed removing the generated tests completely in #133.
However, they add a lot of value to make sure that we are fully compatible with the browser flexbox spec. Thus, they were added back with #145.

We also discussed to not commit the generated files to the repository, but generating them requires installation of `chromedriver` and is a hassle for contributors.

## Feedback wanted

I hope this covers all generated files. I'm not completely sure if this works as I expect it to, I have never used this feature before.