### PR TITLE
Add and cleanup new leaf-nodes methods

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -5,9 +5,11 @@
 ### 0.2.0 Added
 
 - Added `taffy::error::InvalidChild` Error type
+- `taffy::node::Taffy.new_leaf()` which allows the creation of new leaf-nodes without having to supply a measure function
 
 ### 0.2.0 Changed
 
+- renamed `taffy::node::Taffy.new_leaf()` -> `taffy::node::Taffy.new_leaf_with_measure()`
 - removed the public `Number` type; a more idiomatic `Option<f32>` is used instead
   - the associated public `MinMax` and `OrElse` traits have also been removed; these should never have been public
 - `Sprawl::remove` now returns a `Result<usize, Error>`, to indicate if the operation was sucessful, and if it was, which ID was invalidated.

--- a/src/forest.rs
+++ b/src/forest.rs
@@ -26,9 +26,9 @@ pub(crate) struct NodeData {
 }
 
 impl NodeData {
-    /// Create the data for a new leaf node
+    /// Create the data for a new node with a [`MeasureFunc`]
     #[must_use]
-    fn new_leaf(style: FlexboxLayout, measure: MeasureFunc) -> Self {
+    fn new_with_measure(style: FlexboxLayout, measure: MeasureFunc) -> Self {
         Self {
             style,
             measure: Some(measure),
@@ -40,7 +40,6 @@ impl NodeData {
     }
 
     /// Create the data for a new node
-    // TODO: why is this different from new_leaf?
     #[must_use]
     fn new(style: FlexboxLayout) -> Self {
         Self {
@@ -89,16 +88,27 @@ impl Forest {
         }
     }
 
-    /// Adds a new unattached leaf node to the forest, and returns the [`NodeId`] of the new node
-    pub(crate) fn new_leaf(&mut self, style: FlexboxLayout, measure: MeasureFunc) -> NodeId {
+    /// Creates and adds a new unattached leaf node to the forest, and returns the [`NodeId`] of the new node
+    pub(crate) fn new_leaf(&mut self, style: FlexboxLayout) -> NodeId {
         let id = self.nodes.len();
-        self.nodes.push(NodeData::new_leaf(style, measure));
+        self.nodes.push(NodeData::new(style));
         self.children.push(new_vec_with_capacity(0));
         self.parents.push(new_vec_with_capacity(1));
         id
     }
 
-    /// Adds a new unparented node to the forest with the associated children attached, and returns the [`NodeId`] of the new node
+    /// Creates and adds a new unattached leaf node to the forest, and returns the [`NodeId`] of the new node
+    ///
+    /// The node must have a [`MeasureFunc`] supplied
+    pub(crate) fn new_leaf_with_measure(&mut self, style: FlexboxLayout, measure: MeasureFunc) -> NodeId {
+        let id = self.nodes.len();
+        self.nodes.push(NodeData::new_with_measure(style, measure));
+        self.children.push(new_vec_with_capacity(0));
+        self.parents.push(new_vec_with_capacity(1));
+        id
+    }
+
+    /// Creates and adds a new unparented node to the forest with the associated children attached, and returns the [`NodeId`] of the new node
     pub(crate) fn new_with_children(&mut self, style: FlexboxLayout, children: ChildrenVec<NodeId>) -> NodeId {
         let id = self.nodes.len();
         for child in &children {

--- a/src/forest.rs
+++ b/src/forest.rs
@@ -89,9 +89,9 @@ impl Forest {
     }
 
     /// Creates and adds a new unattached leaf node to the forest, and returns the [`NodeId`] of the new node
-    pub(crate) fn new_leaf(&mut self, style: FlexboxLayout) -> NodeId {
+    pub(crate) fn new_leaf(&mut self, layout: FlexboxLayout) -> NodeId {
         let id = self.nodes.len();
-        self.nodes.push(NodeData::new(style));
+        self.nodes.push(NodeData::new(layout));
         self.children.push(new_vec_with_capacity(0));
         self.parents.push(new_vec_with_capacity(1));
         id
@@ -100,21 +100,21 @@ impl Forest {
     /// Creates and adds a new unattached leaf node to the forest, and returns the [`NodeId`] of the new node
     ///
     /// The node must have a [`MeasureFunc`] supplied
-    pub(crate) fn new_leaf_with_measure(&mut self, style: FlexboxLayout, measure: MeasureFunc) -> NodeId {
+    pub(crate) fn new_leaf_with_measure(&mut self, layout: FlexboxLayout, measure: MeasureFunc) -> NodeId {
         let id = self.nodes.len();
-        self.nodes.push(NodeData::new_with_measure(style, measure));
+        self.nodes.push(NodeData::new_with_measure(layout, measure));
         self.children.push(new_vec_with_capacity(0));
         self.parents.push(new_vec_with_capacity(1));
         id
     }
 
     /// Creates and adds a new unparented node to the forest with the associated children attached, and returns the [`NodeId`] of the new node
-    pub(crate) fn new_with_children(&mut self, style: FlexboxLayout, children: ChildrenVec<NodeId>) -> NodeId {
+    pub(crate) fn new_with_children(&mut self, layout: FlexboxLayout, children: ChildrenVec<NodeId>) -> NodeId {
         let id = self.nodes.len();
         for child in &children {
             self.parents[*child].push(id);
         }
-        self.nodes.push(NodeData::new(style));
+        self.nodes.push(NodeData::new(layout));
         self.children.push(children);
         self.parents.push(new_vec_with_capacity(1));
         id

--- a/src/node.rs
+++ b/src/node.rs
@@ -101,9 +101,9 @@ impl Taffy {
     }
 
     /// Creates and adds a new leaf node
-    pub fn new_leaf(&mut self, style: FlexboxLayout) -> Result<Node, error::InvalidNode> {
+    pub fn new_leaf(&mut self, layout: FlexboxLayout) -> Result<Node, error::InvalidNode> {
         let node = self.allocate_node();
-        let id = self.forest.new_leaf(style);
+        let id = self.forest.new_leaf(layout);
         self.add_node(node, id);
         Ok(node)
     }
@@ -111,23 +111,23 @@ impl Taffy {
     /// Creates and adds a new leaf node with a supplied [`MeasureFunc`]
     pub fn new_leaf_with_measure(
         &mut self,
-        style: FlexboxLayout,
+        layout: FlexboxLayout,
         measure: MeasureFunc,
     ) -> Result<Node, error::InvalidNode> {
         let node = self.allocate_node();
-        let id = self.forest.new_leaf_with_measure(style, measure);
+        let id = self.forest.new_leaf_with_measure(layout, measure);
         self.add_node(node, id);
         Ok(node)
     }
 
     /// Creates and adds a new node, which may have any number of `children`
-    pub fn new_with_children(&mut self, style: FlexboxLayout, children: &[Node]) -> Result<Node, error::InvalidNode> {
+    pub fn new_with_children(&mut self, layout: FlexboxLayout, children: &[Node]) -> Result<Node, error::InvalidNode> {
         let node = self.allocate_node();
         let children = children
             .iter()
             .map(|child| self.find_node(*child))
             .collect::<Result<ChildrenVec<_>, error::InvalidNode>>()?;
-        let id = self.forest.new_with_children(style, children);
+        let id = self.forest.new_with_children(layout, children);
         self.add_node(node, id);
         Ok(node)
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -100,16 +100,32 @@ impl Taffy {
         }
     }
 
-    /// Adds a new leaf node, which does not have any children
-    pub fn new_leaf(&mut self, style: FlexboxLayout, measure: MeasureFunc) -> Result<Node, error::InvalidNode> {
+    /// Creates and adds a new leaf node
+    pub fn new_leaf(&mut self, style: FlexboxLayout) -> Result<Node, error::InvalidNode> {
         let node = self.allocate_node();
-        let id = self.forest.new_leaf(style, measure);
+        let id = self.forest.new_leaf(style);
         self.add_node(node, id);
         Ok(node)
     }
 
-    /// Adds a new node, which may have any number of `children`
-    pub fn new_with_children(&mut self, style: FlexboxLayout, children: &[Node]) -> Result<Node, error::InvalidNode> {
+    /// Creates and adds a new leaf node with a supplied [`MeasureFunc`]
+    pub fn new_leaf_with_measure(
+        &mut self,
+        style: FlexboxLayout,
+        measure: MeasureFunc,
+    ) -> Result<Node, error::InvalidNode> {
+        let node = self.allocate_node();
+        let id = self.forest.new_leaf_with_measure(style, measure);
+        self.add_node(node, id);
+        Ok(node)
+    }
+
+    /// Creates and adds a new node, which may have any number of `children`
+    pub fn new_with_children(
+        &mut self,
+        style: FlexboxLayout,
+        children: &[Node],
+    ) -> Result<Node, error::InvalidNode> {
         let node = self.allocate_node();
         let children = children
             .iter()

--- a/src/node.rs
+++ b/src/node.rs
@@ -121,11 +121,7 @@ impl Taffy {
     }
 
     /// Creates and adds a new node, which may have any number of `children`
-    pub fn new_with_children(
-        &mut self,
-        style: FlexboxLayout,
-        children: &[Node],
-    ) -> Result<Node, error::InvalidNode> {
+    pub fn new_with_children(&mut self, style: FlexboxLayout, children: &[Node]) -> Result<Node, error::InvalidNode> {
         let node = self.allocate_node();
         let children = children
             .iter()

--- a/tests/measure.rs
+++ b/tests/measure.rs
@@ -6,7 +6,7 @@ mod measure {
     fn measure_root() {
         let mut taffy = taffy::node::Taffy::new();
         let node = taffy
-            .new_leaf(
+            .new_leaf_with_measure(
                 taffy::style::FlexboxLayout { ..Default::default() },
                 MeasureFunc::Raw(|constraint| taffy::geometry::Size {
                     width: constraint.width.unwrap_or(100.0),
@@ -26,7 +26,7 @@ mod measure {
         let mut taffy = taffy::node::Taffy::new();
 
         let child = taffy
-            .new_leaf(
+            .new_leaf_with_measure(
                 taffy::style::FlexboxLayout { ..Default::default() },
                 MeasureFunc::Raw(|constraint| taffy::geometry::Size {
                     width: constraint.width.unwrap_or(100.0),
@@ -49,7 +49,7 @@ mod measure {
     fn measure_child_constraint() {
         let mut taffy = taffy::node::Taffy::new();
         let child = taffy
-            .new_leaf(
+            .new_leaf_with_measure(
                 taffy::style::FlexboxLayout { ..Default::default() },
                 MeasureFunc::Raw(|constraint| taffy::geometry::Size {
                     width: constraint.width.unwrap_or(100.0),
@@ -81,7 +81,7 @@ mod measure {
     fn measure_child_constraint_padding_parent() {
         let mut taffy = taffy::node::Taffy::new();
         let child = taffy
-            .new_leaf(
+            .new_leaf_with_measure(
                 taffy::style::FlexboxLayout { ..Default::default() },
                 MeasureFunc::Raw(|constraint| taffy::geometry::Size {
                     width: constraint.width.unwrap_or(100.0),
@@ -131,7 +131,7 @@ mod measure {
             .unwrap();
 
         let child1 = taffy
-            .new_leaf(
+            .new_leaf_with_measure(
                 taffy::style::FlexboxLayout { flex_grow: 1.0, ..Default::default() },
                 MeasureFunc::Raw(|constraint| taffy::geometry::Size {
                     width: constraint.width.unwrap_or(10.0),
@@ -174,7 +174,7 @@ mod measure {
             .unwrap();
 
         let child1 = taffy
-            .new_leaf(
+            .new_leaf_with_measure(
                 taffy::style::FlexboxLayout { ..Default::default() },
                 MeasureFunc::Raw(|constraint| taffy::geometry::Size {
                     width: constraint.width.unwrap_or(100.0),
@@ -216,7 +216,7 @@ mod measure {
             .unwrap();
 
         let child1 = taffy
-            .new_leaf(
+            .new_leaf_with_measure(
                 taffy::style::FlexboxLayout { flex_grow: 1.0, ..Default::default() },
                 MeasureFunc::Raw(|constraint| {
                     let width = constraint.width.unwrap_or(10.0);
@@ -262,7 +262,7 @@ mod measure {
             .unwrap();
 
         let child1 = taffy
-            .new_leaf(
+            .new_leaf_with_measure(
                 taffy::style::FlexboxLayout { ..Default::default() },
                 MeasureFunc::Raw(|constraint| {
                     let width = constraint.width.unwrap_or(100.0);
@@ -294,7 +294,7 @@ mod measure {
         let mut taffy = taffy::node::Taffy::new();
 
         let child = taffy
-            .new_leaf(
+            .new_leaf_with_measure(
                 taffy::style::FlexboxLayout { ..Default::default() },
                 MeasureFunc::Raw(|constraint| {
                     let height = constraint.height.unwrap_or(50.0);
@@ -327,7 +327,7 @@ mod measure {
     fn width_overrides_measure() {
         let mut taffy = taffy::node::Taffy::new();
         let child = taffy
-            .new_leaf(
+            .new_leaf_with_measure(
                 taffy::style::FlexboxLayout {
                     size: taffy::geometry::Size { width: taffy::style::Dimension::Points(50.0), ..Default::default() },
                     ..Default::default()
@@ -350,7 +350,7 @@ mod measure {
     fn height_overrides_measure() {
         let mut taffy = taffy::node::Taffy::new();
         let child = taffy
-            .new_leaf(
+            .new_leaf_with_measure(
                 taffy::style::FlexboxLayout {
                     size: taffy::geometry::Size { height: taffy::style::Dimension::Points(50.0), ..Default::default() },
                     ..Default::default()
@@ -384,7 +384,7 @@ mod measure {
             .unwrap();
 
         let child1 = taffy
-            .new_leaf(
+            .new_leaf_with_measure(
                 taffy::style::FlexboxLayout {
                     flex_basis: taffy::style::Dimension::Points(50.0),
                     flex_grow: 1.0,
@@ -422,7 +422,7 @@ mod measure {
     fn stretch_overrides_measure() {
         let mut taffy = taffy::node::Taffy::new();
         let child = taffy
-            .new_leaf(
+            .new_leaf_with_measure(
                 taffy::style::FlexboxLayout { ..Default::default() },
                 MeasureFunc::Raw(|constraint| taffy::geometry::Size {
                     width: constraint.width.unwrap_or(50.0),
@@ -454,7 +454,7 @@ mod measure {
     fn measure_absolute_child() {
         let mut taffy = taffy::node::Taffy::new();
         let child = taffy
-            .new_leaf(
+            .new_leaf_with_measure(
                 taffy::style::FlexboxLayout {
                     position_type: taffy::style::PositionType::Absolute,
                     ..Default::default()
@@ -489,7 +489,7 @@ mod measure {
     fn ignore_invalid_measure() {
         let mut taffy = taffy::node::Taffy::new();
         let child = taffy
-            .new_leaf(
+            .new_leaf_with_measure(
                 taffy::style::FlexboxLayout { flex_grow: 1.0, ..Default::default() },
                 MeasureFunc::Raw(|_| taffy::geometry::Size { width: 200.0, height: 200.0 }),
             )
@@ -522,7 +522,7 @@ mod measure {
         static NUM_MEASURES: atomic::AtomicU32 = atomic::AtomicU32::new(0);
 
         let grandchild = taffy
-            .new_leaf(
+            .new_leaf_with_measure(
                 taffy::style::FlexboxLayout { ..Default::default() },
                 MeasureFunc::Raw(|constraint| {
                     NUM_MEASURES.fetch_add(1, atomic::Ordering::Relaxed);

--- a/tests/measure.rs
+++ b/tests/measure.rs
@@ -488,12 +488,7 @@ mod measure {
     #[test]
     fn ignore_invalid_measure() {
         let mut taffy = taffy::node::Taffy::new();
-        let child = taffy
-            .new_leaf_with_measure(
-                taffy::style::FlexboxLayout { flex_grow: 1.0, ..Default::default() },
-                MeasureFunc::Raw(|_| taffy::geometry::Size { width: 200.0, height: 200.0 }),
-            )
-            .unwrap();
+        let child = taffy.new_leaf(taffy::style::FlexboxLayout { flex_grow: 1.0, ..Default::default() }).unwrap();
 
         let node = taffy
             .new_with_children(

--- a/tests/node.rs
+++ b/tests/node.rs
@@ -20,7 +20,7 @@ mod node {
     fn set_measure() {
         let mut taffy = Taffy::new();
         let node = taffy
-            .new_leaf(FlexboxLayout::default(), MeasureFunc::Raw(|_| Size { width: 200.0, height: 200.0 }))
+            .new_leaf_with_measure(FlexboxLayout::default(), MeasureFunc::Raw(|_| Size { width: 200.0, height: 200.0 }))
             .unwrap();
         taffy.compute_layout(node, Size::undefined()).unwrap();
         assert_eq!(taffy.layout(node).unwrap().size.width, 200.0);


### PR DESCRIPTION
# Objective

- Fixes #180
- Added `taffy::node::Taffy.new_leaf()` which allows the creation of new leaf-nodes without having to supply a measure function
- Renamed `taffy::node::Taffy.new_leaf()` -> `taffy::node::Taffy.new_leaf_with_measure()`