### PR TITLE
Make `MeasureFunc` Send and Sync

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -22,6 +22,7 @@
 - fixed rounding of fractional values to follow latest Chrome - values are now rounded the same regardless of their position
 - fixed computing free space when using both `flex-grow` and a minimum size
 - padding is now only subtracted when determining the available space if the node size is unspecified, following [section 9.2.2 of the flexbox spec](https://www.w3.org/TR/css-flexbox-1/#line-sizing)
+- `MeasureFunc` (and hence `NodeData` and hence `Forest` and hence the public `Taffy` type) are now `Send` and `Sync`, enabling their use in async and parallel applications
 
 ### 0.2.0 Removed
 


### PR DESCRIPTION
# Objective

Fixes #146. This was much more straightforward than I was concerned it might be, we just needed to add a trait bound. This will unblock #27.