### PR TITLE
Remove serde renames from Display

### DIFF
--- a/src/style.rs
+++ b/src/style.rs
@@ -95,10 +95,8 @@ impl Default for AlignContent {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Display {
     /// The children will follow the flexbox layout algorithm
-    #[cfg_attr(feature = "serde", serde(rename = "flex"))]
     Flex,
     /// The children will not be laid out, and will follow absolute positioning
-    #[cfg_attr(feature = "serde", serde(rename = "none"))]
     None,
 }
 


### PR DESCRIPTION
# Objective

This PR removes the rename serde field attribute from the `Display` variants so that the serialized and deserialized values are consistent with the other style enum variants.
