### PR TITLE
Remove unused licenses from DENY.tonl list

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -14,14 +14,8 @@ unlicensed = "deny"
 copyleft = "deny"
 allow = [
     "MIT",
-    "MIT-0",
     "Apache-2.0",
-    "BSD-3-Clause",
-    "ISC",
     "Zlib",
-    "0BSD",
-    "BSD-2-Clause",
-    "CC0-1.0",
 ]
 default = "deny"
 

--- a/deny.toml
+++ b/deny.toml
@@ -14,6 +14,7 @@ unlicensed = "deny"
 copyleft = "deny"
 allow = [
     "MIT",
+    "Unicode-DFS-2016",
     "Apache-2.0",
     "Zlib",
 ]


### PR DESCRIPTION
# Objective

CI is complaining about errors in our license-checking CI following #210.

https://github.com/DioxusLabs/taffy/runs/7567032612?check_suite_focus=true

I've removed those, so then CI will pass again 🎉 I'm also going to configure the repo to make sure that that check is required to merge.
