### PR TITLE
Cleanup `new_with_children()` uses

### DIFF
--- a/benches/complex.rs
+++ b/benches/complex.rs
@@ -2,53 +2,41 @@ use criterion::{criterion_group, criterion_main, Criterion};
 
 fn build_deep_hierarchy(taffy: &mut taffy::node::Taffy) -> taffy::node::Node {
     let node111 = taffy
-        .new_with_children(
-            taffy::style::FlexboxLayout {
-                size: taffy::geometry::Size {
-                    width: taffy::style::Dimension::Points(10.0),
-                    height: taffy::style::Dimension::Points(10.0),
-                },
-                ..Default::default()
+        .new_leaf(taffy::style::FlexboxLayout {
+            size: taffy::geometry::Size {
+                width: taffy::style::Dimension::Points(10.0),
+                height: taffy::style::Dimension::Points(10.0),
             },
-            &[],
-        )
+            ..Default::default()
+        })
         .unwrap();
     let node112 = taffy
-        .new_with_children(
-            taffy::style::FlexboxLayout {
-                size: taffy::geometry::Size {
-                    width: taffy::style::Dimension::Points(10.0),
-                    height: taffy::style::Dimension::Points(10.0),
-                },
-                ..Default::default()
+        .new_leaf(taffy::style::FlexboxLayout {
+            size: taffy::geometry::Size {
+                width: taffy::style::Dimension::Points(10.0),
+                height: taffy::style::Dimension::Points(10.0),
             },
-            &[],
-        )
+            ..Default::default()
+        })
         .unwrap();
 
     let node121 = taffy
-        .new_with_children(
-            taffy::style::FlexboxLayout {
-                size: taffy::geometry::Size {
-                    width: taffy::style::Dimension::Points(10.0),
-                    height: taffy::style::Dimension::Points(10.0),
-                },
-                ..Default::default()
+        .new_leaf(taffy::style::FlexboxLayout {
+            size: taffy::geometry::Size {
+                width: taffy::style::Dimension::Points(10.0),
+                height: taffy::style::Dimension::Points(10.0),
             },
-            &[],
-        )
+            ..Default::default()
+        })
         .unwrap();
     let node122 = taffy
-        .new_with_children(
-            taffy::style::FlexboxLayout {
-                size: taffy::geometry::Size {
-                    width: taffy::style::Dimension::Points(10.0),
-                    height: taffy::style::Dimension::Points(10.0),
-                },
-                ..Default::default()
+        .new_leaf(taffy::style::FlexboxLayout {
+            size: taffy::geometry::Size {
+                width: taffy::style::Dimension::Points(10.0),
+                height: taffy::style::Dimension::Points(10.0),
             },
-            &[],
-        )
+            ..Default::default()
+        })
         .unwrap();
 
     let node11 =
@@ -59,53 +47,41 @@ fn build_deep_hierarchy(taffy: &mut taffy::node::Taffy) -> taffy::node::Node {
         taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node11, node12]).unwrap();
 
     let node211 = taffy
-        .new_with_children(
-            taffy::style::FlexboxLayout {
-                size: taffy::geometry::Size {
-                    width: taffy::style::Dimension::Points(10.0),
-                    height: taffy::style::Dimension::Points(10.0),
-                },
-                ..Default::default()
+        .new_leaf(taffy::style::FlexboxLayout {
+            size: taffy::geometry::Size {
+                width: taffy::style::Dimension::Points(10.0),
+                height: taffy::style::Dimension::Points(10.0),
             },
-            &[],
-        )
+            ..Default::default()
+        })
         .unwrap();
     let node212 = taffy
-        .new_with_children(
-            taffy::style::FlexboxLayout {
-                size: taffy::geometry::Size {
-                    width: taffy::style::Dimension::Points(10.0),
-                    height: taffy::style::Dimension::Points(10.0),
-                },
-                ..Default::default()
+        .new_leaf(taffy::style::FlexboxLayout {
+            size: taffy::geometry::Size {
+                width: taffy::style::Dimension::Points(10.0),
+                height: taffy::style::Dimension::Points(10.0),
             },
-            &[],
-        )
+            ..Default::default()
+        })
         .unwrap();
 
     let node221 = taffy
-        .new_with_children(
-            taffy::style::FlexboxLayout {
-                size: taffy::geometry::Size {
-                    width: taffy::style::Dimension::Points(10.0),
-                    height: taffy::style::Dimension::Points(10.0),
-                },
-                ..Default::default()
+        .new_leaf(taffy::style::FlexboxLayout {
+            size: taffy::geometry::Size {
+                width: taffy::style::Dimension::Points(10.0),
+                height: taffy::style::Dimension::Points(10.0),
             },
-            &[],
-        )
+            ..Default::default()
+        })
         .unwrap();
     let node222 = taffy
-        .new_with_children(
-            taffy::style::FlexboxLayout {
-                size: taffy::geometry::Size {
-                    width: taffy::style::Dimension::Points(10.0),
-                    height: taffy::style::Dimension::Points(10.0),
-                },
-                ..Default::default()
+        .new_leaf(taffy::style::FlexboxLayout {
+            size: taffy::geometry::Size {
+                width: taffy::style::Dimension::Points(10.0),
+                height: taffy::style::Dimension::Points(10.0),
             },
-            &[],
-        )
+            ..Default::default()
+        })
         .unwrap();
 
     let node21 =

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -3,10 +3,10 @@ use taffy::prelude::*;
 fn main() -> Result<(), taffy::error::InvalidNode> {
     let mut taffy = Taffy::new();
 
-    let child = taffy.new_with_children(
-        FlexboxLayout { size: Size { width: Dimension::Percent(0.5), height: Dimension::Auto }, ..Default::default() },
-        &[],
-    )?;
+    let child = taffy.new_leaf(FlexboxLayout {
+        size: Size { width: Dimension::Percent(0.5), height: Dimension::Auto },
+        ..Default::default()
+    })?;
 
     let node = taffy.new_with_children(
         FlexboxLayout {

--- a/examples/nested.rs
+++ b/examples/nested.rs
@@ -4,13 +4,10 @@ fn main() -> Result<(), taffy::error::InvalidNode> {
     let mut taffy = Taffy::new();
 
     // left
-    let child_t1 = taffy.new_with_children(
-        FlexboxLayout {
-            size: Size { width: Dimension::Points(5.0), height: Dimension::Points(5.0) },
-            ..Default::default()
-        },
-        &[],
-    )?;
+    let child_t1 = taffy.new_leaf(FlexboxLayout {
+        size: Size { width: Dimension::Points(5.0), height: Dimension::Points(5.0) },
+        ..Default::default()
+    })?;
 
     let div1 = taffy.new_with_children(
         FlexboxLayout {
@@ -22,13 +19,10 @@ fn main() -> Result<(), taffy::error::InvalidNode> {
     )?;
 
     // right
-    let child_t2 = taffy.new_with_children(
-        FlexboxLayout {
-            size: Size { width: Dimension::Points(5.0), height: Dimension::Points(5.0) },
-            ..Default::default()
-        },
-        &[],
-    )?;
+    let child_t2 = taffy.new_leaf(FlexboxLayout {
+        size: Size { width: Dimension::Points(5.0), height: Dimension::Points(5.0) },
+        ..Default::default()
+    })?;
 
     let div2 = taffy.new_with_children(
         FlexboxLayout {

--- a/scripts/gentest/src/main.rs
+++ b/scripts/gentest/src/main.rs
@@ -425,6 +425,7 @@ fn generate_node(ident: &str, node: &json::JsonValue) -> TokenStream {
             ..Default::default()
         },
         #children
+        // TOOD: Only children if no children
     ).unwrap();)
 }
 

--- a/scripts/gentest/src/main.rs
+++ b/scripts/gentest/src/main.rs
@@ -425,7 +425,7 @@ fn generate_node(ident: &str, node: &json::JsonValue) -> TokenStream {
             ..Default::default()
         },
         #children
-        // TOOD: Only children if no children
+        // TODO: Only add children if they exist
     ).unwrap();)
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -476,7 +476,7 @@ mod tests {
     fn remove_node_should_remove() {
         let mut taffy = Taffy::new();
 
-        let node = taffy.new_with_children(FlexboxLayout::default(), &[]).unwrap();
+        let node = taffy.new_leaf(FlexboxLayout::default()).unwrap();
 
         // node should exist
         assert!(taffy.find_node(node).is_ok());

--- a/tests/measure.rs
+++ b/tests/measure.rs
@@ -118,7 +118,7 @@ mod measure {
     fn measure_child_with_flex_grow() {
         let mut taffy = taffy::node::Taffy::new();
         let child0 = taffy
-            .new_with_children(
+            .new_leaf(
                 taffy::style::FlexboxLayout {
                     size: taffy::geometry::Size {
                         width: taffy::style::Dimension::Points(50.0),
@@ -126,7 +126,6 @@ mod measure {
                     },
                     ..Default::default()
                 },
-                &[],
             )
             .unwrap();
 
@@ -160,7 +159,7 @@ mod measure {
     fn measure_child_with_flex_shrink() {
         let mut taffy = taffy::node::Taffy::new();
         let child0 = taffy
-            .new_with_children(
+            .new_leaf(
                 taffy::style::FlexboxLayout {
                     size: taffy::geometry::Size {
                         width: taffy::style::Dimension::Points(50.0),
@@ -169,7 +168,6 @@ mod measure {
                     flex_shrink: 0.0,
                     ..Default::default()
                 },
-                &[],
             )
             .unwrap();
 
@@ -203,7 +201,7 @@ mod measure {
     fn remeasure_child_after_growing() {
         let mut taffy = taffy::node::Taffy::new();
         let child0 = taffy
-            .new_with_children(
+            .new_leaf(
                 taffy::style::FlexboxLayout {
                     size: taffy::geometry::Size {
                         width: taffy::style::Dimension::Points(50.0),
@@ -211,7 +209,6 @@ mod measure {
                     },
                     ..Default::default()
                 },
-                &[],
             )
             .unwrap();
 
@@ -248,7 +245,7 @@ mod measure {
         let mut taffy = taffy::node::Taffy::new();
 
         let child0 = taffy
-            .new_with_children(
+            .new_leaf(
                 taffy::style::FlexboxLayout {
                     size: taffy::geometry::Size {
                         width: taffy::style::Dimension::Points(50.0),
@@ -257,7 +254,6 @@ mod measure {
                     flex_shrink: 0.0,
                     ..Default::default()
                 },
-                &[],
             )
             .unwrap();
 
@@ -373,13 +369,12 @@ mod measure {
     fn flex_basis_overrides_measure() {
         let mut taffy = taffy::node::Taffy::new();
         let child0 = taffy
-            .new_with_children(
+            .new_leaf(
                 taffy::style::FlexboxLayout {
                     flex_basis: taffy::style::Dimension::Points(50.0),
                     flex_grow: 1.0,
                     ..Default::default()
                 },
-                &[],
             )
             .unwrap();
 

--- a/tests/measure.rs
+++ b/tests/measure.rs
@@ -118,15 +118,13 @@ mod measure {
     fn measure_child_with_flex_grow() {
         let mut taffy = taffy::node::Taffy::new();
         let child0 = taffy
-            .new_leaf(
-                taffy::style::FlexboxLayout {
-                    size: taffy::geometry::Size {
-                        width: taffy::style::Dimension::Points(50.0),
-                        height: taffy::style::Dimension::Points(50.0),
-                    },
-                    ..Default::default()
+            .new_leaf(taffy::style::FlexboxLayout {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50.0),
+                    height: taffy::style::Dimension::Points(50.0),
                 },
-            )
+                ..Default::default()
+            })
             .unwrap();
 
         let child1 = taffy
@@ -159,16 +157,14 @@ mod measure {
     fn measure_child_with_flex_shrink() {
         let mut taffy = taffy::node::Taffy::new();
         let child0 = taffy
-            .new_leaf(
-                taffy::style::FlexboxLayout {
-                    size: taffy::geometry::Size {
-                        width: taffy::style::Dimension::Points(50.0),
-                        height: taffy::style::Dimension::Points(50.0),
-                    },
-                    flex_shrink: 0.0,
-                    ..Default::default()
+            .new_leaf(taffy::style::FlexboxLayout {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50.0),
+                    height: taffy::style::Dimension::Points(50.0),
                 },
-            )
+                flex_shrink: 0.0,
+                ..Default::default()
+            })
             .unwrap();
 
         let child1 = taffy
@@ -201,15 +197,13 @@ mod measure {
     fn remeasure_child_after_growing() {
         let mut taffy = taffy::node::Taffy::new();
         let child0 = taffy
-            .new_leaf(
-                taffy::style::FlexboxLayout {
-                    size: taffy::geometry::Size {
-                        width: taffy::style::Dimension::Points(50.0),
-                        height: taffy::style::Dimension::Points(50.0),
-                    },
-                    ..Default::default()
+            .new_leaf(taffy::style::FlexboxLayout {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50.0),
+                    height: taffy::style::Dimension::Points(50.0),
                 },
-            )
+                ..Default::default()
+            })
             .unwrap();
 
         let child1 = taffy
@@ -245,16 +239,14 @@ mod measure {
         let mut taffy = taffy::node::Taffy::new();
 
         let child0 = taffy
-            .new_leaf(
-                taffy::style::FlexboxLayout {
-                    size: taffy::geometry::Size {
-                        width: taffy::style::Dimension::Points(50.0),
-                        height: taffy::style::Dimension::Points(50.0),
-                    },
-                    flex_shrink: 0.0,
-                    ..Default::default()
+            .new_leaf(taffy::style::FlexboxLayout {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50.0),
+                    height: taffy::style::Dimension::Points(50.0),
                 },
-            )
+                flex_shrink: 0.0,
+                ..Default::default()
+            })
             .unwrap();
 
         let child1 = taffy
@@ -369,13 +361,11 @@ mod measure {
     fn flex_basis_overrides_measure() {
         let mut taffy = taffy::node::Taffy::new();
         let child0 = taffy
-            .new_leaf(
-                taffy::style::FlexboxLayout {
-                    flex_basis: taffy::style::Dimension::Points(50.0),
-                    flex_grow: 1.0,
-                    ..Default::default()
-                },
-            )
+            .new_leaf(taffy::style::FlexboxLayout {
+                flex_basis: taffy::style::Dimension::Points(50.0),
+                flex_grow: 1.0,
+                ..Default::default()
+            })
             .unwrap();
 
         let child1 = taffy

--- a/tests/relayout.rs
+++ b/tests/relayout.rs
@@ -4,12 +4,10 @@ use taffy::style::Dimension;
 fn relayout() {
     let mut taffy = taffy::Taffy::new();
     let node1 = taffy
-        .new_leaf(
-            taffy::style::FlexboxLayout {
-                size: taffy::geometry::Size { width: Dimension::Points(8f32), height: Dimension::Points(80f32) },
-                ..Default::default()
-            },
-        )
+        .new_leaf(taffy::style::FlexboxLayout {
+            size: taffy::geometry::Size { width: Dimension::Points(8f32), height: Dimension::Points(80f32) },
+            ..Default::default()
+        })
         .unwrap();
     let node0 = taffy
         .new_with_children(

--- a/tests/relayout.rs
+++ b/tests/relayout.rs
@@ -4,12 +4,11 @@ use taffy::style::Dimension;
 fn relayout() {
     let mut taffy = taffy::Taffy::new();
     let node1 = taffy
-        .new_with_children(
+        .new_leaf(
             taffy::style::FlexboxLayout {
                 size: taffy::geometry::Size { width: Dimension::Points(8f32), height: Dimension::Points(80f32) },
                 ..Default::default()
             },
-            &[],
         )
         .unwrap();
     let node0 = taffy

--- a/tests/root_constraints.rs
+++ b/tests/root_constraints.rs
@@ -5,15 +5,13 @@ mod root_constraints {
     fn root_with_percentage_size() {
         let mut taffy = taffy::node::Taffy::new();
         let node = taffy
-            .new_leaf(
-                taffy::style::FlexboxLayout {
-                    size: taffy::geometry::Size {
-                        width: taffy::style::Dimension::Percent(1.0),
-                        height: taffy::style::Dimension::Percent(1.0),
-                    },
-                    ..Default::default()
+            .new_leaf(taffy::style::FlexboxLayout {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(1.0),
+                    height: taffy::style::Dimension::Percent(1.0),
                 },
-            )
+                ..Default::default()
+            })
             .unwrap();
 
         taffy.compute_layout(node, taffy::geometry::Size { width: Some(100.0), height: Some(200.0) }).unwrap();
@@ -39,15 +37,13 @@ mod root_constraints {
     fn root_with_larger_size() {
         let mut taffy = taffy::node::Taffy::new();
         let node = taffy
-            .new_leaf(
-                taffy::style::FlexboxLayout {
-                    size: taffy::geometry::Size {
-                        width: taffy::style::Dimension::Points(200.0),
-                        height: taffy::style::Dimension::Points(200.0),
-                    },
-                    ..Default::default()
+            .new_leaf(taffy::style::FlexboxLayout {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200.0),
+                    height: taffy::style::Dimension::Points(200.0),
                 },
-            )
+                ..Default::default()
+            })
             .unwrap();
 
         taffy.compute_layout(node, taffy::geometry::Size { width: Some(100.0), height: Some(100.0) }).unwrap();

--- a/tests/root_constraints.rs
+++ b/tests/root_constraints.rs
@@ -5,7 +5,7 @@ mod root_constraints {
     fn root_with_percentage_size() {
         let mut taffy = taffy::node::Taffy::new();
         let node = taffy
-            .new_with_children(
+            .new_leaf(
                 taffy::style::FlexboxLayout {
                     size: taffy::geometry::Size {
                         width: taffy::style::Dimension::Percent(1.0),
@@ -13,7 +13,6 @@ mod root_constraints {
                     },
                     ..Default::default()
                 },
-                &[],
             )
             .unwrap();
 
@@ -27,7 +26,7 @@ mod root_constraints {
     #[test]
     fn root_with_no_size() {
         let mut taffy = taffy::node::Taffy::new();
-        let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[]).unwrap();
+        let node = taffy.new_leaf(taffy::style::FlexboxLayout { ..Default::default() }).unwrap();
 
         taffy.compute_layout(node, taffy::geometry::Size { width: Some(100.0), height: Some(100.0) }).unwrap();
         let layout = taffy.layout(node).unwrap();
@@ -40,7 +39,7 @@ mod root_constraints {
     fn root_with_larger_size() {
         let mut taffy = taffy::node::Taffy::new();
         let node = taffy
-            .new_with_children(
+            .new_leaf(
                 taffy::style::FlexboxLayout {
                     size: taffy::geometry::Size {
                         width: taffy::style::Dimension::Points(200.0),
@@ -48,7 +47,6 @@ mod root_constraints {
                     },
                     ..Default::default()
                 },
-                &[],
             )
             .unwrap();
 

--- a/tests/simple_child.rs
+++ b/tests/simple_child.rs
@@ -4,14 +4,11 @@ use taffy::{geometry::Point, style::Dimension};
 fn simple_child() {
     let mut taffy = taffy::Taffy::new();
     let node0_0 = taffy
-        .new_with_children(
-            taffy::style::FlexboxLayout {
-                align_self: taffy::prelude::AlignSelf::Center,
-                size: taffy::geometry::Size { width: Dimension::Points(10f32), height: Dimension::Points(10f32) },
-                ..Default::default()
-            },
-            &[],
-        )
+        .new_leaf(taffy::style::FlexboxLayout {
+            align_self: taffy::prelude::AlignSelf::Center,
+            size: taffy::geometry::Size { width: Dimension::Points(10f32), height: Dimension::Points(10f32) },
+            ..Default::default()
+        })
         .unwrap();
     let node0 = taffy
         .new_with_children(
@@ -23,24 +20,18 @@ fn simple_child() {
         )
         .unwrap();
     let node1_0 = taffy
-        .new_with_children(
-            taffy::style::FlexboxLayout {
-                align_self: taffy::prelude::AlignSelf::Center,
-                size: taffy::geometry::Size { width: Dimension::Points(10f32), height: Dimension::Points(10f32) },
-                ..Default::default()
-            },
-            &[],
-        )
+        .new_leaf(taffy::style::FlexboxLayout {
+            align_self: taffy::prelude::AlignSelf::Center,
+            size: taffy::geometry::Size { width: Dimension::Points(10f32), height: Dimension::Points(10f32) },
+            ..Default::default()
+        })
         .unwrap();
     let node1_1 = taffy
-        .new_with_children(
-            taffy::style::FlexboxLayout {
-                align_self: taffy::prelude::AlignSelf::Center,
-                size: taffy::geometry::Size { width: Dimension::Points(10f32), height: Dimension::Points(10f32) },
-                ..Default::default()
-            },
-            &[],
-        )
+        .new_leaf(taffy::style::FlexboxLayout {
+            align_self: taffy::prelude::AlignSelf::Center,
+            size: taffy::geometry::Size { width: Dimension::Points(10f32), height: Dimension::Points(10f32) },
+            ..Default::default()
+        })
         .unwrap();
     let node1 = taffy
         .new_with_children(


### PR DESCRIPTION
# Objective

Fixes #189 

## Context & Feedback

I haven't made any changes to the generated code nor it's generation-script, so it will keep producing leaf-nodes using `new_with_children()` but I reckon that is acceptable.
