### PR TITLE
Remove unused deps: hashbrown, hash32, typenum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,17 +15,13 @@ license = "MIT"
 
 [dependencies]
 arrayvec = { version = "0.7", default-features = false }
-hash32 = "0.2"
-hash32-derive = "0.1"
 num-traits = { version = "0.2", default-features = false }
-typenum = "1"
-hashbrown = { version = "0.12", optional = true }
 serde = { version = "1.0", optional = true, features = ["serde_derive"] }
 slotmap = "1.0.6"
 
 [features]
 default = ["std"]
-alloc = ["hashbrown"]
+alloc = []
 std = ["num-traits/std"]
 serde = ["dep:serde"]
 


### PR DESCRIPTION
# Objective

Remove unused dependencies

# Context

None of these dependencies are even referenced anywhere as far as I can:

- Running ripgrep against the crate names only turns up results in Cargo.toml
- Searching for "use crate_name" in git history shows that uses have been removed

Specifically:
- `typenum` was used with an older version of ArrayVec, and isn't needed now ArrayVec is using const generics
- `hash32` and `hash32` derive were used for the custom forest implementation which has been replaced
- Usage of `hashbrown` was removed in 2019. We're not currently using any HashMaps (unless SlotMap counts), but if we were too then it would make sense to use the one from std/alloc which is now based on hashbrown anyway.

# Notes

I've run `cargo build`, `cargo test`, and `cargo bench` and all still run fine on my machine with this PR.