### PR TITLE
Add unit tests for `MaybeMath`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,17 +21,16 @@ num-traits = { version = "0.2", default-features = false }
 typenum = "1"
 hashbrown = { version = "0.12", optional = true }
 serde = { version = "1.0", optional = true, features = ["serde_derive"] }
-rstest = { version = "0.13.0", optional = true }
 
 [features]
 default = ["std"]
 alloc = ["hashbrown"]
 std = ["num-traits/std"]
 serde = ["dep:serde"]
-test = ["rstest"]
 
 [dev-dependencies]
 criterion = "0.3"
+rstest = "0.13.0"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,14 @@ num-traits = { version = "0.2", default-features = false }
 typenum = "1"
 hashbrown = { version = "0.12", optional = true }
 serde = { version = "1.0", optional = true, features = ["serde_derive"] }
+rstest = { version = "0.13.0", optional = true }
 
 [features]
 default = ["std"]
 alloc = ["hashbrown"]
 std = ["num-traits/std"]
 serde = ["dep:serde"]
+test = ["rstest"]
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/math.rs
+++ b/src/math.rs
@@ -207,4 +207,42 @@ mod tests {
             assert_eq!(lhs.maybe_sub(rhs), expected);
         }
     }
+
+    mod lhs_f32_rhs_option_f32 {
+
+        use crate::math::MaybeMath;
+        use rstest::rstest;
+
+        #[rstest]
+        #[case(3.0, Some(5.0), 3.0)]
+        #[case(5.0, Some(3.0), 3.0)]
+        #[case(3.0, None, 3.0)]
+        fn test_maybe_min(#[case] lhs: f32, #[case] rhs: Option<f32>, #[case] expected: f32) {
+            assert_eq!(lhs.maybe_min(rhs), expected);
+        }
+
+        #[rstest]
+        #[case(3.0, Some(5.0), 5.0)]
+        #[case(5.0, Some(3.0), 5.0)]
+        #[case(3.0, None, 3.0)]
+        fn test_maybe_max(#[case] lhs: f32, #[case] rhs: Option<f32>, #[case] expected: f32) {
+            assert_eq!(lhs.maybe_max(rhs), expected);
+        }
+
+        #[rstest]
+        #[case(3.0, Some(5.0), 8.0)]
+        #[case(5.0, Some(3.0), 8.0)]
+        #[case(3.0, None, 3.0)]
+        fn test_maybe_add(#[case] lhs: f32, #[case] rhs: Option<f32>, #[case] expected: f32) {
+            assert_eq!(lhs.maybe_add(rhs), expected);
+        }
+
+        #[rstest]
+        #[case(3.0, Some(5.0), -2.0)]
+        #[case(5.0, Some(3.0), 2.0)]
+        #[case(3.0, None, 3.0)]
+        fn test_maybe_sub(#[case] lhs: f32, #[case] rhs: Option<f32>, #[case] expected: f32) {
+            assert_eq!(lhs.maybe_sub(rhs), expected);
+        }
+    }
 }

--- a/src/math.rs
+++ b/src/math.rs
@@ -121,3 +121,52 @@ impl MaybeMath<Option<f32>, f32> for f32 {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    mod lhs_option_f32_rhs_option_f32 {
+
+        use crate::math::MaybeMath;
+        use rstest::rstest;
+
+        #[rstest]
+        #[case(Some(3.0), Some(5.0), Some(3.0))]
+        #[case(Some(5.0), Some(3.0), Some(3.0))]
+        #[case(Some(3.0), None, Some(3.0))]
+        #[case(None, Some(3.0), None)]
+        #[case(None, None, None)]
+        fn test_maybe_min(#[case] lhs: Option<f32>, #[case] rhs: Option<f32>, #[case] expected: Option<f32>) {
+            assert_eq!(lhs.maybe_min(rhs), expected);
+        }
+
+        #[rstest]
+        #[case(Some(3.0), Some(5.0), Some(5.0))]
+        #[case(Some(5.0), Some(3.0), Some(5.0))]
+        #[case(Some(3.0), None, Some(3.0))]
+        #[case(None, Some(3.0), None)]
+        #[case(None, None, None)]
+        fn test_maybe_max(#[case] lhs: Option<f32>, #[case] rhs: Option<f32>, #[case] expected: Option<f32>) {
+            assert_eq!(lhs.maybe_max(rhs), expected);
+        }
+
+        #[rstest]
+        #[case(Some(3.0), Some(5.0), Some(8.0))]
+        #[case(Some(5.0), Some(3.0), Some(8.0))]
+        #[case(Some(3.0), None, Some(3.0))]
+        #[case(None, Some(3.0), None)]
+        #[case(None, None, None)]
+        fn test_maybe_add(#[case] lhs: Option<f32>, #[case] rhs: Option<f32>, #[case] expected: Option<f32>) {
+            assert_eq!(lhs.maybe_add(rhs), expected);
+        }
+
+        #[rstest]
+        #[case(Some(3.0), Some(5.0), Some(-2.0))]
+        #[case(Some(5.0), Some(3.0), Some(2.0))]
+        #[case(Some(3.0), None, Some(3.0))]
+        #[case(None, Some(3.0), None)]
+        #[case(None, None, None)]
+        fn test_maybe_sub(#[case] lhs: Option<f32>, #[case] rhs: Option<f32>, #[case] expected: Option<f32>) {
+            assert_eq!(lhs.maybe_sub(rhs), expected);
+        }
+    }
+}

--- a/src/math.rs
+++ b/src/math.rs
@@ -169,4 +169,42 @@ mod tests {
             assert_eq!(lhs.maybe_sub(rhs), expected);
         }
     }
+
+    mod lhs_option_f32_rhs_f32 {
+
+        use crate::math::MaybeMath;
+        use rstest::rstest;
+
+        #[rstest]
+        #[case(Some(3.0), 5.0, Some(3.0))]
+        #[case(Some(5.0), 3.0, Some(3.0))]
+        #[case(None, 3.0, None)]
+        fn test_maybe_min(#[case] lhs: Option<f32>, #[case] rhs: f32, #[case] expected: Option<f32>) {
+            assert_eq!(lhs.maybe_min(rhs), expected);
+        }
+
+        #[rstest]
+        #[case(Some(3.0), 5.0, Some(5.0))]
+        #[case(Some(5.0), 3.0, Some(5.0))]
+        #[case(None, 3.0, None)]
+        fn test_maybe_max(#[case] lhs: Option<f32>, #[case] rhs: f32, #[case] expected: Option<f32>) {
+            assert_eq!(lhs.maybe_max(rhs), expected);
+        }
+
+        #[rstest]
+        #[case(Some(3.0), 5.0, Some(8.0))]
+        #[case(Some(5.0), 3.0, Some(8.0))]
+        #[case(None, 3.0, None)]
+        fn test_maybe_add(#[case] lhs: Option<f32>, #[case] rhs: f32, #[case] expected: Option<f32>) {
+            assert_eq!(lhs.maybe_add(rhs), expected);
+        }
+
+        #[rstest]
+        #[case(Some(3.0), 5.0, Some(-2.0))]
+        #[case(Some(5.0), 3.0, Some(2.0))]
+        #[case(None, 3.0, None)]
+        fn test_maybe_sub(#[case] lhs: Option<f32>, #[case] rhs: f32, #[case] expected: Option<f32>) {
+            assert_eq!(lhs.maybe_sub(rhs), expected);
+        }
+    }
 }


### PR DESCRIPTION
# Objective

Fixes #158.

`MaybeMath` is the foundation for a big part of the layout algorithm, so we need to make sure that it works as expected.

## Solution

- Add [`rstest`](https://crates.io/crates/rstest) as dev-dependency for parameterized testing.
- Introduce a `tests` module in `math.rs` which contains the unit tests.
- Each implementation of `MaybeMath` is in its own sub-module for a clearer organization.
- All functions of `MaybeMath` in all implementations is tested with all important cases.

## Context

I found `rstest` through [this StackOverflow post](https://stackoverflow.com/a/52843365).

How the cases look when passing:
```
test math::tests::lhs_option_f32_rhs_option_f32::test_maybe_add::case_1 ... ok
test math::tests::lhs_option_f32_rhs_option_f32::test_maybe_add::case_2 ... ok
test math::tests::lhs_option_f32_rhs_option_f32::test_maybe_add::case_3 ... ok
test math::tests::lhs_option_f32_rhs_option_f32::test_maybe_add::case_4 ... ok
test math::tests::lhs_option_f32_rhs_option_f32::test_maybe_add::case_5 ... ok
```

How the cases look when failing:
```
failures:

---- math::tests::lhs_option_f32_rhs_option_f32::test_maybe_min::case_1 stdout ----
-------------- TEST START --------------
thread 'math::tests::lhs_option_f32_rhs_option_f32::test_maybe_min::case_1' panicked at 'assertion failed: `(left == right)`
  left: `Some(3.0)`,
 right: `Some(2.0)`', src/math.rs:139:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    math::tests::lhs_option_f32_rhs_option_f32::test_maybe_min::case_1

test result: FAILED. 43 passed; 1 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s
```

## Feedback wanted

- Do we want to keep `rstest`? Personally I really like it so far, a lot better than defining millions of functions for all cases. However, it's a new dependency, so it should be determined if it's worth it.
- Is `mod tests` or `mod test` the standard in Rust?
- Do we want to keep the further subdivision of modules for each implementation of `MaybeMath`?
- Do we need to provide a string for each `assert_eq` in case of failure, or is it clear enough as-is?