### PR TITLE
Add more robust benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,5 +48,10 @@ name = "complex"
 path = "benches/complex.rs"
 harness = false
 
+[[bench]]
+name = "big_tree"
+path = "benches/big_tree.rs"
+harness = false
+
 [workspace]
 members = ["scripts/gentest"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,9 @@ criterion = "0.3"
 rstest = "0.15.0"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
-taffy = { path = ".", features = ["random"] }
+# We need to explicitly set a version here so that cargo deny doesn't complain
+# Don't forget to update this when bumping the version of taffy!
+taffy = { path = ".", version = "0.2.0", features = ["random"] }
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ serde = ["dep:serde"]
 [dev-dependencies]
 criterion = "0.3"
 rstest = "0.15.0"
+rand = "0.8.5"
+rand_chacha = "0.3.1"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ license = "MIT"
 [dependencies]
 arrayvec = { version = "0.7", default-features = false }
 num-traits = { version = "0.2", default-features = false }
+rand = { version = "0.8.5", optional = true }
 serde = { version = "1.0", optional = true, features = ["serde_derive"] }
 slotmap = "1.0.6"
 
@@ -24,12 +25,14 @@ default = ["std"]
 alloc = []
 std = ["num-traits/std"]
 serde = ["dep:serde"]
+random = ["dep:rand"]
 
 [dev-dependencies]
 criterion = "0.3"
 rstest = "0.15.0"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
+taffy = { path = ".", features = ["random"] }
 
 [profile.release]
 lto = true

--- a/benches/big_tree.rs
+++ b/benches/big_tree.rs
@@ -62,7 +62,7 @@ fn build_deep_hierarchy(taffy: &mut Taffy) -> Node {
 
 fn taffy_benchmarks(c: &mut Criterion) {
     // Decrease sample size, because the tasks take longer
-    let mut group = c.benchmark_group("Big tree");
+    let mut group = c.benchmark_group("big tree (100_000 nodes)");
     group.sample_size(10);
 
     group.bench_function("flat hierarchy", |b| {

--- a/benches/big_tree.rs
+++ b/benches/big_tree.rs
@@ -33,7 +33,11 @@ fn build_single_root_flat_hierarchy(taffy: &mut Taffy) -> Node {
 }
 
 fn taffy_benchmarks(c: &mut Criterion) {
-    c.bench_function("single root, flat hierarchy", |b| {
+    // Decrease sample size, because the tasks take longer
+    let mut group = c.benchmark_group("Big tree");
+    group.sample_size(10);
+
+    group.bench_function("single root, flat hierarchy", |b| {
         b.iter(|| {
             let mut taffy = Taffy::new();
             let root = build_single_root_flat_hierarchy(&mut taffy);

--- a/benches/big_tree.rs
+++ b/benches/big_tree.rs
@@ -37,7 +37,7 @@ fn build_random_leaf(taffy: &mut Taffy, rng: &mut ChaCha8Rng) -> Node {
 }
 
 /// A single root node with many children that have shallow depth
-fn build_single_root_flat_hierachy(taffy: &mut Taffy) -> Node {
+fn build_single_root_flat_hierarchy(taffy: &mut Taffy) -> Node {
     let mut rng = ChaCha8Rng::seed_from_u64(12345);
     let mut children = Vec::new();
     let mut node_count = 0;
@@ -55,10 +55,10 @@ fn build_single_root_flat_hierachy(taffy: &mut Taffy) -> Node {
 }
 
 fn taffy_benchmarks(c: &mut Criterion) {
-    c.bench_function("single root, flat hierachy", |b| {
+    c.bench_function("single root, flat hierarchy", |b| {
         b.iter(|| {
             let mut taffy = Taffy::new();
-            let root = build_single_root_flat_hierachy(&mut taffy);
+            let root = build_single_root_flat_hierarchy(&mut taffy);
             taffy.compute_layout(root, Size::undefined()).unwrap()
         })
     });

--- a/benches/big_tree.rs
+++ b/benches/big_tree.rs
@@ -3,6 +3,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use rand::prelude::*;
 use rand_chacha::ChaCha8Rng;
 use taffy::prelude::*;
+use taffy::randomizable::Randomizeable;
 use taffy::style::FlexboxLayout;
 
 /// The number of nodes to include in the trees
@@ -22,7 +23,7 @@ fn build_single_root_flat_hierarchy(taffy: &mut Taffy) -> Node {
     while node_count < NODE_COUNT {
         let sub_children_count = rng.gen_range(0..=3);
         let sub_children: Vec<Node> = (0..sub_children_count).map(|_| build_random_leaf(taffy, &mut rng)).collect();
-        let node = taffy.new_with_children(get_random_style(&mut rng), &sub_children).unwrap();
+        let node = taffy.new_with_children(FlexboxLayout::random(&mut rng), &sub_children).unwrap();
 
         children.push(node);
         node_count += 1 + sub_children_count;
@@ -36,7 +37,7 @@ fn taffy_benchmarks(c: &mut Criterion) {
         b.iter(|| {
             let mut taffy = Taffy::new();
             let root = build_single_root_flat_hierarchy(&mut taffy);
-            taffy.compute_layout(root, Size::undefined()).unwrap()
+            taffy.compute_layout(root, Size::NONE).unwrap()
         })
     });
 }

--- a/benches/big_tree.rs
+++ b/benches/big_tree.rs
@@ -1,0 +1,68 @@
+//! This file includes benchmarks for very large, pseudo-randomly generated trees
+use criterion::{criterion_group, criterion_main, Criterion};
+use rand::prelude::*;
+use rand_chacha::ChaCha8Rng;
+use taffy::prelude::*;
+use taffy::style::FlexboxLayout;
+
+/// The number of nodes to include in the trees
+const NODE_COUNT: u32 = 100_000;
+
+/// Get a randomly generated dimension
+fn get_random_dimension(rng: &mut ChaCha8Rng) -> Dimension {
+    let switch: f32 = rng.gen_range(0.0..=1.0);
+
+    match switch {
+        0.0..=0.2 => Dimension::Auto,
+        0.2..=0.4 => Dimension::Undefined,
+        0.4..=0.8 => Dimension::Points(rng.gen_range(0.0..500.0)),
+        _ => Dimension::Percent(rng.gen_range(0.0..1.0)),
+    }
+}
+
+/// Get a randomly generated size
+fn get_random_size(rng: &mut ChaCha8Rng) -> Size<Dimension> {
+    Size { width: get_random_dimension(rng), height: get_random_dimension(rng) }
+}
+
+/// Get a randomly generated style for a node
+fn get_random_style(rng: &mut ChaCha8Rng) -> FlexboxLayout {
+    // TODO: Add more attributes
+    FlexboxLayout { size: get_random_size(rng), ..Default::default() }
+}
+
+/// Build a random leaf node
+fn build_random_leaf(taffy: &mut Taffy, rng: &mut ChaCha8Rng) -> Node {
+    taffy.new_with_children(get_random_style(rng), &[]).unwrap()
+}
+
+/// A single root node with many children that have shallow depth
+fn build_single_root_flat_hierachy(taffy: &mut Taffy) -> Node {
+    let mut rng = ChaCha8Rng::seed_from_u64(12345);
+    let mut children = Vec::new();
+    let mut node_count = 0;
+
+    while node_count < NODE_COUNT {
+        let sub_children_count = rng.gen_range(0..=3);
+        let sub_children: Vec<Node> = (0..sub_children_count).map(|_| build_random_leaf(taffy, &mut rng)).collect();
+        let node = taffy.new_with_children(get_random_style(&mut rng), &sub_children).unwrap();
+
+        children.push(node);
+        node_count += 1 + sub_children_count;
+    }
+
+    taffy.new_with_children(FlexboxLayout { ..Default::default() }, children.as_slice()).unwrap()
+}
+
+fn taffy_benchmarks(c: &mut Criterion) {
+    c.bench_function("single root, flat hierachy", |b| {
+        b.iter(|| {
+            let mut taffy = Taffy::new();
+            let root = build_single_root_flat_hierachy(&mut taffy);
+            taffy.compute_layout(root, Size::undefined()).unwrap()
+        })
+    });
+}
+
+criterion_group!(benches, taffy_benchmarks);
+criterion_main!(benches);

--- a/benches/big_tree.rs
+++ b/benches/big_tree.rs
@@ -14,14 +14,14 @@ fn build_random_leaf(taffy: &mut Taffy, rng: &mut ChaCha8Rng) -> Node {
     taffy.new_with_children(FlexboxLayout::random(rng), &[]).unwrap()
 }
 
-/// A single root node with many children that have shallow depth
-fn build_single_root_flat_hierarchy(taffy: &mut Taffy) -> Node {
+/// A tree with many children that have shallow depth
+fn build_flat_hierarchy(taffy: &mut Taffy) -> Node {
     let mut rng = ChaCha8Rng::seed_from_u64(12345);
     let mut children = Vec::new();
     let mut node_count = 0;
 
     while node_count < NODE_COUNT {
-        let sub_children_count = rng.gen_range(0..=3);
+        let sub_children_count = rng.gen_range(1..=4);
         let sub_children: Vec<Node> = (0..sub_children_count).map(|_| build_random_leaf(taffy, &mut rng)).collect();
         let node = taffy.new_with_children(FlexboxLayout::random(&mut rng), &sub_children).unwrap();
 
@@ -32,6 +32,7 @@ fn build_single_root_flat_hierarchy(taffy: &mut Taffy) -> Node {
     taffy.new_with_children(FlexboxLayout { ..Default::default() }, children.as_slice()).unwrap()
 }
 
+/// A helper function to recursively construct a deep tree
 fn build_deep_tree(taffy: &mut Taffy, rng: &mut ChaCha8Rng, max_nodes: u32) -> Vec<Node> {
     let branching_factor = 7;
 
@@ -50,7 +51,8 @@ fn build_deep_tree(taffy: &mut Taffy, rng: &mut ChaCha8Rng, max_nodes: u32) -> V
         .collect()
 }
 
-fn build_single_root_deep_hierarchy(taffy: &mut Taffy) -> Node {
+/// A tree with a higher depth for a more realistic scenario
+fn build_deep_hierarchy(taffy: &mut Taffy) -> Node {
     let mut rng = ChaCha8Rng::seed_from_u64(12345);
 
     let tree = build_deep_tree(taffy, &mut rng, NODE_COUNT);
@@ -63,16 +65,16 @@ fn taffy_benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("Big tree");
     group.sample_size(10);
 
-    group.bench_function("single root, flat hierarchy", |b| {
+    group.bench_function("flat hierarchy", |b| {
         let mut taffy = Taffy::new();
-        let root = build_single_root_flat_hierarchy(&mut taffy);
+        let root = build_flat_hierarchy(&mut taffy);
 
         b.iter(|| taffy.compute_layout(root, Size::NONE).unwrap())
     });
 
-    group.bench_function("single root, deep hierarchy", |b| {
+    group.bench_function("deep hierarchy", |b| {
         let mut taffy = Taffy::new();
-        let root = build_single_root_deep_hierarchy(&mut taffy);
+        let root = build_deep_hierarchy(&mut taffy);
 
         b.iter(|| taffy.compute_layout(root, Size::NONE).unwrap())
     });

--- a/benches/big_tree.rs
+++ b/benches/big_tree.rs
@@ -8,32 +8,9 @@ use taffy::style::FlexboxLayout;
 /// The number of nodes to include in the trees
 const NODE_COUNT: u32 = 100_000;
 
-/// Get a randomly generated dimension
-fn get_random_dimension(rng: &mut ChaCha8Rng) -> Dimension {
-    let switch: f32 = rng.gen_range(0.0..=1.0);
-
-    match switch {
-        0.0..=0.2 => Dimension::Auto,
-        0.2..=0.4 => Dimension::Undefined,
-        0.4..=0.8 => Dimension::Points(rng.gen_range(0.0..500.0)),
-        _ => Dimension::Percent(rng.gen_range(0.0..1.0)),
-    }
-}
-
-/// Get a randomly generated size
-fn get_random_size(rng: &mut ChaCha8Rng) -> Size<Dimension> {
-    Size { width: get_random_dimension(rng), height: get_random_dimension(rng) }
-}
-
-/// Get a randomly generated style for a node
-fn get_random_style(rng: &mut ChaCha8Rng) -> FlexboxLayout {
-    // TODO: Add more attributes
-    FlexboxLayout { size: get_random_size(rng), ..Default::default() }
-}
-
 /// Build a random leaf node
 fn build_random_leaf(taffy: &mut Taffy, rng: &mut ChaCha8Rng) -> Node {
-    taffy.new_with_children(get_random_style(rng), &[]).unwrap()
+    taffy.new_with_children(FlexboxLayout::random(rng), &[]).unwrap()
 }
 
 /// A single root node with many children that have shallow depth

--- a/benches/complex.rs
+++ b/benches/complex.rs
@@ -96,14 +96,18 @@ fn build_deep_hierarchy(taffy: &mut taffy::node::Taffy) -> taffy::node::Node {
 }
 
 fn taffy_benchmarks(c: &mut Criterion) {
-    c.bench_function("deep hierarchy - build", |b| {
+    // Increase sample size, because the examples are very small
+    let mut group = c.benchmark_group("deep hierarchy");
+    group.sample_size(200);
+
+    group.bench_function("build", |b| {
         b.iter(|| {
             let mut taffy = taffy::node::Taffy::new();
             build_deep_hierarchy(&mut taffy);
         })
     });
 
-    c.bench_function("deep hierarchy - single", |b| {
+    group.bench_function("single", |b| {
         b.iter(|| {
             let mut taffy = taffy::node::Taffy::new();
             let root = build_deep_hierarchy(&mut taffy);
@@ -111,7 +115,7 @@ fn taffy_benchmarks(c: &mut Criterion) {
         })
     });
 
-    c.bench_function("deep hierarchy - relayout", |b| {
+    group.bench_function("relayout", |b| {
         let mut taffy = taffy::node::Taffy::new();
         let root = build_deep_hierarchy(&mut taffy);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,9 @@ pub mod node;
 pub mod prelude;
 pub mod style;
 
+#[cfg(feature = "random")]
+pub mod randomizable;
+
 mod data;
 mod flexbox;
 mod resolve;

--- a/src/randomizable.rs
+++ b/src/randomizable.rs
@@ -1,0 +1,55 @@
+//! Pseudo-random generation of data (e.g. UI nodes) to use in benchmarks.
+
+use rand::Rng;
+
+use crate::geometry::Size;
+use crate::style::Dimension;
+use crate::style::FlexboxLayout;
+
+/// A trait for generating pseudo-random instances.
+pub trait Randomizeable {
+    /// Generate a pseudo-random instance of this type.
+    ///
+    /// This can be useful for benchmarking.
+    fn random<R>(rng: &mut R) -> Self
+    where
+        R: Rng;
+}
+
+impl Randomizeable for Dimension {
+    fn random<R>(rng: &mut R) -> Self
+    where
+        R: Rng,
+    {
+        let switch: f32 = rng.gen_range(0.0..=1.0);
+
+        if switch < 0.2 {
+            Dimension::Auto
+        } else if switch < 0.4 {
+            Dimension::Undefined
+        } else if switch < 0.8 {
+            Dimension::Points(rng.gen_range(0.0..500.0))
+        } else {
+            Dimension::Percent(rng.gen_range(0.0..1.0))
+        }
+    }
+}
+
+impl Randomizeable for Size<Dimension> {
+    fn random<R>(rng: &mut R) -> Self
+    where
+        R: Rng,
+    {
+        Size { width: Dimension::random(rng), height: Dimension::random(rng) }
+    }
+}
+
+impl Randomizeable for FlexboxLayout {
+    fn random<R>(rng: &mut R) -> Self
+    where
+        R: Rng,
+    {
+        // TODO: Add more attributes
+        FlexboxLayout { size: Size::<Dimension>::random(rng), ..Default::default() }
+    }
+}


### PR DESCRIPTION
# Objective

Closes #128.

This PR aims to add more robust benchmarks that deal with much larger trees to get a better comparison point for performance improvements.

## Solution

This PR generates large trees of 100,000 nodes via pseudo-random generation.

One benchmark uses a very flat hierarchy, the other one has a branching factor of 7 so it goes deeper (about 6).

I also increased the sample size of the other benchmarks from 100 to 200 to reduce noise.

## Context

The current benchmarks worked with rather small trees and are very noisy. We can also think about increasing the sample size to improve the stability of these benchmarks.

## Feedback wanted

- The "deep" benchmark is a _lot_ slower than the "flat" benchmark, even though the depth should only be about log_7(100_000) ~ 6. The flat benchmark takes < 5 ms and the deep benchmark almost 3 sec. While I expected the deep benchmark to be slower, this difference seems to be insane. Did I implement the benchmarks wrong?