### PR TITLE
Improve Errors

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,18 +4,20 @@
 
 ### 0.2.0 Added
 
-- Nothing yet
+- added `taffy::TaffyError::ChildIndexOutOfBounds` variant
 
 ### 0.2.0 Changed
 
 - renamed `taffy::forest::Forest.new-node(..)` `taffy::forest::Forest.new_with_children(..)`
 - renamed `taffy::node::Taffy.new-node(..)` -> `taffy::node::Taffy.new_with_children(..)`
 - renamed `taffy::style::Style` -> `taffy::style::FlexboxLayout` to more precicely indicate its purpose
+- renamed `taffy::Error` -> `taffy::TaffyError`
 
 ### 0.2.0 Fixed
 
 - fixed rounding of fractional values to follow latest Chrome - values are now rounded the same regardless of their position
 - fixed computing free space when using both `flex-grow` and a minimum size
+- `taffy::Taffy::remove_child_at_index`, `taffy::Taffy::replace_child_at_index`, and `taffy::Taffy::child_at_index` now return `Taffy::TaffyError::ChildIndexOutOfBounds` instead of panicing
 
 ### 0.2.0 Removed
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,7 +4,7 @@
 
 ### 0.2.0 Added
 
-- `taffy::error::InvalidNode` and `taffy::error::InvalidChild` Error types
+- Added `taffy::error::InvalidChild` Error type
 
 ### 0.2.0 Changed
 
@@ -12,7 +12,7 @@
 - renamed `taffy::forest::Forest.new-node(..)` `taffy::forest::Forest.new_with_children(..)`
 - renamed `taffy::node::Taffy.new-node(..)` -> `taffy::node::Taffy.new_with_children(..)`
 - renamed `taffy::style::Style` -> `taffy::style::FlexboxLayout` to more precicely indicate its purpose
-- `taffy::Error` was replaced with `taffy::error::InvalidNode` and `taffy::error::InvalidChild`
+- renamed `taffy::Error` -> `taffy::error::InvalidNode`
 - `taffy::Taffy::remove_child_at_index`, `taffy::Taffy::replace_child_at_index`, and `taffy::Taffy::child_at_index` now return `taffy::InvalidChild::ChildIndexOutOfBounds` instead of panicing
 
 ### 0.2.0 Fixed

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,7 +4,7 @@
 
 ### 0.2.0 Added
 
-- added `taffy::TaffyError::ChildIndexOutOfBounds` variant
+- added `taffy::ChildOperationError` enum
 
 ### 0.2.0 Changed
 
@@ -12,13 +12,13 @@
 - renamed `taffy::forest::Forest.new-node(..)` `taffy::forest::Forest.new_with_children(..)`
 - renamed `taffy::node::Taffy.new-node(..)` -> `taffy::node::Taffy.new_with_children(..)`
 - renamed `taffy::style::Style` -> `taffy::style::FlexboxLayout` to more precicely indicate its purpose
-- renamed `taffy::Error` -> `taffy::TaffyError`
+- renamed `taffy::Error` -> `taffy::NodeNotFoundError` and converted it into a tuple struct to precisely show what causes it
+- `taffy::Taffy::remove_child_at_index`, `taffy::Taffy::replace_child_at_index`, and `taffy::Taffy::child_at_index` now return `taffy::ChildOperationError::ChildIndexOutOfBounds` instead of panicing
 
 ### 0.2.0 Fixed
 
 - fixed rounding of fractional values to follow latest Chrome - values are now rounded the same regardless of their position
 - fixed computing free space when using both `flex-grow` and a minimum size
-- `taffy::Taffy::remove_child_at_index`, `taffy::Taffy::replace_child_at_index`, and `taffy::Taffy::child_at_index` now return `Taffy::TaffyError::ChildIndexOutOfBounds` instead of panicing
 
 ### 0.2.0 Removed
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,7 +4,7 @@
 
 ### 0.2.0 Added
 
-- added `taffy::ChildOperationError` enum
+- `taffy::error::InvalidNode` and `taffy::error::InvalidChild` Error types
 
 ### 0.2.0 Changed
 
@@ -12,8 +12,8 @@
 - renamed `taffy::forest::Forest.new-node(..)` `taffy::forest::Forest.new_with_children(..)`
 - renamed `taffy::node::Taffy.new-node(..)` -> `taffy::node::Taffy.new_with_children(..)`
 - renamed `taffy::style::Style` -> `taffy::style::FlexboxLayout` to more precicely indicate its purpose
-- renamed `taffy::Error` -> `taffy::NodeNotFoundError` and converted it into a tuple struct to precisely show what causes it
-- `taffy::Taffy::remove_child_at_index`, `taffy::Taffy::replace_child_at_index`, and `taffy::Taffy::child_at_index` now return `taffy::ChildOperationError::ChildIndexOutOfBounds` instead of panicing
+- `taffy::Error` was replaced with `taffy::error::InvalidNode` and `taffy::error::InvalidChild`
+- `taffy::Taffy::remove_child_at_index`, `taffy::Taffy::replace_child_at_index`, and `taffy::Taffy::child_at_index` now return `taffy::InvalidChild::ChildIndexOutOfBounds` instead of panicing
 
 ### 0.2.0 Fixed
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,6 +1,6 @@
 use taffy::prelude::*;
 
-fn main() -> Result<(), Error> {
+fn main() -> Result<(), NodeNotFoundError> {
     let mut taffy = Taffy::new();
 
     let child = taffy.new_with_children(

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,6 +1,6 @@
 use taffy::prelude::*;
 
-fn main() -> Result<(), Error> {
+fn main() -> Result<(), TaffyError> {
     let mut taffy = Taffy::new();
 
     let child = taffy.new_with_children(

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,6 +1,6 @@
 use taffy::prelude::*;
 
-fn main() -> Result<(), TaffyError> {
+fn main() -> Result<(), Error> {
     let mut taffy = Taffy::new();
 
     let child = taffy.new_with_children(

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,6 +1,6 @@
 use taffy::prelude::*;
 
-fn main() -> Result<(), NodeNotFoundError> {
+fn main() -> Result<(), taffy::error::InvalidNode> {
     let mut taffy = Taffy::new();
 
     let child = taffy.new_with_children(

--- a/examples/nested.rs
+++ b/examples/nested.rs
@@ -1,6 +1,6 @@
 use taffy::prelude::*;
 
-fn main() -> Result<(), NodeNotFoundError> {
+fn main() -> Result<(), taffy::error::InvalidNode> {
     let mut taffy = Taffy::new();
 
     // left

--- a/examples/nested.rs
+++ b/examples/nested.rs
@@ -1,6 +1,6 @@
 use taffy::prelude::*;
 
-fn main() -> Result<(), Error> {
+fn main() -> Result<(), TaffyError> {
     let mut taffy = Taffy::new();
 
     // left

--- a/examples/nested.rs
+++ b/examples/nested.rs
@@ -1,6 +1,6 @@
 use taffy::prelude::*;
 
-fn main() -> Result<(), Error> {
+fn main() -> Result<(), NodeNotFoundError> {
     let mut taffy = Taffy::new();
 
     // left

--- a/examples/nested.rs
+++ b/examples/nested.rs
@@ -1,6 +1,6 @@
 use taffy::prelude::*;
 
-fn main() -> Result<(), TaffyError> {
+fn main() -> Result<(), Error> {
     let mut taffy = Taffy::new();
 
     // left

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@ use core::fmt::{Display, Formatter, Result};
 
 use crate::node::Node;
 
-/// The [`Node`](node::Node) was not found in the [`Taffy`] instance
+/// The [`Node`] was not found in the [`Taffy`](crate::Taffy) instance
 #[derive(Debug)]
 pub struct InvalidNode(pub Node);
 
@@ -18,10 +18,10 @@ impl Display for InvalidNode {
 #[cfg(feature = "std")]
 impl std::error::Error for InvalidNode {}
 
-/// An error that occurs while trying to access or modify a [`Node`](node::Node)'s children by index.
+/// An error that occurs while trying to access or modify a [`Node`]'s children by index.
 #[derive(Debug)]
 pub enum InvalidChild {
-    /// The parent [`Node`](node::Node) does not have a child at `child_index`. It only has `child_count` children
+    /// The parent [`Node`] does not have a child at `child_index`. It only has `child_count` children
     ChildIndexOutOfBounds {
         /// The parent node whose child was being looked up
         parent: Node,
@@ -30,8 +30,10 @@ pub enum InvalidChild {
         /// The total number of children the parent has
         child_count: usize,
     },
-    /// The [`Node`](node::Node) was not found in the [`Taffy`] instance.
-    InvalidNode(InvalidNode),
+    /// The parent [`Node`] was not found in the [`Taffy`](crate::Taffy) instance.
+    InvalidParentNode(Node),
+    /// The child [`Node`] was not found in the [`Taffy`](crate::Taffy) instance.
+    InvalidChildNode(Node),
 }
 
 #[cfg(feature = "std")]
@@ -43,23 +45,20 @@ impl Display for InvalidChild {
                 "Index (is {}) should be < child_count ({}) for parent node {:?}",
                 child_index, child_count, parent
             ),
-            InvalidChild::InvalidNode(inner) => inner.fmt(f),
+            InvalidChild::InvalidParentNode(parent) => write!(
+                f,
+                "Parent Node {:?} is not in the Taffy instance",
+                parent
+            ),
+            InvalidChild::InvalidChildNode(child) => write!(
+                f,
+                "Child Node {:?} is not in the Taffy instance",
+                child
+            ),
         }
     }
 }
 
 #[cfg(feature = "std")]
 impl std::error::Error for InvalidChild {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            InvalidChild::ChildIndexOutOfBounds { .. } => None,
-            InvalidChild::InvalidNode(node) => Some(node),
-        }
-    }
-}
-
-impl From<InvalidNode> for InvalidChild {
-    fn from(node: InvalidNode) -> Self {
-        Self::InvalidNode(node)
-    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,65 @@
+//! The Error types produced by Taffy.
+#[cfg(feature = "std")]
+use core::fmt::{Display, Formatter, Result};
+
+use crate::node::Node;
+
+/// The [`Node`](node::Node) was not found in the [`Taffy`] instance
+#[derive(Debug)]
+pub struct InvalidNode(pub Node);
+
+#[cfg(feature = "std")]
+impl Display for InvalidNode {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        write!(f, "Node {:?} is not in the Taffy instance", self.0)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for InvalidNode {}
+
+/// An error that occurs while trying to access or modify a [`Node`](node::Node)'s children by index.
+#[derive(Debug)]
+pub enum InvalidChild {
+    /// The parent [`Node`](node::Node) does not have a child at `child_index`. It only has `child_count` children
+    ChildIndexOutOfBounds {
+        /// The parent node whose child was being looked up
+        parent: Node,
+        /// The index that was looked up
+        child_index: usize,
+        /// The total number of children the parent has
+        child_count: usize,
+    },
+    /// The [`Node`](node::Node) was not found in the [`Taffy`] instance.
+    InvalidNode(InvalidNode),
+}
+
+#[cfg(feature = "std")]
+impl Display for InvalidChild {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        match self {
+            InvalidChild::ChildIndexOutOfBounds { parent, child_index, child_count } => write!(
+                f,
+                "Index (is {}) should be < child_count ({}) for parent node {:?}",
+                child_index, child_count, parent
+            ),
+            InvalidChild::InvalidNode(inner) => inner.fmt(f),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for InvalidChild {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            InvalidChild::ChildIndexOutOfBounds { .. } => None,
+            InvalidChild::InvalidNode(node) => Some(node),
+        }
+    }
+}
+
+impl From<InvalidNode> for InvalidChild {
+    fn from(node: InvalidNode) -> Self {
+        Self::InvalidNode(node)
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,20 +45,13 @@ impl Display for InvalidChild {
                 "Index (is {}) should be < child_count ({}) for parent node {:?}",
                 child_index, child_count, parent
             ),
-            InvalidChild::InvalidParentNode(parent) => write!(
-                f,
-                "Parent Node {:?} is not in the Taffy instance",
-                parent
-            ),
-            InvalidChild::InvalidChildNode(child) => write!(
-                f,
-                "Child Node {:?} is not in the Taffy instance",
-                child
-            ),
+            InvalidChild::InvalidParentNode(parent) => {
+                write!(f, "Parent Node {:?} is not in the Taffy instance", parent)
+            }
+            InvalidChild::InvalidChildNode(child) => write!(f, "Child Node {:?} is not in the Taffy instance", child),
         }
     }
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for InvalidChild {
-}
+impl std::error::Error for InvalidChild {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ extern crate alloc;
 #[cfg(feature = "serde")]
 extern crate serde;
 
+pub mod error;
 pub mod geometry;
 pub mod layout;
 pub mod node;
@@ -25,66 +26,3 @@ mod indexmap;
 mod sys;
 
 pub use crate::node::Taffy;
-
-#[cfg(feature = "std")]
-use core::fmt::{Display, Formatter, Result};
-
-/// The [`Node`](node::Node) was not found in the [`Taffy`] instance
-#[derive(Debug)]
-pub struct NodeNotFoundError(pub node::Node);
-
-#[cfg(feature = "std")]
-impl Display for NodeNotFoundError {
-    fn fmt(&self, f: &mut Formatter) -> Result {
-        write!(f, "Node {:?} is not in the Taffy instance", self.0)
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for NodeNotFoundError {}
-
-/// An error that occurs while trying to access or modify a [`Node`](node::Node)'s children by index.
-#[derive(Debug)]
-pub enum ChildOperationError {
-    /// The parent [`Node`](node::Node) does not have a child at `child_index`. It only has `child_count` children
-    ChildIndexOutOfBounds {
-        /// The parent node whose child was being looked up
-        parent: node::Node,
-        /// The index that was looked up
-        child_index: usize,
-        /// The total number of children the parent has
-        child_count: usize,
-    },
-    ///The [`Node`](node::Node) was not found in the [`Taffy`] instance
-    NodeNotFoundError(NodeNotFoundError),
-}
-
-#[cfg(feature = "std")]
-impl Display for ChildOperationError {
-    fn fmt(&self, f: &mut Formatter) -> Result {
-        match self {
-            ChildOperationError::ChildIndexOutOfBounds { parent, child_index, child_count } => write!(
-                f,
-                "Index (is {}) should be < child_count ({}) for parent node {:?}",
-                child_index, child_count, parent
-            ),
-            ChildOperationError::NodeNotFoundError(inner) => inner.fmt(f),
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for ChildOperationError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            ChildOperationError::ChildIndexOutOfBounds { .. } => None,
-            ChildOperationError::NodeNotFoundError(node) => Some(node),
-        }
-    }
-}
-
-impl From<NodeNotFoundError> for ChildOperationError {
-    fn from(node: NodeNotFoundError) -> Self {
-        Self::NodeNotFoundError(node)
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,25 +31,36 @@ use core::fmt::{Display, Formatter, Result};
 
 /// An error that can occur when performing layout
 #[derive(Debug)]
-pub enum Error {
-    /// The [`Node`](node::Node) was invalid
+pub enum TaffyError {
+    /// The [`Node`](node::Node) is not part of the [`Taffy`](Taffy) instance.
     InvalidNode(node::Node),
+    IndexOutOfBounds {
+        /// The parent node whose child was being looked up
+        parent: node::Node,
+        /// The index that was looked up
+        child_index: usize,
+        /// The total number of children the parent has
+        child_count: usize,
+    }
 }
 
 #[cfg(feature = "std")]
-impl Display for Error {
+impl Display for TaffyError {
     fn fmt(&self, f: &mut Formatter) -> Result {
         match *self {
-            Error::InvalidNode(ref node) => write!(f, "Invalid node {:?}", node),
+            TaffyError::InvalidNode(ref node) => write!(f, "Invalid node {:?}", node),
+            TaffyError::IndexOutOfBounds { parent, child_index, child_count } => 
+                write!(f, "Index (is {}) should be < len ({}) for parent node {:?}", child_index, child_count, parent),
         }
     }
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for Error {
+impl std::error::Error for TaffyError {
     fn description(&self) -> &str {
         match *self {
-            Error::InvalidNode(_) => "The node is not part of the Taffy instance",
+            TaffyError::InvalidNode(_) => "The node is not part of the Taffy instance",
+            TaffyError::IndexOutOfBounds { .. } => todo!(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ use core::fmt::{Display, Formatter, Result};
 
 /// An error that can occur when performing layout
 #[derive(Debug)]
-pub enum TaffyError {
+pub enum Error {
     /// The [`Node`](node::Node) is not part of the [`Taffy`](Taffy) instance.
     InvalidNode(node::Node),
     /// The parent [`Node`](node::Node) does not have a child at `child_index`. It only has `child_count` children
@@ -46,22 +46,22 @@ pub enum TaffyError {
 }
 
 #[cfg(feature = "std")]
-impl Display for TaffyError {
+impl Display for Error {
     fn fmt(&self, f: &mut Formatter) -> Result {
         match *self {
-            TaffyError::InvalidNode(ref node) => write!(f, "Node {:?} is not in the Taffy instance", node),
-            TaffyError::ChildIndexOutOfBounds { parent, child_index, child_count } => 
+            Error::InvalidNode(ref node) => write!(f, "Node {:?} is not in the Taffy instance", node),
+            Error::ChildIndexOutOfBounds { parent, child_index, child_count } => 
                 write!(f, "Index (is {}) should be < child_count ({}) for parent node {:?}", child_index, child_count, parent),
         }
     }
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for TaffyError {
+impl std::error::Error for Error {
     fn description(&self) -> &str {
         match *self {
-            TaffyError::InvalidNode(_) => "The node is not part of the Taffy instance",
-            TaffyError::ChildIndexOutOfBounds { .. } => "The parent node didn't have a child at child_index. It only has child_count children",
+            Error::InvalidNode(_) => "The node is not part of the Taffy instance",
+            Error::ChildIndexOutOfBounds { .. } => "The parent node didn't have a child at child_index. It only has child_count children",
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,8 +41,7 @@ impl Display for NodeNotFoundError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for NodeNotFoundError {
-}
+impl std::error::Error for NodeNotFoundError {}
 
 /// An error that occurs while trying to access or modify a [`Node`](node::Node)'s children by index.
 #[derive(Debug)]
@@ -64,8 +63,11 @@ pub enum ChildOperationError {
 impl Display for ChildOperationError {
     fn fmt(&self, f: &mut Formatter) -> Result {
         match self {
-            ChildOperationError::ChildIndexOutOfBounds { parent, child_index, child_count } => 
-                write!(f, "Index (is {}) should be < child_count ({}) for parent node {:?}", child_index, child_count, parent),
+            ChildOperationError::ChildIndexOutOfBounds { parent, child_index, child_count } => write!(
+                f,
+                "Index (is {}) should be < child_count ({}) for parent node {:?}",
+                child_index, child_count, parent
+            ),
             ChildOperationError::NodeNotFoundError(inner) => inner.fmt(f),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,8 @@ use core::fmt::{Display, Formatter, Result};
 pub enum TaffyError {
     /// The [`Node`](node::Node) is not part of the [`Taffy`](Taffy) instance.
     InvalidNode(node::Node),
-    IndexOutOfBounds {
+    /// The parent [`Node`](node::Node) does not have a child at `child_index`. It only has `child_count` children
+    ChildIndexOutOfBounds {
         /// The parent node whose child was being looked up
         parent: node::Node,
         /// The index that was looked up
@@ -48,9 +49,9 @@ pub enum TaffyError {
 impl Display for TaffyError {
     fn fmt(&self, f: &mut Formatter) -> Result {
         match *self {
-            TaffyError::InvalidNode(ref node) => write!(f, "Invalid node {:?}", node),
-            TaffyError::IndexOutOfBounds { parent, child_index, child_count } => 
-                write!(f, "Index (is {}) should be < len ({}) for parent node {:?}", child_index, child_count, parent),
+            TaffyError::InvalidNode(ref node) => write!(f, "Node {:?} is not in the Taffy instance", node),
+            TaffyError::ChildIndexOutOfBounds { parent, child_index, child_count } => 
+                write!(f, "Index (is {}) should be < child_count ({}) for parent node {:?}", child_index, child_count, parent),
         }
     }
 }
@@ -60,7 +61,7 @@ impl std::error::Error for TaffyError {
     fn description(&self) -> &str {
         match *self {
             TaffyError::InvalidNode(_) => "The node is not part of the Taffy instance",
-            TaffyError::IndexOutOfBounds { .. } => todo!(),
+            TaffyError::ChildIndexOutOfBounds { .. } => "The parent node didn't have a child at child_index. It only has child_count children",
         }
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -9,7 +9,7 @@ use crate::style::FlexboxLayout;
 #[cfg(any(feature = "std", feature = "alloc"))]
 use crate::sys::Box;
 use crate::sys::{new_map_with_capacity, ChildrenVec, Map, Vec};
-use crate::{ChildOperationError, NodeNotFoundError};
+use crate::error;
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 /// A function that can be applied to a `Size<Number>` to obtain a `Size<f32>`
@@ -87,15 +87,15 @@ impl Taffy {
     }
 
     /// Returns the `NodeId` of the provided node within the forest
-    fn find_node(&self, node: Node) -> Result<NodeId, NodeNotFoundError> {
+    fn find_node(&self, node: Node) -> Result<NodeId, error::InvalidNode> {
         match self.nodes_to_ids.get(&node) {
             Some(id) => Ok(*id),
-            None => Err(NodeNotFoundError(node)),
+            None => Err(error::InvalidNode(node)),
         }
     }
 
     /// Adds a new leaf node, which does not have any children
-    pub fn new_leaf(&mut self, style: FlexboxLayout, measure: MeasureFunc) -> Result<Node, NodeNotFoundError> {
+    pub fn new_leaf(&mut self, style: FlexboxLayout, measure: MeasureFunc) -> Result<Node, error::InvalidNode> {
         let node = self.allocate_node();
         let id = self.forest.new_leaf(style, measure);
         self.add_node(node, id);
@@ -103,12 +103,12 @@ impl Taffy {
     }
 
     /// Adds a new node, which may have any number of `children`
-    pub fn new_with_children(&mut self, style: FlexboxLayout, children: &[Node]) -> Result<Node, NodeNotFoundError> {
+    pub fn new_with_children(&mut self, style: FlexboxLayout, children: &[Node]) -> Result<Node, error::InvalidNode> {
         let node = self.allocate_node();
         let children = children
             .iter()
             .map(|child| self.find_node(*child))
-            .collect::<Result<ChildrenVec<_>, NodeNotFoundError>>()?;
+            .collect::<Result<ChildrenVec<_>, error::InvalidNode>>()?;
         let id = self.forest.new_with_children(style, children);
         self.add_node(node, id);
         Ok(node)
@@ -126,7 +126,7 @@ impl Taffy {
     /// Remove a specific [`Node`] from the tree
     ///
     /// Its [`Id`] is marked as invalid. Returns the id of the node removed.
-    pub fn remove(&mut self, node: Node) -> Result<usize, NodeNotFoundError> {
+    pub fn remove(&mut self, node: Node) -> Result<usize, error::InvalidNode> {
         let id = self.find_node(node)?;
 
         self.nodes_to_ids.remove(&node);
@@ -142,7 +142,7 @@ impl Taffy {
     }
 
     /// Sets the [`MeasureFunc`] of the associated node
-    pub fn set_measure(&mut self, node: Node, measure: Option<MeasureFunc>) -> Result<(), NodeNotFoundError> {
+    pub fn set_measure(&mut self, node: Node, measure: Option<MeasureFunc>) -> Result<(), error::InvalidNode> {
         let id = self.find_node(node)?;
         self.forest.nodes[id].measure = measure;
         self.forest.mark_dirty(id);
@@ -150,7 +150,7 @@ impl Taffy {
     }
 
     /// Adds a `child` [`Node`] under the supplied `parent`
-    pub fn add_child(&mut self, parent: Node, child: Node) -> Result<(), NodeNotFoundError> {
+    pub fn add_child(&mut self, parent: Node, child: Node) -> Result<(), error::InvalidNode> {
         let node_id = self.find_node(parent)?;
         let child_id = self.find_node(child)?;
 
@@ -159,7 +159,7 @@ impl Taffy {
     }
 
     /// Directly sets the `children` of the supplied `parent`
-    pub fn set_children(&mut self, parent: Node, children: &[Node]) -> Result<(), NodeNotFoundError> {
+    pub fn set_children(&mut self, parent: Node, children: &[Node]) -> Result<(), error::InvalidNode> {
         let node_id = self.find_node(parent)?;
         let children_id = children.iter().map(|child| self.find_node(*child)).collect::<Result<ChildrenVec<_>, _>>()?;
 
@@ -181,7 +181,7 @@ impl Taffy {
     /// Removes the `child` of the parent `node`
     ///
     /// The child is not removed from the forest entirely, it is simply no longer attached to its previous parent.
-    pub fn remove_child(&mut self, parent: Node, child: Node) -> Result<Node, NodeNotFoundError> {
+    pub fn remove_child(&mut self, parent: Node, child: Node) -> Result<Node, error::InvalidNode> {
         let node_id = self.find_node(parent)?;
         let child_id = self.find_node(child)?;
 
@@ -192,12 +192,12 @@ impl Taffy {
     /// Removes the child at the given `index` from the `parent`
     ///
     /// The child is not removed from the forest entirely, it is simply no longer attached to its previous parent.
-    pub fn remove_child_at_index(&mut self, parent: Node, child_index: usize) -> Result<Node, ChildOperationError> {
+    pub fn remove_child_at_index(&mut self, parent: Node, child_index: usize) -> Result<Node, error::InvalidChild> {
         let node_id = self.find_node(parent)?;
 
         let child_count = self.forest.children[node_id].len();
         if child_index >= child_count {
-            return Err(ChildOperationError::ChildIndexOutOfBounds { parent, child_index, child_count });
+            return Err(error::InvalidChild::ChildIndexOutOfBounds { parent, child_index, child_count });
         }
 
         let prev_id = self.forest.remove_child_at_index(node_id, child_index);
@@ -212,13 +212,13 @@ impl Taffy {
         parent: Node,
         child_index: usize,
         new_child: Node,
-    ) -> Result<Node, ChildOperationError> {
+    ) -> Result<Node, error::InvalidChild> {
         let node_id = self.find_node(parent)?;
         let child_id = self.find_node(new_child)?;
         // TODO: index check
         let child_count = self.forest.children[node_id].len();
         if child_index >= child_count {
-            return Err(ChildOperationError::ChildIndexOutOfBounds { parent, child_index, child_count });
+            return Err(error::InvalidChild::ChildIndexOutOfBounds { parent, child_index, child_count });
         }
 
         self.forest.parents[child_id].push(node_id);
@@ -231,31 +231,31 @@ impl Taffy {
     }
 
     /// Returns the child [`Node`] of the parent `node` at the provided `child_index`
-    pub fn child_at_index(&self, parent: Node, child_index: usize) -> Result<Node, ChildOperationError> {
+    pub fn child_at_index(&self, parent: Node, child_index: usize) -> Result<Node, error::InvalidChild> {
         let id = self.find_node(parent)?;
 
         let child_count = self.forest.children[id].len();
         if child_index >= child_count {
-            return Err(ChildOperationError::ChildIndexOutOfBounds { parent, child_index, child_count });
+            return Err(error::InvalidChild::ChildIndexOutOfBounds { parent, child_index, child_count });
         }
 
         Ok(self.ids_to_nodes[&self.forest.children[id][child_index]])
     }
 
     /// Returns the number of children of the `parent` [`Node`]
-    pub fn child_count(&self, parent: Node) -> Result<usize, NodeNotFoundError> {
+    pub fn child_count(&self, parent: Node) -> Result<usize, error::InvalidNode> {
         let id = self.find_node(parent)?;
         Ok(self.forest.children[id].len())
     }
 
     /// Returns a list of children that belong to the [`Parent`]
-    pub fn children(&self, parent: Node) -> Result<Vec<Node>, NodeNotFoundError> {
+    pub fn children(&self, parent: Node) -> Result<Vec<Node>, error::InvalidNode> {
         let id = self.find_node(parent)?;
         Ok(self.forest.children[id].iter().map(|child| self.ids_to_nodes[child]).collect())
     }
 
     /// Sets the [`Style`] of the provided `node`
-    pub fn set_style(&mut self, node: Node, style: FlexboxLayout) -> Result<(), NodeNotFoundError> {
+    pub fn set_style(&mut self, node: Node, style: FlexboxLayout) -> Result<(), error::InvalidNode> {
         let id = self.find_node(node)?;
         self.forest.nodes[id].style = style;
         self.forest.mark_dirty(id);
@@ -263,32 +263,32 @@ impl Taffy {
     }
 
     /// Gets the [`Style`] of the provided `node`
-    pub fn style(&self, node: Node) -> Result<&FlexboxLayout, NodeNotFoundError> {
+    pub fn style(&self, node: Node) -> Result<&FlexboxLayout, error::InvalidNode> {
         let id = self.find_node(node)?;
         Ok(&self.forest.nodes[id].style)
     }
 
     /// Return this node layout relative to its parent
-    pub fn layout(&self, node: Node) -> Result<&Layout, NodeNotFoundError> {
+    pub fn layout(&self, node: Node) -> Result<&Layout, error::InvalidNode> {
         let id = self.find_node(node)?;
         Ok(&self.forest.nodes[id].layout)
     }
 
     /// Marks the layout computation of this node and its children as outdated
-    pub fn mark_dirty(&mut self, node: Node) -> Result<(), NodeNotFoundError> {
+    pub fn mark_dirty(&mut self, node: Node) -> Result<(), error::InvalidNode> {
         let id = self.find_node(node)?;
         self.forest.mark_dirty(id);
         Ok(())
     }
 
     /// Indicates whether the layout of this node (and its children) need to be recomputed
-    pub fn dirty(&self, node: Node) -> Result<bool, NodeNotFoundError> {
+    pub fn dirty(&self, node: Node) -> Result<bool, error::InvalidNode> {
         let id = self.find_node(node)?;
         Ok(self.forest.nodes[id].is_dirty)
     }
 
     /// Updates the stored layout of the provided `node` and its children
-    pub fn compute_layout(&mut self, node: Node, size: Size<Number>) -> Result<(), NodeNotFoundError> {
+    pub fn compute_layout(&mut self, node: Node, size: Size<Number>) -> Result<(), error::InvalidNode> {
         let id = self.find_node(node)?;
         self.forest.compute_layout(id, size);
         Ok(())

--- a/src/node.rs
+++ b/src/node.rs
@@ -193,7 +193,8 @@ impl Taffy {
     ///
     /// The child is not removed from the forest entirely, it is simply no longer attached to its previous parent.
     pub fn remove_child_at_index(&mut self, parent: Node, child_index: usize) -> Result<Node, error::InvalidChild> {
-        let node_id = self.find_node(parent)?;
+        let node_id = self.find_node(parent)
+            .map_err(|e| error::InvalidChild::InvalidParentNode(e.0))?;
 
         let child_count = self.forest.children[node_id].len();
         if child_index >= child_count {
@@ -213,8 +214,10 @@ impl Taffy {
         child_index: usize,
         new_child: Node,
     ) -> Result<Node, error::InvalidChild> {
-        let node_id = self.find_node(parent)?;
-        let child_id = self.find_node(new_child)?;
+        let node_id = self.find_node(parent)
+            .map_err(|e| error::InvalidChild::InvalidParentNode(e.0))?;
+        let child_id = self.find_node(new_child)
+            .map_err(|e| error::InvalidChild::InvalidChildNode(e.0))?;
         // TODO: index check
         let child_count = self.forest.children[node_id].len();
         if child_index >= child_count {
@@ -232,7 +235,8 @@ impl Taffy {
 
     /// Returns the child [`Node`] of the parent `node` at the provided `child_index`
     pub fn child_at_index(&self, parent: Node, child_index: usize) -> Result<Node, error::InvalidChild> {
-        let id = self.find_node(parent)?;
+        let id = self.find_node(parent)
+            .map_err(|e| error::InvalidChild::InvalidParentNode(e.0))?;
 
         let child_count = self.forest.children[id].len();
         if child_index >= child_count {

--- a/src/node.rs
+++ b/src/node.rs
@@ -193,7 +193,7 @@ impl Taffy {
 
         let child_count = self.forest.children[node_id].len();
         if child_index >= child_count {
-            return Err(TaffyError::IndexOutOfBounds { parent, child_index, child_count });
+            return Err(TaffyError::ChildIndexOutOfBounds { parent, child_index, child_count });
         }
 
         let prev_id = self.forest.remove_child_at_index(node_id, child_index);
@@ -209,7 +209,7 @@ impl Taffy {
         // TODO: index check
         let child_count = self.forest.children[node_id].len();
         if child_index >= child_count {
-            return Err(TaffyError::IndexOutOfBounds { parent, child_index, child_count });
+            return Err(TaffyError::ChildIndexOutOfBounds { parent, child_index, child_count });
         }
 
         self.forest.parents[child_id].push(node_id);
@@ -227,7 +227,7 @@ impl Taffy {
 
         let child_count = self.forest.children[id].len();
         if child_index >= child_count {
-            return Err(TaffyError::IndexOutOfBounds { parent, child_index, child_count });
+            return Err(TaffyError::ChildIndexOutOfBounds { parent, child_index, child_count });
         }
 
         Ok(self.ids_to_nodes[&self.forest.children[id][child_index]])

--- a/src/node.rs
+++ b/src/node.rs
@@ -9,7 +9,7 @@ use crate::style::FlexboxLayout;
 #[cfg(any(feature = "std", feature = "alloc"))]
 use crate::sys::Box;
 use crate::sys::{new_map_with_capacity, ChildrenVec, Map, Vec};
-use crate::{NodeNotFoundError, ChildOperationError};
+use crate::{ChildOperationError, NodeNotFoundError};
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 /// A function that can be applied to a `Size<Number>` to obtain a `Size<f32>`
@@ -105,8 +105,10 @@ impl Taffy {
     /// Adds a new node, which may have any number of `children`
     pub fn new_with_children(&mut self, style: FlexboxLayout, children: &[Node]) -> Result<Node, NodeNotFoundError> {
         let node = self.allocate_node();
-        let children =
-            children.iter().map(|child| self.find_node(*child)).collect::<Result<ChildrenVec<_>, NodeNotFoundError>>()?;
+        let children = children
+            .iter()
+            .map(|child| self.find_node(*child))
+            .collect::<Result<ChildrenVec<_>, NodeNotFoundError>>()?;
         let id = self.forest.new_with_children(style, children);
         self.add_node(node, id);
         Ok(node)
@@ -205,7 +207,12 @@ impl Taffy {
     /// Replaces the child at the given `child_index` from the `parent` node with the new `child` node
     ///
     /// The child is not removed from the forest entirely, it is simply no longer attached to its previous parent.
-    pub fn replace_child_at_index(&mut self, parent: Node, child_index: usize, new_child: Node) -> Result<Node, ChildOperationError> {
+    pub fn replace_child_at_index(
+        &mut self,
+        parent: Node,
+        child_index: usize,
+        new_child: Node,
+    ) -> Result<Node, ChildOperationError> {
         let node_id = self.find_node(parent)?;
         let child_id = self.find_node(new_child)?;
         // TODO: index check

--- a/src/node.rs
+++ b/src/node.rs
@@ -9,7 +9,7 @@ use crate::style::FlexboxLayout;
 #[cfg(any(feature = "std", feature = "alloc"))]
 use crate::sys::Box;
 use crate::sys::{new_map_with_capacity, ChildrenVec, Map, Vec};
-use crate::Error;
+use crate::{NodeNotFoundError, ChildOperationError};
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 /// A function that can be applied to a `Size<Number>` to obtain a `Size<f32>`
@@ -87,15 +87,15 @@ impl Taffy {
     }
 
     /// Returns the `NodeId` of the provided node within the forest
-    fn find_node(&self, node: Node) -> Result<NodeId, Error> {
+    fn find_node(&self, node: Node) -> Result<NodeId, NodeNotFoundError> {
         match self.nodes_to_ids.get(&node) {
             Some(id) => Ok(*id),
-            None => Err(Error::InvalidNode(node)),
+            None => Err(NodeNotFoundError(node)),
         }
     }
 
     /// Adds a new leaf node, which does not have any children
-    pub fn new_leaf(&mut self, style: FlexboxLayout, measure: MeasureFunc) -> Result<Node, Error> {
+    pub fn new_leaf(&mut self, style: FlexboxLayout, measure: MeasureFunc) -> Result<Node, NodeNotFoundError> {
         let node = self.allocate_node();
         let id = self.forest.new_leaf(style, measure);
         self.add_node(node, id);
@@ -103,10 +103,10 @@ impl Taffy {
     }
 
     /// Adds a new node, which may have any number of `children`
-    pub fn new_with_children(&mut self, style: FlexboxLayout, children: &[Node]) -> Result<Node, Error> {
+    pub fn new_with_children(&mut self, style: FlexboxLayout, children: &[Node]) -> Result<Node, NodeNotFoundError> {
         let node = self.allocate_node();
         let children =
-            children.iter().map(|child| self.find_node(*child)).collect::<Result<ChildrenVec<_>, Error>>()?;
+            children.iter().map(|child| self.find_node(*child)).collect::<Result<ChildrenVec<_>, NodeNotFoundError>>()?;
         let id = self.forest.new_with_children(style, children);
         self.add_node(node, id);
         Ok(node)
@@ -140,7 +140,7 @@ impl Taffy {
     }
 
     /// Sets the [`MeasureFunc`] of the associated node
-    pub fn set_measure(&mut self, node: Node, measure: Option<MeasureFunc>) -> Result<(), Error> {
+    pub fn set_measure(&mut self, node: Node, measure: Option<MeasureFunc>) -> Result<(), NodeNotFoundError> {
         let id = self.find_node(node)?;
         self.forest.nodes[id].measure = measure;
         self.forest.mark_dirty(id);
@@ -148,7 +148,7 @@ impl Taffy {
     }
 
     /// Adds a `child` [`Node`] under the supplied `parent`
-    pub fn add_child(&mut self, parent: Node, child: Node) -> Result<(), Error> {
+    pub fn add_child(&mut self, parent: Node, child: Node) -> Result<(), NodeNotFoundError> {
         let node_id = self.find_node(parent)?;
         let child_id = self.find_node(child)?;
 
@@ -157,7 +157,7 @@ impl Taffy {
     }
 
     /// Directly sets the `children` of the supplied `parent`
-    pub fn set_children(&mut self, parent: Node, children: &[Node]) -> Result<(), Error> {
+    pub fn set_children(&mut self, parent: Node, children: &[Node]) -> Result<(), NodeNotFoundError> {
         let node_id = self.find_node(parent)?;
         let children_id = children.iter().map(|child| self.find_node(*child)).collect::<Result<ChildrenVec<_>, _>>()?;
 
@@ -179,7 +179,7 @@ impl Taffy {
     /// Removes the `child` of the parent `node`
     ///
     /// The child is not removed from the forest entirely, it is simply no longer attached to its previous parent.
-    pub fn remove_child(&mut self, parent: Node, child: Node) -> Result<Node, Error> {
+    pub fn remove_child(&mut self, parent: Node, child: Node) -> Result<Node, NodeNotFoundError> {
         let node_id = self.find_node(parent)?;
         let child_id = self.find_node(child)?;
 
@@ -190,12 +190,12 @@ impl Taffy {
     /// Removes the child at the given `index` from the `parent`
     ///
     /// The child is not removed from the forest entirely, it is simply no longer attached to its previous parent.
-    pub fn remove_child_at_index(&mut self, parent: Node, child_index: usize) -> Result<Node, Error> {
+    pub fn remove_child_at_index(&mut self, parent: Node, child_index: usize) -> Result<Node, ChildOperationError> {
         let node_id = self.find_node(parent)?;
 
         let child_count = self.forest.children[node_id].len();
         if child_index >= child_count {
-            return Err(Error::ChildIndexOutOfBounds { parent, child_index, child_count });
+            return Err(ChildOperationError::ChildIndexOutOfBounds { parent, child_index, child_count });
         }
 
         let prev_id = self.forest.remove_child_at_index(node_id, child_index);
@@ -205,13 +205,13 @@ impl Taffy {
     /// Replaces the child at the given `child_index` from the `parent` node with the new `child` node
     ///
     /// The child is not removed from the forest entirely, it is simply no longer attached to its previous parent.
-    pub fn replace_child_at_index(&mut self, parent: Node, child_index: usize, new_child: Node) -> Result<Node, Error> {
+    pub fn replace_child_at_index(&mut self, parent: Node, child_index: usize, new_child: Node) -> Result<Node, ChildOperationError> {
         let node_id = self.find_node(parent)?;
         let child_id = self.find_node(new_child)?;
         // TODO: index check
         let child_count = self.forest.children[node_id].len();
         if child_index >= child_count {
-            return Err(Error::ChildIndexOutOfBounds { parent, child_index, child_count });
+            return Err(ChildOperationError::ChildIndexOutOfBounds { parent, child_index, child_count });
         }
 
         self.forest.parents[child_id].push(node_id);
@@ -224,31 +224,31 @@ impl Taffy {
     }
 
     /// Returns the child [`Node`] of the parent `node` at the provided `child_index`
-    pub fn child_at_index(&self, parent: Node, child_index: usize) -> Result<Node, Error> {
+    pub fn child_at_index(&self, parent: Node, child_index: usize) -> Result<Node, ChildOperationError> {
         let id = self.find_node(parent)?;
 
         let child_count = self.forest.children[id].len();
         if child_index >= child_count {
-            return Err(Error::ChildIndexOutOfBounds { parent, child_index, child_count });
+            return Err(ChildOperationError::ChildIndexOutOfBounds { parent, child_index, child_count });
         }
 
         Ok(self.ids_to_nodes[&self.forest.children[id][child_index]])
     }
 
     /// Returns the number of children of the `parent` [`Node`]
-    pub fn child_count(&self, parent: Node) -> Result<usize, Error> {
+    pub fn child_count(&self, parent: Node) -> Result<usize, NodeNotFoundError> {
         let id = self.find_node(parent)?;
         Ok(self.forest.children[id].len())
     }
 
     /// Returns a list of children that belong to the [`Parent`]
-    pub fn children(&self, parent: Node) -> Result<Vec<Node>, Error> {
+    pub fn children(&self, parent: Node) -> Result<Vec<Node>, NodeNotFoundError> {
         let id = self.find_node(parent)?;
         Ok(self.forest.children[id].iter().map(|child| self.ids_to_nodes[child]).collect())
     }
 
     /// Sets the [`Style`] of the provided `node`
-    pub fn set_style(&mut self, node: Node, style: FlexboxLayout) -> Result<(), Error> {
+    pub fn set_style(&mut self, node: Node, style: FlexboxLayout) -> Result<(), NodeNotFoundError> {
         let id = self.find_node(node)?;
         self.forest.nodes[id].style = style;
         self.forest.mark_dirty(id);
@@ -256,32 +256,32 @@ impl Taffy {
     }
 
     /// Gets the [`Style`] of the provided `node`
-    pub fn style(&self, node: Node) -> Result<&FlexboxLayout, Error> {
+    pub fn style(&self, node: Node) -> Result<&FlexboxLayout, NodeNotFoundError> {
         let id = self.find_node(node)?;
         Ok(&self.forest.nodes[id].style)
     }
 
     /// Return this node layout relative to its parent
-    pub fn layout(&self, node: Node) -> Result<&Layout, Error> {
+    pub fn layout(&self, node: Node) -> Result<&Layout, NodeNotFoundError> {
         let id = self.find_node(node)?;
         Ok(&self.forest.nodes[id].layout)
     }
 
     /// Marks the layout computation of this node and its children as outdated
-    pub fn mark_dirty(&mut self, node: Node) -> Result<(), Error> {
+    pub fn mark_dirty(&mut self, node: Node) -> Result<(), NodeNotFoundError> {
         let id = self.find_node(node)?;
         self.forest.mark_dirty(id);
         Ok(())
     }
 
     /// Indicates whether the layout of this node (and its children) need to be recomputed
-    pub fn dirty(&self, node: Node) -> Result<bool, Error> {
+    pub fn dirty(&self, node: Node) -> Result<bool, NodeNotFoundError> {
         let id = self.find_node(node)?;
         Ok(self.forest.nodes[id].is_dirty)
     }
 
     /// Updates the stored layout of the provided `node` and its children
-    pub fn compute_layout(&mut self, node: Node, size: Size<Number>) -> Result<(), Error> {
+    pub fn compute_layout(&mut self, node: Node, size: Size<Number>) -> Result<(), NodeNotFoundError> {
         let id = self.find_node(node)?;
         self.forest.compute_layout(id, size);
         Ok(())

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,6 +1,7 @@
 //! UI [`Node`] types and related data structures.
 //!
 //! Layouts are composed of multiple nodes, which live in a forest-like data structure.
+use crate::error;
 use crate::forest::Forest;
 use crate::geometry::Size;
 use crate::layout::Layout;
@@ -9,7 +10,6 @@ use crate::style::FlexboxLayout;
 #[cfg(any(feature = "std", feature = "alloc"))]
 use crate::sys::Box;
 use crate::sys::{new_map_with_capacity, ChildrenVec, Map, Vec};
-use crate::error;
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 /// A function that can be applied to a `Size<Number>` to obtain a `Size<f32>`
@@ -193,8 +193,7 @@ impl Taffy {
     ///
     /// The child is not removed from the forest entirely, it is simply no longer attached to its previous parent.
     pub fn remove_child_at_index(&mut self, parent: Node, child_index: usize) -> Result<Node, error::InvalidChild> {
-        let node_id = self.find_node(parent)
-            .map_err(|e| error::InvalidChild::InvalidParentNode(e.0))?;
+        let node_id = self.find_node(parent).map_err(|e| error::InvalidChild::InvalidParentNode(e.0))?;
 
         let child_count = self.forest.children[node_id].len();
         if child_index >= child_count {
@@ -214,10 +213,8 @@ impl Taffy {
         child_index: usize,
         new_child: Node,
     ) -> Result<Node, error::InvalidChild> {
-        let node_id = self.find_node(parent)
-            .map_err(|e| error::InvalidChild::InvalidParentNode(e.0))?;
-        let child_id = self.find_node(new_child)
-            .map_err(|e| error::InvalidChild::InvalidChildNode(e.0))?;
+        let node_id = self.find_node(parent).map_err(|e| error::InvalidChild::InvalidParentNode(e.0))?;
+        let child_id = self.find_node(new_child).map_err(|e| error::InvalidChild::InvalidChildNode(e.0))?;
         // TODO: index check
         let child_count = self.forest.children[node_id].len();
         if child_index >= child_count {
@@ -235,8 +232,7 @@ impl Taffy {
 
     /// Returns the child [`Node`] of the parent `node` at the provided `child_index`
     pub fn child_at_index(&self, parent: Node, child_index: usize) -> Result<Node, error::InvalidChild> {
-        let id = self.find_node(parent)
-            .map_err(|e| error::InvalidChild::InvalidParentNode(e.0))?;
+        let id = self.find_node(parent).map_err(|e| error::InvalidChild::InvalidParentNode(e.0))?;
 
         let child_count = self.forest.children[id].len();
         if child_index >= child_count {

--- a/src/node.rs
+++ b/src/node.rs
@@ -9,7 +9,7 @@ use crate::style::FlexboxLayout;
 #[cfg(any(feature = "std", feature = "alloc"))]
 use crate::sys::Box;
 use crate::sys::{new_map_with_capacity, ChildrenVec, Map, Vec};
-use crate::TaffyError;
+use crate::Error;
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 /// A function that can be applied to a `Size<Number>` to obtain a `Size<f32>`
@@ -87,15 +87,15 @@ impl Taffy {
     }
 
     /// Returns the `NodeId` of the provided node within the forest
-    fn find_node(&self, node: Node) -> Result<NodeId, TaffyError> {
+    fn find_node(&self, node: Node) -> Result<NodeId, Error> {
         match self.nodes_to_ids.get(&node) {
             Some(id) => Ok(*id),
-            None => Err(TaffyError::InvalidNode(node)),
+            None => Err(Error::InvalidNode(node)),
         }
     }
 
     /// Adds a new leaf node, which does not have any children
-    pub fn new_leaf(&mut self, style: FlexboxLayout, measure: MeasureFunc) -> Result<Node, TaffyError> {
+    pub fn new_leaf(&mut self, style: FlexboxLayout, measure: MeasureFunc) -> Result<Node, Error> {
         let node = self.allocate_node();
         let id = self.forest.new_leaf(style, measure);
         self.add_node(node, id);
@@ -103,10 +103,10 @@ impl Taffy {
     }
 
     /// Adds a new node, which may have any number of `children`
-    pub fn new_with_children(&mut self, style: FlexboxLayout, children: &[Node]) -> Result<Node, TaffyError> {
+    pub fn new_with_children(&mut self, style: FlexboxLayout, children: &[Node]) -> Result<Node, Error> {
         let node = self.allocate_node();
         let children =
-            children.iter().map(|child| self.find_node(*child)).collect::<Result<ChildrenVec<_>, TaffyError>>()?;
+            children.iter().map(|child| self.find_node(*child)).collect::<Result<ChildrenVec<_>, Error>>()?;
         let id = self.forest.new_with_children(style, children);
         self.add_node(node, id);
         Ok(node)
@@ -138,7 +138,7 @@ impl Taffy {
     }
 
     /// Sets the [`MeasureFunc`] of the associated node
-    pub fn set_measure(&mut self, node: Node, measure: Option<MeasureFunc>) -> Result<(), TaffyError> {
+    pub fn set_measure(&mut self, node: Node, measure: Option<MeasureFunc>) -> Result<(), Error> {
         let id = self.find_node(node)?;
         self.forest.nodes[id].measure = measure;
         self.forest.mark_dirty(id);
@@ -146,7 +146,7 @@ impl Taffy {
     }
 
     /// Adds a `child` [`Node`] under the supplied `parent`
-    pub fn add_child(&mut self, parent: Node, child: Node) -> Result<(), TaffyError> {
+    pub fn add_child(&mut self, parent: Node, child: Node) -> Result<(), Error> {
         let node_id = self.find_node(parent)?;
         let child_id = self.find_node(child)?;
 
@@ -155,7 +155,7 @@ impl Taffy {
     }
 
     /// Directly sets the `children` of the supplied `parent`
-    pub fn set_children(&mut self, parent: Node, children: &[Node]) -> Result<(), TaffyError> {
+    pub fn set_children(&mut self, parent: Node, children: &[Node]) -> Result<(), Error> {
         let node_id = self.find_node(parent)?;
         let children_id = children.iter().map(|child| self.find_node(*child)).collect::<Result<ChildrenVec<_>, _>>()?;
 
@@ -177,7 +177,7 @@ impl Taffy {
     /// Removes the `child` of the parent `node`
     ///
     /// The child is not removed from the forest entirely, it is simply no longer attached to its previous parent.
-    pub fn remove_child(&mut self, parent: Node, child: Node) -> Result<Node, TaffyError> {
+    pub fn remove_child(&mut self, parent: Node, child: Node) -> Result<Node, Error> {
         let node_id = self.find_node(parent)?;
         let child_id = self.find_node(child)?;
 
@@ -188,12 +188,12 @@ impl Taffy {
     /// Removes the child at the given `index` from the `parent`
     ///
     /// The child is not removed from the forest entirely, it is simply no longer attached to its previous parent.
-    pub fn remove_child_at_index(&mut self, parent: Node, child_index: usize) -> Result<Node, TaffyError> {
+    pub fn remove_child_at_index(&mut self, parent: Node, child_index: usize) -> Result<Node, Error> {
         let node_id = self.find_node(parent)?;
 
         let child_count = self.forest.children[node_id].len();
         if child_index >= child_count {
-            return Err(TaffyError::ChildIndexOutOfBounds { parent, child_index, child_count });
+            return Err(Error::ChildIndexOutOfBounds { parent, child_index, child_count });
         }
 
         let prev_id = self.forest.remove_child_at_index(node_id, child_index);
@@ -203,13 +203,13 @@ impl Taffy {
     /// Replaces the child at the given `child_index` from the `parent` node with the new `child` node
     ///
     /// The child is not removed from the forest entirely, it is simply no longer attached to its previous parent.
-    pub fn replace_child_at_index(&mut self, parent: Node, child_index: usize, new_child: Node) -> Result<Node, TaffyError> {
+    pub fn replace_child_at_index(&mut self, parent: Node, child_index: usize, new_child: Node) -> Result<Node, Error> {
         let node_id = self.find_node(parent)?;
         let child_id = self.find_node(new_child)?;
         // TODO: index check
         let child_count = self.forest.children[node_id].len();
         if child_index >= child_count {
-            return Err(TaffyError::ChildIndexOutOfBounds { parent, child_index, child_count });
+            return Err(Error::ChildIndexOutOfBounds { parent, child_index, child_count });
         }
 
         self.forest.parents[child_id].push(node_id);
@@ -222,31 +222,31 @@ impl Taffy {
     }
 
     /// Returns the child [`Node`] of the parent `node` at the provided `child_index`
-    pub fn child_at_index(&self, parent: Node, child_index: usize) -> Result<Node, TaffyError> {
+    pub fn child_at_index(&self, parent: Node, child_index: usize) -> Result<Node, Error> {
         let id = self.find_node(parent)?;
 
         let child_count = self.forest.children[id].len();
         if child_index >= child_count {
-            return Err(TaffyError::ChildIndexOutOfBounds { parent, child_index, child_count });
+            return Err(Error::ChildIndexOutOfBounds { parent, child_index, child_count });
         }
 
         Ok(self.ids_to_nodes[&self.forest.children[id][child_index]])
     }
 
     /// Returns the number of children of the `parent` [`Node`]
-    pub fn child_count(&self, parent: Node) -> Result<usize, TaffyError> {
+    pub fn child_count(&self, parent: Node) -> Result<usize, Error> {
         let id = self.find_node(parent)?;
         Ok(self.forest.children[id].len())
     }
 
     /// Returns a list of children that belong to the [`Parent`]
-    pub fn children(&self, parent: Node) -> Result<Vec<Node>, TaffyError> {
+    pub fn children(&self, parent: Node) -> Result<Vec<Node>, Error> {
         let id = self.find_node(parent)?;
         Ok(self.forest.children[id].iter().map(|child| self.ids_to_nodes[child]).collect())
     }
 
     /// Sets the [`Style`] of the provided `node`
-    pub fn set_style(&mut self, node: Node, style: FlexboxLayout) -> Result<(), TaffyError> {
+    pub fn set_style(&mut self, node: Node, style: FlexboxLayout) -> Result<(), Error> {
         let id = self.find_node(node)?;
         self.forest.nodes[id].style = style;
         self.forest.mark_dirty(id);
@@ -254,32 +254,32 @@ impl Taffy {
     }
 
     /// Gets the [`Style`] of the provided `node`
-    pub fn style(&self, node: Node) -> Result<&FlexboxLayout, TaffyError> {
+    pub fn style(&self, node: Node) -> Result<&FlexboxLayout, Error> {
         let id = self.find_node(node)?;
         Ok(&self.forest.nodes[id].style)
     }
 
     /// Return this node layout relative to its parent
-    pub fn layout(&self, node: Node) -> Result<&Layout, TaffyError> {
+    pub fn layout(&self, node: Node) -> Result<&Layout, Error> {
         let id = self.find_node(node)?;
         Ok(&self.forest.nodes[id].layout)
     }
 
     /// Marks the layout computation of this node and its children as outdated
-    pub fn mark_dirty(&mut self, node: Node) -> Result<(), TaffyError> {
+    pub fn mark_dirty(&mut self, node: Node) -> Result<(), Error> {
         let id = self.find_node(node)?;
         self.forest.mark_dirty(id);
         Ok(())
     }
 
     /// Indicates whether the layout of this node (and its children) need to be recomputed
-    pub fn dirty(&self, node: Node) -> Result<bool, TaffyError> {
+    pub fn dirty(&self, node: Node) -> Result<bool, Error> {
         let id = self.find_node(node)?;
         Ok(self.forest.nodes[id].is_dirty)
     }
 
     /// Updates the stored layout of the provided `node` and its children
-    pub fn compute_layout(&mut self, node: Node, size: Size<Number>) -> Result<(), TaffyError> {
+    pub fn compute_layout(&mut self, node: Node, size: Size<Number>) -> Result<(), Error> {
         let id = self.find_node(node)?;
         self.forest.compute_layout(id, size);
         Ok(())

--- a/src/node.rs
+++ b/src/node.rs
@@ -124,7 +124,7 @@ impl Taffy {
     /// Remove a specific [`Node`] from the tree
     ///
     /// Its [`Id`] is marked as invalid. Returns the id of the node removed.
-    pub fn remove(&mut self, node: Node) -> Result<usize, Error> {
+    pub fn remove(&mut self, node: Node) -> Result<usize, NodeNotFoundError> {
         let id = self.find_node(node)?;
 
         self.nodes_to_ids.remove(&node);

--- a/src/node.rs
+++ b/src/node.rs
@@ -9,7 +9,7 @@ use crate::style::FlexboxLayout;
 #[cfg(any(feature = "std", feature = "alloc"))]
 use crate::sys::Box;
 use crate::sys::{new_map_with_capacity, ChildrenVec, Map, Vec};
-use crate::Error;
+use crate::TaffyError;
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 /// A function that can be applied to a `Size<Number>` to obtain a `Size<f32>`
@@ -87,15 +87,15 @@ impl Taffy {
     }
 
     /// Returns the `NodeId` of the provided node within the forest
-    fn find_node(&self, node: Node) -> Result<NodeId, Error> {
+    fn find_node(&self, node: Node) -> Result<NodeId, TaffyError> {
         match self.nodes_to_ids.get(&node) {
             Some(id) => Ok(*id),
-            None => Err(Error::InvalidNode(node)),
+            None => Err(TaffyError::InvalidNode(node)),
         }
     }
 
     /// Adds a new leaf node, which does not have any children
-    pub fn new_leaf(&mut self, style: FlexboxLayout, measure: MeasureFunc) -> Result<Node, Error> {
+    pub fn new_leaf(&mut self, style: FlexboxLayout, measure: MeasureFunc) -> Result<Node, TaffyError> {
         let node = self.allocate_node();
         let id = self.forest.new_leaf(style, measure);
         self.add_node(node, id);
@@ -103,10 +103,10 @@ impl Taffy {
     }
 
     /// Adds a new node, which may have any number of `children`
-    pub fn new_with_children(&mut self, style: FlexboxLayout, children: &[Node]) -> Result<Node, Error> {
+    pub fn new_with_children(&mut self, style: FlexboxLayout, children: &[Node]) -> Result<Node, TaffyError> {
         let node = self.allocate_node();
         let children =
-            children.iter().map(|child| self.find_node(*child)).collect::<Result<ChildrenVec<_>, Error>>()?;
+            children.iter().map(|child| self.find_node(*child)).collect::<Result<ChildrenVec<_>, TaffyError>>()?;
         let id = self.forest.new_with_children(style, children);
         self.add_node(node, id);
         Ok(node)
@@ -138,7 +138,7 @@ impl Taffy {
     }
 
     /// Sets the [`MeasureFunc`] of the associated node
-    pub fn set_measure(&mut self, node: Node, measure: Option<MeasureFunc>) -> Result<(), Error> {
+    pub fn set_measure(&mut self, node: Node, measure: Option<MeasureFunc>) -> Result<(), TaffyError> {
         let id = self.find_node(node)?;
         self.forest.nodes[id].measure = measure;
         self.forest.mark_dirty(id);
@@ -146,7 +146,7 @@ impl Taffy {
     }
 
     /// Adds a `child` [`Node`] under the supplied `parent`
-    pub fn add_child(&mut self, parent: Node, child: Node) -> Result<(), Error> {
+    pub fn add_child(&mut self, parent: Node, child: Node) -> Result<(), TaffyError> {
         let node_id = self.find_node(parent)?;
         let child_id = self.find_node(child)?;
 
@@ -155,7 +155,7 @@ impl Taffy {
     }
 
     /// Directly sets the `children` of the supplied `parent`
-    pub fn set_children(&mut self, parent: Node, children: &[Node]) -> Result<(), Error> {
+    pub fn set_children(&mut self, parent: Node, children: &[Node]) -> Result<(), TaffyError> {
         let node_id = self.find_node(parent)?;
         let children_id = children.iter().map(|child| self.find_node(*child)).collect::<Result<ChildrenVec<_>, _>>()?;
 
@@ -177,7 +177,7 @@ impl Taffy {
     /// Removes the `child` of the parent `node`
     ///
     /// The child is not removed from the forest entirely, it is simply no longer attached to its previous parent.
-    pub fn remove_child(&mut self, parent: Node, child: Node) -> Result<Node, Error> {
+    pub fn remove_child(&mut self, parent: Node, child: Node) -> Result<Node, TaffyError> {
         let node_id = self.find_node(parent)?;
         let child_id = self.find_node(child)?;
 
@@ -188,9 +188,13 @@ impl Taffy {
     /// Removes the child at the given `index` from the `parent`
     ///
     /// The child is not removed from the forest entirely, it is simply no longer attached to its previous parent.
-    pub fn remove_child_at_index(&mut self, parent: Node, child_index: usize) -> Result<Node, Error> {
+    pub fn remove_child_at_index(&mut self, parent: Node, child_index: usize) -> Result<Node, TaffyError> {
         let node_id = self.find_node(parent)?;
-        // TODO: index check
+
+        let child_count = self.forest.children[node_id].len();
+        if child_index >= child_count {
+            return Err(TaffyError::IndexOutOfBounds { parent, child_index, child_count });
+        }
 
         let prev_id = self.forest.remove_child_at_index(node_id, child_index);
         Ok(self.ids_to_nodes[&prev_id])
@@ -199,10 +203,14 @@ impl Taffy {
     /// Replaces the child at the given `child_index` from the `parent` node with the new `child` node
     ///
     /// The child is not removed from the forest entirely, it is simply no longer attached to its previous parent.
-    pub fn replace_child_at_index(&mut self, parent: Node, child_index: usize, new_child: Node) -> Result<Node, Error> {
+    pub fn replace_child_at_index(&mut self, parent: Node, child_index: usize, new_child: Node) -> Result<Node, TaffyError> {
         let node_id = self.find_node(parent)?;
         let child_id = self.find_node(new_child)?;
         // TODO: index check
+        let child_count = self.forest.children[node_id].len();
+        if child_index >= child_count {
+            return Err(TaffyError::IndexOutOfBounds { parent, child_index, child_count });
+        }
 
         self.forest.parents[child_id].push(node_id);
         let old_child = core::mem::replace(&mut self.forest.children[node_id][child_index], child_id);
@@ -214,25 +222,31 @@ impl Taffy {
     }
 
     /// Returns the child [`Node`] of the parent `node` at the provided `child_index`
-    pub fn child_at_index(&self, parent: Node, child_index: usize) -> Result<Node, Error> {
+    pub fn child_at_index(&self, parent: Node, child_index: usize) -> Result<Node, TaffyError> {
         let id = self.find_node(parent)?;
+
+        let child_count = self.forest.children[id].len();
+        if child_index >= child_count {
+            return Err(TaffyError::IndexOutOfBounds { parent, child_index, child_count });
+        }
+
         Ok(self.ids_to_nodes[&self.forest.children[id][child_index]])
     }
 
     /// Returns the number of children of the `parent` [`Node`]
-    pub fn child_count(&self, parent: Node) -> Result<usize, Error> {
+    pub fn child_count(&self, parent: Node) -> Result<usize, TaffyError> {
         let id = self.find_node(parent)?;
         Ok(self.forest.children[id].len())
     }
 
     /// Returns a list of children that belong to the [`Parent`]
-    pub fn children(&self, parent: Node) -> Result<Vec<Node>, Error> {
+    pub fn children(&self, parent: Node) -> Result<Vec<Node>, TaffyError> {
         let id = self.find_node(parent)?;
         Ok(self.forest.children[id].iter().map(|child| self.ids_to_nodes[child]).collect())
     }
 
     /// Sets the [`Style`] of the provided `node`
-    pub fn set_style(&mut self, node: Node, style: FlexboxLayout) -> Result<(), Error> {
+    pub fn set_style(&mut self, node: Node, style: FlexboxLayout) -> Result<(), TaffyError> {
         let id = self.find_node(node)?;
         self.forest.nodes[id].style = style;
         self.forest.mark_dirty(id);
@@ -240,32 +254,32 @@ impl Taffy {
     }
 
     /// Gets the [`Style`] of the provided `node`
-    pub fn style(&self, node: Node) -> Result<&FlexboxLayout, Error> {
+    pub fn style(&self, node: Node) -> Result<&FlexboxLayout, TaffyError> {
         let id = self.find_node(node)?;
         Ok(&self.forest.nodes[id].style)
     }
 
     /// Return this node layout relative to its parent
-    pub fn layout(&self, node: Node) -> Result<&Layout, Error> {
+    pub fn layout(&self, node: Node) -> Result<&Layout, TaffyError> {
         let id = self.find_node(node)?;
         Ok(&self.forest.nodes[id].layout)
     }
 
     /// Marks the layout computation of this node and its children as outdated
-    pub fn mark_dirty(&mut self, node: Node) -> Result<(), Error> {
+    pub fn mark_dirty(&mut self, node: Node) -> Result<(), TaffyError> {
         let id = self.find_node(node)?;
         self.forest.mark_dirty(id);
         Ok(())
     }
 
     /// Indicates whether the layout of this node (and its children) need to be recomputed
-    pub fn dirty(&self, node: Node) -> Result<bool, Error> {
+    pub fn dirty(&self, node: Node) -> Result<bool, TaffyError> {
         let id = self.find_node(node)?;
         Ok(self.forest.nodes[id].is_dirty)
     }
 
     /// Updates the stored layout of the provided `node` and its children
-    pub fn compute_layout(&mut self, node: Node, size: Size<Number>) -> Result<(), Error> {
+    pub fn compute_layout(&mut self, node: Node, size: Size<Number>) -> Result<(), TaffyError> {
         let id = self.find_node(node)?;
         self.forest.compute_layout(id, size);
         Ok(())

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,5 +9,4 @@ pub use crate::{
         AlignContent, AlignItems, AlignSelf, Dimension, Display, FlexDirection, FlexWrap, FlexboxLayout,
         JustifyContent, PositionType,
     },
-    NodeNotFoundError,
 };

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,5 +9,5 @@ pub use crate::{
         AlignContent, AlignItems, AlignSelf, Dimension, Display, FlexDirection, FlexWrap, FlexboxLayout,
         JustifyContent, PositionType,
     },
-    Error,
+    NodeNotFoundError,
 };

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,5 +9,5 @@ pub use crate::{
         AlignContent, AlignItems, AlignSelf, Dimension, Display, FlexDirection, FlexWrap, FlexboxLayout,
         JustifyContent, PositionType,
     },
-    TaffyError,
+    Error,
 };

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,5 +9,5 @@ pub use crate::{
         AlignContent, AlignItems, AlignSelf, Dimension, Display, FlexDirection, FlexWrap, FlexboxLayout,
         JustifyContent, PositionType,
     },
-    Error,
+    TaffyError,
 };


### PR DESCRIPTION
# Objective

Replaces `taffy::Error` with `taffy::NodeNotFoundError` to make code much more legible. Also adds `taffy::ChildOperationError` so that `remove_child_at_index`, `replace_child_at_index`, and `child_at_index` can return an error instead of panicing.

Fixes #100 #104

## Feedback wanted

I'm not happy with the name of `ChildOperationError`. It feels a little vague to me. Is it fine, or is there possibly a better name for it?

Also, I'm not sure I should have flattened NodeNotFoundError into a tuple struct.