### PR TITLE
Make library more usable in a `const` context

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,10 @@ If you are developing on macOS this is easy to do through brew.
 brew install chromedriver
 ```
 
+If you are Ubuntu, you will have to install `openssl` first,
+and then can follow [these instructions](https://tecadmin.net/setup-selenium-chromedriver-on-ubuntu/).
+Be sure that your Chrome vesion matches the downloaded `chromedriver` version!
+
 Once you have chromedriver installed and available in `PATH` you can re-generate all tests by running `cargo run --package gentest`. You should not manually update the tests in `tests/generated`. Instead, fix the script in `scripts/gentest/` and re-generate them. This can happen after a refactor. It can be helpful to commit the updated tests in a dedicated commit so that they can be easier to ignore during review.
 
 To add a new test case add another HTML file to `/test_fixtures` following the current tests as a template for new tests.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -26,7 +26,7 @@
 - `taffy::error::InvalidChild` is now `taffy::error::TaffyError`
 - `taffy::error::InvalidNode` has been removed and is now just a branch on the `TaffyError` enum
 - `taffy::forest::Forest` has been merged into `taffy::node::Taffy` for a performance boost up to 90%
-- `Size::NONE` has been removed, use `Size::NONE` instead.
+- `Size::undefined()` has been removed, use `Size::NONE` instead.
 
 ### 0.2.0 Fixed
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -26,7 +26,7 @@
 - `taffy::error::InvalidChild` is now `taffy::error::TaffyError`
 - `taffy::error::InvalidNode` has been removed and is now just a branch on the `TaffyError` enum
 - `taffy::forest::Forest` has been merged into `taffy::node::Taffy` for a performance boost up to 90%
-- `Size::undefined()` has been removed, use `Size::NONE` instead.
+- `Size::NONE` has been removed, use `Size::NONE` instead.
 
 ### 0.2.0 Fixed
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,8 @@
 
 - Added `taffy::error::InvalidChild` Error type
 - `taffy::node::Taffy.new_leaf()` which allows the creation of new leaf-nodes without having to supply a measure function
+- Builder methods are now `const` where possible
+  - Several convenenience constants have been defined: notably `FlexboxLayout::DEFAULT`
 
 ### 0.2.0 Changed
 
@@ -24,6 +26,7 @@
 - `taffy::error::InvalidChild` is now `taffy::error::TaffyError`
 - `taffy::error::InvalidNode` has been removed and is now just a branch on the `TaffyError` enum
 - `taffy::forest::Forest` has been merged into `taffy::node::Taffy` for a performance boost up to 90%
+- `Size::undefined()` has been removed, use `Size::NONE` instead.
 
 ### 0.2.0 Fixed
 

--- a/benches/complex.rs
+++ b/benches/complex.rs
@@ -107,7 +107,7 @@ fn taffy_benchmarks(c: &mut Criterion) {
         b.iter(|| {
             let mut taffy = taffy::node::Taffy::new();
             let root = build_deep_hierarchy(&mut taffy);
-            taffy.compute_layout(root, taffy::geometry::Size::undefined()).unwrap()
+            taffy.compute_layout(root, taffy::geometry::Size::NONE).unwrap()
         })
     });
 
@@ -117,7 +117,7 @@ fn taffy_benchmarks(c: &mut Criterion) {
 
         b.iter(|| {
             taffy.mark_dirty(root).unwrap();
-            taffy.compute_layout(root, taffy::geometry::Size::undefined()).unwrap()
+            taffy.compute_layout(root, taffy::geometry::Size::NONE).unwrap()
         })
     });
 }

--- a/benches/generated/absolute_layout_align_items_and_justify_content_center.rs
+++ b/benches/generated/absolute_layout_align_items_and_justify_content_center.rs
@@ -29,5 +29,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/absolute_layout_align_items_and_justify_content_center_and_bottom_position.rs
+++ b/benches/generated/absolute_layout_align_items_and_justify_content_center_and_bottom_position.rs
@@ -33,5 +33,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/absolute_layout_align_items_and_justify_content_center_and_left_position.rs
+++ b/benches/generated/absolute_layout_align_items_and_justify_content_center_and_left_position.rs
@@ -30,5 +30,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/absolute_layout_align_items_and_justify_content_center_and_right_position.rs
+++ b/benches/generated/absolute_layout_align_items_and_justify_content_center_and_right_position.rs
@@ -30,5 +30,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/absolute_layout_align_items_and_justify_content_center_and_top_position.rs
+++ b/benches/generated/absolute_layout_align_items_and_justify_content_center_and_top_position.rs
@@ -30,5 +30,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/absolute_layout_align_items_and_justify_content_flex_end.rs
+++ b/benches/generated/absolute_layout_align_items_and_justify_content_flex_end.rs
@@ -29,5 +29,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/absolute_layout_align_items_center.rs
+++ b/benches/generated/absolute_layout_align_items_center.rs
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/absolute_layout_align_items_center_on_child_only.rs
+++ b/benches/generated/absolute_layout_align_items_center_on_child_only.rs
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/absolute_layout_child_order.rs
+++ b/benches/generated/absolute_layout_child_order.rs
@@ -55,5 +55,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/absolute_layout_in_wrap_reverse_column_container.rs
+++ b/benches/generated/absolute_layout_in_wrap_reverse_column_container.rs
@@ -29,5 +29,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/absolute_layout_in_wrap_reverse_column_container_flex_end.rs
+++ b/benches/generated/absolute_layout_in_wrap_reverse_column_container_flex_end.rs
@@ -30,5 +30,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/absolute_layout_in_wrap_reverse_row_container.rs
+++ b/benches/generated/absolute_layout_in_wrap_reverse_row_container.rs
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/absolute_layout_in_wrap_reverse_row_container_flex_end.rs
+++ b/benches/generated/absolute_layout_in_wrap_reverse_row_container_flex_end.rs
@@ -29,5 +29,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/absolute_layout_justify_content_center.rs
+++ b/benches/generated/absolute_layout_justify_content_center.rs
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/absolute_layout_no_size.rs
+++ b/benches/generated/absolute_layout_no_size.rs
@@ -19,5 +19,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/absolute_layout_percentage_bottom_based_on_parent_height.rs
+++ b/benches/generated/absolute_layout_percentage_bottom_based_on_parent_height.rs
@@ -61,5 +61,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/absolute_layout_start_top_end_bottom.rs
+++ b/benches/generated/absolute_layout_start_top_end_bottom.rs
@@ -29,5 +29,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/absolute_layout_width_height_end_bottom.rs
+++ b/benches/generated/absolute_layout_width_height_end_bottom.rs
@@ -32,5 +32,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/absolute_layout_width_height_start_top.rs
+++ b/benches/generated/absolute_layout_width_height_start_top.rs
@@ -32,5 +32,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/absolute_layout_width_height_start_top_end_bottom.rs
+++ b/benches/generated/absolute_layout_width_height_start_top_end_bottom.rs
@@ -34,5 +34,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/absolute_layout_within_border.rs
+++ b/benches/generated/absolute_layout_within_border.rs
@@ -117,5 +117,5 @@ pub fn compute() {
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/align_baseline.rs
+++ b/benches/generated/align_baseline.rs
@@ -40,5 +40,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/align_baseline_child_multiline.rs
+++ b/benches/generated/align_baseline_child_multiline.rs
@@ -85,5 +85,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/align_baseline_nested_child.rs
+++ b/benches/generated/align_baseline_nested_child.rs
@@ -54,5 +54,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/align_center_should_size_based_on_content.rs
+++ b/benches/generated/align_center_should_size_based_on_content.rs
@@ -44,5 +44,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/align_flex_start_with_shrinking_children.rs
+++ b/benches/generated/align_flex_start_with_shrinking_children.rs
@@ -31,5 +31,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/align_flex_start_with_shrinking_children_with_stretch.rs
+++ b/benches/generated/align_flex_start_with_shrinking_children_with_stretch.rs
@@ -31,5 +31,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/align_flex_start_with_stretching_children.rs
+++ b/benches/generated/align_flex_start_with_stretching_children.rs
@@ -26,5 +26,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/align_items_center.rs
+++ b/benches/generated/align_items_center.rs
@@ -27,5 +27,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/align_items_center_child_with_margin_bigger_than_parent.rs
+++ b/benches/generated/align_items_center_child_with_margin_bigger_than_parent.rs
@@ -39,5 +39,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/align_items_center_child_without_margin_bigger_than_parent.rs
+++ b/benches/generated/align_items_center_child_without_margin_bigger_than_parent.rs
@@ -34,5 +34,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/align_items_center_with_child_margin.rs
+++ b/benches/generated/align_items_center_with_child_margin.rs
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/align_items_center_with_child_top.rs
+++ b/benches/generated/align_items_center_with_child_top.rs
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/align_items_flex_end.rs
+++ b/benches/generated/align_items_flex_end.rs
@@ -27,5 +27,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/align_items_flex_end_child_with_margin_bigger_than_parent.rs
+++ b/benches/generated/align_items_flex_end_child_with_margin_bigger_than_parent.rs
@@ -39,5 +39,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/align_items_flex_end_child_without_margin_bigger_than_parent.rs
+++ b/benches/generated/align_items_flex_end_child_without_margin_bigger_than_parent.rs
@@ -34,5 +34,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/align_items_flex_start.rs
+++ b/benches/generated/align_items_flex_start.rs
@@ -27,5 +27,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/align_items_min_max.rs
+++ b/benches/generated/align_items_min_max.rs
@@ -32,5 +32,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/align_items_stretch.rs
+++ b/benches/generated/align_items_stretch.rs
@@ -22,5 +22,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/align_self_baseline.rs
+++ b/benches/generated/align_self_baseline.rs
@@ -54,5 +54,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/align_self_center.rs
+++ b/benches/generated/align_self_center.rs
@@ -27,5 +27,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/align_self_flex_end.rs
+++ b/benches/generated/align_self_flex_end.rs
@@ -27,5 +27,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/align_self_flex_end_override_flex_start.rs
+++ b/benches/generated/align_self_flex_end_override_flex_start.rs
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/align_self_flex_start.rs
+++ b/benches/generated/align_self_flex_start.rs
@@ -27,5 +27,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/align_strech_should_size_based_on_parent.rs
+++ b/benches/generated/align_strech_should_size_based_on_parent.rs
@@ -43,5 +43,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/border_center_child.rs
+++ b/benches/generated/border_center_child.rs
@@ -33,5 +33,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/border_flex_child.rs
+++ b/benches/generated/border_flex_child.rs
@@ -30,5 +30,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/border_no_child.rs
+++ b/benches/generated/border_no_child.rs
@@ -15,5 +15,5 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/border_stretch_child.rs
+++ b/benches/generated/border_stretch_child.rs
@@ -29,5 +29,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/child_min_max_width_flexing.rs
+++ b/benches/generated/child_min_max_width_flexing.rs
@@ -37,5 +37,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/container_with_unsized_child.rs
+++ b/benches/generated/container_with_unsized_child.rs
@@ -14,5 +14,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/display_none.rs
+++ b/benches/generated/display_none.rs
@@ -21,5 +21,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/display_none_fixed_size.rs
+++ b/benches/generated/display_none_fixed_size.rs
@@ -29,5 +29,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/display_none_with_child.rs
+++ b/benches/generated/display_none_with_child.rs
@@ -60,5 +60,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/display_none_with_margin.rs
+++ b/benches/generated/display_none_with_margin.rs
@@ -36,5 +36,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/display_none_with_position.rs
+++ b/benches/generated/display_none_with_position.rs
@@ -26,5 +26,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_basis_and_main_dimen_set_when_flexing.rs
+++ b/benches/generated/flex_basis_and_main_dimen_set_when_flexing.rs
@@ -39,5 +39,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_basis_flex_grow_column.rs
+++ b/benches/generated/flex_basis_flex_grow_column.rs
@@ -26,5 +26,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_basis_flex_grow_row.rs
+++ b/benches/generated/flex_basis_flex_grow_row.rs
@@ -25,5 +25,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_basis_flex_shrink_column.rs
+++ b/benches/generated/flex_basis_flex_shrink_column.rs
@@ -26,5 +26,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_basis_flex_shrink_row.rs
+++ b/benches/generated/flex_basis_flex_shrink_row.rs
@@ -25,5 +25,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_basis_larger_than_content_column.rs
+++ b/benches/generated/flex_basis_larger_than_content_column.rs
@@ -33,5 +33,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_basis_larger_than_content_row.rs
+++ b/benches/generated/flex_basis_larger_than_content_row.rs
@@ -32,5 +32,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_basis_overrides_main_size.rs
+++ b/benches/generated/flex_basis_overrides_main_size.rs
@@ -44,5 +44,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_basis_slightly_smaller_then_content_with_flex_grow_large_size.rs
+++ b/benches/generated/flex_basis_slightly_smaller_then_content_with_flex_grow_large_size.rs
@@ -57,5 +57,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_basis_smaller_than_content_column.rs
+++ b/benches/generated/flex_basis_smaller_than_content_column.rs
@@ -33,5 +33,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_basis_smaller_than_content_row.rs
+++ b/benches/generated/flex_basis_smaller_than_content_row.rs
@@ -32,5 +32,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_basis_smaller_than_main_dimen_column.rs
+++ b/benches/generated/flex_basis_smaller_than_main_dimen_column.rs
@@ -24,5 +24,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_basis_smaller_than_main_dimen_row.rs
+++ b/benches/generated/flex_basis_smaller_than_main_dimen_row.rs
@@ -23,5 +23,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_basis_smaller_then_content_with_flex_grow_large_size.rs
+++ b/benches/generated/flex_basis_smaller_then_content_with_flex_grow_large_size.rs
@@ -57,5 +57,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_basis_smaller_then_content_with_flex_grow_small_size.rs
+++ b/benches/generated/flex_basis_smaller_then_content_with_flex_grow_small_size.rs
@@ -57,5 +57,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_basis_smaller_then_content_with_flex_grow_unconstraint_size.rs
+++ b/benches/generated/flex_basis_smaller_then_content_with_flex_grow_unconstraint_size.rs
@@ -49,5 +49,5 @@ pub fn compute() {
         )
         .unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0, node1]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_basis_smaller_then_content_with_flex_grow_very_large_size.rs
+++ b/benches/generated/flex_basis_smaller_then_content_with_flex_grow_very_large_size.rs
@@ -57,5 +57,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_basis_unconstraint_column.rs
+++ b/benches/generated/flex_basis_unconstraint_column.rs
@@ -16,5 +16,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_basis_unconstraint_row.rs
+++ b/benches/generated/flex_basis_unconstraint_row.rs
@@ -11,5 +11,5 @@ pub fn compute() {
         )
         .unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_direction_column.rs
+++ b/benches/generated/flex_direction_column.rs
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_direction_column_no_height.rs
+++ b/benches/generated/flex_direction_column_no_height.rs
@@ -37,5 +37,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_direction_column_reverse.rs
+++ b/benches/generated/flex_direction_column_reverse.rs
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_direction_row.rs
+++ b/benches/generated/flex_direction_row.rs
@@ -40,5 +40,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_direction_row_no_width.rs
+++ b/benches/generated/flex_direction_row_no_width.rs
@@ -36,5 +36,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_direction_row_reverse.rs
+++ b/benches/generated/flex_direction_row_reverse.rs
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_grow_child.rs
+++ b/benches/generated/flex_grow_child.rs
@@ -12,5 +12,5 @@ pub fn compute() {
         )
         .unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_grow_flex_basis_percent_min_max.rs
+++ b/benches/generated/flex_grow_flex_basis_percent_min_max.rs
@@ -39,5 +39,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_grow_height_maximized.rs
+++ b/benches/generated/flex_grow_height_maximized.rs
@@ -51,5 +51,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_grow_in_at_most_container.rs
+++ b/benches/generated/flex_grow_in_at_most_container.rs
@@ -25,5 +25,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_grow_less_than_factor_one.rs
+++ b/benches/generated/flex_grow_less_than_factor_one.rs
@@ -36,5 +36,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_grow_root_minimized.rs
+++ b/benches/generated/flex_grow_root_minimized.rs
@@ -55,5 +55,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_grow_shrink_at_most.rs
+++ b/benches/generated/flex_grow_shrink_at_most.rs
@@ -20,5 +20,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_grow_to_min.rs
+++ b/benches/generated/flex_grow_to_min.rs
@@ -33,5 +33,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_grow_within_constrained_max_column.rs
+++ b/benches/generated/flex_grow_within_constrained_max_column.rs
@@ -33,5 +33,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_grow_within_constrained_max_row.rs
+++ b/benches/generated/flex_grow_within_constrained_max_row.rs
@@ -42,5 +42,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_grow_within_constrained_max_width.rs
+++ b/benches/generated/flex_grow_within_constrained_max_width.rs
@@ -36,5 +36,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_grow_within_constrained_min_column.rs
+++ b/benches/generated/flex_grow_within_constrained_min_column.rs
@@ -24,5 +24,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_grow_within_constrained_min_max_column.rs
+++ b/benches/generated/flex_grow_within_constrained_min_max_column.rs
@@ -23,5 +23,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_grow_within_constrained_min_row.rs
+++ b/benches/generated/flex_grow_within_constrained_min_row.rs
@@ -24,5 +24,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_grow_within_max_width.rs
+++ b/benches/generated/flex_grow_within_max_width.rs
@@ -36,5 +36,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_root_ignored.rs
+++ b/benches/generated/flex_root_ignored.rs
@@ -37,5 +37,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_shrink_by_outer_margin_with_max_size.rs
+++ b/benches/generated/flex_shrink_by_outer_margin_with_max_size.rs
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_shrink_flex_grow_child_flex_shrink_other_child.rs
+++ b/benches/generated/flex_shrink_flex_grow_child_flex_shrink_other_child.rs
@@ -43,5 +43,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_shrink_flex_grow_row.rs
+++ b/benches/generated/flex_shrink_flex_grow_row.rs
@@ -43,5 +43,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_shrink_to_zero.rs
+++ b/benches/generated/flex_shrink_to_zero.rs
@@ -51,5 +51,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_wrap_align_stretch_fits_one_row.rs
+++ b/benches/generated/flex_wrap_align_stretch_fits_one_row.rs
@@ -32,5 +32,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_wrap_children_with_min_main_overriding_flex_basis.rs
+++ b/benches/generated/flex_wrap_children_with_min_main_overriding_flex_basis.rs
@@ -32,5 +32,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/flex_wrap_wrap_to_child_height.rs
+++ b/benches/generated/flex_wrap_wrap_to_child_height.rs
@@ -52,5 +52,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/justify_content_column_center.rs
+++ b/benches/generated/justify_content_column_center.rs
@@ -42,5 +42,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/justify_content_column_flex_end.rs
+++ b/benches/generated/justify_content_column_flex_end.rs
@@ -42,5 +42,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/justify_content_column_flex_start.rs
+++ b/benches/generated/justify_content_column_flex_start.rs
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/justify_content_column_min_height_and_margin_bottom.rs
+++ b/benches/generated/justify_content_column_min_height_and_margin_bottom.rs
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/justify_content_column_min_height_and_margin_top.rs
+++ b/benches/generated/justify_content_column_min_height_and_margin_top.rs
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/justify_content_column_space_around.rs
+++ b/benches/generated/justify_content_column_space_around.rs
@@ -42,5 +42,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/justify_content_column_space_between.rs
+++ b/benches/generated/justify_content_column_space_between.rs
@@ -42,5 +42,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/justify_content_column_space_evenly.rs
+++ b/benches/generated/justify_content_column_space_evenly.rs
@@ -42,5 +42,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/justify_content_min_max.rs
+++ b/benches/generated/justify_content_min_max.rs
@@ -32,5 +32,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/justify_content_min_width_with_padding_child_width_greater_than_parent.rs
+++ b/benches/generated/justify_content_min_width_with_padding_child_width_greater_than_parent.rs
@@ -46,5 +46,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/justify_content_min_width_with_padding_child_width_lower_than_parent.rs
+++ b/benches/generated/justify_content_min_width_with_padding_child_width_lower_than_parent.rs
@@ -46,5 +46,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/justify_content_overflow_min_max.rs
+++ b/benches/generated/justify_content_overflow_min_max.rs
@@ -60,5 +60,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/justify_content_row_center.rs
+++ b/benches/generated/justify_content_row_center.rs
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/justify_content_row_flex_end.rs
+++ b/benches/generated/justify_content_row_flex_end.rs
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/justify_content_row_flex_start.rs
+++ b/benches/generated/justify_content_row_flex_start.rs
@@ -40,5 +40,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/justify_content_row_max_width_and_margin.rs
+++ b/benches/generated/justify_content_row_max_width_and_margin.rs
@@ -25,5 +25,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/justify_content_row_min_width_and_margin.rs
+++ b/benches/generated/justify_content_row_min_width_and_margin.rs
@@ -24,5 +24,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/justify_content_row_space_around.rs
+++ b/benches/generated/justify_content_row_space_around.rs
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/justify_content_row_space_between.rs
+++ b/benches/generated/justify_content_row_space_between.rs
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/justify_content_row_space_evenly.rs
+++ b/benches/generated/justify_content_row_space_evenly.rs
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/margin_and_flex_column.rs
+++ b/benches/generated/margin_and_flex_column.rs
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/margin_and_flex_row.rs
+++ b/benches/generated/margin_and_flex_row.rs
@@ -27,5 +27,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/margin_and_stretch_column.rs
+++ b/benches/generated/margin_and_stretch_column.rs
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/margin_and_stretch_row.rs
+++ b/benches/generated/margin_and_stretch_row.rs
@@ -27,5 +27,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/margin_auto_bottom.rs
+++ b/benches/generated/margin_auto_bottom.rs
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/margin_auto_bottom_and_top.rs
+++ b/benches/generated/margin_auto_bottom_and_top.rs
@@ -45,5 +45,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/margin_auto_bottom_and_top_justify_center.rs
+++ b/benches/generated/margin_auto_bottom_and_top_justify_center.rs
@@ -45,5 +45,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/margin_auto_left.rs
+++ b/benches/generated/margin_auto_left.rs
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/margin_auto_left_and_right.rs
+++ b/benches/generated/margin_auto_left_and_right.rs
@@ -44,5 +44,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/margin_auto_left_and_right_column.rs
+++ b/benches/generated/margin_auto_left_and_right_column.rs
@@ -45,5 +45,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/margin_auto_left_and_right_column_and_center.rs
+++ b/benches/generated/margin_auto_left_and_right_column_and_center.rs
@@ -45,5 +45,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/margin_auto_left_and_right_strech.rs
+++ b/benches/generated/margin_auto_left_and_right_strech.rs
@@ -44,5 +44,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/margin_auto_left_child_bigger_than_parent.rs
+++ b/benches/generated/margin_auto_left_child_bigger_than_parent.rs
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/margin_auto_left_fix_right_child_bigger_than_parent.rs
+++ b/benches/generated/margin_auto_left_fix_right_child_bigger_than_parent.rs
@@ -32,5 +32,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/margin_auto_left_right_child_bigger_than_parent.rs
+++ b/benches/generated/margin_auto_left_right_child_bigger_than_parent.rs
@@ -32,5 +32,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/margin_auto_left_stretching_child.rs
+++ b/benches/generated/margin_auto_left_stretching_child.rs
@@ -39,5 +39,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/margin_auto_mutiple_children_column.rs
+++ b/benches/generated/margin_auto_mutiple_children_column.rs
@@ -56,5 +56,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/margin_auto_mutiple_children_row.rs
+++ b/benches/generated/margin_auto_mutiple_children_row.rs
@@ -55,5 +55,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/margin_auto_right.rs
+++ b/benches/generated/margin_auto_right.rs
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/margin_auto_top.rs
+++ b/benches/generated/margin_auto_top.rs
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/margin_auto_top_and_bottom_strech.rs
+++ b/benches/generated/margin_auto_top_and_bottom_strech.rs
@@ -45,5 +45,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/margin_auto_top_stretching_child.rs
+++ b/benches/generated/margin_auto_top_stretching_child.rs
@@ -39,5 +39,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/margin_bottom.rs
+++ b/benches/generated/margin_bottom.rs
@@ -25,5 +25,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/margin_fix_left_auto_right_child_bigger_than_parent.rs
+++ b/benches/generated/margin_fix_left_auto_right_child_bigger_than_parent.rs
@@ -32,5 +32,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/margin_left.rs
+++ b/benches/generated/margin_left.rs
@@ -23,5 +23,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/margin_right.rs
+++ b/benches/generated/margin_right.rs
@@ -24,5 +24,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/margin_should_not_be_part_of_max_height.rs
+++ b/benches/generated/margin_should_not_be_part_of_max_height.rs
@@ -31,5 +31,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/margin_should_not_be_part_of_max_width.rs
+++ b/benches/generated/margin_should_not_be_part_of_max_width.rs
@@ -31,5 +31,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/margin_top.rs
+++ b/benches/generated/margin_top.rs
@@ -24,5 +24,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/margin_with_sibling_column.rs
+++ b/benches/generated/margin_with_sibling_column.rs
@@ -26,5 +26,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/margin_with_sibling_row.rs
+++ b/benches/generated/margin_with_sibling_row.rs
@@ -25,5 +25,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/max_height.rs
+++ b/benches/generated/max_height.rs
@@ -26,5 +26,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/max_height_overrides_height.rs
+++ b/benches/generated/max_height_overrides_height.rs
@@ -14,5 +14,5 @@ pub fn compute() {
         )
         .unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/max_height_overrides_height_on_root.rs
+++ b/benches/generated/max_height_overrides_height_on_root.rs
@@ -13,5 +13,5 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/max_width.rs
+++ b/benches/generated/max_width.rs
@@ -24,5 +24,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/max_width_overrides_width.rs
+++ b/benches/generated/max_width_overrides_width.rs
@@ -14,5 +14,5 @@ pub fn compute() {
         )
         .unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/max_width_overrides_width_on_root.rs
+++ b/benches/generated/max_width_overrides_width_on_root.rs
@@ -13,5 +13,5 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/min_height.rs
+++ b/benches/generated/min_height.rs
@@ -29,5 +29,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/min_height_overrides_height.rs
+++ b/benches/generated/min_height_overrides_height.rs
@@ -14,5 +14,5 @@ pub fn compute() {
         )
         .unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/min_height_overrides_height_on_root.rs
+++ b/benches/generated/min_height_overrides_height_on_root.rs
@@ -13,5 +13,5 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/min_max_percent_no_width_height.rs
+++ b/benches/generated/min_max_percent_no_width_height.rs
@@ -33,5 +33,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/min_width.rs
+++ b/benches/generated/min_width.rs
@@ -25,5 +25,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/min_width_overrides_width.rs
+++ b/benches/generated/min_width_overrides_width.rs
@@ -14,5 +14,5 @@ pub fn compute() {
         )
         .unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/min_width_overrides_width_on_root.rs
+++ b/benches/generated/min_width_overrides_width_on_root.rs
@@ -13,5 +13,5 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/nested_overflowing_child.rs
+++ b/benches/generated/nested_overflowing_child.rs
@@ -27,5 +27,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/nested_overflowing_child_in_constraint_parent.rs
+++ b/benches/generated/nested_overflowing_child_in_constraint_parent.rs
@@ -39,5 +39,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/overflow_cross_axis.rs
+++ b/benches/generated/overflow_cross_axis.rs
@@ -26,5 +26,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/overflow_main_axis.rs
+++ b/benches/generated/overflow_main_axis.rs
@@ -23,5 +23,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/padding_align_end_child.rs
+++ b/benches/generated/padding_align_end_child.rs
@@ -35,5 +35,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/padding_center_child.rs
+++ b/benches/generated/padding_center_child.rs
@@ -35,5 +35,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/padding_flex_child.rs
+++ b/benches/generated/padding_flex_child.rs
@@ -30,5 +30,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/padding_no_child.rs
+++ b/benches/generated/padding_no_child.rs
@@ -15,5 +15,5 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/padding_stretch_child.rs
+++ b/benches/generated/padding_stretch_child.rs
@@ -29,5 +29,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/parent_wrap_child_size_overflowing_parent.rs
+++ b/benches/generated/parent_wrap_child_size_overflowing_parent.rs
@@ -35,5 +35,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/percent_absolute_position.rs
+++ b/benches/generated/percent_absolute_position.rs
@@ -50,5 +50,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/percent_within_flex_grow.rs
+++ b/benches/generated/percent_within_flex_grow.rs
@@ -50,5 +50,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/percentage_absolute_position.rs
+++ b/benches/generated/percentage_absolute_position.rs
@@ -33,5 +33,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/percentage_container_in_wrapping_container.rs
+++ b/benches/generated/percentage_container_in_wrapping_container.rs
@@ -58,5 +58,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/percentage_flex_basis.rs
+++ b/benches/generated/percentage_flex_basis.rs
@@ -33,5 +33,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/percentage_flex_basis_cross.rs
+++ b/benches/generated/percentage_flex_basis_cross.rs
@@ -34,5 +34,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/percentage_flex_basis_cross_max_height.rs
+++ b/benches/generated/percentage_flex_basis_cross_max_height.rs
@@ -42,5 +42,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/percentage_flex_basis_cross_max_width.rs
+++ b/benches/generated/percentage_flex_basis_cross_max_width.rs
@@ -42,5 +42,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/percentage_flex_basis_cross_min_height.rs
+++ b/benches/generated/percentage_flex_basis_cross_min_height.rs
@@ -40,5 +40,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/percentage_flex_basis_cross_min_width.rs
+++ b/benches/generated/percentage_flex_basis_cross_min_width.rs
@@ -42,5 +42,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/percentage_flex_basis_main_max_height.rs
+++ b/benches/generated/percentage_flex_basis_main_max_height.rs
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/percentage_flex_basis_main_max_width.rs
+++ b/benches/generated/percentage_flex_basis_main_max_width.rs
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/percentage_flex_basis_main_min_width.rs
+++ b/benches/generated/percentage_flex_basis_main_min_width.rs
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/percentage_margin_should_calculate_based_only_on_width.rs
+++ b/benches/generated/percentage_margin_should_calculate_based_only_on_width.rs
@@ -44,5 +44,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/percentage_multiple_nested_with_padding_margin_and_percentage_values.rs
+++ b/benches/generated/percentage_multiple_nested_with_padding_margin_and_percentage_values.rs
@@ -104,5 +104,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/percentage_padding_should_calculate_based_only_on_width.rs
+++ b/benches/generated/percentage_padding_should_calculate_based_only_on_width.rs
@@ -44,5 +44,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/percentage_position_bottom_right.rs
+++ b/benches/generated/percentage_position_bottom_right.rs
@@ -31,5 +31,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/percentage_position_left_top.rs
+++ b/benches/generated/percentage_position_left_top.rs
@@ -31,5 +31,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/percentage_size_based_on_parent_inner_size.rs
+++ b/benches/generated/percentage_size_based_on_parent_inner_size.rs
@@ -34,5 +34,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/percentage_size_of_flex_basis.rs
+++ b/benches/generated/percentage_size_of_flex_basis.rs
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/percentage_width_height.rs
+++ b/benches/generated/percentage_width_height.rs
@@ -26,5 +26,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/percentage_width_height_undefined_parent_size.rs
+++ b/benches/generated/percentage_width_height_undefined_parent_size.rs
@@ -19,5 +19,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/relative_position_should_not_nudge_siblings.rs
+++ b/benches/generated/relative_position_should_not_nudge_siblings.rs
@@ -34,5 +34,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/rounding_flex_basis_flex_grow_row_prime_number_width.rs
+++ b/benches/generated/rounding_flex_basis_flex_grow_row_prime_number_width.rs
@@ -23,5 +23,5 @@ pub fn compute() {
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/rounding_flex_basis_flex_grow_row_width_of_100.rs
+++ b/benches/generated/rounding_flex_basis_flex_grow_row_width_of_100.rs
@@ -19,5 +19,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/rounding_flex_basis_flex_shrink_row.rs
+++ b/benches/generated/rounding_flex_basis_flex_shrink_row.rs
@@ -35,5 +35,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/rounding_flex_basis_overrides_main_size.rs
+++ b/benches/generated/rounding_flex_basis_overrides_main_size.rs
@@ -45,5 +45,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/rounding_fractial_input_1.rs
+++ b/benches/generated/rounding_fractial_input_1.rs
@@ -45,5 +45,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/rounding_fractial_input_2.rs
+++ b/benches/generated/rounding_fractial_input_2.rs
@@ -45,5 +45,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/rounding_fractial_input_3.rs
+++ b/benches/generated/rounding_fractial_input_3.rs
@@ -45,5 +45,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/rounding_fractial_input_4.rs
+++ b/benches/generated/rounding_fractial_input_4.rs
@@ -45,5 +45,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/rounding_total_fractial.rs
+++ b/benches/generated/rounding_total_fractial.rs
@@ -45,5 +45,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/rounding_total_fractial_nested.rs
+++ b/benches/generated/rounding_total_fractial_nested.rs
@@ -73,5 +73,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/size_defined_by_child.rs
+++ b/benches/generated/size_defined_by_child.rs
@@ -14,5 +14,5 @@ pub fn compute() {
         )
         .unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/size_defined_by_child_with_border.rs
+++ b/benches/generated/size_defined_by_child_with_border.rs
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/size_defined_by_child_with_padding.rs
+++ b/benches/generated/size_defined_by_child_with_padding.rs
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/size_defined_by_grand_child.rs
+++ b/benches/generated/size_defined_by_grand_child.rs
@@ -15,5 +15,5 @@ pub fn compute() {
         .unwrap();
     let node0 = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node00]).unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/width_smaller_then_content_with_flex_grow_large_size.rs
+++ b/benches/generated/width_smaller_then_content_with_flex_grow_large_size.rs
@@ -57,5 +57,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/width_smaller_then_content_with_flex_grow_small_size.rs
+++ b/benches/generated/width_smaller_then_content_with_flex_grow_small_size.rs
@@ -57,5 +57,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/width_smaller_then_content_with_flex_grow_unconstraint_size.rs
+++ b/benches/generated/width_smaller_then_content_with_flex_grow_unconstraint_size.rs
@@ -49,5 +49,5 @@ pub fn compute() {
         )
         .unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0, node1]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/width_smaller_then_content_with_flex_grow_very_large_size.rs
+++ b/benches/generated/width_smaller_then_content_with_flex_grow_very_large_size.rs
@@ -57,5 +57,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/wrap_column.rs
+++ b/benches/generated/wrap_column.rs
@@ -67,5 +67,5 @@ pub fn compute() {
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/wrap_nodes_with_content_sizing_margin_cross.rs
+++ b/benches/generated/wrap_nodes_with_content_sizing_margin_cross.rs
@@ -66,5 +66,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/wrap_nodes_with_content_sizing_overflowing_margin.rs
+++ b/benches/generated/wrap_nodes_with_content_sizing_overflowing_margin.rs
@@ -66,5 +66,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/wrap_reverse_column.rs
+++ b/benches/generated/wrap_reverse_column.rs
@@ -67,5 +67,5 @@ pub fn compute() {
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/wrap_reverse_column_fixed_size.rs
+++ b/benches/generated/wrap_reverse_column_fixed_size.rs
@@ -81,5 +81,5 @@ pub fn compute() {
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/wrap_reverse_row.rs
+++ b/benches/generated/wrap_reverse_row.rs
@@ -62,5 +62,5 @@ pub fn compute() {
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/wrap_reverse_row_align_content_center.rs
+++ b/benches/generated/wrap_reverse_row_align_content_center.rs
@@ -76,5 +76,5 @@ pub fn compute() {
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/wrap_reverse_row_align_content_flex_start.rs
+++ b/benches/generated/wrap_reverse_row_align_content_flex_start.rs
@@ -76,5 +76,5 @@ pub fn compute() {
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/wrap_reverse_row_align_content_space_around.rs
+++ b/benches/generated/wrap_reverse_row_align_content_space_around.rs
@@ -76,5 +76,5 @@ pub fn compute() {
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/wrap_reverse_row_align_content_stretch.rs
+++ b/benches/generated/wrap_reverse_row_align_content_stretch.rs
@@ -75,5 +75,5 @@ pub fn compute() {
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/wrap_reverse_row_single_line_different_size.rs
+++ b/benches/generated/wrap_reverse_row_single_line_different_size.rs
@@ -76,5 +76,5 @@ pub fn compute() {
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/wrap_row.rs
+++ b/benches/generated/wrap_row.rs
@@ -62,5 +62,5 @@ pub fn compute() {
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/wrap_row_align_items_center.rs
+++ b/benches/generated/wrap_row_align_items_center.rs
@@ -63,5 +63,5 @@ pub fn compute() {
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/wrap_row_align_items_flex_end.rs
+++ b/benches/generated/wrap_row_align_items_flex_end.rs
@@ -63,5 +63,5 @@ pub fn compute() {
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/wrapped_column_max_height.rs
+++ b/benches/generated/wrapped_column_max_height.rs
@@ -68,5 +68,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/wrapped_column_max_height_flex.rs
+++ b/benches/generated/wrapped_column_max_height_flex.rs
@@ -74,5 +74,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/wrapped_row_within_align_items_center.rs
+++ b/benches/generated/wrapped_row_within_align_items_center.rs
@@ -47,5 +47,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/wrapped_row_within_align_items_flex_end.rs
+++ b/benches/generated/wrapped_row_within_align_items_flex_end.rs
@@ -47,5 +47,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/benches/generated/wrapped_row_within_align_items_flex_start.rs
+++ b/benches/generated/wrapped_row_within_align_items_flex_start.rs
@@ -47,5 +47,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -20,7 +20,7 @@ fn main() -> Result<(), taffy::error::TaffyError> {
     taffy.compute_layout(node, Size { height: Some(100.0), width: Some(100.0) })?;
 
     // or just use undefined for 100 x 100
-    // taffy.compute_layout(node, Size::undefined())?;
+    // taffy.compute_layout(node, Size::NONE)?;
 
     println!("node: {:#?}", taffy.layout(node)?);
     println!("child: {:#?}", taffy.layout(child)?);

--- a/scripts/gentest/src/main.rs
+++ b/scripts/gentest/src/main.rs
@@ -150,7 +150,7 @@ fn generate_bench(description: &json::JsonValue) -> TokenStream {
         pub fn compute() {
             let mut taffy = taffy::Taffy::new();
             #node_description
-            taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+            taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
         }
     )
 }
@@ -166,7 +166,7 @@ fn generate_test(name: impl AsRef<str>, description: &json::JsonValue) -> TokenS
         fn #name() {
             let mut taffy = taffy::Taffy::new();
             #node_description
-            taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+            taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
             #assertions
         }
     )

--- a/src/data.rs
+++ b/src/data.rs
@@ -27,7 +27,7 @@ pub(crate) struct NodeData {
 impl NodeData {
     /// Create the data for a new node with a [`MeasureFunc`]
     #[must_use]
-    pub fn new_with_measure(style: FlexboxLayout, measure: MeasureFunc) -> Self {
+    pub const fn new_with_measure(style: FlexboxLayout, measure: MeasureFunc) -> Self {
         Self {
             style,
             measure: Some(measure),
@@ -40,7 +40,7 @@ impl NodeData {
 
     /// Create the data for a new node
     #[must_use]
-    pub fn new(style: FlexboxLayout) -> Self {
+    pub const fn new(style: FlexboxLayout) -> Self {
         Self {
             style,
             measure: None,

--- a/src/flexbox.rs
+++ b/src/flexbox.rs
@@ -465,7 +465,7 @@ impl Taffy {
             // webkit handled various scenarios. Can probably be solved better by passing in
             // min-content max-content constraints from the top
             let min_main = self
-                .compute_preliminary(child.node, Size::undefined(), available_space, false, false)
+                .compute_preliminary(child.node, Size::NONE, available_space, false, false)
                 .main(constants.dir)
                 .maybe_max(child.min_size.main(constants.dir))
                 .maybe_min(child.size.main(constants.dir))
@@ -724,7 +724,7 @@ impl Taffy {
                 // min-content max-content constraints from the top. Need to figure out correct thing to do here as
                 // just piling on more conditionals.
                 let min_main = if constants.is_row && self.nodes[child.node].measure.is_none() {
-                    self.compute_preliminary(child.node, Size::undefined(), available_space, false, false)
+                    self.compute_preliminary(child.node, Size::NONE, available_space, false, false)
                         .width
                         .maybe_min(child.size.width)
                         .maybe_max(child.min_size.width)
@@ -1762,8 +1762,8 @@ mod tests {
         let style = FlexboxLayout::default();
         let node_id = tree.new_leaf(style).unwrap();
 
-        let node_size = Size::undefined();
-        let parent_size = Size::undefined();
+        let node_size = Size::NONE;
+        let parent_size = Size::NONE;
 
         let constants = Taffy::compute_constants(&tree.nodes[node_id], node_size, parent_size);
 

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -160,15 +160,6 @@ pub struct Size<T> {
     pub height: T,
 }
 
-impl Size<()> {
-    /// Generates a `Size<Option<f32>>` with undefined width and height
-    #[must_use]
-    // FIXME: swap to a const
-    pub const fn undefined() -> Size<Option<f32>> {
-        Size { width: None, height: None }
-    }
-}
-
 impl<T> Size<T> {
     /// Applies the function `f` to both the width and height
     ///

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -144,7 +144,7 @@ impl Rect<f32> {
 
     /// Creates a new Rect
     #[must_use]
-    pub fn new(start: f32, end: f32, top: f32, bottom: f32) -> Self {
+    pub const fn new(start: f32, end: f32, top: f32, bottom: f32) -> Self {
         Self { start, end, top, bottom }
     }
 }
@@ -163,7 +163,8 @@ pub struct Size<T> {
 impl Size<()> {
     /// Generates a `Size<Option<f32>>` with undefined width and height
     #[must_use]
-    pub fn undefined() -> Size<Option<f32>> {
+    // FIXME: swap to a const
+    pub const fn undefined() -> Size<Option<f32>> {
         Size { width: None, height: None }
     }
 }
@@ -235,7 +236,7 @@ impl Size<Option<f32>> {
 
     /// A [`Size<Option<f32>>`] with `Some(width)` and `Some(height)` as parameters
     #[must_use]
-    pub fn new(width: f32, height: f32) -> Self {
+    pub const fn new(width: f32, height: f32) -> Self {
         Size { width: Some(width), height: Some(height) }
     }
 }
@@ -243,13 +244,13 @@ impl Size<Option<f32>> {
 impl Size<Dimension> {
     /// Generates a [`Size<Dimension>`] using [`Dimension::Points`] values
     #[must_use]
-    pub fn from_points(width: f32, height: f32) -> Self {
+    pub const fn from_points(width: f32, height: f32) -> Self {
         Size { width: Dimension::Points(width), height: Dimension::Points(height) }
     }
 
     /// Generates a [`Size<Dimension>`] using [`Dimension::Percent`] values
     #[must_use]
-    pub fn from_percent(width: f32, height: f32) -> Self {
+    pub const fn from_percent(width: f32, height: f32) -> Self {
         Size { width: Dimension::Percent(width), height: Dimension::Percent(height) }
     }
 

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -18,8 +18,9 @@ pub struct Layout {
 
 impl Layout {
     /// Creates a new [`Layout`] struct with zero size positioned at the origin
+    // FIXME: use a constant
     #[must_use]
-    pub(crate) fn new() -> Self {
+    pub const fn new() -> Self {
         Self { order: 0, size: Size::ZERO, location: Point::ZERO }
     }
 }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -18,7 +18,6 @@ pub struct Layout {
 
 impl Layout {
     /// Creates a new [`Layout`] struct with zero size positioned at the origin
-    // FIXME: use a constant
     #[must_use]
     pub const fn new() -> Self {
         Self { order: 0, size: Size::ZERO, location: Point::ZERO }

--- a/src/node.rs
+++ b/src/node.rs
@@ -49,7 +49,7 @@ pub struct Taffy {
 
 impl Default for Taffy {
     fn default() -> Self {
-        Self::with_capacity(16)
+        Taffy::new()
     }
 }
 
@@ -60,13 +60,15 @@ impl Taffy {
     /// The default capacity of a [`Taffy`] is 16 nodes.
     #[must_use]
     pub fn new() -> Self {
-        Taffy::default()
+        Self::with_capacity(16)
     }
 
     /// Creates a new [`Taffy`] that can store `capacity` nodes before reallocation
     #[must_use]
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
+            // TODO: make this method const upstream,
+            // so constructors here can be const
             nodes: SlotMap::with_capacity(capacity),
             children: SlotMap::with_capacity(capacity),
             parents: SlotMap::with_capacity(capacity),

--- a/src/node.rs
+++ b/src/node.rs
@@ -401,11 +401,11 @@ mod tests {
         let node = taffy
             .new_leaf_with_measure(FlexboxLayout::default(), MeasureFunc::Raw(|_| Size { width: 200.0, height: 200.0 }))
             .unwrap();
-        taffy.compute_layout(node, Size::undefined()).unwrap();
+        taffy.compute_layout(node, Size::NONE).unwrap();
         assert_eq!(taffy.layout(node).unwrap().size.width, 200.0);
 
         taffy.set_measure(node, Some(MeasureFunc::Raw(|_| Size { width: 100.0, height: 100.0 }))).unwrap();
-        taffy.compute_layout(node, Size::undefined()).unwrap();
+        taffy.compute_layout(node, Size::NONE).unwrap();
         assert_eq!(taffy.layout(node).unwrap().size.width, 100.0);
     }
 
@@ -575,7 +575,7 @@ mod tests {
         let child1 = taffy.new_leaf(FlexboxLayout::default()).unwrap();
         let node = taffy.new_with_children(FlexboxLayout::default(), &[child0, child1]).unwrap();
 
-        taffy.compute_layout(node, Size::undefined()).unwrap();
+        taffy.compute_layout(node, Size::NONE).unwrap();
 
         assert_eq!(taffy.dirty(child0).unwrap(), false);
         assert_eq!(taffy.dirty(child1).unwrap(), false);
@@ -586,7 +586,7 @@ mod tests {
         assert_eq!(taffy.dirty(child1).unwrap(), false);
         assert_eq!(taffy.dirty(node).unwrap(), true);
 
-        taffy.compute_layout(node, Size::undefined()).unwrap();
+        taffy.compute_layout(node, Size::NONE).unwrap();
         taffy.mark_dirty(child0).unwrap();
         assert_eq!(taffy.dirty(child0).unwrap(), true);
         assert_eq!(taffy.dirty(child1).unwrap(), false);

--- a/src/style.rs
+++ b/src/style.rs
@@ -413,29 +413,34 @@ pub struct FlexboxLayout {
     pub aspect_ratio: Option<f32>,
 }
 
+impl FlexboxLayout {
+    /// The [`Default`] layout, in a form that can be used in const functions
+    pub const DEFAULT: FlexboxLayout = FlexboxLayout {
+        display: Display::Flex,
+        position_type: PositionType::Relative,
+        flex_direction: FlexDirection::Row,
+        flex_wrap: FlexWrap::NoWrap,
+        align_items: AlignItems::Stretch,
+        align_self: AlignSelf::Auto,
+        align_content: AlignContent::Stretch,
+        justify_content: JustifyContent::FlexStart,
+        position: Rect::UNDEFINED,
+        margin: Rect::UNDEFINED,
+        padding: Rect::UNDEFINED,
+        border: Rect::UNDEFINED,
+        flex_grow: 0.0,
+        flex_shrink: 1.0,
+        flex_basis: Dimension::Auto,
+        size: Size::AUTO,
+        min_size: Size::AUTO,
+        max_size: Size::AUTO,
+        aspect_ratio: None,
+    };
+}
+
 impl Default for FlexboxLayout {
     fn default() -> Self {
-        Self {
-            display: Default::default(),
-            position_type: Default::default(),
-            flex_direction: Default::default(),
-            flex_wrap: Default::default(),
-            align_items: Default::default(),
-            align_self: Default::default(),
-            align_content: Default::default(),
-            justify_content: Default::default(),
-            position: Default::default(),
-            margin: Default::default(),
-            padding: Default::default(),
-            border: Default::default(),
-            flex_grow: 0.0,
-            flex_shrink: 1.0,
-            flex_basis: Dimension::Auto,
-            size: Default::default(),
-            min_size: Default::default(),
-            max_size: Default::default(),
-            aspect_ratio: Default::default(),
-        }
+        FlexboxLayout::DEFAULT
     }
 }
 
@@ -543,6 +548,36 @@ impl FlexboxLayout {
 #[allow(clippy::bool_assert_comparison)]
 #[cfg(test)]
 mod tests {
+    use super::FlexboxLayout;
+
+    #[test]
+    fn defaults_match() {
+        let old_defaults = FlexboxLayout {
+            display: Default::default(),
+            position_type: Default::default(),
+            flex_direction: Default::default(),
+            flex_wrap: Default::default(),
+            align_items: Default::default(),
+            align_self: Default::default(),
+            align_content: Default::default(),
+            justify_content: Default::default(),
+            position: Default::default(),
+            margin: Default::default(),
+            padding: Default::default(),
+            border: Default::default(),
+            flex_grow: 0.0,
+            flex_shrink: 1.0,
+            flex_basis: super::Dimension::Auto,
+            size: Default::default(),
+            min_size: Default::default(),
+            max_size: Default::default(),
+            aspect_ratio: Default::default(),
+        };
+
+        assert_eq!(FlexboxLayout::DEFAULT, FlexboxLayout::default());
+        assert_eq!(FlexboxLayout::DEFAULT, old_defaults);
+    }
+
     mod test_flex_direction {
         use crate::style::*;
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -285,26 +285,26 @@ impl Default for Rect<Dimension> {
 impl Rect<Dimension> {
     /// Generates a [`Rect<Dimension>`] using [`Dimension::Points`] values for `start` and `top`
     #[must_use]
-    pub fn top_from_points(start: f32, top: f32) -> Rect<Dimension> {
-        Rect { start: Dimension::Points(start), top: Dimension::Points(top), ..Default::default() }
+    pub const fn top_from_points(start: f32, top: f32) -> Rect<Dimension> {
+        Rect { start: Dimension::Points(start), top: Dimension::Points(top), ..Rect::AUTO }
     }
 
     /// Generates a [`Rect<Dimension>`] using [`Dimension::Points`] values for `end` and `bottom`
     #[must_use]
-    pub fn bot_from_points(end: f32, bottom: f32) -> Rect<Dimension> {
-        Rect { end: Dimension::Points(end), bottom: Dimension::Points(bottom), ..Default::default() }
+    pub const fn bot_from_points(end: f32, bottom: f32) -> Rect<Dimension> {
+        Rect { end: Dimension::Points(end), bottom: Dimension::Points(bottom), ..Rect::AUTO }
     }
 
     /// Generates a [`Rect<Dimension>`] using [`Dimension::Percent`] values for `start` and `top`
     #[must_use]
-    pub fn top_from_percent(start: f32, top: f32) -> Rect<Dimension> {
-        Rect { start: Dimension::Percent(start), top: Dimension::Percent(top), ..Default::default() }
+    pub const fn top_from_percent(start: f32, top: f32) -> Rect<Dimension> {
+        Rect { start: Dimension::Percent(start), top: Dimension::Percent(top), ..Rect::AUTO }
     }
 
     /// Generates a [`Rect<Dimension>`] using [`Dimension::Percent`] values for `end` and `bottom`
     #[must_use]
-    pub fn bot_from_percent(end: f32, bottom: f32) -> Rect<Dimension> {
-        Rect { end: Dimension::Percent(end), bottom: Dimension::Percent(bottom), ..Default::default() }
+    pub const fn bot_from_percent(end: f32, bottom: f32) -> Rect<Dimension> {
+        Rect { end: Dimension::Percent(end), bottom: Dimension::Percent(bottom), ..Rect::AUTO }
     }
 
     /// Generates a [`Rect<Dimension>`] using [`Dimension::Undefined`] for all values
@@ -321,7 +321,7 @@ impl Rect<Dimension> {
 
     /// Create a new Rect with [`Dimension::Points`]
     #[must_use]
-    pub fn from_points(start: f32, end: f32, top: f32, bottom: f32) -> Self {
+    pub const fn from_points(start: f32, end: f32, top: f32, bottom: f32) -> Self {
         Rect {
             start: Dimension::Points(start),
             end: Dimension::Points(end),
@@ -332,7 +332,7 @@ impl Rect<Dimension> {
 
     /// Create a new Rect with [`Dimension::Percent`]
     #[must_use]
-    pub fn from_percent(start: f32, end: f32, top: f32, bottom: f32) -> Self {
+    pub const fn from_percent(start: f32, end: f32, top: f32, bottom: f32) -> Self {
         Rect {
             start: Dimension::Percent(start),
             end: Dimension::Percent(end),

--- a/tests/generated/absolute_layout_align_items_and_justify_content_center.rs
+++ b/tests/generated/absolute_layout_align_items_and_justify_content_center.rs
@@ -30,7 +30,7 @@ fn absolute_layout_align_items_and_justify_content_center() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 110f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_align_items_and_justify_content_center_and_bottom_position.rs
+++ b/tests/generated/absolute_layout_align_items_and_justify_content_center_and_bottom_position.rs
@@ -34,7 +34,7 @@ fn absolute_layout_align_items_and_justify_content_center_and_bottom_position() 
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 110f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_align_items_and_justify_content_center_and_left_position.rs
+++ b/tests/generated/absolute_layout_align_items_and_justify_content_center_and_left_position.rs
@@ -31,7 +31,7 @@ fn absolute_layout_align_items_and_justify_content_center_and_left_position() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 110f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_align_items_and_justify_content_center_and_right_position.rs
+++ b/tests/generated/absolute_layout_align_items_and_justify_content_center_and_right_position.rs
@@ -31,7 +31,7 @@ fn absolute_layout_align_items_and_justify_content_center_and_right_position() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 110f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_align_items_and_justify_content_center_and_top_position.rs
+++ b/tests/generated/absolute_layout_align_items_and_justify_content_center_and_top_position.rs
@@ -31,7 +31,7 @@ fn absolute_layout_align_items_and_justify_content_center_and_top_position() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 110f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_align_items_and_justify_content_flex_end.rs
+++ b/tests/generated/absolute_layout_align_items_and_justify_content_flex_end.rs
@@ -30,7 +30,7 @@ fn absolute_layout_align_items_and_justify_content_flex_end() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 110f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_align_items_center.rs
+++ b/tests/generated/absolute_layout_align_items_center.rs
@@ -29,7 +29,7 @@ fn absolute_layout_align_items_center() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 110f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_align_items_center_on_child_only.rs
+++ b/tests/generated/absolute_layout_align_items_center_on_child_only.rs
@@ -29,7 +29,7 @@ fn absolute_layout_align_items_center_on_child_only() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 110f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_child_order.rs
+++ b/tests/generated/absolute_layout_child_order.rs
@@ -56,7 +56,7 @@ fn absolute_layout_child_order() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 110f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_in_wrap_reverse_column_container.rs
+++ b/tests/generated/absolute_layout_in_wrap_reverse_column_container.rs
@@ -30,7 +30,7 @@ fn absolute_layout_in_wrap_reverse_column_container() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_in_wrap_reverse_column_container_flex_end.rs
+++ b/tests/generated/absolute_layout_in_wrap_reverse_column_container_flex_end.rs
@@ -31,7 +31,7 @@ fn absolute_layout_in_wrap_reverse_column_container_flex_end() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_in_wrap_reverse_row_container.rs
+++ b/tests/generated/absolute_layout_in_wrap_reverse_row_container.rs
@@ -29,7 +29,7 @@ fn absolute_layout_in_wrap_reverse_row_container() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_in_wrap_reverse_row_container_flex_end.rs
+++ b/tests/generated/absolute_layout_in_wrap_reverse_row_container_flex_end.rs
@@ -30,7 +30,7 @@ fn absolute_layout_in_wrap_reverse_row_container_flex_end() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_justify_content_center.rs
+++ b/tests/generated/absolute_layout_justify_content_center.rs
@@ -29,7 +29,7 @@ fn absolute_layout_justify_content_center() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 110f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_no_size.rs
+++ b/tests/generated/absolute_layout_no_size.rs
@@ -20,7 +20,7 @@ fn absolute_layout_no_size() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_percentage_bottom_based_on_parent_height.rs
+++ b/tests/generated/absolute_layout_percentage_bottom_based_on_parent_height.rs
@@ -62,7 +62,7 @@ fn absolute_layout_percentage_bottom_based_on_parent_height() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_start_top_end_bottom.rs
+++ b/tests/generated/absolute_layout_start_top_end_bottom.rs
@@ -30,7 +30,7 @@ fn absolute_layout_start_top_end_bottom() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_width_height_end_bottom.rs
+++ b/tests/generated/absolute_layout_width_height_end_bottom.rs
@@ -33,7 +33,7 @@ fn absolute_layout_width_height_end_bottom() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_width_height_start_top.rs
+++ b/tests/generated/absolute_layout_width_height_start_top.rs
@@ -33,7 +33,7 @@ fn absolute_layout_width_height_start_top() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_width_height_start_top_end_bottom.rs
+++ b/tests/generated/absolute_layout_width_height_start_top_end_bottom.rs
@@ -35,7 +35,7 @@ fn absolute_layout_width_height_start_top_end_bottom() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_within_border.rs
+++ b/tests/generated/absolute_layout_within_border.rs
@@ -118,7 +118,7 @@ fn absolute_layout_within_border() {
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_baseline.rs
+++ b/tests/generated/align_baseline.rs
@@ -41,7 +41,7 @@ fn align_baseline() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_baseline_child_multiline.rs
+++ b/tests/generated/align_baseline_child_multiline.rs
@@ -86,7 +86,7 @@ fn align_baseline_child_multiline() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 80f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_baseline_nested_child.rs
+++ b/tests/generated/align_baseline_nested_child.rs
@@ -55,7 +55,7 @@ fn align_baseline_nested_child() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_center_should_size_based_on_content.rs
+++ b/tests/generated/align_center_should_size_based_on_content.rs
@@ -45,7 +45,7 @@ fn align_center_should_size_based_on_content() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_flex_start_with_shrinking_children.rs
+++ b/tests/generated/align_flex_start_with_shrinking_children.rs
@@ -32,7 +32,7 @@ fn align_flex_start_with_shrinking_children() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 500f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 500f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_flex_start_with_shrinking_children_with_stretch.rs
+++ b/tests/generated/align_flex_start_with_shrinking_children_with_stretch.rs
@@ -32,7 +32,7 @@ fn align_flex_start_with_shrinking_children_with_stretch() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 500f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 500f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_flex_start_with_stretching_children.rs
+++ b/tests/generated/align_flex_start_with_stretching_children.rs
@@ -27,7 +27,7 @@ fn align_flex_start_with_stretching_children() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 500f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 500f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_items_center.rs
+++ b/tests/generated/align_items_center.rs
@@ -28,7 +28,7 @@ fn align_items_center() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_items_center_child_with_margin_bigger_than_parent.rs
+++ b/tests/generated/align_items_center_child_with_margin_bigger_than_parent.rs
@@ -40,7 +40,7 @@ fn align_items_center_child_with_margin_bigger_than_parent() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 50f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_items_center_child_without_margin_bigger_than_parent.rs
+++ b/tests/generated/align_items_center_child_without_margin_bigger_than_parent.rs
@@ -35,7 +35,7 @@ fn align_items_center_child_without_margin_bigger_than_parent() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 50f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_items_center_with_child_margin.rs
+++ b/tests/generated/align_items_center_with_child_margin.rs
@@ -29,7 +29,7 @@ fn align_items_center_with_child_margin() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_items_center_with_child_top.rs
+++ b/tests/generated/align_items_center_with_child_top.rs
@@ -29,7 +29,7 @@ fn align_items_center_with_child_top() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_items_flex_end.rs
+++ b/tests/generated/align_items_flex_end.rs
@@ -28,7 +28,7 @@ fn align_items_flex_end() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_items_flex_end_child_with_margin_bigger_than_parent.rs
+++ b/tests/generated/align_items_flex_end_child_with_margin_bigger_than_parent.rs
@@ -40,7 +40,7 @@ fn align_items_flex_end_child_with_margin_bigger_than_parent() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 50f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_items_flex_end_child_without_margin_bigger_than_parent.rs
+++ b/tests/generated/align_items_flex_end_child_without_margin_bigger_than_parent.rs
@@ -35,7 +35,7 @@ fn align_items_flex_end_child_without_margin_bigger_than_parent() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 50f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_items_flex_start.rs
+++ b/tests/generated/align_items_flex_start.rs
@@ -28,7 +28,7 @@ fn align_items_flex_start() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_items_min_max.rs
+++ b/tests/generated/align_items_min_max.rs
@@ -33,7 +33,7 @@ fn align_items_min_max() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_items_stretch.rs
+++ b/tests/generated/align_items_stretch.rs
@@ -23,7 +23,7 @@ fn align_items_stretch() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_self_baseline.rs
+++ b/tests/generated/align_self_baseline.rs
@@ -55,7 +55,7 @@ fn align_self_baseline() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_self_center.rs
+++ b/tests/generated/align_self_center.rs
@@ -28,7 +28,7 @@ fn align_self_center() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_self_flex_end.rs
+++ b/tests/generated/align_self_flex_end.rs
@@ -28,7 +28,7 @@ fn align_self_flex_end() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_self_flex_end_override_flex_start.rs
+++ b/tests/generated/align_self_flex_end_override_flex_start.rs
@@ -29,7 +29,7 @@ fn align_self_flex_end_override_flex_start() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_self_flex_start.rs
+++ b/tests/generated/align_self_flex_start.rs
@@ -28,7 +28,7 @@ fn align_self_flex_start() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_strech_should_size_based_on_parent.rs
+++ b/tests/generated/align_strech_should_size_based_on_parent.rs
@@ -44,7 +44,7 @@ fn align_strech_should_size_based_on_parent() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/border_center_child.rs
+++ b/tests/generated/border_center_child.rs
@@ -34,7 +34,7 @@ fn border_center_child() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/border_flex_child.rs
+++ b/tests/generated/border_flex_child.rs
@@ -31,7 +31,7 @@ fn border_flex_child() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/border_no_child.rs
+++ b/tests/generated/border_no_child.rs
@@ -16,7 +16,7 @@ fn border_no_child() {
             &[],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 20f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 20f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/border_stretch_child.rs
+++ b/tests/generated/border_stretch_child.rs
@@ -30,7 +30,7 @@ fn border_stretch_child() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/child_min_max_width_flexing.rs
+++ b/tests/generated/child_min_max_width_flexing.rs
@@ -38,7 +38,7 @@ fn child_min_max_width_flexing() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 120f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/container_with_unsized_child.rs
+++ b/tests/generated/container_with_unsized_child.rs
@@ -15,7 +15,7 @@ fn container_with_unsized_child() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/display_none.rs
+++ b/tests/generated/display_none.rs
@@ -22,7 +22,7 @@ fn display_none() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/display_none_fixed_size.rs
+++ b/tests/generated/display_none_fixed_size.rs
@@ -30,7 +30,7 @@ fn display_none_fixed_size() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/display_none_with_child.rs
+++ b/tests/generated/display_none_with_child.rs
@@ -61,7 +61,7 @@ fn display_none_with_child() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/display_none_with_margin.rs
+++ b/tests/generated/display_none_with_margin.rs
@@ -37,7 +37,7 @@ fn display_none_with_margin() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/display_none_with_position.rs
+++ b/tests/generated/display_none_with_position.rs
@@ -27,7 +27,7 @@ fn display_none_with_position() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_and_main_dimen_set_when_flexing.rs
+++ b/tests/generated/flex_basis_and_main_dimen_set_when_flexing.rs
@@ -40,7 +40,7 @@ fn flex_basis_and_main_dimen_set_when_flexing() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_flex_grow_column.rs
+++ b/tests/generated/flex_basis_flex_grow_column.rs
@@ -27,7 +27,7 @@ fn flex_basis_flex_grow_column() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_flex_grow_row.rs
+++ b/tests/generated/flex_basis_flex_grow_row.rs
@@ -26,7 +26,7 @@ fn flex_basis_flex_grow_row() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_flex_shrink_column.rs
+++ b/tests/generated/flex_basis_flex_shrink_column.rs
@@ -27,7 +27,7 @@ fn flex_basis_flex_shrink_column() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_flex_shrink_row.rs
+++ b/tests/generated/flex_basis_flex_shrink_row.rs
@@ -26,7 +26,7 @@ fn flex_basis_flex_shrink_row() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_larger_than_content_column.rs
+++ b/tests/generated/flex_basis_larger_than_content_column.rs
@@ -34,7 +34,7 @@ fn flex_basis_larger_than_content_column() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_larger_than_content_row.rs
+++ b/tests/generated/flex_basis_larger_than_content_row.rs
@@ -33,7 +33,7 @@ fn flex_basis_larger_than_content_row() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_overrides_main_size.rs
+++ b/tests/generated/flex_basis_overrides_main_size.rs
@@ -45,7 +45,7 @@ fn flex_basis_overrides_main_size() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_slightly_smaller_then_content_with_flex_grow_large_size.rs
+++ b/tests/generated/flex_basis_slightly_smaller_then_content_with_flex_grow_large_size.rs
@@ -58,7 +58,7 @@ fn flex_basis_slightly_smaller_then_content_with_flex_grow_large_size() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_smaller_than_content_column.rs
+++ b/tests/generated/flex_basis_smaller_than_content_column.rs
@@ -34,7 +34,7 @@ fn flex_basis_smaller_than_content_column() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_smaller_than_content_row.rs
+++ b/tests/generated/flex_basis_smaller_than_content_row.rs
@@ -33,7 +33,7 @@ fn flex_basis_smaller_than_content_row() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_smaller_than_main_dimen_column.rs
+++ b/tests/generated/flex_basis_smaller_than_main_dimen_column.rs
@@ -25,7 +25,7 @@ fn flex_basis_smaller_than_main_dimen_column() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 50f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_smaller_than_main_dimen_row.rs
+++ b/tests/generated/flex_basis_smaller_than_main_dimen_row.rs
@@ -24,7 +24,7 @@ fn flex_basis_smaller_than_main_dimen_row() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_smaller_then_content_with_flex_grow_large_size.rs
+++ b/tests/generated/flex_basis_smaller_then_content_with_flex_grow_large_size.rs
@@ -58,7 +58,7 @@ fn flex_basis_smaller_then_content_with_flex_grow_large_size() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_smaller_then_content_with_flex_grow_small_size.rs
+++ b/tests/generated/flex_basis_smaller_then_content_with_flex_grow_small_size.rs
@@ -58,7 +58,7 @@ fn flex_basis_smaller_then_content_with_flex_grow_small_size() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 10f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_smaller_then_content_with_flex_grow_unconstraint_size.rs
+++ b/tests/generated/flex_basis_smaller_then_content_with_flex_grow_unconstraint_size.rs
@@ -50,7 +50,7 @@ fn flex_basis_smaller_then_content_with_flex_grow_unconstraint_size() {
         )
         .unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0, node1]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 90f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_smaller_then_content_with_flex_grow_very_large_size.rs
+++ b/tests/generated/flex_basis_smaller_then_content_with_flex_grow_very_large_size.rs
@@ -58,7 +58,7 @@ fn flex_basis_smaller_then_content_with_flex_grow_very_large_size() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_unconstraint_column.rs
+++ b/tests/generated/flex_basis_unconstraint_column.rs
@@ -17,7 +17,7 @@ fn flex_basis_unconstraint_column() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_unconstraint_row.rs
+++ b/tests/generated/flex_basis_unconstraint_row.rs
@@ -12,7 +12,7 @@ fn flex_basis_unconstraint_row() {
         )
         .unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 0f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_direction_column.rs
+++ b/tests/generated/flex_direction_column.rs
@@ -42,7 +42,7 @@ fn flex_direction_column() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_direction_column_no_height.rs
+++ b/tests/generated/flex_direction_column_no_height.rs
@@ -38,7 +38,7 @@ fn flex_direction_column_no_height() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 30f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_direction_column_reverse.rs
+++ b/tests/generated/flex_direction_column_reverse.rs
@@ -42,7 +42,7 @@ fn flex_direction_column_reverse() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_direction_row.rs
+++ b/tests/generated/flex_direction_row.rs
@@ -41,7 +41,7 @@ fn flex_direction_row() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_direction_row_no_width.rs
+++ b/tests/generated/flex_direction_row_no_width.rs
@@ -37,7 +37,7 @@ fn flex_direction_row_no_width() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 30f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_direction_row_reverse.rs
+++ b/tests/generated/flex_direction_row_reverse.rs
@@ -42,7 +42,7 @@ fn flex_direction_row_reverse() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_grow_child.rs
+++ b/tests/generated/flex_grow_child.rs
@@ -13,7 +13,7 @@ fn flex_grow_child() {
         )
         .unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 0f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_grow_flex_basis_percent_min_max.rs
+++ b/tests/generated/flex_grow_flex_basis_percent_min_max.rs
@@ -40,7 +40,7 @@ fn flex_grow_flex_basis_percent_min_max() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 120f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 20f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_grow_height_maximized.rs
+++ b/tests/generated/flex_grow_height_maximized.rs
@@ -52,7 +52,7 @@ fn flex_grow_height_maximized() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 500f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_grow_in_at_most_container.rs
+++ b/tests/generated/flex_grow_in_at_most_container.rs
@@ -26,7 +26,7 @@ fn flex_grow_in_at_most_container() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_grow_less_than_factor_one.rs
+++ b/tests/generated/flex_grow_less_than_factor_one.rs
@@ -37,7 +37,7 @@ fn flex_grow_less_than_factor_one() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 500f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_grow_root_minimized.rs
+++ b/tests/generated/flex_grow_root_minimized.rs
@@ -56,7 +56,7 @@ fn flex_grow_root_minimized() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 300f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_grow_shrink_at_most.rs
+++ b/tests/generated/flex_grow_shrink_at_most.rs
@@ -21,7 +21,7 @@ fn flex_grow_shrink_at_most() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_grow_to_min.rs
+++ b/tests/generated/flex_grow_to_min.rs
@@ -34,7 +34,7 @@ fn flex_grow_to_min() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_grow_within_constrained_max_column.rs
+++ b/tests/generated/flex_grow_within_constrained_max_column.rs
@@ -34,7 +34,7 @@ fn flex_grow_within_constrained_max_column() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_grow_within_constrained_max_row.rs
+++ b/tests/generated/flex_grow_within_constrained_max_row.rs
@@ -43,7 +43,7 @@ fn flex_grow_within_constrained_max_row() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_grow_within_constrained_max_width.rs
+++ b/tests/generated/flex_grow_within_constrained_max_width.rs
@@ -37,7 +37,7 @@ fn flex_grow_within_constrained_max_width() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_grow_within_constrained_min_column.rs
+++ b/tests/generated/flex_grow_within_constrained_min_column.rs
@@ -25,7 +25,7 @@ fn flex_grow_within_constrained_min_column() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 0f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_grow_within_constrained_min_max_column.rs
+++ b/tests/generated/flex_grow_within_constrained_min_max_column.rs
@@ -24,7 +24,7 @@ fn flex_grow_within_constrained_min_max_column() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 0f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_grow_within_constrained_min_row.rs
+++ b/tests/generated/flex_grow_within_constrained_min_row.rs
@@ -25,7 +25,7 @@ fn flex_grow_within_constrained_min_row() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_grow_within_max_width.rs
+++ b/tests/generated/flex_grow_within_max_width.rs
@@ -37,7 +37,7 @@ fn flex_grow_within_max_width() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_root_ignored.rs
+++ b/tests/generated/flex_root_ignored.rs
@@ -38,7 +38,7 @@ fn flex_root_ignored() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 300f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_shrink_by_outer_margin_with_max_size.rs
+++ b/tests/generated/flex_shrink_by_outer_margin_with_max_size.rs
@@ -29,7 +29,7 @@ fn flex_shrink_by_outer_margin_with_max_size() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 20f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 80f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_shrink_flex_grow_child_flex_shrink_other_child.rs
+++ b/tests/generated/flex_shrink_flex_grow_child_flex_shrink_other_child.rs
@@ -44,7 +44,7 @@ fn flex_shrink_flex_grow_child_flex_shrink_other_child() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 500f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 500f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_shrink_flex_grow_row.rs
+++ b/tests/generated/flex_shrink_flex_grow_row.rs
@@ -44,7 +44,7 @@ fn flex_shrink_flex_grow_row() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 500f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 500f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_shrink_to_zero.rs
+++ b/tests/generated/flex_shrink_to_zero.rs
@@ -52,7 +52,7 @@ fn flex_shrink_to_zero() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 75f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_wrap_align_stretch_fits_one_row.rs
+++ b/tests/generated/flex_wrap_align_stretch_fits_one_row.rs
@@ -33,7 +33,7 @@ fn flex_wrap_align_stretch_fits_one_row() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 150f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_wrap_children_with_min_main_overriding_flex_basis.rs
+++ b/tests/generated/flex_wrap_children_with_min_main_overriding_flex_basis.rs
@@ -33,7 +33,7 @@ fn flex_wrap_children_with_min_main_overriding_flex_basis() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_wrap_wrap_to_child_height.rs
+++ b/tests/generated/flex_wrap_wrap_to_child_height.rs
@@ -53,7 +53,7 @@ fn flex_wrap_wrap_to_child_height() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_column_center.rs
+++ b/tests/generated/justify_content_column_center.rs
@@ -43,7 +43,7 @@ fn justify_content_column_center() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_column_flex_end.rs
+++ b/tests/generated/justify_content_column_flex_end.rs
@@ -43,7 +43,7 @@ fn justify_content_column_flex_end() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_column_flex_start.rs
+++ b/tests/generated/justify_content_column_flex_start.rs
@@ -42,7 +42,7 @@ fn justify_content_column_flex_start() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_column_min_height_and_margin_bottom.rs
+++ b/tests/generated/justify_content_column_min_height_and_margin_bottom.rs
@@ -29,7 +29,7 @@ fn justify_content_column_min_height_and_margin_bottom() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 20f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_column_min_height_and_margin_top.rs
+++ b/tests/generated/justify_content_column_min_height_and_margin_top.rs
@@ -29,7 +29,7 @@ fn justify_content_column_min_height_and_margin_top() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 20f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_column_space_around.rs
+++ b/tests/generated/justify_content_column_space_around.rs
@@ -43,7 +43,7 @@ fn justify_content_column_space_around() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_column_space_between.rs
+++ b/tests/generated/justify_content_column_space_between.rs
@@ -43,7 +43,7 @@ fn justify_content_column_space_between() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_column_space_evenly.rs
+++ b/tests/generated/justify_content_column_space_evenly.rs
@@ -43,7 +43,7 @@ fn justify_content_column_space_evenly() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_min_max.rs
+++ b/tests/generated/justify_content_min_max.rs
@@ -33,7 +33,7 @@ fn justify_content_min_max() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_min_width_with_padding_child_width_greater_than_parent.rs
+++ b/tests/generated/justify_content_min_width_with_padding_child_width_greater_than_parent.rs
@@ -47,7 +47,7 @@ fn justify_content_min_width_with_padding_child_width_greater_than_parent() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 1000f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 1584f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_min_width_with_padding_child_width_lower_than_parent.rs
+++ b/tests/generated/justify_content_min_width_with_padding_child_width_lower_than_parent.rs
@@ -47,7 +47,7 @@ fn justify_content_min_width_with_padding_child_width_lower_than_parent() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 1080f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 1584f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_overflow_min_max.rs
+++ b/tests/generated/justify_content_overflow_min_max.rs
@@ -61,7 +61,7 @@ fn justify_content_overflow_min_max() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 50f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 110f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_row_center.rs
+++ b/tests/generated/justify_content_row_center.rs
@@ -42,7 +42,7 @@ fn justify_content_row_center() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_row_flex_end.rs
+++ b/tests/generated/justify_content_row_flex_end.rs
@@ -42,7 +42,7 @@ fn justify_content_row_flex_end() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_row_flex_start.rs
+++ b/tests/generated/justify_content_row_flex_start.rs
@@ -41,7 +41,7 @@ fn justify_content_row_flex_start() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_row_max_width_and_margin.rs
+++ b/tests/generated/justify_content_row_max_width_and_margin.rs
@@ -26,7 +26,7 @@ fn justify_content_row_max_width_and_margin() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 80f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 20f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_row_min_width_and_margin.rs
+++ b/tests/generated/justify_content_row_min_width_and_margin.rs
@@ -25,7 +25,7 @@ fn justify_content_row_min_width_and_margin() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 50f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 20f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_row_space_around.rs
+++ b/tests/generated/justify_content_row_space_around.rs
@@ -42,7 +42,7 @@ fn justify_content_row_space_around() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_row_space_between.rs
+++ b/tests/generated/justify_content_row_space_between.rs
@@ -42,7 +42,7 @@ fn justify_content_row_space_between() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_row_space_evenly.rs
+++ b/tests/generated/justify_content_row_space_evenly.rs
@@ -42,7 +42,7 @@ fn justify_content_row_space_evenly() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_and_flex_column.rs
+++ b/tests/generated/margin_and_flex_column.rs
@@ -29,7 +29,7 @@ fn margin_and_flex_column() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_and_flex_row.rs
+++ b/tests/generated/margin_and_flex_row.rs
@@ -28,7 +28,7 @@ fn margin_and_flex_row() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_and_stretch_column.rs
+++ b/tests/generated/margin_and_stretch_column.rs
@@ -29,7 +29,7 @@ fn margin_and_stretch_column() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_and_stretch_row.rs
+++ b/tests/generated/margin_and_stretch_row.rs
@@ -28,7 +28,7 @@ fn margin_and_stretch_row() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_auto_bottom.rs
+++ b/tests/generated/margin_auto_bottom.rs
@@ -42,7 +42,7 @@ fn margin_auto_bottom() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_auto_bottom_and_top.rs
+++ b/tests/generated/margin_auto_bottom_and_top.rs
@@ -46,7 +46,7 @@ fn margin_auto_bottom_and_top() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_auto_bottom_and_top_justify_center.rs
+++ b/tests/generated/margin_auto_bottom_and_top_justify_center.rs
@@ -46,7 +46,7 @@ fn margin_auto_bottom_and_top_justify_center() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_auto_left.rs
+++ b/tests/generated/margin_auto_left.rs
@@ -42,7 +42,7 @@ fn margin_auto_left() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_auto_left_and_right.rs
+++ b/tests/generated/margin_auto_left_and_right.rs
@@ -45,7 +45,7 @@ fn margin_auto_left_and_right() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_auto_left_and_right_column.rs
+++ b/tests/generated/margin_auto_left_and_right_column.rs
@@ -46,7 +46,7 @@ fn margin_auto_left_and_right_column() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_auto_left_and_right_column_and_center.rs
+++ b/tests/generated/margin_auto_left_and_right_column_and_center.rs
@@ -46,7 +46,7 @@ fn margin_auto_left_and_right_column_and_center() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_auto_left_and_right_strech.rs
+++ b/tests/generated/margin_auto_left_and_right_strech.rs
@@ -45,7 +45,7 @@ fn margin_auto_left_and_right_strech() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_auto_left_child_bigger_than_parent.rs
+++ b/tests/generated/margin_auto_left_child_bigger_than_parent.rs
@@ -29,7 +29,7 @@ fn margin_auto_left_child_bigger_than_parent() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 52f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 52f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_auto_left_fix_right_child_bigger_than_parent.rs
+++ b/tests/generated/margin_auto_left_fix_right_child_bigger_than_parent.rs
@@ -33,7 +33,7 @@ fn margin_auto_left_fix_right_child_bigger_than_parent() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 52f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 52f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_auto_left_right_child_bigger_than_parent.rs
+++ b/tests/generated/margin_auto_left_right_child_bigger_than_parent.rs
@@ -33,7 +33,7 @@ fn margin_auto_left_right_child_bigger_than_parent() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 52f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 52f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_auto_left_stretching_child.rs
+++ b/tests/generated/margin_auto_left_stretching_child.rs
@@ -40,7 +40,7 @@ fn margin_auto_left_stretching_child() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_auto_mutiple_children_column.rs
+++ b/tests/generated/margin_auto_mutiple_children_column.rs
@@ -57,7 +57,7 @@ fn margin_auto_mutiple_children_column() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_auto_mutiple_children_row.rs
+++ b/tests/generated/margin_auto_mutiple_children_row.rs
@@ -56,7 +56,7 @@ fn margin_auto_mutiple_children_row() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_auto_right.rs
+++ b/tests/generated/margin_auto_right.rs
@@ -42,7 +42,7 @@ fn margin_auto_right() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_auto_top.rs
+++ b/tests/generated/margin_auto_top.rs
@@ -42,7 +42,7 @@ fn margin_auto_top() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_auto_top_and_bottom_strech.rs
+++ b/tests/generated/margin_auto_top_and_bottom_strech.rs
@@ -46,7 +46,7 @@ fn margin_auto_top_and_bottom_strech() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_auto_top_stretching_child.rs
+++ b/tests/generated/margin_auto_top_stretching_child.rs
@@ -40,7 +40,7 @@ fn margin_auto_top_stretching_child() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_bottom.rs
+++ b/tests/generated/margin_bottom.rs
@@ -26,7 +26,7 @@ fn margin_bottom() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_fix_left_auto_right_child_bigger_than_parent.rs
+++ b/tests/generated/margin_fix_left_auto_right_child_bigger_than_parent.rs
@@ -33,7 +33,7 @@ fn margin_fix_left_auto_right_child_bigger_than_parent() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 52f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 52f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_left.rs
+++ b/tests/generated/margin_left.rs
@@ -24,7 +24,7 @@ fn margin_left() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_right.rs
+++ b/tests/generated/margin_right.rs
@@ -25,7 +25,7 @@ fn margin_right() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_should_not_be_part_of_max_height.rs
+++ b/tests/generated/margin_should_not_be_part_of_max_height.rs
@@ -32,7 +32,7 @@ fn margin_should_not_be_part_of_max_height() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 250f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 250f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_should_not_be_part_of_max_width.rs
+++ b/tests/generated/margin_should_not_be_part_of_max_width.rs
@@ -32,7 +32,7 @@ fn margin_should_not_be_part_of_max_width() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 250f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 250f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_top.rs
+++ b/tests/generated/margin_top.rs
@@ -25,7 +25,7 @@ fn margin_top() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_with_sibling_column.rs
+++ b/tests/generated/margin_with_sibling_column.rs
@@ -27,7 +27,7 @@ fn margin_with_sibling_column() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_with_sibling_row.rs
+++ b/tests/generated/margin_with_sibling_row.rs
@@ -26,7 +26,7 @@ fn margin_with_sibling_row() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/max_height.rs
+++ b/tests/generated/max_height.rs
@@ -27,7 +27,7 @@ fn max_height() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/max_height_overrides_height.rs
+++ b/tests/generated/max_height_overrides_height.rs
@@ -15,7 +15,7 @@ fn max_height_overrides_height() {
         )
         .unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 0f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/max_height_overrides_height_on_root.rs
+++ b/tests/generated/max_height_overrides_height_on_root.rs
@@ -14,7 +14,7 @@ fn max_height_overrides_height_on_root() {
             &[],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 0f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/max_width.rs
+++ b/tests/generated/max_width.rs
@@ -25,7 +25,7 @@ fn max_width() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/max_width_overrides_width.rs
+++ b/tests/generated/max_width_overrides_width.rs
@@ -15,7 +15,7 @@ fn max_width_overrides_width() {
         )
         .unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 0f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/max_width_overrides_width_on_root.rs
+++ b/tests/generated/max_width_overrides_width_on_root.rs
@@ -14,7 +14,7 @@ fn max_width_overrides_width_on_root() {
             &[],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 0f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/min_height.rs
+++ b/tests/generated/min_height.rs
@@ -30,7 +30,7 @@ fn min_height() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/min_height_overrides_height.rs
+++ b/tests/generated/min_height_overrides_height.rs
@@ -15,7 +15,7 @@ fn min_height_overrides_height() {
         )
         .unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 0f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/min_height_overrides_height_on_root.rs
+++ b/tests/generated/min_height_overrides_height_on_root.rs
@@ -14,7 +14,7 @@ fn min_height_overrides_height_on_root() {
             &[],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 0f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/min_max_percent_no_width_height.rs
+++ b/tests/generated/min_max_percent_no_width_height.rs
@@ -34,7 +34,7 @@ fn min_max_percent_no_width_height() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/min_width.rs
+++ b/tests/generated/min_width.rs
@@ -26,7 +26,7 @@ fn min_width() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/min_width_overrides_width.rs
+++ b/tests/generated/min_width_overrides_width.rs
@@ -15,7 +15,7 @@ fn min_width_overrides_width() {
         )
         .unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 0f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/min_width_overrides_width_on_root.rs
+++ b/tests/generated/min_width_overrides_width_on_root.rs
@@ -14,7 +14,7 @@ fn min_width_overrides_width_on_root() {
             &[],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 0f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/nested_overflowing_child.rs
+++ b/tests/generated/nested_overflowing_child.rs
@@ -28,7 +28,7 @@ fn nested_overflowing_child() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/nested_overflowing_child_in_constraint_parent.rs
+++ b/tests/generated/nested_overflowing_child_in_constraint_parent.rs
@@ -40,7 +40,7 @@ fn nested_overflowing_child_in_constraint_parent() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/overflow_cross_axis.rs
+++ b/tests/generated/overflow_cross_axis.rs
@@ -27,7 +27,7 @@ fn overflow_cross_axis() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/overflow_main_axis.rs
+++ b/tests/generated/overflow_main_axis.rs
@@ -24,7 +24,7 @@ fn overflow_main_axis() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/padding_align_end_child.rs
+++ b/tests/generated/padding_align_end_child.rs
@@ -36,7 +36,7 @@ fn padding_align_end_child() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/padding_center_child.rs
+++ b/tests/generated/padding_center_child.rs
@@ -36,7 +36,7 @@ fn padding_center_child() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/padding_flex_child.rs
+++ b/tests/generated/padding_flex_child.rs
@@ -31,7 +31,7 @@ fn padding_flex_child() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/padding_no_child.rs
+++ b/tests/generated/padding_no_child.rs
@@ -16,7 +16,7 @@ fn padding_no_child() {
             &[],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 20f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 20f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/padding_stretch_child.rs
+++ b/tests/generated/padding_stretch_child.rs
@@ -30,7 +30,7 @@ fn padding_stretch_child() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/parent_wrap_child_size_overflowing_parent.rs
+++ b/tests/generated/parent_wrap_child_size_overflowing_parent.rs
@@ -36,7 +36,7 @@ fn parent_wrap_child_size_overflowing_parent() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percent_absolute_position.rs
+++ b/tests/generated/percent_absolute_position.rs
@@ -51,7 +51,7 @@ fn percent_absolute_position() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 60f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percent_within_flex_grow.rs
+++ b/tests/generated/percent_within_flex_grow.rs
@@ -51,7 +51,7 @@ fn percent_within_flex_grow() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 350f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_absolute_position.rs
+++ b/tests/generated/percentage_absolute_position.rs
@@ -34,7 +34,7 @@ fn percentage_absolute_position() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_container_in_wrapping_container.rs
+++ b/tests/generated/percentage_container_in_wrapping_container.rs
@@ -59,7 +59,7 @@ fn percentage_container_in_wrapping_container() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_flex_basis.rs
+++ b/tests/generated/percentage_flex_basis.rs
@@ -34,7 +34,7 @@ fn percentage_flex_basis() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_flex_basis_cross.rs
+++ b/tests/generated/percentage_flex_basis_cross.rs
@@ -35,7 +35,7 @@ fn percentage_flex_basis_cross() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 400f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_flex_basis_cross_max_height.rs
+++ b/tests/generated/percentage_flex_basis_cross_max_height.rs
@@ -43,7 +43,7 @@ fn percentage_flex_basis_cross_max_height() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 400f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_flex_basis_cross_max_width.rs
+++ b/tests/generated/percentage_flex_basis_cross_max_width.rs
@@ -43,7 +43,7 @@ fn percentage_flex_basis_cross_max_width() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 400f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_flex_basis_cross_min_height.rs
+++ b/tests/generated/percentage_flex_basis_cross_min_height.rs
@@ -41,7 +41,7 @@ fn percentage_flex_basis_cross_min_height() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 400f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_flex_basis_cross_min_width.rs
+++ b/tests/generated/percentage_flex_basis_cross_min_width.rs
@@ -43,7 +43,7 @@ fn percentage_flex_basis_cross_min_width() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 400f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_flex_basis_main_max_height.rs
+++ b/tests/generated/percentage_flex_basis_main_max_height.rs
@@ -42,7 +42,7 @@ fn percentage_flex_basis_main_max_height() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 400f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_flex_basis_main_max_width.rs
+++ b/tests/generated/percentage_flex_basis_main_max_width.rs
@@ -42,7 +42,7 @@ fn percentage_flex_basis_main_max_width() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 400f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_flex_basis_main_min_width.rs
+++ b/tests/generated/percentage_flex_basis_main_min_width.rs
@@ -42,7 +42,7 @@ fn percentage_flex_basis_main_min_width() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 400f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_margin_should_calculate_based_only_on_width.rs
+++ b/tests/generated/percentage_margin_should_calculate_based_only_on_width.rs
@@ -45,7 +45,7 @@ fn percentage_margin_should_calculate_based_only_on_width() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_multiple_nested_with_padding_margin_and_percentage_values.rs
+++ b/tests/generated/percentage_multiple_nested_with_padding_margin_and_percentage_values.rs
@@ -105,7 +105,7 @@ fn percentage_multiple_nested_with_padding_margin_and_percentage_values() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_padding_should_calculate_based_only_on_width.rs
+++ b/tests/generated/percentage_padding_should_calculate_based_only_on_width.rs
@@ -45,7 +45,7 @@ fn percentage_padding_should_calculate_based_only_on_width() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_position_bottom_right.rs
+++ b/tests/generated/percentage_position_bottom_right.rs
@@ -32,7 +32,7 @@ fn percentage_position_bottom_right() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 500f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 500f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_position_left_top.rs
+++ b/tests/generated/percentage_position_left_top.rs
@@ -32,7 +32,7 @@ fn percentage_position_left_top() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 400f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 400f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_size_based_on_parent_inner_size.rs
+++ b/tests/generated/percentage_size_based_on_parent_inner_size.rs
@@ -35,7 +35,7 @@ fn percentage_size_based_on_parent_inner_size() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 400f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_size_of_flex_basis.rs
+++ b/tests/generated/percentage_size_of_flex_basis.rs
@@ -29,7 +29,7 @@ fn percentage_size_of_flex_basis() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_width_height.rs
+++ b/tests/generated/percentage_width_height.rs
@@ -27,7 +27,7 @@ fn percentage_width_height() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 400f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_width_height_undefined_parent_size.rs
+++ b/tests/generated/percentage_width_height_undefined_parent_size.rs
@@ -20,7 +20,7 @@ fn percentage_width_height_undefined_parent_size() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 0f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 0f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/relative_position_should_not_nudge_siblings.rs
+++ b/tests/generated/relative_position_should_not_nudge_siblings.rs
@@ -35,7 +35,7 @@ fn relative_position_should_not_nudge_siblings() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/rounding_flex_basis_flex_grow_row_prime_number_width.rs
+++ b/tests/generated/rounding_flex_basis_flex_grow_row_prime_number_width.rs
@@ -24,7 +24,7 @@ fn rounding_flex_basis_flex_grow_row_prime_number_width() {
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 113f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/rounding_flex_basis_flex_grow_row_width_of_100.rs
+++ b/tests/generated/rounding_flex_basis_flex_grow_row_width_of_100.rs
@@ -20,7 +20,7 @@ fn rounding_flex_basis_flex_grow_row_width_of_100() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/rounding_flex_basis_flex_shrink_row.rs
+++ b/tests/generated/rounding_flex_basis_flex_shrink_row.rs
@@ -36,7 +36,7 @@ fn rounding_flex_basis_flex_shrink_row() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 101f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/rounding_flex_basis_overrides_main_size.rs
+++ b/tests/generated/rounding_flex_basis_overrides_main_size.rs
@@ -46,7 +46,7 @@ fn rounding_flex_basis_overrides_main_size() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 113f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/rounding_fractial_input_1.rs
+++ b/tests/generated/rounding_fractial_input_1.rs
@@ -46,7 +46,7 @@ fn rounding_fractial_input_1() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 113f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/rounding_fractial_input_2.rs
+++ b/tests/generated/rounding_fractial_input_2.rs
@@ -46,7 +46,7 @@ fn rounding_fractial_input_2() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 114f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/rounding_fractial_input_3.rs
+++ b/tests/generated/rounding_fractial_input_3.rs
@@ -46,7 +46,7 @@ fn rounding_fractial_input_3() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 113f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/rounding_fractial_input_4.rs
+++ b/tests/generated/rounding_fractial_input_4.rs
@@ -46,7 +46,7 @@ fn rounding_fractial_input_4() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 113f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/rounding_total_fractial.rs
+++ b/tests/generated/rounding_total_fractial.rs
@@ -46,7 +46,7 @@ fn rounding_total_fractial() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 87f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 113f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/rounding_total_fractial_nested.rs
+++ b/tests/generated/rounding_total_fractial_nested.rs
@@ -74,7 +74,7 @@ fn rounding_total_fractial_nested() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 87f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 113f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/size_defined_by_child.rs
+++ b/tests/generated/size_defined_by_child.rs
@@ -15,7 +15,7 @@ fn size_defined_by_child() {
         )
         .unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/size_defined_by_child_with_border.rs
+++ b/tests/generated/size_defined_by_child_with_border.rs
@@ -29,7 +29,7 @@ fn size_defined_by_child_with_border() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 30f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 30f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/size_defined_by_child_with_padding.rs
+++ b/tests/generated/size_defined_by_child_with_padding.rs
@@ -29,7 +29,7 @@ fn size_defined_by_child_with_padding() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 30f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 30f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/size_defined_by_grand_child.rs
+++ b/tests/generated/size_defined_by_grand_child.rs
@@ -16,7 +16,7 @@ fn size_defined_by_grand_child() {
         .unwrap();
     let node0 = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node00]).unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/width_smaller_then_content_with_flex_grow_large_size.rs
+++ b/tests/generated/width_smaller_then_content_with_flex_grow_large_size.rs
@@ -58,7 +58,7 @@ fn width_smaller_then_content_with_flex_grow_large_size() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/width_smaller_then_content_with_flex_grow_small_size.rs
+++ b/tests/generated/width_smaller_then_content_with_flex_grow_small_size.rs
@@ -58,7 +58,7 @@ fn width_smaller_then_content_with_flex_grow_small_size() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 10f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/width_smaller_then_content_with_flex_grow_unconstraint_size.rs
+++ b/tests/generated/width_smaller_then_content_with_flex_grow_unconstraint_size.rs
@@ -50,7 +50,7 @@ fn width_smaller_then_content_with_flex_grow_unconstraint_size() {
         )
         .unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0, node1]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 0f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/width_smaller_then_content_with_flex_grow_very_large_size.rs
+++ b/tests/generated/width_smaller_then_content_with_flex_grow_very_large_size.rs
@@ -58,7 +58,7 @@ fn width_smaller_then_content_with_flex_grow_very_large_size() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrap_column.rs
+++ b/tests/generated/wrap_column.rs
@@ -68,7 +68,7 @@ fn wrap_column() {
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrap_nodes_with_content_sizing_margin_cross.rs
+++ b/tests/generated/wrap_nodes_with_content_sizing_margin_cross.rs
@@ -67,7 +67,7 @@ fn wrap_nodes_with_content_sizing_margin_cross() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 500f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 500f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrap_nodes_with_content_sizing_overflowing_margin.rs
+++ b/tests/generated/wrap_nodes_with_content_sizing_overflowing_margin.rs
@@ -67,7 +67,7 @@ fn wrap_nodes_with_content_sizing_overflowing_margin() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 500f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 500f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrap_reverse_column.rs
+++ b/tests/generated/wrap_reverse_column.rs
@@ -68,7 +68,7 @@ fn wrap_reverse_column() {
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrap_reverse_column_fixed_size.rs
+++ b/tests/generated/wrap_reverse_column_fixed_size.rs
@@ -82,7 +82,7 @@ fn wrap_reverse_column_fixed_size() {
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrap_reverse_row.rs
+++ b/tests/generated/wrap_reverse_row.rs
@@ -63,7 +63,7 @@ fn wrap_reverse_row() {
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 60f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrap_reverse_row_align_content_center.rs
+++ b/tests/generated/wrap_reverse_row_align_content_center.rs
@@ -77,7 +77,7 @@ fn wrap_reverse_row_align_content_center() {
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 80f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrap_reverse_row_align_content_flex_start.rs
+++ b/tests/generated/wrap_reverse_row_align_content_flex_start.rs
@@ -77,7 +77,7 @@ fn wrap_reverse_row_align_content_flex_start() {
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 80f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrap_reverse_row_align_content_space_around.rs
+++ b/tests/generated/wrap_reverse_row_align_content_space_around.rs
@@ -77,7 +77,7 @@ fn wrap_reverse_row_align_content_space_around() {
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 80f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrap_reverse_row_align_content_stretch.rs
+++ b/tests/generated/wrap_reverse_row_align_content_stretch.rs
@@ -76,7 +76,7 @@ fn wrap_reverse_row_align_content_stretch() {
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 80f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrap_reverse_row_single_line_different_size.rs
+++ b/tests/generated/wrap_reverse_row_single_line_different_size.rs
@@ -77,7 +77,7 @@ fn wrap_reverse_row_single_line_different_size() {
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 300f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrap_row.rs
+++ b/tests/generated/wrap_row.rs
@@ -63,7 +63,7 @@ fn wrap_row() {
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 60f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrap_row_align_items_center.rs
+++ b/tests/generated/wrap_row_align_items_center.rs
@@ -64,7 +64,7 @@ fn wrap_row_align_items_center() {
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 60f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrap_row_align_items_flex_end.rs
+++ b/tests/generated/wrap_row_align_items_flex_end.rs
@@ -64,7 +64,7 @@ fn wrap_row_align_items_flex_end() {
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 60f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrapped_column_max_height.rs
+++ b/tests/generated/wrapped_column_max_height.rs
@@ -69,7 +69,7 @@ fn wrapped_column_max_height() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 700f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 500f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrapped_column_max_height_flex.rs
+++ b/tests/generated/wrapped_column_max_height_flex.rs
@@ -75,7 +75,7 @@ fn wrapped_column_max_height_flex() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 700f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 500f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrapped_row_within_align_items_center.rs
+++ b/tests/generated/wrapped_row_within_align_items_center.rs
@@ -48,7 +48,7 @@ fn wrapped_row_within_align_items_center() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrapped_row_within_align_items_flex_end.rs
+++ b/tests/generated/wrapped_row_within_align_items_flex_end.rs
@@ -48,7 +48,7 @@ fn wrapped_row_within_align_items_flex_end() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrapped_row_within_align_items_flex_start.rs
+++ b/tests/generated/wrapped_row_within_align_items_flex_start.rs
@@ -48,7 +48,7 @@ fn wrapped_row_within_align_items_flex_start() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/measure.rs
+++ b/tests/measure.rs
@@ -15,7 +15,7 @@ mod measure {
             )
             .unwrap();
 
-        taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 
         assert_eq!(taffy.layout(node).unwrap().size.width, 100.0);
         assert_eq!(taffy.layout(node).unwrap().size.height, 100.0);
@@ -36,7 +36,7 @@ mod measure {
             .unwrap();
 
         let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[child]).unwrap();
-        taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 
         assert_eq!(taffy.layout(node).unwrap().size.width, 100.0);
         assert_eq!(taffy.layout(node).unwrap().size.height, 100.0);
@@ -68,7 +68,7 @@ mod measure {
             )
             .unwrap();
 
-        taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 
         assert_eq!(taffy.layout(node).unwrap().size.width, 50.0);
         assert_eq!(taffy.layout(node).unwrap().size.height, 100.0);
@@ -105,7 +105,7 @@ mod measure {
                 &[child],
             )
             .unwrap();
-        taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 
         assert_eq!(taffy.layout(node).unwrap().size.width, 50.0);
         assert_eq!(taffy.layout(node).unwrap().size.height, 120.0);
@@ -147,7 +147,7 @@ mod measure {
             )
             .unwrap();
 
-        taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 
         assert_eq!(taffy.layout(child1).unwrap().size.width, 50.0);
         assert_eq!(taffy.layout(child1).unwrap().size.height, 50.0);
@@ -187,7 +187,7 @@ mod measure {
             )
             .unwrap();
 
-        taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 
         assert_eq!(taffy.layout(child1).unwrap().size.width, 50.0);
         assert_eq!(taffy.layout(child1).unwrap().size.height, 50.0);
@@ -228,7 +228,7 @@ mod measure {
             )
             .unwrap();
 
-        taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 
         assert_eq!(taffy.layout(child1).unwrap().size.width, 50.0);
         assert_eq!(taffy.layout(child1).unwrap().size.height, 100.0);
@@ -271,7 +271,7 @@ mod measure {
             )
             .unwrap();
 
-        taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 
         assert_eq!(taffy.layout(child1).unwrap().size.width, 50.0);
         assert_eq!(taffy.layout(child1).unwrap().size.height, 100.0);
@@ -305,7 +305,7 @@ mod measure {
             )
             .unwrap();
 
-        taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 
         assert_eq!(taffy.layout(child).unwrap().size.width, 100.0);
         assert_eq!(taffy.layout(child).unwrap().size.height, 100.0);
@@ -328,7 +328,7 @@ mod measure {
             .unwrap();
 
         let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[child]).unwrap();
-        taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 
         assert_eq!(taffy.layout(child).unwrap().size.width, 50.0);
         assert_eq!(taffy.layout(child).unwrap().size.height, 100.0);
@@ -351,7 +351,7 @@ mod measure {
             .unwrap();
 
         let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[child]).unwrap();
-        taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 
         assert_eq!(taffy.layout(child).unwrap().size.width, 100.0);
         assert_eq!(taffy.layout(child).unwrap().size.height, 50.0);
@@ -395,7 +395,7 @@ mod measure {
             )
             .unwrap();
 
-        taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 
         assert_eq!(taffy.layout(child0).unwrap().size.width, 100.0);
         assert_eq!(taffy.layout(child0).unwrap().size.height, 100.0);
@@ -429,7 +429,7 @@ mod measure {
             )
             .unwrap();
 
-        taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 
         assert_eq!(taffy.layout(child).unwrap().size.width, 50.0);
         assert_eq!(taffy.layout(child).unwrap().size.height, 100.0);
@@ -464,7 +464,7 @@ mod measure {
             )
             .unwrap();
 
-        taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 
         assert_eq!(taffy.layout(child).unwrap().size.width, 50.0);
         assert_eq!(taffy.layout(child).unwrap().size.height, 50.0);
@@ -488,7 +488,7 @@ mod measure {
             )
             .unwrap();
 
-        taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 
         assert_eq!(taffy.layout(child).unwrap().size.width, 100.0);
         assert_eq!(taffy.layout(child).unwrap().size.height, 100.0);
@@ -518,7 +518,7 @@ mod measure {
             taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[grandchild]).unwrap();
 
         let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[child]).unwrap();
-        taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
 
         assert_eq!(NUM_MEASURES.load(atomic::Ordering::Relaxed), 2);
     }


### PR DESCRIPTION
# Objective

When working with `Style` in Bevy, I noticed that a common pattern was to use `..Default::default()` on what is now `FlexboxLayout`.

However, trait methods can't be constant in Rust (yet), so this can't be used to define new constant layout styles.

Changes:
1. Add `FlexboxLayout::DEFAULT`.
2. Clean up uses of constants.
3. Make builder patterns constant where possible.

## Context

Upstream tracking issue for the Rustl limitation: https://github.com/rust-lang/rust/issues/63065.

Some builder methods could not be made const because of https://github.com/orlp/slotmap/issues/85.