### PR TITLE
Unit test `compute_constants()`

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,8 +9,8 @@
 
 ### 0.2.0 Changed
 
-- **[BREAKING]** `Size<f32>.zero()` is now `Size::<f32>::ZERO`
-- **[BREAKING]** `Point<f32>.zero()` is now  `Point::<f32>::ZERO`
+- `Size<f32>.zero()` is now `Size::<f32>::ZERO`
+- `Point<f32>.zero()` is now  `Point::<f32>::ZERO`
 - renamed `taffy::node::Taffy.new_leaf()` -> `taffy::node::Taffy.new_leaf_with_measure()`
 - removed the public `Number` type; a more idiomatic `Option<f32>` is used instead
   - the associated public `MinMax` and `OrElse` traits have also been removed; these should never have been public

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,8 +9,8 @@
 
 ### 0.2.0 Changed
 
-- **[BREAKING]** `Size<f32>.zero()` has now become `Size::<f32>::ZERO`
-- **[BREAKING]** `Point<f32>.zero()` has now become `Point::<f32>::ZERO`
+- **[BREAKING]** `Size<f32>.zero()` is now `Size::<f32>::ZERO`
+- **[BREAKING]** `Point<f32>.zero()` is now  `Point::<f32>::ZERO`
 - renamed `taffy::node::Taffy.new_leaf()` -> `taffy::node::Taffy.new_leaf_with_measure()`
 - removed the public `Number` type; a more idiomatic `Option<f32>` is used instead
   - the associated public `MinMax` and `OrElse` traits have also been removed; these should never have been public

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,6 +9,8 @@
 
 ### 0.2.0 Changed
 
+- **[BREAKING]** `Size<f32>.zero()` has now become `Size::<f32>::ZERO`
+- **[BREAKING]** `Point<f32>.zero()` has now become `Point::<f32>::ZERO`
 - renamed `taffy::node::Taffy.new_leaf()` -> `taffy::node::Taffy.new_leaf_with_measure()`
 - removed the public `Number` type; a more idiomatic `Option<f32>` is used instead
   - the associated public `MinMax` and `OrElse` traits have also been removed; these should never have been public

--- a/src/flexbox.rs
+++ b/src/flexbox.rs
@@ -137,7 +137,7 @@ impl Forest {
             self.compute_preliminary(root, style.size.maybe_resolve(size), size, true, true)
         };
 
-        self.nodes[root].layout = Layout { order: 0, size: preliminary_size, location: Point::zero() };
+        self.nodes[root].layout = Layout { order: 0, size: preliminary_size, location: Point::ZERO };
 
         Self::round_layout(&mut self.nodes, &self.children, root, 0.0, 0.0);
     }
@@ -233,8 +233,8 @@ impl Forest {
             height: node_size.height.maybe_sub(padding_border.vertical_axis_sum()),
         };
 
-        let container_size = Size::zero();
-        let inner_container_size = Size::zero();
+        let container_size = Size::ZERO;
+        let inner_container_size = Size::ZERO;
 
         AlgoConstants {
             dir,
@@ -277,10 +277,10 @@ impl Forest {
                 violation: 0.0,
                 frozen: false,
 
-                hypothetical_inner_size: Size::zero(),
-                hypothetical_outer_size: Size::zero(),
-                target_size: Size::zero(),
-                outer_target_size: Size::zero(),
+                hypothetical_inner_size: Size::ZERO,
+                hypothetical_outer_size: Size::ZERO,
+                target_size: Size::ZERO,
+                outer_target_size: Size::ZERO,
 
                 baseline: 0.0,
 
@@ -865,7 +865,7 @@ impl Forest {
                     &Layout {
                         order: self.children[node].iter().position(|n| *n == child.node).unwrap() as u32,
                         size: preliminary_size,
-                        location: Point::zero(),
+                        location: Point::ZERO,
                     },
                 );
             }
@@ -1719,7 +1719,7 @@ impl Forest {
         ///
         /// Each hidden node has zero size and is placed at the origin
         fn hidden_layout(nodes: &mut [NodeData], children: &[ChildrenVec<NodeId>], node: NodeId, order: u32) {
-            nodes[node].layout = Layout { order, size: Size::zero(), location: Point::zero() };
+            nodes[node].layout = Layout { order, size: Size::ZERO, location: Point::ZERO };
 
             for (order, child) in children[node].iter().enumerate() {
                 hidden_layout(nodes, children, *child, order as _);
@@ -1777,8 +1777,8 @@ mod tests {
 
         // inner size
 
-        assert_eq!(constants.container_size, Size::zero());
-        assert_eq!(constants.inner_container_size, Size::zero());
+        assert_eq!(constants.container_size, Size::ZERO);
+        assert_eq!(constants.inner_container_size, Size::ZERO);
     }
 
     // Margin Dimension::Undefined

--- a/src/flexbox.rs
+++ b/src/flexbox.rs
@@ -217,10 +217,9 @@ impl Forest {
         let is_column = dir.is_column();
         let is_wrap_reverse = node.style.flex_wrap == FlexWrap::WrapReverse;
 
-        // TODO: This applies the width to all four sides. Should this be applying
-        let margin = node.style.margin.resolve_or_default(parent_size);
-        let padding = node.style.padding.resolve_or_default(parent_size);
-        let border = node.style.border.resolve_or_default(parent_size);
+        let margin = node.style.margin.resolve_or_default(parent_size.width);
+        let padding = node.style.padding.resolve_or_default(parent_size.width);
+        let border = node.style.border.resolve_or_default(parent_size.width);
 
         let padding_border = Rect {
             start: padding.start + border.start,
@@ -270,9 +269,9 @@ impl Forest {
                 max_size: child_style.max_size.maybe_resolve(constants.node_inner_size),
 
                 position: child_style.position.zip_size(constants.node_inner_size, |p, s| p.maybe_resolve(s)),
-                margin: child_style.margin.resolve_or_default(constants.node_inner_size),
-                padding: child_style.padding.resolve_or_default(constants.node_inner_size),
-                border: child_style.border.resolve_or_default(constants.node_inner_size),
+                margin: child_style.margin.resolve_or_default(constants.node_inner_size.width),
+                padding: child_style.padding.resolve_or_default(constants.node_inner_size.width),
+                border: child_style.border.resolve_or_default(constants.node_inner_size.width),
                 flex_basis: 0.0,
                 inner_flex_basis: 0.0,
                 violation: 0.0,

--- a/src/flexbox.rs
+++ b/src/flexbox.rs
@@ -1743,9 +1743,10 @@ impl Forest {
 mod tests {
     use crate::{
         forest::Forest,
+        math::MaybeMath,
         prelude::{Rect, Size},
         resolve::ResolveOrDefault,
-        style::{Dimension, FlexWrap, FlexboxLayout},
+        style::{FlexWrap, FlexboxLayout},
     };
 
     // Make sure we get correct constants
@@ -1772,31 +1773,26 @@ mod tests {
         let border = style.border.resolve_or_default(parent_size);
         assert_eq!(constants.border, border);
 
-        let padding_border = style.padding.resolve_or_default(parent_size);
+        let padding = style.padding.resolve_or_default(parent_size);
+
+        // TODO: Replace with something less hardcoded?
+        let padding_border = Rect {
+            start: padding.start + border.start,
+            end: padding.end + border.end,
+            top: padding.top + border.top,
+            bottom: padding.bottom + border.bottom,
+        };
+
         assert_eq!(constants.padding_border, padding_border);
 
-        // inner size
+        // TODO: Replace with something less hardcoded?
+        let inner_size = Size {
+            width: node_size.width.maybe_sub(padding_border.horizontal_axis_sum()),
+            height: node_size.height.maybe_sub(padding_border.vertical_axis_sum()),
+        };
+        assert_eq!(constants.node_inner_size, inner_size);
 
         assert_eq!(constants.container_size, Size::ZERO);
         assert_eq!(constants.inner_container_size, Size::ZERO);
     }
-
-    // Margin Dimension::Undefined
-    #[test]
-    fn dimension_undefined_margin() {
-        let mut forest = Forest::with_capacity(16);
-        let style = FlexboxLayout {
-            margin: Rect {
-                start: Dimension::Undefined,
-                end: Dimension::Undefined,
-                top: Dimension::Undefined,
-                bottom: Dimension::Undefined,
-            },
-            ..Default::default()
-        };
-        let node_id = forest.new_leaf(style);
-    }
-    // Padding Dimension::Undefined
-    // Border Dimension::Undefined
-    // Margin Dimension::Undefined
 }

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -231,15 +231,43 @@ impl Size<f32> {
     }
 }
 
+impl Size<Option<f32>> {
+    /// TODO
+    #[must_use]
+    pub fn from_none() -> Self {
+        Size { width: None, height: None }
+    }
+
+    /// TODO
+    #[must_use]
+    pub fn from_some(width: f32, height: f32) -> Self {
+        Size { width: Some(width), height: Some(height) }
+    }
+}
+
 impl Size<Dimension> {
     /// Generates a [`Size<Dimension>`] using [`Dimension::Points`] values
+    #[must_use]
     pub fn from_points(width: f32, height: f32) -> Self {
         Size { width: Dimension::Points(width), height: Dimension::Points(height) }
     }
 
     /// Generates a [`Size<Dimension>`] using [`Dimension::Percent`] values
+    #[must_use]
     pub fn from_percent(width: f32, height: f32) -> Self {
         Size { width: Dimension::Percent(width), height: Dimension::Percent(height) }
+    }
+
+    /// TODO
+    #[must_use]
+    pub fn from_auto() -> Self {
+        Size { width: Dimension::Auto, height: Dimension::Auto }
+    }
+
+    /// TODO
+    #[must_use]
+    pub fn from_undefined() -> Self {
+        Size { width: Dimension::Undefined, height: Dimension::Undefined }
     }
 }
 

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -225,18 +225,12 @@ impl<T> Size<T> {
 
 impl Size<f32> {
     /// A [`Size`] with zero width and height
-    #[must_use]
-    pub fn zero() -> Self {
-        Self { width: 0.0, height: 0.0 }
-    }
+    pub const ZERO: Size<f32> = Self { width: 0.0, height: 0.0 };
 }
 
 impl Size<Option<f32>> {
-    /// TODO
-    #[must_use]
-    pub fn from_none() -> Self {
-        Size { width: None, height: None }
-    }
+    /// A [`Size`] with `None` width and height
+    pub const NONE: Size<Option<f32>> = Self { width: None, height: None };
 
     /// TODO
     #[must_use]
@@ -284,8 +278,5 @@ pub struct Point<T> {
 
 impl Point<f32> {
     /// A [`Point`] with values (0,0), representing the origin
-    #[must_use]
-    pub fn zero() -> Self {
-        Self { x: 0.0, y: 0.0 }
-    }
+    pub const ZERO: Point<f32> = Self { x: 0.0, y: 0.0 };
 }

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -29,17 +29,6 @@ pub struct Rect<T> {
 }
 
 impl<T> Rect<T> {
-    /// Applies the function `f` to all four sides of the [`Rect`]
-    ///
-    /// This is used to transform a `Rect<T>` into a `Rect<R>`.
-    #[allow(dead_code)]
-    pub(crate) fn map<R, F>(self, f: F) -> Rect<R>
-    where
-        F: Fn(T) -> R,
-    {
-        Rect { start: f(self.start), end: f(self.end), top: f(self.top), bottom: f(self.bottom) }
-    }
-
     /// Applies the function `f` to all four sides of the rect
     ///
     /// When applied to the left and right sides, the width is used

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -32,6 +32,7 @@ impl<T> Rect<T> {
     /// Applies the function `f` to all four sides of the [`Rect`]
     ///
     /// This is used to transform a `Rect<T>` into a `Rect<R>`.
+    #[allow(dead_code)]
     pub(crate) fn map<R, F>(self, f: F) -> Rect<R>
     where
         F: Fn(T) -> R,
@@ -243,7 +244,7 @@ impl Size<Option<f32>> {
     /// A [`Size`] with `None` width and height
     pub const NONE: Size<Option<f32>> = Self { width: None, height: None };
 
-    /// TODO
+    /// A [`Size<Option<f32>>`] with `Some(width)` and `Some(height)` as parameters
     #[must_use]
     pub fn new(width: f32, height: f32) -> Self {
         Size { width: Some(width), height: Some(height) }

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -289,38 +289,3 @@ impl Point<f32> {
         Self { x: 0.0, y: 0.0 }
     }
 }
-
-#[cfg(test)]
-mod tests {
-    mod test_resolve_size {
-        use crate::geometry::Size;
-        use crate::resolve::MaybeResolve;
-        use crate::style::Dimension;
-        use rstest::rstest;
-
-        #[rstest]
-        #[case(Size { width: Dimension::Undefined, height: Dimension::Undefined }, Size { width: None, height: None }, Size { width: None, height: None })]
-        #[case(Size { width: Dimension::Undefined, height: Dimension::Undefined }, Size { width: Some(0.0), height: Some(0.0) }, Size { width: None, height: None })]
-        #[case(Size { width: Dimension::Undefined, height: Dimension::Undefined }, Size { width: Some(1.0), height: Some(1.0) }, Size { width: None, height: None })]
-        #[case(Size { width: Dimension::Undefined, height: Dimension::Undefined }, Size { width: Some(-1.0), height: Some(-1.0) }, Size { width: None, height: None })]
-        #[case(Size { width: Dimension::Auto, height: Dimension::Auto }, Size { width: None, height: None }, Size { width: None, height: None })]
-        #[case(Size { width: Dimension::Auto, height: Dimension::Auto }, Size { width: Some(0.0), height: Some(0.0) }, Size { width: None, height: None })]
-        #[case(Size { width: Dimension::Auto, height: Dimension::Auto }, Size { width: Some(1.0), height: Some(1.0) }, Size { width: None, height: None })]
-        #[case(Size { width: Dimension::Auto, height: Dimension::Auto }, Size { width: Some(-1.0), height: Some(-1.0) }, Size { width: None, height: None })]
-        #[case(Size { width: Dimension::Points(5.0), height: Dimension::Points(5.0) }, Size { width: None, height: None }, Size { width: Some(5.0), height: Some(5.0) })]
-        #[case(Size { width: Dimension::Points(5.0), height: Dimension::Points(5.0) }, Size { width: Some(0.0), height: Some(0.0) }, Size { width: Some(5.0), height: Some(5.0) })]
-        #[case(Size { width: Dimension::Points(5.0), height: Dimension::Points(5.0) }, Size { width: Some(1.0), height: Some(1.0) }, Size { width: Some(5.0), height: Some(5.0) })]
-        #[case(Size { width: Dimension::Points(5.0), height: Dimension::Points(5.0) }, Size { width: Some(-1.0), height: Some(-1.0) }, Size { width: Some(5.0), height: Some(5.0) })]
-        #[case(Size { width: Dimension::Percent(50.0), height: Dimension::Percent(50.0) }, Size { width: None, height: None }, Size { width: None, height: None })]
-        #[case(Size { width: Dimension::Percent(50.0), height: Dimension::Percent(50.0) }, Size { width: Some(0.0), height: Some(0.0) }, Size { width: Some(0.0), height: Some(0.0) })]
-        #[case(Size { width: Dimension::Percent(50.0), height: Dimension::Percent(50.0) }, Size { width: Some(1.0), height: Some(1.0) }, Size { width: Some(50.0), height: Some(50.0) })]
-        #[case(Size { width: Dimension::Percent(50.0), height: Dimension::Percent(50.0) }, Size { width: Some(-1.0), height: Some(-1.0) }, Size { width: Some(-50.0), height: Some(-50.0) })]
-        fn resolve_size(
-            #[case] input: Size<Dimension>,
-            #[case] parent: Size<Option<f32>>,
-            #[case] expected: Size<Option<f32>>,
-        ) {
-            assert_eq!(input.maybe_resolve(parent), expected);
-        }
-    }
-}

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -234,7 +234,7 @@ impl Size<Option<f32>> {
 
     /// TODO
     #[must_use]
-    pub fn from_some(width: f32, height: f32) -> Self {
+    pub fn new(width: f32, height: f32) -> Self {
         Size { width: Some(width), height: Some(height) }
     }
 }

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -252,17 +252,11 @@ impl Size<Dimension> {
         Size { width: Dimension::Percent(width), height: Dimension::Percent(height) }
     }
 
-    /// TODO
-    #[must_use]
-    pub fn from_auto() -> Self {
-        Size { width: Dimension::Auto, height: Dimension::Auto }
-    }
+    /// Generates a [`Size<Dimension>`] using [`Dimension::Auto`] in both width and height
+    pub const AUTO: Size<Dimension> = Self { width: Dimension::Auto, height: Dimension::Auto };
 
-    /// TODO
-    #[must_use]
-    pub fn from_undefined() -> Self {
-        Size { width: Dimension::Undefined, height: Dimension::Undefined }
-    }
+    /// Generates a [`Size<Dimension>`] using [`Dimension::Undefined`] in both width and height
+    pub const UNDEFINED: Size<Dimension> = Self { width: Dimension::Undefined, height: Dimension::Undefined };
 }
 
 /// A 2-dimensional coordinate.

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -148,6 +148,17 @@ where
     }
 }
 
+impl Rect<f32> {
+    /// Creates a new Rect with `0.0` as all parameters
+    pub const ZERO: Rect<f32> = Self { start: 0.0, end: 0.0, top: 0.0, bottom: 0.0 };
+
+    /// Creates a new Rect
+    #[must_use]
+    pub fn new(start: f32, end: f32, top: f32, bottom: f32) -> Self {
+        Self { start, end, top, bottom }
+    }
+}
+
 /// The width and height of a [`Rect`]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -241,11 +241,6 @@ impl Size<Dimension> {
     pub fn from_percent(width: f32, height: f32) -> Self {
         Size { width: Dimension::Percent(width), height: Dimension::Percent(height) }
     }
-
-    /// Converts any `parent`-relative values for size into an absolute size
-    pub(crate) fn resolve(&self, parent: Size<Option<f32>>) -> Size<Option<f32>> {
-        Size { width: self.width.resolve(parent.width), height: self.height.resolve(parent.height) }
-    }
 }
 
 /// A 2-dimensional coordinate.
@@ -271,6 +266,7 @@ impl Point<f32> {
 mod tests {
     mod test_resolve_size {
         use crate::geometry::Size;
+        use crate::resolve::MaybeResolve;
         use crate::style::Dimension;
         use rstest::rstest;
 
@@ -296,7 +292,7 @@ mod tests {
             #[case] parent: Size<Option<f32>>,
             #[case] expected: Size<Option<f32>>,
         ) {
-            assert_eq!(input.resolve(parent), expected);
+            assert_eq!(input.maybe_resolve(parent), expected);
         }
     }
 }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -20,7 +20,7 @@ impl Layout {
     /// Creates a new [`Layout`] struct with zero size positioned at the origin
     #[must_use]
     pub(crate) fn new() -> Self {
-        Self { order: 0, size: Size::zero(), location: Point::zero() }
+        Self { order: 0, size: Size::ZERO, location: Point::ZERO }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ mod flexbox;
 mod forest;
 #[cfg(all(not(feature = "alloc"), not(feature = "std")))]
 mod indexmap;
+mod resolve;
 mod sys;
 
 pub use crate::node::Taffy;

--- a/src/node.rs
+++ b/src/node.rs
@@ -429,7 +429,7 @@ mod tests {
     fn new_leaf_with_measure() {
         let mut taffy = Taffy::new();
 
-        let res = taffy.new_leaf_with_measure(FlexboxLayout::default(), MeasureFunc::Raw(|_| Size::zero()));
+        let res = taffy.new_leaf_with_measure(FlexboxLayout::default(), MeasureFunc::Raw(|_| Size::ZERO));
         assert!(res.is_ok());
         let node = res.unwrap();
 

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -193,4 +193,43 @@ mod tests {
             assert_eq!(input.maybe_resolve(context), expected);
         }
     }
+
+    mod resolve_or_default_dimension_to_option_f32 {
+        use crate::resolve::ResolveOrDefault;
+        use crate::style::Dimension;
+        use rstest::rstest;
+
+        #[rstest]
+        #[case(Dimension::Undefined, None, 0.0)]
+        #[case(Dimension::Undefined, Some(5.0), 0.0)]
+        #[case(Dimension::Undefined, Some(-5.0), 0.0)]
+        #[case(Dimension::Undefined, Some(0.0), 0.0)]
+        fn resolve_or_default_undefined(#[case] input: Dimension, #[case] context: Option<f32>, #[case] expected: f32) {
+            assert_eq!(input.resolve_or_default(context), expected);
+        }
+        #[rstest]
+        #[case(Dimension::Auto, None, 0.0)]
+        #[case(Dimension::Auto, Some(5.0), 0.0)]
+        #[case(Dimension::Auto, Some(-5.0), 0.0)]
+        #[case(Dimension::Auto, Some(0.0), 0.0)]
+        fn resolve_or_default_auto(#[case] input: Dimension, #[case] context: Option<f32>, #[case] expected: f32) {
+            assert_eq!(input.resolve_or_default(context), expected);
+        }
+        #[rstest]
+        #[case(Dimension::Points(5.0), None, 5.0)]
+        #[case(Dimension::Points(5.0), Some(5.0), 5.0)]
+        #[case(Dimension::Points(5.0), Some(-5.0), 5.0)]
+        #[case(Dimension::Points(5.0), Some(0.0), 5.0)]
+        fn resolve_or_default_points(#[case] input: Dimension, #[case] context: Option<f32>, #[case] expected: f32) {
+            assert_eq!(input.resolve_or_default(context), expected);
+        }
+        #[rstest]
+        #[case(Dimension::Percent(5.0), None, 0.0)]
+        #[case(Dimension::Percent(5.0), Some(5.0), 25.0)]
+        #[case(Dimension::Percent(5.0), Some(-5.0), -25.0)]
+        #[case(Dimension::Percent(5.0), Some(0.0), 0.0)]
+        fn resolve_or_default_percent(#[case] input: Dimension, #[case] context: Option<f32>, #[case] expected: f32) {
+            assert_eq!(input.resolve_or_default(context), expected);
+        }
+    }
 }

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -50,3 +50,14 @@ impl ResolveOrDefault<Size<Option<f32>>, Rect<f32>> for Rect<Dimension> {
         }
     }
 }
+
+impl ResolveOrDefault<Option<f32>, Rect<f32>> for Rect<Dimension> {
+    fn resolve_or_default(self, context: Option<f32>) -> Rect<f32> {
+        Rect {
+            start: self.start.resolve_or_default(context),
+            end: self.end.resolve_or_default(context),
+            top: self.top.resolve_or_default(context),
+            bottom: self.bottom.resolve_or_default(context),
+        }
+    }
+}

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -136,10 +136,10 @@ mod tests {
         #[case(Size::from_undefined(), Size::from_some(0.0, 0.0), Size::from_none())]
         fn maybe_resolve_undefined(
             #[case] input: Size<Dimension>,
-            #[case] parent: Size<Option<f32>>,
+            #[case] context: Size<Option<f32>>,
             #[case] expected: Size<Option<f32>>,
         ) {
-            assert_eq!(input.maybe_resolve(parent), expected);
+            assert_eq!(input.maybe_resolve(context), expected);
         }
 
         /// Size<Dimension::Auto> should always return Size<None>
@@ -152,10 +152,10 @@ mod tests {
         #[case(Size::from_auto(), Size::from_some(0.0, 0.0), Size::from_none())]
         fn maybe_resolve_auto(
             #[case] input: Size<Dimension>,
-            #[case] parent: Size<Option<f32>>,
+            #[case] context: Size<Option<f32>>,
             #[case] expected: Size<Option<f32>>,
         ) {
-            assert_eq!(input.maybe_resolve(parent), expected);
+            assert_eq!(input.maybe_resolve(context), expected);
         }
 
         /// Size<Dimension::Points> should always return a Size<Some(f32)>
@@ -169,10 +169,10 @@ mod tests {
         #[case(Size::from_points(5.0, 5.0), Size::from_some(0.0, 0.0), Size::from_some(5.0, 5.0))]
         fn maybe_resolve_points(
             #[case] input: Size<Dimension>,
-            #[case] parent: Size<Option<f32>>,
+            #[case] context: Size<Option<f32>>,
             #[case] expected: Size<Option<f32>>,
         ) {
-            assert_eq!(input.maybe_resolve(parent), expected);
+            assert_eq!(input.maybe_resolve(context), expected);
         }
     }
 }

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -61,3 +61,65 @@ impl ResolveOrDefault<Option<f32>, Rect<f32>> for Rect<Dimension> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    mod maybe_resolve_dimension {
+
+        use crate::resolve::MaybeResolve;
+        use crate::style::Dimension;
+        use rstest::rstest;
+
+        /// `Dimension::Undefined` should always return `None`
+        ///
+        /// The parent / context should not affect the outcome.
+        #[rstest]
+        #[case(Dimension::Undefined, None, None)]
+        #[case(Dimension::Undefined, Some(5.0), None)]
+        #[case(Dimension::Undefined, Some(-5.0), None)]
+        #[case(Dimension::Undefined, Some(0.), None)]
+        fn resolve_undefined(#[case] input: Dimension, #[case] context: Option<f32>, #[case] expected: Option<f32>) {
+            assert_eq!(input.maybe_resolve(context), expected);
+        }
+
+        /// `Dimension::Auto` should always return `None`
+        ///
+        /// The parent / context should not affect the outcome.
+        #[rstest]
+        #[case(Dimension::Auto, None, None)]
+        #[case(Dimension::Auto, Some(5.0), None)]
+        #[case(Dimension::Auto, Some(-5.0), None)]
+        #[case(Dimension::Auto, Some(0.), None)]
+        fn resolve_auto(#[case] input: Dimension, #[case] context: Option<f32>, #[case] expected: Option<f32>) {
+            assert_eq!(input.maybe_resolve(context), expected);
+        }
+
+        /// `Dimension::Points` should always return `Some(f32)`
+        /// where the f32 value is the inner value of the points.
+        ///
+        /// The parent / context should not affect the outcome.
+        #[rstest]
+        #[case(Dimension::Points(1.0), None, Some(1.0))]
+        #[case(Dimension::Points(1.0), Some(5.0), Some(1.0))]
+        #[case(Dimension::Points(1.0), Some(-5.0), Some(1.0))]
+        #[case(Dimension::Points(1.0), Some(0.), Some(1.0))]
+        fn resolve_points(#[case] input: Dimension, #[case] context: Option<f32>, #[case] expected: Option<f32>) {
+            assert_eq!(input.maybe_resolve(context), expected);
+        }
+
+        /// `Dimension::Percent` should return `None` if context is  `None`.
+        /// Otherwise it should return `Some(f32)`
+        /// where the f32 value is the inner value of the percent * context value.
+        ///
+        /// The parent / context __should__ affect the outcome.
+        #[rstest]
+        #[case(Dimension::Percent(1.0), None, None)]
+        #[case(Dimension::Percent(1.0), Some(5.0), Some(5.0))]
+        #[case(Dimension::Percent(1.0), Some(-5.0), Some(-5.0))]
+        #[case(Dimension::Percent(1.0), Some(50.0), Some(50.0))]
+        fn resolve_percent(#[case] input: Dimension, #[case] context: Option<f32>, #[case] expected: Option<f32>) {
+            assert_eq!(input.maybe_resolve(context), expected);
+        }
+    }
+
+}

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -302,9 +302,8 @@ mod tests {
         }
     }
 
-    // TODO: Add tests for ResolveOrDefault<Option<f32>, Rect<f32>> for Rect<Dimension>
     mod resolve_or_default_rect_dimension_to_rect_f32_via_option {
-        use crate::geometry::{Rect, Size};
+        use crate::geometry::Rect;
         use crate::resolve::ResolveOrDefault;
         use crate::style::Dimension;
         use rstest::rstest;

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -174,5 +174,23 @@ mod tests {
         ) {
             assert_eq!(input.maybe_resolve(context), expected);
         }
+
+        /// `Size<Dimension::Percent>` should return `Size<None>` if context is `Size<None>`.
+        /// Otherwise it should return `Size<Some(f32)>`
+        /// where the f32 value is the inner value of the percent * context value.
+        ///
+        /// The context __should__ affect the outcome.
+        #[rstest]
+        #[case(Size::from_percent(5.0, 5.0), Size::from_none(), Size::from_none())]
+        #[case(Size::from_percent(5.0, 5.0), Size::from_some(5.0, 5.0), Size::from_some(25.0, 25.0))]
+        #[case(Size::from_percent(5.0, 5.0), Size::from_some(-5.0, -5.0), Size::from_some(-25.0, -25.0))]
+        #[case(Size::from_percent(5.0, 5.0), Size::from_some(0.0, 0.0), Size::from_some(0.0, 0.0))]
+        fn maybe_resolve_percent(
+            #[case] input: Size<Dimension>,
+            #[case] context: Size<Option<f32>>,
+            #[case] expected: Size<Option<f32>>,
+        ) {
+            assert_eq!(input.maybe_resolve(context), expected);
+        }
     }
 }

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -232,4 +232,65 @@ mod tests {
             assert_eq!(input.resolve_or_default(context), expected);
         }
     }
+
+    mod resolve_or_default_rect_dimension_to_rect {
+        use crate::geometry::{Rect, Size};
+        use crate::resolve::ResolveOrDefault;
+        use crate::style::Dimension;
+        use rstest::rstest;
+
+        #[rstest]
+        #[case(Rect::UNDEFINED, Size::NONE, Rect::ZERO)]
+        #[case(Rect::UNDEFINED, Size::new(5.0, 5.0), Rect::ZERO)]
+        #[case(Rect::UNDEFINED, Size::new(-5.0, -5.0), Rect::ZERO)]
+        #[case(Rect::UNDEFINED, Size::new(0.0, 0.0), Rect::ZERO)]
+        fn resolve_or_default_undefined(
+            #[case] input: Rect<Dimension>,
+            #[case] context: Size<Option<f32>>,
+            #[case] expected: Rect<f32>,
+        ) {
+            assert_eq!(input.resolve_or_default(context), expected);
+        }
+
+        #[rstest]
+        #[case(Rect::AUTO, Size::NONE, Rect::ZERO)]
+        #[case(Rect::AUTO, Size::new(5.0, 5.0), Rect::ZERO)]
+        #[case(Rect::AUTO, Size::new(-5.0, -5.0), Rect::ZERO)]
+        #[case(Rect::AUTO, Size::new(0.0, 0.0), Rect::ZERO)]
+        fn resolve_or_default_auto(
+            #[case] input: Rect<Dimension>,
+            #[case] context: Size<Option<f32>>,
+            #[case] expected: Rect<f32>,
+        ) {
+            assert_eq!(input.resolve_or_default(context), expected);
+        }
+
+        #[rstest]
+        #[case(Rect::from_points(5.0, 5.0, 5.0, 5.0), Size::NONE, Rect::new(5.0, 5.0, 5.0, 5.0))]
+        #[case(Rect::from_points(5.0, 5.0, 5.0, 5.0), Size::new(5.0, 5.0), Rect::new(5.0, 5.0, 5.0, 5.0))]
+        #[case(Rect::from_points(5.0, 5.0, 5.0, 5.0), Size::new(-5.0, -5.0), Rect::new(5.0, 5.0, 5.0, 5.0))]
+        #[case(Rect::from_points(5.0, 5.0, 5.0, 5.0), Size::new(0.0, 0.0), Rect::new(5.0, 5.0, 5.0, 5.0))]
+        fn resolve_or_default_points(
+            #[case] input: Rect<Dimension>,
+            #[case] context: Size<Option<f32>>,
+            #[case] expected: Rect<f32>,
+        ) {
+            assert_eq!(input.resolve_or_default(context), expected);
+        }
+
+        #[rstest]
+        #[case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), Size::NONE, Rect::ZERO)]
+        #[case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), Size::new(5.0, 5.0), Rect::new(25.0, 25.0, 25.0, 25.0))]
+        #[case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), Size::new(-5.0, -5.0), Rect::new(-25.0, -25.0, -25.0, -25.0))]
+        #[case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), Size::new(0.0, 0.0), Rect::ZERO)]
+        fn resolve_or_default_percent(
+            #[case] input: Rect<Dimension>,
+            #[case] context: Size<Option<f32>>,
+            #[case] expected: Rect<f32>,
+        ) {
+            assert_eq!(input.resolve_or_default(context), expected);
+        }
+    }
+
+    // TODO: Add tests for ResolveOrDefault<Option<f32>, Rect<f32>> for Rect<Dimension>
 }

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -130,10 +130,10 @@ mod tests {
         ///
         /// The parent / context should not affect the outcome.
         #[rstest]
-        #[case(Size::from_undefined(), Size::NONE, Size::NONE)]
-        #[case(Size::from_undefined(), Size::new(5.0, 5.0), Size::NONE)]
-        #[case(Size::from_undefined(), Size::new(-5.0, -5.0), Size::NONE)]
-        #[case(Size::from_undefined(), Size::new(0.0, 0.0), Size::NONE)]
+        #[case(Size::UNDEFINED, Size::NONE, Size::NONE)]
+        #[case(Size::UNDEFINED, Size::new(5.0, 5.0), Size::NONE)]
+        #[case(Size::UNDEFINED, Size::new(-5.0, -5.0), Size::NONE)]
+        #[case(Size::UNDEFINED, Size::new(0.0, 0.0), Size::NONE)]
         fn maybe_resolve_undefined(
             #[case] input: Size<Dimension>,
             #[case] context: Size<Option<f32>>,
@@ -146,10 +146,10 @@ mod tests {
         ///
         /// The parent / context should not affect the outcome.
         #[rstest]
-        #[case(Size::from_auto(), Size::NONE, Size::NONE)]
-        #[case(Size::from_auto(), Size::new(5.0, 5.0), Size::NONE)]
-        #[case(Size::from_auto(), Size::new(-5.0, -5.0), Size::NONE)]
-        #[case(Size::from_auto(), Size::new(0.0, 0.0), Size::NONE)]
+        #[case(Size::AUTO, Size::NONE, Size::NONE)]
+        #[case(Size::AUTO, Size::new(5.0, 5.0), Size::NONE)]
+        #[case(Size::AUTO, Size::new(-5.0, -5.0), Size::NONE)]
+        #[case(Size::AUTO, Size::new(0.0, 0.0), Size::NONE)]
         fn maybe_resolve_auto(
             #[case] input: Size<Dimension>,
             #[case] context: Size<Option<f32>>,

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -303,4 +303,62 @@ mod tests {
     }
 
     // TODO: Add tests for ResolveOrDefault<Option<f32>, Rect<f32>> for Rect<Dimension>
+    mod resolve_or_default_rect_dimension_to_rect_f32_via_option {
+        use crate::geometry::{Rect, Size};
+        use crate::resolve::ResolveOrDefault;
+        use crate::style::Dimension;
+        use rstest::rstest;
+
+        #[rstest]
+        #[case(Rect::UNDEFINED, None, Rect::ZERO)]
+        #[case(Rect::UNDEFINED, Some(5.0), Rect::ZERO)]
+        #[case(Rect::UNDEFINED, Some(-5.0), Rect::ZERO)]
+        #[case(Rect::UNDEFINED, Some(0.0), Rect::ZERO)]
+        fn resolve_or_default_undefined(
+            #[case] input: Rect<Dimension>,
+            #[case] context: Option<f32>,
+            #[case] expected: Rect<f32>,
+        ) {
+            assert_eq!(input.resolve_or_default(context), expected);
+        }
+
+        #[rstest]
+        #[case(Rect::AUTO, None, Rect::ZERO)]
+        #[case(Rect::AUTO, Some(5.0), Rect::ZERO)]
+        #[case(Rect::AUTO, Some(-5.0), Rect::ZERO)]
+        #[case(Rect::AUTO, Some(0.0), Rect::ZERO)]
+        fn resolve_or_default_auto(
+            #[case] input: Rect<Dimension>,
+            #[case] context: Option<f32>,
+            #[case] expected: Rect<f32>,
+        ) {
+            assert_eq!(input.resolve_or_default(context), expected);
+        }
+
+        #[rstest]
+        #[case(Rect::from_points(5.0, 5.0, 5.0, 5.0), None, Rect::new(5.0, 5.0, 5.0, 5.0))]
+        #[case(Rect::from_points(5.0, 5.0, 5.0, 5.0), Some(5.0), Rect::new(5.0, 5.0, 5.0, 5.0))]
+        #[case(Rect::from_points(5.0, 5.0, 5.0, 5.0), Some(-5.0), Rect::new(5.0, 5.0, 5.0, 5.0))]
+        #[case(Rect::from_points(5.0, 5.0, 5.0, 5.0), Some(0.0), Rect::new(5.0, 5.0, 5.0, 5.0))]
+        fn resolve_or_default_points(
+            #[case] input: Rect<Dimension>,
+            #[case] context: Option<f32>,
+            #[case] expected: Rect<f32>,
+        ) {
+            assert_eq!(input.resolve_or_default(context), expected);
+        }
+
+        #[rstest]
+        #[case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), None, Rect::ZERO)]
+        #[case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), Some(5.0), Rect::new(25.0, 25.0, 25.0, 25.0))]
+        #[case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), Some(-5.0), Rect::new(-25.0, -25.0, -25.0, -25.0))]
+        #[case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), Some(0.0), Rect::ZERO)]
+        fn resolve_or_default_percent(
+            #[case] input: Rect<Dimension>,
+            #[case] context: Option<f32>,
+            #[case] expected: Rect<f32>,
+        ) {
+            assert_eq!(input.resolve_or_default(context), expected);
+        }
+    }
 }

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -130,10 +130,10 @@ mod tests {
         ///
         /// The parent / context should not affect the outcome.
         #[rstest]
-        #[case(Size::from_undefined(), Size::from_none(), Size::from_none())]
-        #[case(Size::from_undefined(), Size::from_some(5.0, 5.0), Size::from_none())]
-        #[case(Size::from_undefined(), Size::from_some(-5.0, -5.0), Size::from_none())]
-        #[case(Size::from_undefined(), Size::from_some(0.0, 0.0), Size::from_none())]
+        #[case(Size::from_undefined(), Size::NONE, Size::NONE)]
+        #[case(Size::from_undefined(), Size::from_some(5.0, 5.0), Size::NONE)]
+        #[case(Size::from_undefined(), Size::from_some(-5.0, -5.0), Size::NONE)]
+        #[case(Size::from_undefined(), Size::from_some(0.0, 0.0), Size::NONE)]
         fn maybe_resolve_undefined(
             #[case] input: Size<Dimension>,
             #[case] context: Size<Option<f32>>,
@@ -146,10 +146,10 @@ mod tests {
         ///
         /// The parent / context should not affect the outcome.
         #[rstest]
-        #[case(Size::from_auto(), Size::from_none(), Size::from_none())]
-        #[case(Size::from_auto(), Size::from_some(5.0, 5.0), Size::from_none())]
-        #[case(Size::from_auto(), Size::from_some(-5.0, -5.0), Size::from_none())]
-        #[case(Size::from_auto(), Size::from_some(0.0, 0.0), Size::from_none())]
+        #[case(Size::from_auto(), Size::NONE, Size::NONE)]
+        #[case(Size::from_auto(), Size::from_some(5.0, 5.0), Size::NONE)]
+        #[case(Size::from_auto(), Size::from_some(-5.0, -5.0), Size::NONE)]
+        #[case(Size::from_auto(), Size::from_some(0.0, 0.0), Size::NONE)]
         fn maybe_resolve_auto(
             #[case] input: Size<Dimension>,
             #[case] context: Size<Option<f32>>,
@@ -163,7 +163,7 @@ mod tests {
         ///
         /// The parent / context should not affect the outcome.
         #[rstest]
-        #[case(Size::from_points(5.0, 5.0), Size::from_none(), Size::from_some(5.0, 5.0))]
+        #[case(Size::from_points(5.0, 5.0), Size::NONE, Size::from_some(5.0, 5.0))]
         #[case(Size::from_points(5.0, 5.0), Size::from_some(5.0, 5.0), Size::from_some(5.0, 5.0))]
         #[case(Size::from_points(5.0, 5.0), Size::from_some(-5.0, -5.0), Size::from_some(5.0, 5.0))]
         #[case(Size::from_points(5.0, 5.0), Size::from_some(0.0, 0.0), Size::from_some(5.0, 5.0))]
@@ -181,7 +181,7 @@ mod tests {
         ///
         /// The context __should__ affect the outcome.
         #[rstest]
-        #[case(Size::from_percent(5.0, 5.0), Size::from_none(), Size::from_none())]
+        #[case(Size::from_percent(5.0, 5.0), Size::NONE, Size::NONE)]
         #[case(Size::from_percent(5.0, 5.0), Size::from_some(5.0, 5.0), Size::from_some(25.0, 25.0))]
         #[case(Size::from_percent(5.0, 5.0), Size::from_some(-5.0, -5.0), Size::from_some(-25.0, -25.0))]
         #[case(Size::from_percent(5.0, 5.0), Size::from_some(0.0, 0.0), Size::from_some(0.0, 0.0))]

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -1,0 +1,52 @@
+use crate::prelude::{Dimension, Rect, Size};
+
+pub(crate) trait ResolveOrDefault<TContext, TOutput> {
+    /// Resolves a value from something that can be either absolute or relative
+    /// into one that is absolute.
+    ///
+    /// `context` is size of the parent
+    fn resolve_or_default(self, context: TContext) -> TOutput;
+}
+
+pub(crate) trait MaybeResolve<T> {
+    fn maybe_resolve(self, context: T) -> T;
+}
+
+impl MaybeResolve<Option<f32>> for Dimension {
+    /// Converts the given [`Dimension`] into a concrete value of points
+    ///
+    /// Can return `None`
+    fn maybe_resolve(self, context: Option<f32>) -> Option<f32> {
+        match self {
+            Dimension::Points(points) => Some(points),
+            // parent_dim * percent
+            Dimension::Percent(percent) => context.map(|dim| dim * percent),
+            _ => None,
+        }
+    }
+}
+
+impl MaybeResolve<Size<Option<f32>>> for Size<Dimension> {
+    /// Converts any `parent`-relative values for size into an absolute size
+    fn maybe_resolve(self, context: Size<Option<f32>>) -> Size<Option<f32>> {
+        Size { width: self.width.maybe_resolve(context.width), height: self.height.maybe_resolve(context.height) }
+    }
+}
+
+impl ResolveOrDefault<Option<f32>, f32> for Dimension {
+    /// Will return a default value of result is evaluated to `None`
+    fn resolve_or_default(self, context: Option<f32>) -> f32 {
+        self.maybe_resolve(context).unwrap_or(0.0)
+    }
+}
+
+impl ResolveOrDefault<Size<Option<f32>>, Rect<f32>> for Rect<Dimension> {
+    fn resolve_or_default(self, context: Size<Option<f32>>) -> Rect<f32> {
+        Rect {
+            start: self.start.resolve_or_default(context.width),
+            end: self.end.resolve_or_default(context.width),
+            top: self.top.resolve_or_default(context.height),
+            bottom: self.bottom.resolve_or_default(context.height),
+        }
+    }
+}

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -1,14 +1,24 @@
+//! Helper trait to calculate dimensions during layout resolution
+
 use crate::prelude::{Dimension, Rect, Size};
 
+/// Trait to encapsulate behaviour where we need to resolve from a
+/// potentially context-dependent size or dimension into
+/// a context-independent size or dimension.
+///
+/// Will return a default value if it unable to resolve.
 pub(crate) trait ResolveOrDefault<TContext, TOutput> {
-    /// Resolves a value from something that can be either absolute or relative
-    /// into one that is absolute.
-    ///
-    /// `context` is size of the parent
+    /// Resolve a dimension that might be dependent on a context, with a default fallback value
     fn resolve_or_default(self, context: TContext) -> TOutput;
 }
 
+/// Trait to encapsulate behaviour where we need to resolve from a
+/// potentially context-dependent size or dimension into
+/// a context-independent size or dimension.
+///
+/// Will return a `None` if it unable to resolve.
 pub(crate) trait MaybeResolve<T> {
+    /// Resolve a dimension that might be dependent on a context, with `None` as fallback value
     fn maybe_resolve(self, context: T) -> T;
 }
 

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -131,9 +131,9 @@ mod tests {
         /// The parent / context should not affect the outcome.
         #[rstest]
         #[case(Size::from_undefined(), Size::NONE, Size::NONE)]
-        #[case(Size::from_undefined(), Size::from_some(5.0, 5.0), Size::NONE)]
-        #[case(Size::from_undefined(), Size::from_some(-5.0, -5.0), Size::NONE)]
-        #[case(Size::from_undefined(), Size::from_some(0.0, 0.0), Size::NONE)]
+        #[case(Size::from_undefined(), Size::new(5.0, 5.0), Size::NONE)]
+        #[case(Size::from_undefined(), Size::new(-5.0, -5.0), Size::NONE)]
+        #[case(Size::from_undefined(), Size::new(0.0, 0.0), Size::NONE)]
         fn maybe_resolve_undefined(
             #[case] input: Size<Dimension>,
             #[case] context: Size<Option<f32>>,
@@ -147,9 +147,9 @@ mod tests {
         /// The parent / context should not affect the outcome.
         #[rstest]
         #[case(Size::from_auto(), Size::NONE, Size::NONE)]
-        #[case(Size::from_auto(), Size::from_some(5.0, 5.0), Size::NONE)]
-        #[case(Size::from_auto(), Size::from_some(-5.0, -5.0), Size::NONE)]
-        #[case(Size::from_auto(), Size::from_some(0.0, 0.0), Size::NONE)]
+        #[case(Size::from_auto(), Size::new(5.0, 5.0), Size::NONE)]
+        #[case(Size::from_auto(), Size::new(-5.0, -5.0), Size::NONE)]
+        #[case(Size::from_auto(), Size::new(0.0, 0.0), Size::NONE)]
         fn maybe_resolve_auto(
             #[case] input: Size<Dimension>,
             #[case] context: Size<Option<f32>>,
@@ -163,10 +163,10 @@ mod tests {
         ///
         /// The parent / context should not affect the outcome.
         #[rstest]
-        #[case(Size::from_points(5.0, 5.0), Size::NONE, Size::from_some(5.0, 5.0))]
-        #[case(Size::from_points(5.0, 5.0), Size::from_some(5.0, 5.0), Size::from_some(5.0, 5.0))]
-        #[case(Size::from_points(5.0, 5.0), Size::from_some(-5.0, -5.0), Size::from_some(5.0, 5.0))]
-        #[case(Size::from_points(5.0, 5.0), Size::from_some(0.0, 0.0), Size::from_some(5.0, 5.0))]
+        #[case(Size::from_points(5.0, 5.0), Size::NONE, Size::new(5.0, 5.0))]
+        #[case(Size::from_points(5.0, 5.0), Size::new(5.0, 5.0), Size::new(5.0, 5.0))]
+        #[case(Size::from_points(5.0, 5.0), Size::new(-5.0, -5.0), Size::new(5.0, 5.0))]
+        #[case(Size::from_points(5.0, 5.0), Size::new(0.0, 0.0), Size::new(5.0, 5.0))]
         fn maybe_resolve_points(
             #[case] input: Size<Dimension>,
             #[case] context: Size<Option<f32>>,
@@ -182,9 +182,9 @@ mod tests {
         /// The context __should__ affect the outcome.
         #[rstest]
         #[case(Size::from_percent(5.0, 5.0), Size::NONE, Size::NONE)]
-        #[case(Size::from_percent(5.0, 5.0), Size::from_some(5.0, 5.0), Size::from_some(25.0, 25.0))]
-        #[case(Size::from_percent(5.0, 5.0), Size::from_some(-5.0, -5.0), Size::from_some(-25.0, -25.0))]
-        #[case(Size::from_percent(5.0, 5.0), Size::from_some(0.0, 0.0), Size::from_some(0.0, 0.0))]
+        #[case(Size::from_percent(5.0, 5.0), Size::new(5.0, 5.0), Size::new(25.0, 25.0))]
+        #[case(Size::from_percent(5.0, 5.0), Size::new(-5.0, -5.0), Size::new(-25.0, -25.0))]
+        #[case(Size::from_percent(5.0, 5.0), Size::new(0.0, 0.0), Size::new(0.0, 0.0))]
         fn maybe_resolve_percent(
             #[case] input: Size<Dimension>,
             #[case] context: Size<Option<f32>>,

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -122,4 +122,57 @@ mod tests {
         }
     }
 
+    mod maybe_resolve_size_dimension {
+        use crate::{prelude::Size, resolve::MaybeResolve, style::Dimension};
+        use rstest::rstest;
+
+        /// Size<Dimension::Undefined> should always return Size<None>
+        ///
+        /// The parent / context should not affect the outcome.
+        #[rstest]
+        #[case(Size::from_undefined(), Size::from_none(), Size::from_none())]
+        #[case(Size::from_undefined(), Size::from_some(5.0, 5.0), Size::from_none())]
+        #[case(Size::from_undefined(), Size::from_some(-5.0, -5.0), Size::from_none())]
+        #[case(Size::from_undefined(), Size::from_some(0.0, 0.0), Size::from_none())]
+        fn maybe_resolve_undefined(
+            #[case] input: Size<Dimension>,
+            #[case] parent: Size<Option<f32>>,
+            #[case] expected: Size<Option<f32>>,
+        ) {
+            assert_eq!(input.maybe_resolve(parent), expected);
+        }
+
+        /// Size<Dimension::Auto> should always return Size<None>
+        ///
+        /// The parent / context should not affect the outcome.
+        #[rstest]
+        #[case(Size::from_auto(), Size::from_none(), Size::from_none())]
+        #[case(Size::from_auto(), Size::from_some(5.0, 5.0), Size::from_none())]
+        #[case(Size::from_auto(), Size::from_some(-5.0, -5.0), Size::from_none())]
+        #[case(Size::from_auto(), Size::from_some(0.0, 0.0), Size::from_none())]
+        fn maybe_resolve_auto(
+            #[case] input: Size<Dimension>,
+            #[case] parent: Size<Option<f32>>,
+            #[case] expected: Size<Option<f32>>,
+        ) {
+            assert_eq!(input.maybe_resolve(parent), expected);
+        }
+
+        /// Size<Dimension::Points> should always return a Size<Some(f32)>
+        /// where the f32 values are the inner value of the points.
+        ///
+        /// The parent / context should not affect the outcome.
+        #[rstest]
+        #[case(Size::from_points(5.0, 5.0), Size::from_none(), Size::from_some(5.0, 5.0))]
+        #[case(Size::from_points(5.0, 5.0), Size::from_some(5.0, 5.0), Size::from_some(5.0, 5.0))]
+        #[case(Size::from_points(5.0, 5.0), Size::from_some(-5.0, -5.0), Size::from_some(5.0, 5.0))]
+        #[case(Size::from_points(5.0, 5.0), Size::from_some(0.0, 0.0), Size::from_some(5.0, 5.0))]
+        fn maybe_resolve_points(
+            #[case] input: Size<Dimension>,
+            #[case] parent: Size<Option<f32>>,
+            #[case] expected: Size<Option<f32>>,
+        ) {
+            assert_eq!(input.maybe_resolve(parent), expected);
+        }
+    }
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -307,23 +307,19 @@ impl Rect<Dimension> {
         Rect { end: Dimension::Percent(end), bottom: Dimension::Percent(bottom), ..Default::default() }
     }
 
-    /// Create a new Rect where all rect-parameters are `Dimension::Undefined`
-    #[must_use]
-    pub fn from_undefined() -> Self {
-        Rect {
-            start: Dimension::Undefined,
-            end: Dimension::Undefined,
-            top: Dimension::Undefined,
-            bottom: Dimension::Undefined,
-        }
-    }
-    /// Create a new Rect where all rect-parameters are `Dimension::Auto`
-    #[must_use]
-    pub fn from_auto() -> Self {
-        Rect { start: Dimension::Auto, end: Dimension::Auto, top: Dimension::Auto, bottom: Dimension::Auto }
-    }
+    /// Generates a [`Rect<Dimension>`] using [`Dimension::Undefined`] for all values
+    pub const UNDEFINED: Rect<Dimension> = Self {
+        start: Dimension::Undefined,
+        end: Dimension::Undefined,
+        top: Dimension::Undefined,
+        bottom: Dimension::Undefined,
+    };
 
-    /// Create a new Rect with `Dimension::Points`
+    /// Generates a [`Rect<Dimension>`] using [`Dimension::Auto`] for all values
+    pub const AUTO: Rect<Dimension> =
+        Self { start: Dimension::Auto, end: Dimension::Auto, top: Dimension::Auto, bottom: Dimension::Auto };
+
+    /// Create a new Rect with [`Dimension::Points`]
     #[must_use]
     pub fn from_points(start: f32, end: f32, top: f32, bottom: f32) -> Self {
         Rect {
@@ -334,7 +330,7 @@ impl Rect<Dimension> {
         }
     }
 
-    /// Create a new Rect with `Dimension::Percent`
+    /// Create a new Rect with [`Dimension::Percent`]
     #[must_use]
     pub fn from_percent(start: f32, end: f32, top: f32, bottom: f32) -> Self {
         Rect {

--- a/src/style.rs
+++ b/src/style.rs
@@ -284,23 +284,65 @@ impl Default for Rect<Dimension> {
 
 impl Rect<Dimension> {
     /// Generates a [`Rect<Dimension>`] using [`Dimension::Points`] values for `start` and `top`
+    #[must_use]
     pub fn top_from_points(start: f32, top: f32) -> Rect<Dimension> {
         Rect { start: Dimension::Points(start), top: Dimension::Points(top), ..Default::default() }
     }
 
     /// Generates a [`Rect<Dimension>`] using [`Dimension::Points`] values for `end` and `bottom`
+    #[must_use]
     pub fn bot_from_points(end: f32, bottom: f32) -> Rect<Dimension> {
         Rect { end: Dimension::Points(end), bottom: Dimension::Points(bottom), ..Default::default() }
     }
 
     /// Generates a [`Rect<Dimension>`] using [`Dimension::Percent`] values for `start` and `top`
+    #[must_use]
     pub fn top_from_percent(start: f32, top: f32) -> Rect<Dimension> {
         Rect { start: Dimension::Percent(start), top: Dimension::Percent(top), ..Default::default() }
     }
 
     /// Generates a [`Rect<Dimension>`] using [`Dimension::Percent`] values for `end` and `bottom`
+    #[must_use]
     pub fn bot_from_percent(end: f32, bottom: f32) -> Rect<Dimension> {
         Rect { end: Dimension::Percent(end), bottom: Dimension::Percent(bottom), ..Default::default() }
+    }
+
+    /// Create a new Rect where all rect-parameters are `Dimension::Undefined`
+    #[must_use]
+    pub fn from_undefined() -> Self {
+        Rect {
+            start: Dimension::Undefined,
+            end: Dimension::Undefined,
+            top: Dimension::Undefined,
+            bottom: Dimension::Undefined,
+        }
+    }
+    /// Create a new Rect where all rect-parameters are `Dimension::Auto`
+    #[must_use]
+    pub fn from_auto() -> Self {
+        Rect { start: Dimension::Auto, end: Dimension::Auto, top: Dimension::Auto, bottom: Dimension::Auto }
+    }
+
+    /// Create a new Rect with `Dimension::Points`
+    #[must_use]
+    pub fn from_points(start: f32, end: f32, top: f32, bottom: f32) -> Self {
+        Rect {
+            start: Dimension::Points(start),
+            end: Dimension::Points(end),
+            top: Dimension::Points(top),
+            bottom: Dimension::Points(bottom),
+        }
+    }
+
+    /// Create a new Rect with `Dimension::Percent`
+    #[must_use]
+    pub fn from_percent(start: f32, end: f32, top: f32, bottom: f32) -> Self {
+        Rect {
+            start: Dimension::Percent(start),
+            end: Dimension::Percent(end),
+            top: Dimension::Percent(top),
+            bottom: Dimension::Percent(bottom),
+        }
     }
 }
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -270,16 +270,6 @@ impl Default for Dimension {
 }
 
 impl Dimension {
-    /// Converts the given [`Dimension`] into a concrete value of points
-    pub(crate) fn resolve(self, parent_dim: Option<f32>) -> Option<f32> {
-        match self {
-            Dimension::Points(points) => Some(points),
-            // parent_dim * percent
-            Dimension::Percent(percent) => parent_dim.map(|dim| dim * percent),
-            _ => None,
-        }
-    }
-
     /// Is this value defined?
     pub(crate) fn is_defined(self) -> bool {
         matches!(self, Dimension::Points(_) | Dimension::Percent(_))
@@ -512,6 +502,7 @@ impl FlexboxLayout {
 #[cfg(test)]
 mod tests {
     mod test_resolve_dimensions {
+        use crate::resolve::MaybeResolve;
         use crate::style::Dimension;
         use rstest::rstest;
 
@@ -521,7 +512,7 @@ mod tests {
         #[case(Dimension::Undefined, Some(-5.0), None)]
         #[case(Dimension::Undefined, Some(0.), None)]
         fn resolve_undefined(#[case] input: Dimension, #[case] parent: Option<f32>, #[case] expected: Option<f32>) {
-            assert_eq!(input.resolve(parent), expected);
+            assert_eq!(input.maybe_resolve(parent), expected);
         }
 
         #[rstest]
@@ -530,7 +521,7 @@ mod tests {
         #[case(Dimension::Auto, Some(-5.0), None)]
         #[case(Dimension::Auto, Some(0.), None)]
         fn resolve_auto(#[case] input: Dimension, #[case] parent: Option<f32>, #[case] expected: Option<f32>) {
-            assert_eq!(input.resolve(parent), expected);
+            assert_eq!(input.maybe_resolve(parent), expected);
         }
 
         #[rstest]
@@ -539,7 +530,7 @@ mod tests {
         #[case(Dimension::Points(-1.), Some(-5.0), Some(-1.))]
         #[case(Dimension::Points(1.0), Some(0.), Some(1.0))]
         fn resolve_points(#[case] input: Dimension, #[case] parent: Option<f32>, #[case] expected: Option<f32>) {
-            assert_eq!(input.resolve(parent), expected);
+            assert_eq!(input.maybe_resolve(parent), expected);
         }
 
         #[rstest]
@@ -548,7 +539,7 @@ mod tests {
         #[case(Dimension::Percent(1.0), Some(-5.0), Some(-5.0))]
         #[case(Dimension::Percent(10.0), Some(5.0), Some(50.0))]
         fn resolve_percent(#[case] input: Dimension, #[case] parent: Option<f32>, #[case] expected: Option<f32>) {
-            assert_eq!(input.resolve(parent), expected);
+            assert_eq!(input.maybe_resolve(parent), expected);
         }
     }
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -501,48 +501,6 @@ impl FlexboxLayout {
 
 #[cfg(test)]
 mod tests {
-    mod test_resolve_dimensions {
-        use crate::resolve::MaybeResolve;
-        use crate::style::Dimension;
-        use rstest::rstest;
-
-        #[rstest]
-        #[case(Dimension::Undefined, None, None)]
-        #[case(Dimension::Undefined, Some(5.0), None)]
-        #[case(Dimension::Undefined, Some(-5.0), None)]
-        #[case(Dimension::Undefined, Some(0.), None)]
-        fn resolve_undefined(#[case] input: Dimension, #[case] parent: Option<f32>, #[case] expected: Option<f32>) {
-            assert_eq!(input.maybe_resolve(parent), expected);
-        }
-
-        #[rstest]
-        #[case(Dimension::Auto, None, None)]
-        #[case(Dimension::Auto, Some(5.0), None)]
-        #[case(Dimension::Auto, Some(-5.0), None)]
-        #[case(Dimension::Auto, Some(0.), None)]
-        fn resolve_auto(#[case] input: Dimension, #[case] parent: Option<f32>, #[case] expected: Option<f32>) {
-            assert_eq!(input.maybe_resolve(parent), expected);
-        }
-
-        #[rstest]
-        #[case(Dimension::Points(0.), None, Some(0.))]
-        #[case(Dimension::Points(1.), Some(5.0), Some(1.))]
-        #[case(Dimension::Points(-1.), Some(-5.0), Some(-1.))]
-        #[case(Dimension::Points(1.0), Some(0.), Some(1.0))]
-        fn resolve_points(#[case] input: Dimension, #[case] parent: Option<f32>, #[case] expected: Option<f32>) {
-            assert_eq!(input.maybe_resolve(parent), expected);
-        }
-
-        #[rstest]
-        #[case(Dimension::Percent(1.0), None, None)]
-        #[case(Dimension::Percent(1.0), Some(5.0), Some(5.0))]
-        #[case(Dimension::Percent(1.0), Some(-5.0), Some(-5.0))]
-        #[case(Dimension::Percent(10.0), Some(5.0), Some(50.0))]
-        fn resolve_percent(#[case] input: Dimension, #[case] parent: Option<f32>, #[case] expected: Option<f32>) {
-            assert_eq!(input.maybe_resolve(parent), expected);
-        }
-    }
-
     mod test_flex_direction {
         use crate::style::*;
 


### PR DESCRIPTION
# Objective

One more step towards #92

This PR is a bit of a mixed bag, so let me know if I should split it up. 

The objective of this PR is to set us up so that we can start testing the flexbox algorithm.

## Context

While trying to cover the `compute_constants()` in tests, I discovered the code needed a bit refactoring and massaging in order to actually be testable. 

Here I realized that the different `resolve()` methods can be abstracted to a "Resolve" trait, and following the convention of `MaybeMath`, we now have `MaybeResolve` and `ResolveOrDefault`. 

These traits encapsulate behaviour where we need to resolve from a potentially context-dependent size / dimension into a context-independent size / dimensions. In other words:

1. A size can be one (`Dimension`) or two dimensional (`Size<Dimension>` / `Rect<Dimension>`)
2. These sizes can be fully defined on their own:
     1. `Dimension::Points(n)` tells us that this is `n` long
3. Or sizes can be dependent on the size of its parent
     1. `Dimension::Percent(n)` tells us that this is `n * parent.width` long
     2. _Hence "context-dependent"_
4. In order perform calculation of the node, we need the sizes to be fully independent of any parent context. This is where the `resolve` come in.

The only real difference between the two is what they output when they are unable to resolve the size
- `MaybeResolve` will return a `Option<f32>` with a `None` as the fallback
- `ResolveOrDefault` will return a `f32` with the value `0.0` as the fallback

## Changelog

- Created a new module `resolve` which houses all code related code
- Created the trait `MaybeResolve`
- Create the trait `ResolveOrDefault`
- `Dimension.resolve()` and `Size<Dimension>.resolve()` has been replaced by `impl MaybeResolve`
- Changed the signature of `compute_constants()` to make it easier to test
- Added `#[must_use]` on static constructors that was missing them
- Added convenience constructors on `Size<Dimension>`, `Rect<Dimension>`
- **[BREAKING]** `Size<f32>.zero()` has now become `Size::<f32>::ZERO`
- **[BREAKING]** `Point<f32>.zero()` has now become `Point::<f32>::ZERO`
- Added a `new()` constructor to `Size<f32>`
- Removed `Rect<T>.map` as not used anymore


## Feedback wanted

- Does the traits make sense and make the code cleaner + easier to understand?
- Docs help plz
