### PR TITLE
Remove manual map implementation in `MaybeMath`

### DIFF
--- a/src/math.rs
+++ b/src/math.rs
@@ -57,38 +57,20 @@ impl MaybeMath<Option<f32>, Option<f32>> for Option<f32> {
 }
 
 impl MaybeMath<f32, Option<f32>> for Option<f32> {
-    // The logic here is subtle and critical;
-    // explicit match statements make it more clear what's going on
-    #[allow(clippy::manual_map)]
     fn maybe_min(self, rhs: f32) -> Option<f32> {
-        match self {
-            Some(val) => Some(val.min(rhs)),
-            None => None,
-        }
+        self.map(|val| val.min(rhs))
     }
 
-    #[allow(clippy::manual_map)]
     fn maybe_max(self, rhs: f32) -> Option<f32> {
-        match self {
-            Some(val) => Some(val.max(rhs)),
-            None => None,
-        }
+        self.map(|val| val.max(rhs))
     }
 
-    #[allow(clippy::manual_map)]
     fn maybe_add(self, rhs: f32) -> Option<f32> {
-        match self {
-            Some(val) => Some(val + rhs),
-            None => None,
-        }
+        self.map(|val| val + rhs)
     }
 
-    #[allow(clippy::manual_map)]
     fn maybe_sub(self, rhs: f32) -> Option<f32> {
-        match self {
-            Some(val) => Some(val - rhs),
-            None => None,
-        }
+        self.map(|val| val - rhs)
     }
 }
 


### PR DESCRIPTION
# Objective

The implementations of `MaybeMath` used `#[allow(clippy::manual_map)]`.
This PR removes this lint suppression and applies `cargo clippy --fix` to use `map` instead of the `match` statement.

## Context

The original implementation justified the lint suppression as follows:

> The logic here is subtle and critical;
> explicit match statements make it more clear what's going on

## Feedback wanted

Do the explicit map statements really make it more clear what's going on?
Personally, I think the `map` statements are also clear.
If we're unsure if something works we should add unit tests instead.
I think it's good to suppress as little lints as possible.
