### PR TITLE
Run Clippy CI on the entire workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,8 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
-  
+          args: --workspace -- -D warnings
+
   markdownlint:
     name: Markdown Lint
     runs-on: ubuntu-latest

--- a/scripts/gentest/src/main.rs
+++ b/scripts/gentest/src/main.rs
@@ -183,14 +183,10 @@ fn generate_assertions(ident: &str, node: &json::JsonValue) -> TokenStream {
 
     let children = {
         let mut c = Vec::new();
-        match node["children"] {
-            json::JsonValue::Array(ref value) => {
-                for i in 0..value.len() {
-                    let child = &value[i];
-                    c.push(generate_assertions(&format!("{}{}", ident, i), child));
-                }
+        if let json::JsonValue::Array(ref value) = node["children"] {
+            for (idx, child) in value.iter().enumerate() {
+                c.push(generate_assertions(&format!("{}{}", ident, idx), child));
             }
-            _ => (),
         };
         c.into_iter().fold(quote!(), |a, b| quote!(#a #b))
     };

--- a/scripts/gentest/src/main.rs
+++ b/scripts/gentest/src/main.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use fantoccini::{Client, ClientBuilder};
-use json;
+
 use log::*;
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
@@ -25,7 +25,7 @@ async fn main() {
         .filter_map(|a| a.ok())
         .filter(|f| f.path().is_file() && f.path().extension().map(|p| p == "html").unwrap_or(false))
         .map(|f| {
-            let fixture_path = f.path().to_path_buf();
+            let fixture_path = f.path();
             let name = fixture_path.file_stem().unwrap().to_str().unwrap().to_string();
             (name, fixture_path)
         })
@@ -144,7 +144,7 @@ async fn test_root_element(client: Client, name: String, fixture_path: impl AsRe
 }
 
 fn generate_bench(description: &json::JsonValue) -> TokenStream {
-    let node_description = generate_node("node", &description);
+    let node_description = generate_node("node", description);
 
     quote!(
         pub fn compute() {
@@ -158,8 +158,8 @@ fn generate_bench(description: &json::JsonValue) -> TokenStream {
 fn generate_test(name: impl AsRef<str>, description: &json::JsonValue) -> TokenStream {
     let name = name.as_ref();
     let name = Ident::new(name, Span::call_site());
-    let node_description = generate_node("node", &description);
-    let assertions = generate_assertions("node", &description);
+    let node_description = generate_node("node", description);
+    let assertions = generate_assertions("node", description);
 
     quote!(
         #[test]
@@ -378,7 +378,7 @@ fn generate_node(ident: &str, node: &json::JsonValue) -> TokenStream {
 
     let (children_body, children) = match node["children"] {
         json::JsonValue::Array(ref value) => {
-            if value.len() > 0 {
+            if !value.is_empty() {
                 let body = value
                     .iter()
                     .enumerate()
@@ -397,7 +397,7 @@ fn generate_node(ident: &str, node: &json::JsonValue) -> TokenStream {
         _ => (quote!(), quote!()),
     };
 
-    let ident = Ident::new(&format!("{}", ident), Span::call_site());
+    let ident = Ident::new(ident, Span::call_site());
 
     quote!(
         #children_body

--- a/src/node.rs
+++ b/src/node.rs
@@ -533,7 +533,7 @@ mod tests {
         let children_result = taffy.children(node).unwrap();
         assert_eq!(children_result, children);
 
-        assert!(taffy.children(child0).unwrap().len() == 0);
+        assert!(taffy.children(child0).unwrap().is_empty());
     }
     #[test]
     fn test_set_style() {


### PR DESCRIPTION
# Objective

Clippy generated a bunch of warnings for the `scripts/gentest` project in the workspace.

This PR fixes those warnings and modifies the CI workflow to run Clippy on the entire workspace. This forces us to keep all the code clean and tidy.