### PR TITLE
Layout algorithm decoupling, Sizing Constraints & Perf Improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ alloc = []
 std = ["num-traits/std"]
 serde = ["dep:serde"]
 random = ["dep:rand"]
+debug = []
 
 [dev-dependencies]
 criterion = "0.4"

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ let root_node = taffy
     .unwrap();
 
 // Call compute_layout on the root of your tree to run the layout algorithm
-taffy.compute_layout(root_node, Size::NONE).unwrap();
+taffy.compute_layout(root_node, Size::MAX_CONTENT).unwrap();
 
 // Inspect the computed layout using taffy.layout
 assert_eq!(taffy.layout(root_node).unwrap().size.width, 800.0);

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -11,6 +11,7 @@
 - New `Layout` convenience constructor: `with_order(order: u32)`
 - Added support for `AlignContent::SpaceEvenly`
 - Added `AvailableSpace` enum
+- Added `debug` modules with a `print_tree` function, which prints a debug representation of the computed layout for a tree of nodes.
 
 ### 0.2.0 Changed
 
@@ -30,7 +31,7 @@
 - `taffy::error::InvalidNode` has been removed and is now just a branch on the `TaffyError` enum
 - `taffy::forest::Forest` has been merged into `taffy::node::Taffy` for a performance boost up to 90%
 - `Size::undefined()` has been removed, use `Size::NONE` instead.
-- `Taffy.compute_layout()` now takes `Size<AvailableSpace>` instead of `Size<Option<f32>>`
+- `Taffy.compute_layout()` now takes `Size<AvailableSpace>` instead of `Size<Option<f32>>`. If you were previously passing `Size::NONE` to this function, you will now need to pass `Size::MAX_CONTENT`
 - Measure functions now have an additional `available_space` parameter which indicates the size of the parent or a min/max-content sizing constraint.
 
 ### 0.2.0 Fixed

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -10,6 +10,7 @@
   - Several convenience constants have been defined: notably `FlexboxLayout::DEFAULT`
 - New `Layout` convenience constructor: `with_order(order: u32)`
 - Added support for `AlignContent::SpaceEvenly`
+- Added `AvailableSpace` enum
 
 ### 0.2.0 Changed
 
@@ -29,9 +30,12 @@
 - `taffy::error::InvalidNode` has been removed and is now just a branch on the `TaffyError` enum
 - `taffy::forest::Forest` has been merged into `taffy::node::Taffy` for a performance boost up to 90%
 - `Size::undefined()` has been removed, use `Size::NONE` instead.
+- `Taffy.compute_layout()` now takes `Size<AvailableSpace>` instead of `Size<Option<f32>>`
+- Measure functions now have an additional `available_space` parameter which indicates the size of the parent or a min/max-content sizing constraint.
 
 ### 0.2.0 Fixed
 
+- Performance with deep hierarchies is greatly improved. It is now comparable to that of shallow hierarchies with the same number of nodes.
 - nodes can only ever have one parent
 - fixed rounding of fractional values to follow latest Chrome - values are now rounded the same regardless of their position
 - fixed computing free space when using both `flex-grow` and a minimum size

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -33,6 +33,7 @@
 - `Size::undefined()` has been removed, use `Size::NONE` instead.
 - `Taffy.compute_layout()` now takes `Size<AvailableSpace>` instead of `Size<Option<f32>>`. If you were previously passing `Size::NONE` to this function, you will now need to pass `Size::MAX_CONTENT`
 - Measure functions now have an additional `available_space` parameter which indicates the size of the parent or a min/max-content sizing constraint.
+- Added `Size::MIN_CONTENT` and `Size::MAX_CONTENT` constants. In many cases, you will want to replace `Size::NONE` with `Size::MAX_CONTENT`.
 
 ### 0.2.0 Fixed
 

--- a/benches/big_tree.rs
+++ b/benches/big_tree.rs
@@ -87,6 +87,24 @@ fn taffy_benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("yoga benchmarks");
     group.sample_size(10);
 
+    group.bench_function("10 nodes", |b| {
+        let mut taffy = Taffy::new();
+        let root = build_yoga_deep_hierarchy(&mut taffy, 10, 10);
+        b.iter(|| taffy.compute_layout(root, Size::MAX_CONTENT).unwrap())
+    });
+
+    group.bench_function("100 nodes", |b| {
+        let mut taffy = Taffy::new();
+        let root = build_yoga_deep_hierarchy(&mut taffy, 100, 10);
+        b.iter(|| taffy.compute_layout(root, Size::MAX_CONTENT).unwrap())
+    });
+
+    group.bench_function("1_000 nodes", |b| {
+        let mut taffy = Taffy::new();
+        let root = build_yoga_deep_hierarchy(&mut taffy, 1_000, 10);
+        b.iter(|| taffy.compute_layout(root, Size::MAX_CONTENT).unwrap())
+    });
+
     group.bench_function("10_000 nodes", |b| {
         let mut taffy = Taffy::new();
         let root = build_yoga_deep_hierarchy(&mut taffy, 10_000, 10);

--- a/benches/big_tree.rs
+++ b/benches/big_tree.rs
@@ -30,19 +30,25 @@ fn build_flat_hierarchy(taffy: &mut Taffy, total_node_count: u32) -> Node {
 }
 
 /// A helper function to recursively construct a deep tree
-fn build_deep_tree(taffy: &mut Taffy, rng: &mut ChaCha8Rng, max_nodes: u32, branching_factor: u32) -> Vec<Node> {
+fn build_deep_tree(
+    taffy: &mut Taffy,
+    max_nodes: u32,
+    branching_factor: u32,
+    create_leaf_node: &mut impl FnMut(&mut Taffy) -> Node,
+    create_flex_node: &mut impl FnMut(&mut Taffy, Vec<Node>) -> Node,
+) -> Vec<Node> {
     if max_nodes <= branching_factor {
         // Build leaf nodes
-        return (0..max_nodes).map(|_| build_random_leaf(taffy, rng)).collect();
+        return (0..max_nodes).map(|_| create_leaf_node(taffy)).collect();
     }
 
     // Add another layer to the tree
     // Each child gets an equal amount of the remaining nodes
     (0..branching_factor)
         .map(|_| {
-            let sub_children =
-                build_deep_tree(taffy, rng, (max_nodes - branching_factor) / branching_factor, branching_factor);
-            taffy.new_with_children(FlexboxLayout::random(rng), &sub_children).unwrap()
+            let max_nodes = (max_nodes - branching_factor) / branching_factor;
+            let sub_children = build_deep_tree(taffy, max_nodes, branching_factor, create_leaf_node, create_flex_node);
+            create_flex_node(taffy, sub_children)
         })
         .collect()
 }
@@ -50,13 +56,56 @@ fn build_deep_tree(taffy: &mut Taffy, rng: &mut ChaCha8Rng, max_nodes: u32, bran
 /// A tree with a higher depth for a more realistic scenario
 fn build_deep_hierarchy(taffy: &mut Taffy, node_count: u32, branching_factor: u32) -> Node {
     let mut rng = ChaCha8Rng::seed_from_u64(12345);
+    let mut build_leaf_node = |taffy: &mut Taffy| build_random_leaf(taffy, &mut rng);
+    let mut rng = ChaCha8Rng::seed_from_u64(12345);
+    let mut build_flex_node = |taffy: &mut Taffy, children: Vec<Node>| taffy.new_with_children(FlexboxLayout::random(&mut rng), &children).unwrap();
 
-    let tree = build_deep_tree(taffy, &mut rng, node_count, branching_factor);
+    let tree = build_deep_tree(taffy, node_count, branching_factor, &mut build_leaf_node, &mut build_flex_node);
 
     taffy.new_with_children(FlexboxLayout { ..Default::default() }, &tree).unwrap()
 }
 
+/// A deep tree that matches the shape and styling that yoga use on their benchmarks
+fn build_yoga_deep_hierarchy(taffy: &mut Taffy, node_count: u32, branching_factor: u32) -> Node {
+   let style = FlexboxLayout {
+        size: Size { width: Dimension::Points(10.0), height: Dimension::Points(10.0) },
+        flex_grow: 1.0,
+        ..Default::default()
+    };
+    let mut build_leaf_node = |taffy: &mut Taffy| taffy.new_leaf(style.clone()).unwrap();
+    let mut build_flex_node = |taffy: &mut Taffy, children: Vec<Node>| taffy.new_with_children(style.clone(), &children).unwrap();
+
+    let tree = build_deep_tree(taffy, node_count, branching_factor, &mut build_leaf_node, &mut build_flex_node);
+    let root = taffy.new_with_children(FlexboxLayout::DEFAULT, &tree).unwrap();
+
+    root
+}
+
+
 fn taffy_benchmarks(c: &mut Criterion) {
+
+    let mut group = c.benchmark_group("yoga benchmarks");
+    group.sample_size(10);
+
+    group.bench_function("10_000 nodes", |b| {
+        let mut taffy = Taffy::new();
+        let root = build_yoga_deep_hierarchy(&mut taffy, 10_000, 10);
+        b.iter(|| taffy.compute_layout(root, Size::MAX_CONTENT).unwrap())
+    });
+
+    group.bench_function("100_000 nodes", |b| {
+        let mut taffy = Taffy::new();
+        let root = build_yoga_deep_hierarchy(&mut taffy, 100_000, 10);
+        b.iter(|| taffy.compute_layout(root, Size::MAX_CONTENT).unwrap())
+    });
+
+    group.bench_function("1_000_000 nodes", |b| {
+        let mut taffy = Taffy::new();
+        let root = build_yoga_deep_hierarchy(&mut taffy, 1_000_000, 10);
+        b.iter(|| taffy.compute_layout(root, Size::MAX_CONTENT).unwrap())
+    });
+    drop(group);
+
     // Decrease sample size, because the tasks take longer
     let mut group = c.benchmark_group("big trees");
     group.sample_size(10);

--- a/benches/big_tree.rs
+++ b/benches/big_tree.rs
@@ -96,13 +96,19 @@ fn taffy_benchmarks(c: &mut Criterion) {
         b.iter(|| taffy.compute_layout(root, Size::MAX_CONTENT).unwrap())
     });
 
-    // Slow. To be enabled once performance improvements land.
-    // group.bench_function("100_000 nodes (17-level hierarchy)", |b| {
-    //     let mut taffy = Taffy::new();
-    //     let root = build_deep_hierarchy(&mut taffy, 100_000, 2);
+    group.bench_function("100_000 nodes (17-level hierarchy)", |b| {
+        let mut taffy = Taffy::new();
+        let root = build_deep_hierarchy(&mut taffy, 100_000, 2);
 
-    //     b.iter(|| taffy.compute_layout(root, Size::MAX_CONTENT).unwrap())
-    // });
+        b.iter(|| taffy.compute_layout(root, Size::MAX_CONTENT).unwrap())
+    });
+
+    group.bench_function("1_000_000 nodes (20-level hierarchy)", |b| {
+        let mut taffy = Taffy::new();
+        let root = build_deep_hierarchy(&mut taffy, 1_000_000, 2);
+
+        b.iter(|| taffy.compute_layout(root, Size::MAX_CONTENT).unwrap())
+    });
 }
 
 criterion_group!(benches, taffy_benchmarks);

--- a/benches/big_tree.rs
+++ b/benches/big_tree.rs
@@ -31,6 +31,7 @@ fn build_flat_hierarchy(taffy: &mut Taffy, total_node_count: u32) -> Node {
 
 /// A helper function to recursively construct a deep tree
 fn build_deep_tree(taffy: &mut Taffy, rng: &mut ChaCha8Rng, max_nodes: u32, branching_factor: u32) -> Vec<Node> {
+
     if max_nodes <= branching_factor {
         // Build leaf nodes
         return (0..max_nodes).map(|_| build_random_leaf(taffy, rng)).collect();

--- a/benches/big_tree.rs
+++ b/benches/big_tree.rs
@@ -65,14 +65,14 @@ fn taffy_benchmarks(c: &mut Criterion) {
         let mut taffy = Taffy::new();
         let root = build_flat_hierarchy(&mut taffy, 10_000);
 
-        b.iter(|| taffy.compute_layout(root, Size::NONE).unwrap())
+        b.iter(|| taffy.compute_layout(root, Size::MAX_CONTENT).unwrap())
     });
 
     group.bench_function("100_000 nodes (2-level hierarchy)", |b| {
         let mut taffy = Taffy::new();
         let root = build_flat_hierarchy(&mut taffy, 100_000);
 
-        b.iter(|| taffy.compute_layout(root, Size::NONE).unwrap())
+        b.iter(|| taffy.compute_layout(root, Size::MAX_CONTENT).unwrap())
     });
 
     group.bench_function("100_000 nodes (7-level hierarchy)", |b| {

--- a/benches/big_tree.rs
+++ b/benches/big_tree.rs
@@ -58,7 +58,9 @@ fn build_deep_hierarchy(taffy: &mut Taffy, node_count: u32, branching_factor: u3
     let mut rng = ChaCha8Rng::seed_from_u64(12345);
     let mut build_leaf_node = |taffy: &mut Taffy| build_random_leaf(taffy, &mut rng);
     let mut rng = ChaCha8Rng::seed_from_u64(12345);
-    let mut build_flex_node = |taffy: &mut Taffy, children: Vec<Node>| taffy.new_with_children(FlexboxLayout::random(&mut rng), &children).unwrap();
+    let mut build_flex_node = |taffy: &mut Taffy, children: Vec<Node>| {
+        taffy.new_with_children(FlexboxLayout::random(&mut rng), &children).unwrap()
+    };
 
     let tree = build_deep_tree(taffy, node_count, branching_factor, &mut build_leaf_node, &mut build_flex_node);
 
@@ -67,13 +69,14 @@ fn build_deep_hierarchy(taffy: &mut Taffy, node_count: u32, branching_factor: u3
 
 /// A deep tree that matches the shape and styling that yoga use on their benchmarks
 fn build_yoga_deep_hierarchy(taffy: &mut Taffy, node_count: u32, branching_factor: u32) -> Node {
-   let style = FlexboxLayout {
+    let style = FlexboxLayout {
         size: Size { width: Dimension::Points(10.0), height: Dimension::Points(10.0) },
         flex_grow: 1.0,
         ..Default::default()
     };
     let mut build_leaf_node = |taffy: &mut Taffy| taffy.new_leaf(style.clone()).unwrap();
-    let mut build_flex_node = |taffy: &mut Taffy, children: Vec<Node>| taffy.new_with_children(style.clone(), &children).unwrap();
+    let mut build_flex_node =
+        |taffy: &mut Taffy, children: Vec<Node>| taffy.new_with_children(style.clone(), &children).unwrap();
 
     let tree = build_deep_tree(taffy, node_count, branching_factor, &mut build_leaf_node, &mut build_flex_node);
     let root = taffy.new_with_children(FlexboxLayout::DEFAULT, &tree).unwrap();
@@ -81,9 +84,7 @@ fn build_yoga_deep_hierarchy(taffy: &mut Taffy, node_count: u32, branching_facto
     root
 }
 
-
 fn taffy_benchmarks(c: &mut Criterion) {
-
     let mut group = c.benchmark_group("yoga benchmarks");
     group.sample_size(10);
 

--- a/benches/big_tree.rs
+++ b/benches/big_tree.rs
@@ -79,30 +79,29 @@ fn taffy_benchmarks(c: &mut Criterion) {
         let mut taffy = Taffy::new();
         let root = build_deep_hierarchy(&mut taffy, 100_000, 7);
 
-        b.iter(|| taffy.compute_layout(root, Size::NONE).unwrap())
+        b.iter(|| taffy.compute_layout(root, Size::MAX_CONTENT).unwrap())
     });
 
     group.bench_function("4000 nodes (12-level hierarchy)", |b| {
         let mut taffy = Taffy::new();
         let root = build_deep_hierarchy(&mut taffy, 4000, 2);
 
-        b.iter(|| taffy.compute_layout(root, Size::NONE).unwrap())
+        b.iter(|| taffy.compute_layout(root, Size::MAX_CONTENT).unwrap())
     });
 
-    // Slow. To be enabled once performance improvements land.
-    // group.bench_function("10_000 nodes (14-level hierarchy)", |b| {
-    //     let mut taffy = Taffy::new();
-    //     let root = build_deep_hierarchy(&mut taffy, 10_000, 2);
+    group.bench_function("10_000 nodes (14-level hierarchy)", |b| {
+        let mut taffy = Taffy::new();
+        let root = build_deep_hierarchy(&mut taffy, 10_000, 2);
 
-    //     b.iter(|| taffy.compute_layout(root, Size::NONE).unwrap())
-    // });
+        b.iter(|| taffy.compute_layout(root, Size::MAX_CONTENT).unwrap())
+    });
 
     // Slow. To be enabled once performance improvements land.
     // group.bench_function("100_000 nodes (17-level hierarchy)", |b| {
     //     let mut taffy = Taffy::new();
     //     let root = build_deep_hierarchy(&mut taffy, 100_000, 2);
 
-    //     b.iter(|| taffy.compute_layout(root, Size::NONE).unwrap())
+    //     b.iter(|| taffy.compute_layout(root, Size::MAX_CONTENT).unwrap())
     // });
 }
 

--- a/benches/big_tree.rs
+++ b/benches/big_tree.rs
@@ -31,7 +31,6 @@ fn build_flat_hierarchy(taffy: &mut Taffy, total_node_count: u32) -> Node {
 
 /// A helper function to recursively construct a deep tree
 fn build_deep_tree(taffy: &mut Taffy, rng: &mut ChaCha8Rng, max_nodes: u32, branching_factor: u32) -> Vec<Node> {
-
     if max_nodes <= branching_factor {
         // Build leaf nodes
         return (0..max_nodes).map(|_| build_random_leaf(taffy, rng)).collect();

--- a/benches/complex.rs
+++ b/benches/complex.rs
@@ -111,7 +111,7 @@ fn taffy_benchmarks(c: &mut Criterion) {
         b.iter(|| {
             let mut taffy = taffy::node::Taffy::new();
             let root = build_deep_hierarchy(&mut taffy);
-            taffy.compute_layout(root, taffy::geometry::Size::NONE).unwrap()
+            taffy.compute_layout(root, taffy::geometry::Size::MAX_CONTENT).unwrap()
         })
     });
 
@@ -121,7 +121,7 @@ fn taffy_benchmarks(c: &mut Criterion) {
 
         b.iter(|| {
             taffy.mark_dirty(root).unwrap();
-            taffy.compute_layout(root, taffy::geometry::Size::NONE).unwrap()
+            taffy.compute_layout(root, taffy::geometry::Size::MAX_CONTENT).unwrap()
         })
     });
 }

--- a/benches/generated/absolute_layout_align_items_and_justify_content_center.rs
+++ b/benches/generated/absolute_layout_align_items_and_justify_content_center.rs
@@ -29,5 +29,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/absolute_layout_align_items_and_justify_content_center_and_bottom_position.rs
+++ b/benches/generated/absolute_layout_align_items_and_justify_content_center_and_bottom_position.rs
@@ -33,5 +33,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/absolute_layout_align_items_and_justify_content_center_and_left_position.rs
+++ b/benches/generated/absolute_layout_align_items_and_justify_content_center_and_left_position.rs
@@ -30,5 +30,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/absolute_layout_align_items_and_justify_content_center_and_right_position.rs
+++ b/benches/generated/absolute_layout_align_items_and_justify_content_center_and_right_position.rs
@@ -30,5 +30,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/absolute_layout_align_items_and_justify_content_center_and_top_position.rs
+++ b/benches/generated/absolute_layout_align_items_and_justify_content_center_and_top_position.rs
@@ -30,5 +30,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/absolute_layout_align_items_and_justify_content_flex_end.rs
+++ b/benches/generated/absolute_layout_align_items_and_justify_content_flex_end.rs
@@ -29,5 +29,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/absolute_layout_align_items_center.rs
+++ b/benches/generated/absolute_layout_align_items_center.rs
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/absolute_layout_align_items_center_on_child_only.rs
+++ b/benches/generated/absolute_layout_align_items_center_on_child_only.rs
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/absolute_layout_child_order.rs
+++ b/benches/generated/absolute_layout_child_order.rs
@@ -55,5 +55,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/absolute_layout_in_wrap_reverse_column_container.rs
+++ b/benches/generated/absolute_layout_in_wrap_reverse_column_container.rs
@@ -29,5 +29,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/absolute_layout_in_wrap_reverse_column_container_flex_end.rs
+++ b/benches/generated/absolute_layout_in_wrap_reverse_column_container_flex_end.rs
@@ -30,5 +30,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/absolute_layout_in_wrap_reverse_row_container.rs
+++ b/benches/generated/absolute_layout_in_wrap_reverse_row_container.rs
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/absolute_layout_in_wrap_reverse_row_container_flex_end.rs
+++ b/benches/generated/absolute_layout_in_wrap_reverse_row_container_flex_end.rs
@@ -29,5 +29,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/absolute_layout_justify_content_center.rs
+++ b/benches/generated/absolute_layout_justify_content_center.rs
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/absolute_layout_no_size.rs
+++ b/benches/generated/absolute_layout_no_size.rs
@@ -19,5 +19,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/absolute_layout_percentage_bottom_based_on_parent_height.rs
+++ b/benches/generated/absolute_layout_percentage_bottom_based_on_parent_height.rs
@@ -61,5 +61,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/absolute_layout_start_top_end_bottom.rs
+++ b/benches/generated/absolute_layout_start_top_end_bottom.rs
@@ -29,5 +29,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/absolute_layout_width_height_end_bottom.rs
+++ b/benches/generated/absolute_layout_width_height_end_bottom.rs
@@ -32,5 +32,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/absolute_layout_width_height_start_top.rs
+++ b/benches/generated/absolute_layout_width_height_start_top.rs
@@ -32,5 +32,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/absolute_layout_width_height_start_top_end_bottom.rs
+++ b/benches/generated/absolute_layout_width_height_start_top_end_bottom.rs
@@ -34,5 +34,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/absolute_layout_within_border.rs
+++ b/benches/generated/absolute_layout_within_border.rs
@@ -117,5 +117,5 @@ pub fn compute() {
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/align_baseline.rs
+++ b/benches/generated/align_baseline.rs
@@ -40,5 +40,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/align_baseline_child_multiline.rs
+++ b/benches/generated/align_baseline_child_multiline.rs
@@ -85,5 +85,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/align_baseline_nested_child.rs
+++ b/benches/generated/align_baseline_nested_child.rs
@@ -54,5 +54,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/align_center_should_size_based_on_content.rs
+++ b/benches/generated/align_center_should_size_based_on_content.rs
@@ -44,5 +44,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/align_content_space_around_single_line.rs
+++ b/benches/generated/align_content_space_around_single_line.rs
@@ -92,5 +92,5 @@ pub fn compute() {
             &[node0, node1, node2, node3, node4, node5],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/align_content_space_around_wrapped.rs
+++ b/benches/generated/align_content_space_around_wrapped.rs
@@ -93,5 +93,5 @@ pub fn compute() {
             &[node0, node1, node2, node3, node4, node5],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/align_content_space_between_single_line.rs
+++ b/benches/generated/align_content_space_between_single_line.rs
@@ -92,5 +92,5 @@ pub fn compute() {
             &[node0, node1, node2, node3, node4, node5],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/align_content_space_between_wrapped.rs
+++ b/benches/generated/align_content_space_between_wrapped.rs
@@ -93,5 +93,5 @@ pub fn compute() {
             &[node0, node1, node2, node3, node4, node5],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/align_content_space_evenly_single_line.rs
+++ b/benches/generated/align_content_space_evenly_single_line.rs
@@ -92,5 +92,5 @@ pub fn compute() {
             &[node0, node1, node2, node3, node4, node5],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/align_content_space_evenly_wrapped.rs
+++ b/benches/generated/align_content_space_evenly_wrapped.rs
@@ -93,5 +93,5 @@ pub fn compute() {
             &[node0, node1, node2, node3, node4, node5],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/align_flex_start_with_shrinking_children.rs
+++ b/benches/generated/align_flex_start_with_shrinking_children.rs
@@ -31,5 +31,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/align_flex_start_with_shrinking_children_with_stretch.rs
+++ b/benches/generated/align_flex_start_with_shrinking_children_with_stretch.rs
@@ -31,5 +31,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/align_flex_start_with_stretching_children.rs
+++ b/benches/generated/align_flex_start_with_stretching_children.rs
@@ -26,5 +26,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/align_items_center.rs
+++ b/benches/generated/align_items_center.rs
@@ -27,5 +27,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/align_items_center_child_with_margin_bigger_than_parent.rs
+++ b/benches/generated/align_items_center_child_with_margin_bigger_than_parent.rs
@@ -39,5 +39,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/align_items_center_child_without_margin_bigger_than_parent.rs
+++ b/benches/generated/align_items_center_child_without_margin_bigger_than_parent.rs
@@ -34,5 +34,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/align_items_center_with_child_margin.rs
+++ b/benches/generated/align_items_center_with_child_margin.rs
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/align_items_center_with_child_top.rs
+++ b/benches/generated/align_items_center_with_child_top.rs
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/align_items_flex_end.rs
+++ b/benches/generated/align_items_flex_end.rs
@@ -27,5 +27,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/align_items_flex_end_child_with_margin_bigger_than_parent.rs
+++ b/benches/generated/align_items_flex_end_child_with_margin_bigger_than_parent.rs
@@ -39,5 +39,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/align_items_flex_end_child_without_margin_bigger_than_parent.rs
+++ b/benches/generated/align_items_flex_end_child_without_margin_bigger_than_parent.rs
@@ -34,5 +34,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/align_items_flex_start.rs
+++ b/benches/generated/align_items_flex_start.rs
@@ -27,5 +27,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/align_items_min_max.rs
+++ b/benches/generated/align_items_min_max.rs
@@ -32,5 +32,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/align_items_stretch.rs
+++ b/benches/generated/align_items_stretch.rs
@@ -22,5 +22,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/align_self_baseline.rs
+++ b/benches/generated/align_self_baseline.rs
@@ -54,5 +54,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/align_self_center.rs
+++ b/benches/generated/align_self_center.rs
@@ -27,5 +27,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/align_self_flex_end.rs
+++ b/benches/generated/align_self_flex_end.rs
@@ -27,5 +27,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/align_self_flex_end_override_flex_start.rs
+++ b/benches/generated/align_self_flex_end_override_flex_start.rs
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/align_self_flex_start.rs
+++ b/benches/generated/align_self_flex_start.rs
@@ -27,5 +27,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/align_strech_should_size_based_on_parent.rs
+++ b/benches/generated/align_strech_should_size_based_on_parent.rs
@@ -43,5 +43,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/border_center_child.rs
+++ b/benches/generated/border_center_child.rs
@@ -33,5 +33,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/border_flex_child.rs
+++ b/benches/generated/border_flex_child.rs
@@ -30,5 +30,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/border_no_child.rs
+++ b/benches/generated/border_no_child.rs
@@ -15,5 +15,5 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/border_stretch_child.rs
+++ b/benches/generated/border_stretch_child.rs
@@ -29,5 +29,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/child_min_max_width_flexing.rs
+++ b/benches/generated/child_min_max_width_flexing.rs
@@ -37,5 +37,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/container_with_unsized_child.rs
+++ b/benches/generated/container_with_unsized_child.rs
@@ -14,5 +14,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/display_none.rs
+++ b/benches/generated/display_none.rs
@@ -21,5 +21,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/display_none_fixed_size.rs
+++ b/benches/generated/display_none_fixed_size.rs
@@ -29,5 +29,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/display_none_with_child.rs
+++ b/benches/generated/display_none_with_child.rs
@@ -60,5 +60,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/display_none_with_margin.rs
+++ b/benches/generated/display_none_with_margin.rs
@@ -36,5 +36,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/display_none_with_position.rs
+++ b/benches/generated/display_none_with_position.rs
@@ -26,5 +26,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_basis_and_main_dimen_set_when_flexing.rs
+++ b/benches/generated/flex_basis_and_main_dimen_set_when_flexing.rs
@@ -39,5 +39,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_basis_flex_grow_column.rs
+++ b/benches/generated/flex_basis_flex_grow_column.rs
@@ -26,5 +26,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_basis_flex_grow_row.rs
+++ b/benches/generated/flex_basis_flex_grow_row.rs
@@ -25,5 +25,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_basis_flex_shrink_column.rs
+++ b/benches/generated/flex_basis_flex_shrink_column.rs
@@ -26,5 +26,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_basis_flex_shrink_row.rs
+++ b/benches/generated/flex_basis_flex_shrink_row.rs
@@ -25,5 +25,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_basis_larger_than_content_column.rs
+++ b/benches/generated/flex_basis_larger_than_content_column.rs
@@ -33,5 +33,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_basis_larger_than_content_row.rs
+++ b/benches/generated/flex_basis_larger_than_content_row.rs
@@ -32,5 +32,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_basis_overrides_main_size.rs
+++ b/benches/generated/flex_basis_overrides_main_size.rs
@@ -44,5 +44,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_basis_slightly_smaller_then_content_with_flex_grow_large_size.rs
+++ b/benches/generated/flex_basis_slightly_smaller_then_content_with_flex_grow_large_size.rs
@@ -57,5 +57,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_basis_smaller_than_content_column.rs
+++ b/benches/generated/flex_basis_smaller_than_content_column.rs
@@ -33,5 +33,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_basis_smaller_than_content_row.rs
+++ b/benches/generated/flex_basis_smaller_than_content_row.rs
@@ -32,5 +32,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_basis_smaller_than_main_dimen_column.rs
+++ b/benches/generated/flex_basis_smaller_than_main_dimen_column.rs
@@ -24,5 +24,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_basis_smaller_than_main_dimen_row.rs
+++ b/benches/generated/flex_basis_smaller_than_main_dimen_row.rs
@@ -23,5 +23,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_basis_smaller_then_content_with_flex_grow_large_size.rs
+++ b/benches/generated/flex_basis_smaller_then_content_with_flex_grow_large_size.rs
@@ -57,5 +57,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_basis_smaller_then_content_with_flex_grow_small_size.rs
+++ b/benches/generated/flex_basis_smaller_then_content_with_flex_grow_small_size.rs
@@ -57,5 +57,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_basis_smaller_then_content_with_flex_grow_unconstraint_size.rs
+++ b/benches/generated/flex_basis_smaller_then_content_with_flex_grow_unconstraint_size.rs
@@ -49,5 +49,5 @@ pub fn compute() {
         )
         .unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0, node1]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_basis_smaller_then_content_with_flex_grow_very_large_size.rs
+++ b/benches/generated/flex_basis_smaller_then_content_with_flex_grow_very_large_size.rs
@@ -57,5 +57,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_basis_unconstraint_column.rs
+++ b/benches/generated/flex_basis_unconstraint_column.rs
@@ -16,5 +16,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_basis_unconstraint_row.rs
+++ b/benches/generated/flex_basis_unconstraint_row.rs
@@ -11,5 +11,5 @@ pub fn compute() {
         )
         .unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_direction_column.rs
+++ b/benches/generated/flex_direction_column.rs
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_direction_column_no_height.rs
+++ b/benches/generated/flex_direction_column_no_height.rs
@@ -37,5 +37,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_direction_column_reverse.rs
+++ b/benches/generated/flex_direction_column_reverse.rs
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_direction_row.rs
+++ b/benches/generated/flex_direction_row.rs
@@ -40,5 +40,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_direction_row_no_width.rs
+++ b/benches/generated/flex_direction_row_no_width.rs
@@ -36,5 +36,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_direction_row_reverse.rs
+++ b/benches/generated/flex_direction_row_reverse.rs
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_grow_child.rs
+++ b/benches/generated/flex_grow_child.rs
@@ -12,5 +12,5 @@ pub fn compute() {
         )
         .unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_grow_flex_basis_percent_min_max.rs
+++ b/benches/generated/flex_grow_flex_basis_percent_min_max.rs
@@ -39,5 +39,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_grow_height_maximized.rs
+++ b/benches/generated/flex_grow_height_maximized.rs
@@ -51,5 +51,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_grow_in_at_most_container.rs
+++ b/benches/generated/flex_grow_in_at_most_container.rs
@@ -25,5 +25,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_grow_less_than_factor_one.rs
+++ b/benches/generated/flex_grow_less_than_factor_one.rs
@@ -36,5 +36,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_grow_root_minimized.rs
+++ b/benches/generated/flex_grow_root_minimized.rs
@@ -55,5 +55,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_grow_shrink_at_most.rs
+++ b/benches/generated/flex_grow_shrink_at_most.rs
@@ -20,5 +20,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_grow_to_min.rs
+++ b/benches/generated/flex_grow_to_min.rs
@@ -33,5 +33,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_grow_within_constrained_max_column.rs
+++ b/benches/generated/flex_grow_within_constrained_max_column.rs
@@ -33,5 +33,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_grow_within_constrained_max_row.rs
+++ b/benches/generated/flex_grow_within_constrained_max_row.rs
@@ -42,5 +42,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_grow_within_constrained_max_width.rs
+++ b/benches/generated/flex_grow_within_constrained_max_width.rs
@@ -36,5 +36,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_grow_within_constrained_min_column.rs
+++ b/benches/generated/flex_grow_within_constrained_min_column.rs
@@ -24,5 +24,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_grow_within_constrained_min_max_column.rs
+++ b/benches/generated/flex_grow_within_constrained_min_max_column.rs
@@ -23,5 +23,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_grow_within_constrained_min_row.rs
+++ b/benches/generated/flex_grow_within_constrained_min_row.rs
@@ -24,5 +24,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_grow_within_max_width.rs
+++ b/benches/generated/flex_grow_within_max_width.rs
@@ -36,5 +36,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_root_ignored.rs
+++ b/benches/generated/flex_root_ignored.rs
@@ -37,5 +37,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_shrink_by_outer_margin_with_max_size.rs
+++ b/benches/generated/flex_shrink_by_outer_margin_with_max_size.rs
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_shrink_flex_grow_child_flex_shrink_other_child.rs
+++ b/benches/generated/flex_shrink_flex_grow_child_flex_shrink_other_child.rs
@@ -43,5 +43,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_shrink_flex_grow_row.rs
+++ b/benches/generated/flex_shrink_flex_grow_row.rs
@@ -43,5 +43,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_shrink_to_zero.rs
+++ b/benches/generated/flex_shrink_to_zero.rs
@@ -51,5 +51,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_wrap_align_stretch_fits_one_row.rs
+++ b/benches/generated/flex_wrap_align_stretch_fits_one_row.rs
@@ -32,5 +32,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_wrap_children_with_min_main_overriding_flex_basis.rs
+++ b/benches/generated/flex_wrap_children_with_min_main_overriding_flex_basis.rs
@@ -32,5 +32,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/flex_wrap_wrap_to_child_height.rs
+++ b/benches/generated/flex_wrap_wrap_to_child_height.rs
@@ -52,5 +52,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/justify_content_column_center.rs
+++ b/benches/generated/justify_content_column_center.rs
@@ -42,5 +42,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/justify_content_column_flex_end.rs
+++ b/benches/generated/justify_content_column_flex_end.rs
@@ -42,5 +42,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/justify_content_column_flex_start.rs
+++ b/benches/generated/justify_content_column_flex_start.rs
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/justify_content_column_min_height_and_margin_bottom.rs
+++ b/benches/generated/justify_content_column_min_height_and_margin_bottom.rs
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/justify_content_column_min_height_and_margin_top.rs
+++ b/benches/generated/justify_content_column_min_height_and_margin_top.rs
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/justify_content_column_space_around.rs
+++ b/benches/generated/justify_content_column_space_around.rs
@@ -42,5 +42,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/justify_content_column_space_between.rs
+++ b/benches/generated/justify_content_column_space_between.rs
@@ -42,5 +42,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/justify_content_column_space_evenly.rs
+++ b/benches/generated/justify_content_column_space_evenly.rs
@@ -42,5 +42,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/justify_content_min_max.rs
+++ b/benches/generated/justify_content_min_max.rs
@@ -32,5 +32,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/justify_content_min_width_with_padding_child_width_greater_than_parent.rs
+++ b/benches/generated/justify_content_min_width_with_padding_child_width_greater_than_parent.rs
@@ -46,5 +46,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/justify_content_min_width_with_padding_child_width_lower_than_parent.rs
+++ b/benches/generated/justify_content_min_width_with_padding_child_width_lower_than_parent.rs
@@ -46,5 +46,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/justify_content_overflow_min_max.rs
+++ b/benches/generated/justify_content_overflow_min_max.rs
@@ -60,5 +60,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/justify_content_row_center.rs
+++ b/benches/generated/justify_content_row_center.rs
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/justify_content_row_flex_end.rs
+++ b/benches/generated/justify_content_row_flex_end.rs
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/justify_content_row_flex_start.rs
+++ b/benches/generated/justify_content_row_flex_start.rs
@@ -40,5 +40,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/justify_content_row_max_width_and_margin.rs
+++ b/benches/generated/justify_content_row_max_width_and_margin.rs
@@ -25,5 +25,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/justify_content_row_min_width_and_margin.rs
+++ b/benches/generated/justify_content_row_min_width_and_margin.rs
@@ -24,5 +24,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/justify_content_row_space_around.rs
+++ b/benches/generated/justify_content_row_space_around.rs
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/justify_content_row_space_between.rs
+++ b/benches/generated/justify_content_row_space_between.rs
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/justify_content_row_space_evenly.rs
+++ b/benches/generated/justify_content_row_space_evenly.rs
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/margin_and_flex_column.rs
+++ b/benches/generated/margin_and_flex_column.rs
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/margin_and_flex_row.rs
+++ b/benches/generated/margin_and_flex_row.rs
@@ -27,5 +27,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/margin_and_stretch_column.rs
+++ b/benches/generated/margin_and_stretch_column.rs
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/margin_and_stretch_row.rs
+++ b/benches/generated/margin_and_stretch_row.rs
@@ -27,5 +27,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/margin_auto_bottom.rs
+++ b/benches/generated/margin_auto_bottom.rs
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/margin_auto_bottom_and_top.rs
+++ b/benches/generated/margin_auto_bottom_and_top.rs
@@ -45,5 +45,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/margin_auto_bottom_and_top_justify_center.rs
+++ b/benches/generated/margin_auto_bottom_and_top_justify_center.rs
@@ -45,5 +45,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/margin_auto_left.rs
+++ b/benches/generated/margin_auto_left.rs
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/margin_auto_left_and_right.rs
+++ b/benches/generated/margin_auto_left_and_right.rs
@@ -44,5 +44,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/margin_auto_left_and_right_column.rs
+++ b/benches/generated/margin_auto_left_and_right_column.rs
@@ -45,5 +45,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/margin_auto_left_and_right_column_and_center.rs
+++ b/benches/generated/margin_auto_left_and_right_column_and_center.rs
@@ -45,5 +45,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/margin_auto_left_and_right_strech.rs
+++ b/benches/generated/margin_auto_left_and_right_strech.rs
@@ -44,5 +44,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/margin_auto_left_child_bigger_than_parent.rs
+++ b/benches/generated/margin_auto_left_child_bigger_than_parent.rs
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/margin_auto_left_fix_right_child_bigger_than_parent.rs
+++ b/benches/generated/margin_auto_left_fix_right_child_bigger_than_parent.rs
@@ -32,5 +32,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/margin_auto_left_right_child_bigger_than_parent.rs
+++ b/benches/generated/margin_auto_left_right_child_bigger_than_parent.rs
@@ -32,5 +32,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/margin_auto_left_stretching_child.rs
+++ b/benches/generated/margin_auto_left_stretching_child.rs
@@ -39,5 +39,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/margin_auto_mutiple_children_column.rs
+++ b/benches/generated/margin_auto_mutiple_children_column.rs
@@ -56,5 +56,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/margin_auto_mutiple_children_row.rs
+++ b/benches/generated/margin_auto_mutiple_children_row.rs
@@ -55,5 +55,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/margin_auto_right.rs
+++ b/benches/generated/margin_auto_right.rs
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/margin_auto_top.rs
+++ b/benches/generated/margin_auto_top.rs
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/margin_auto_top_and_bottom_strech.rs
+++ b/benches/generated/margin_auto_top_and_bottom_strech.rs
@@ -45,5 +45,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/margin_auto_top_stretching_child.rs
+++ b/benches/generated/margin_auto_top_stretching_child.rs
@@ -39,5 +39,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/margin_bottom.rs
+++ b/benches/generated/margin_bottom.rs
@@ -25,5 +25,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/margin_fix_left_auto_right_child_bigger_than_parent.rs
+++ b/benches/generated/margin_fix_left_auto_right_child_bigger_than_parent.rs
@@ -32,5 +32,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/margin_left.rs
+++ b/benches/generated/margin_left.rs
@@ -23,5 +23,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/margin_right.rs
+++ b/benches/generated/margin_right.rs
@@ -24,5 +24,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/margin_should_not_be_part_of_max_height.rs
+++ b/benches/generated/margin_should_not_be_part_of_max_height.rs
@@ -31,5 +31,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/margin_should_not_be_part_of_max_width.rs
+++ b/benches/generated/margin_should_not_be_part_of_max_width.rs
@@ -31,5 +31,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/margin_top.rs
+++ b/benches/generated/margin_top.rs
@@ -24,5 +24,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/margin_with_sibling_column.rs
+++ b/benches/generated/margin_with_sibling_column.rs
@@ -26,5 +26,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/margin_with_sibling_row.rs
+++ b/benches/generated/margin_with_sibling_row.rs
@@ -25,5 +25,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/max_height.rs
+++ b/benches/generated/max_height.rs
@@ -26,5 +26,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/max_height_overrides_height.rs
+++ b/benches/generated/max_height_overrides_height.rs
@@ -14,5 +14,5 @@ pub fn compute() {
         )
         .unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/max_height_overrides_height_on_root.rs
+++ b/benches/generated/max_height_overrides_height_on_root.rs
@@ -13,5 +13,5 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/max_width.rs
+++ b/benches/generated/max_width.rs
@@ -24,5 +24,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/max_width_overrides_width.rs
+++ b/benches/generated/max_width_overrides_width.rs
@@ -14,5 +14,5 @@ pub fn compute() {
         )
         .unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/max_width_overrides_width_on_root.rs
+++ b/benches/generated/max_width_overrides_width_on_root.rs
@@ -13,5 +13,5 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/min_height.rs
+++ b/benches/generated/min_height.rs
@@ -29,5 +29,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/min_height_overrides_height.rs
+++ b/benches/generated/min_height_overrides_height.rs
@@ -14,5 +14,5 @@ pub fn compute() {
         )
         .unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/min_height_overrides_height_on_root.rs
+++ b/benches/generated/min_height_overrides_height_on_root.rs
@@ -13,5 +13,5 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/min_max_percent_no_width_height.rs
+++ b/benches/generated/min_max_percent_no_width_height.rs
@@ -33,5 +33,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/min_width.rs
+++ b/benches/generated/min_width.rs
@@ -25,5 +25,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/min_width_overrides_width.rs
+++ b/benches/generated/min_width_overrides_width.rs
@@ -14,5 +14,5 @@ pub fn compute() {
         )
         .unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/min_width_overrides_width_on_root.rs
+++ b/benches/generated/min_width_overrides_width_on_root.rs
@@ -13,5 +13,5 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/nested_overflowing_child.rs
+++ b/benches/generated/nested_overflowing_child.rs
@@ -27,5 +27,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/nested_overflowing_child_in_constraint_parent.rs
+++ b/benches/generated/nested_overflowing_child_in_constraint_parent.rs
@@ -39,5 +39,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/overflow_cross_axis.rs
+++ b/benches/generated/overflow_cross_axis.rs
@@ -26,5 +26,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/overflow_main_axis.rs
+++ b/benches/generated/overflow_main_axis.rs
@@ -23,5 +23,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/padding_align_end_child.rs
+++ b/benches/generated/padding_align_end_child.rs
@@ -35,5 +35,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/padding_center_child.rs
+++ b/benches/generated/padding_center_child.rs
@@ -35,5 +35,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/padding_flex_child.rs
+++ b/benches/generated/padding_flex_child.rs
@@ -30,5 +30,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/padding_no_child.rs
+++ b/benches/generated/padding_no_child.rs
@@ -15,5 +15,5 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/padding_stretch_child.rs
+++ b/benches/generated/padding_stretch_child.rs
@@ -29,5 +29,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/parent_wrap_child_size_overflowing_parent.rs
+++ b/benches/generated/parent_wrap_child_size_overflowing_parent.rs
@@ -35,5 +35,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/percent_absolute_position.rs
+++ b/benches/generated/percent_absolute_position.rs
@@ -50,5 +50,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/percent_within_flex_grow.rs
+++ b/benches/generated/percent_within_flex_grow.rs
@@ -50,5 +50,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/percentage_absolute_position.rs
+++ b/benches/generated/percentage_absolute_position.rs
@@ -33,5 +33,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/percentage_container_in_wrapping_container.rs
+++ b/benches/generated/percentage_container_in_wrapping_container.rs
@@ -58,5 +58,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/percentage_flex_basis.rs
+++ b/benches/generated/percentage_flex_basis.rs
@@ -33,5 +33,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/percentage_flex_basis_cross.rs
+++ b/benches/generated/percentage_flex_basis_cross.rs
@@ -34,5 +34,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/percentage_flex_basis_cross_max_height.rs
+++ b/benches/generated/percentage_flex_basis_cross_max_height.rs
@@ -42,5 +42,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/percentage_flex_basis_cross_max_width.rs
+++ b/benches/generated/percentage_flex_basis_cross_max_width.rs
@@ -42,5 +42,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/percentage_flex_basis_cross_min_height.rs
+++ b/benches/generated/percentage_flex_basis_cross_min_height.rs
@@ -40,5 +40,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/percentage_flex_basis_cross_min_width.rs
+++ b/benches/generated/percentage_flex_basis_cross_min_width.rs
@@ -42,5 +42,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/percentage_flex_basis_main_max_height.rs
+++ b/benches/generated/percentage_flex_basis_main_max_height.rs
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/percentage_flex_basis_main_max_width.rs
+++ b/benches/generated/percentage_flex_basis_main_max_width.rs
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/percentage_flex_basis_main_min_width.rs
+++ b/benches/generated/percentage_flex_basis_main_min_width.rs
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/percentage_margin_should_calculate_based_only_on_width.rs
+++ b/benches/generated/percentage_margin_should_calculate_based_only_on_width.rs
@@ -44,5 +44,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/percentage_multiple_nested_with_padding_margin_and_percentage_values.rs
+++ b/benches/generated/percentage_multiple_nested_with_padding_margin_and_percentage_values.rs
@@ -104,5 +104,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/percentage_padding_should_calculate_based_only_on_width.rs
+++ b/benches/generated/percentage_padding_should_calculate_based_only_on_width.rs
@@ -44,5 +44,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/percentage_position_bottom_right.rs
+++ b/benches/generated/percentage_position_bottom_right.rs
@@ -31,5 +31,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/percentage_position_left_top.rs
+++ b/benches/generated/percentage_position_left_top.rs
@@ -31,5 +31,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/percentage_size_based_on_parent_inner_size.rs
+++ b/benches/generated/percentage_size_based_on_parent_inner_size.rs
@@ -34,5 +34,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/percentage_size_of_flex_basis.rs
+++ b/benches/generated/percentage_size_of_flex_basis.rs
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/percentage_width_height.rs
+++ b/benches/generated/percentage_width_height.rs
@@ -26,5 +26,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/percentage_width_height_undefined_parent_size.rs
+++ b/benches/generated/percentage_width_height_undefined_parent_size.rs
@@ -19,5 +19,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/relative_position_should_not_nudge_siblings.rs
+++ b/benches/generated/relative_position_should_not_nudge_siblings.rs
@@ -34,5 +34,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/rounding_flex_basis_flex_grow_row_prime_number_width.rs
+++ b/benches/generated/rounding_flex_basis_flex_grow_row_prime_number_width.rs
@@ -23,5 +23,5 @@ pub fn compute() {
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/rounding_flex_basis_flex_grow_row_width_of_100.rs
+++ b/benches/generated/rounding_flex_basis_flex_grow_row_width_of_100.rs
@@ -19,5 +19,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/rounding_flex_basis_flex_shrink_row.rs
+++ b/benches/generated/rounding_flex_basis_flex_shrink_row.rs
@@ -35,5 +35,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/rounding_flex_basis_overrides_main_size.rs
+++ b/benches/generated/rounding_flex_basis_overrides_main_size.rs
@@ -45,5 +45,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/rounding_fractial_input_1.rs
+++ b/benches/generated/rounding_fractial_input_1.rs
@@ -45,5 +45,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/rounding_fractial_input_2.rs
+++ b/benches/generated/rounding_fractial_input_2.rs
@@ -45,5 +45,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/rounding_fractial_input_3.rs
+++ b/benches/generated/rounding_fractial_input_3.rs
@@ -45,5 +45,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/rounding_fractial_input_4.rs
+++ b/benches/generated/rounding_fractial_input_4.rs
@@ -45,5 +45,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/rounding_total_fractial.rs
+++ b/benches/generated/rounding_total_fractial.rs
@@ -45,5 +45,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/rounding_total_fractial_nested.rs
+++ b/benches/generated/rounding_total_fractial_nested.rs
@@ -73,5 +73,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/size_defined_by_child.rs
+++ b/benches/generated/size_defined_by_child.rs
@@ -14,5 +14,5 @@ pub fn compute() {
         )
         .unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/size_defined_by_child_with_border.rs
+++ b/benches/generated/size_defined_by_child_with_border.rs
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/size_defined_by_child_with_padding.rs
+++ b/benches/generated/size_defined_by_child_with_padding.rs
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/size_defined_by_grand_child.rs
+++ b/benches/generated/size_defined_by_grand_child.rs
@@ -15,5 +15,5 @@ pub fn compute() {
         .unwrap();
     let node0 = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node00]).unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/width_smaller_then_content_with_flex_grow_large_size.rs
+++ b/benches/generated/width_smaller_then_content_with_flex_grow_large_size.rs
@@ -57,5 +57,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/width_smaller_then_content_with_flex_grow_small_size.rs
+++ b/benches/generated/width_smaller_then_content_with_flex_grow_small_size.rs
@@ -57,5 +57,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/width_smaller_then_content_with_flex_grow_unconstraint_size.rs
+++ b/benches/generated/width_smaller_then_content_with_flex_grow_unconstraint_size.rs
@@ -49,5 +49,5 @@ pub fn compute() {
         )
         .unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0, node1]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/width_smaller_then_content_with_flex_grow_very_large_size.rs
+++ b/benches/generated/width_smaller_then_content_with_flex_grow_very_large_size.rs
@@ -57,5 +57,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/wrap_column.rs
+++ b/benches/generated/wrap_column.rs
@@ -67,5 +67,5 @@ pub fn compute() {
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/wrap_nodes_with_content_sizing_margin_cross.rs
+++ b/benches/generated/wrap_nodes_with_content_sizing_margin_cross.rs
@@ -66,5 +66,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/wrap_nodes_with_content_sizing_overflowing_margin.rs
+++ b/benches/generated/wrap_nodes_with_content_sizing_overflowing_margin.rs
@@ -66,5 +66,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/wrap_reverse_column.rs
+++ b/benches/generated/wrap_reverse_column.rs
@@ -67,5 +67,5 @@ pub fn compute() {
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/wrap_reverse_column_fixed_size.rs
+++ b/benches/generated/wrap_reverse_column_fixed_size.rs
@@ -81,5 +81,5 @@ pub fn compute() {
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/wrap_reverse_row.rs
+++ b/benches/generated/wrap_reverse_row.rs
@@ -62,5 +62,5 @@ pub fn compute() {
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/wrap_reverse_row_align_content_center.rs
+++ b/benches/generated/wrap_reverse_row_align_content_center.rs
@@ -76,5 +76,5 @@ pub fn compute() {
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/wrap_reverse_row_align_content_flex_start.rs
+++ b/benches/generated/wrap_reverse_row_align_content_flex_start.rs
@@ -76,5 +76,5 @@ pub fn compute() {
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/wrap_reverse_row_align_content_space_around.rs
+++ b/benches/generated/wrap_reverse_row_align_content_space_around.rs
@@ -76,5 +76,5 @@ pub fn compute() {
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/wrap_reverse_row_align_content_stretch.rs
+++ b/benches/generated/wrap_reverse_row_align_content_stretch.rs
@@ -75,5 +75,5 @@ pub fn compute() {
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/wrap_reverse_row_single_line_different_size.rs
+++ b/benches/generated/wrap_reverse_row_single_line_different_size.rs
@@ -76,5 +76,5 @@ pub fn compute() {
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/wrap_row.rs
+++ b/benches/generated/wrap_row.rs
@@ -62,5 +62,5 @@ pub fn compute() {
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/wrap_row_align_items_center.rs
+++ b/benches/generated/wrap_row_align_items_center.rs
@@ -63,5 +63,5 @@ pub fn compute() {
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/wrap_row_align_items_flex_end.rs
+++ b/benches/generated/wrap_row_align_items_flex_end.rs
@@ -63,5 +63,5 @@ pub fn compute() {
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/wrapped_column_max_height.rs
+++ b/benches/generated/wrapped_column_max_height.rs
@@ -68,5 +68,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/wrapped_column_max_height_flex.rs
+++ b/benches/generated/wrapped_column_max_height_flex.rs
@@ -74,5 +74,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/wrapped_row_within_align_items_center.rs
+++ b/benches/generated/wrapped_row_within_align_items_center.rs
@@ -47,5 +47,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/wrapped_row_within_align_items_flex_end.rs
+++ b/benches/generated/wrapped_row_within_align_items_flex_end.rs
@@ -47,5 +47,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/benches/generated/wrapped_row_within_align_items_flex_start.rs
+++ b/benches/generated/wrapped_row_within_align_items_flex_start.rs
@@ -47,5 +47,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -17,7 +17,10 @@ fn main() -> Result<(), taffy::error::TaffyError> {
         &[child],
     )?;
 
-    taffy.compute_layout(node, Size { height: Some(100.0), width: Some(100.0) })?;
+    taffy.compute_layout(
+        node,
+        Size { height: AvailableSpace::Definite(100.0), width: AvailableSpace::Definite(100.0) },
+    )?;
 
     // or just use undefined for 100 x 100
     // taffy.compute_layout(node, Size::NONE)?;

--- a/examples/nested.rs
+++ b/examples/nested.rs
@@ -41,7 +41,10 @@ fn main() -> Result<(), taffy::error::TaffyError> {
         &[div1, div2],
     )?;
 
-    taffy.compute_layout(container, Size { height: Some(100.0), width: Some(100.0) })?;
+    taffy.compute_layout(
+        container,
+        Size { height: AvailableSpace::Definite(100.0), width: AvailableSpace::Definite(100.0) },
+    )?;
 
     println!("node: {:#?}", taffy.layout(container)?);
 

--- a/scripts/gentest/src/main.rs
+++ b/scripts/gentest/src/main.rs
@@ -150,7 +150,7 @@ fn generate_bench(description: &json::JsonValue) -> TokenStream {
         pub fn compute() {
             let mut taffy = taffy::Taffy::new();
             #node_description
-            taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+            taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
         }
     )
 }
@@ -166,7 +166,7 @@ fn generate_test(name: impl AsRef<str>, description: &json::JsonValue) -> TokenS
         fn #name() {
             let mut taffy = taffy::Taffy::new();
             #node_description
-            taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+            taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
             #assertions
         }
     )

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -1808,7 +1808,6 @@ fn hidden_layout(tree: &mut impl LayoutTree, node: Node, order: u32) {
 
 #[cfg(test)]
 mod tests {
-    use crate::flexbox::hidden_layout;
     use crate::geometry::Point;
     use crate::style::Display;
     use crate::style::Display::Flex;
@@ -1819,6 +1818,7 @@ mod tests {
         style::{FlexWrap, FlexboxLayout},
         Taffy,
     };
+    use super::hidden_layout;
 
     // Make sure we get correct constants
     #[test]

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -6,13 +6,13 @@ use core::f32;
 use crate::compute::compute_node_layout;
 use crate::debug::NODE_LOGGER;
 use crate::geometry::{Point, Rect, Size};
-use crate::layout::{AvailableSpace, Cache, Layout, RunMode, SizingMode};
+use crate::layout::{AvailableSpace, Layout, RunMode, SizingMode};
 use crate::math::MaybeMath;
 use crate::node::Node;
 use crate::resolve::{MaybeResolve, ResolveOrDefault};
 use crate::style::{AlignContent, AlignSelf, Dimension, Display, FlexWrap, JustifyContent, PositionType};
 use crate::style::{FlexDirection, FlexboxLayout};
-use crate::sys::{abs, round, Vec};
+use crate::sys::{round, Vec};
 use crate::tree::LayoutTree;
 
 /// The intermediate results of a flexbox calculation for a single item
@@ -154,10 +154,6 @@ pub fn compute(
             RunMode::PeformLayout,
         )
     }
-
-    // *tree.layout_mut(node) = Layout { order: 0, size: preliminary_size, location: Point::ZERO };
-
-    // round_layout(tree, node, 0.0, 0.0);
 }
 
 /// Compute a preliminary size for an item
@@ -171,32 +167,8 @@ fn compute_preliminary(
     // clear the dirtiness of the node now that we've computed it
     tree.mark_dirty(node, false);
 
-    // // First we check if we have a result for the given input
-    // if let Some(cached_size) = compute_from_cache(tree, node, known_dimensions, parent_size, run_mode, main_size) {
-    //     return cached_size;
-    // }
-
     // Define some general constants we will need for the remainder of the algorithm.
     let mut constants = compute_constants(tree.style(node), known_dimensions, parent_size);
-
-    // // If this is a leaf node we can skip a lot of this function in some cases
-    // if tree.children(node).is_empty() {
-    //     if known_dimensions.width.is_some() && known_dimensions.height.is_some() {
-    //         return known_dimensions.map(|s| s.unwrap_or(0.0));
-    //     }
-
-    //     if tree.needs_measure(node) {
-    //         let converted_size = tree.measure_node(node, known_dimensions);
-    //         *cache(tree, node, main_size) =
-    //             Some(Cache { node_size: known_dimensions, parent_size, run_mode, size: converted_size });
-    //         return converted_size;
-    //     }
-
-    //     return Size {
-    //         width: known_dimensions.width.unwrap_or(0.0) + constants.padding_border.horizontal_axis_sum(),
-    //         height: known_dimensions.height.unwrap_or(0.0) + constants.padding_border.vertical_axis_sum(),
-    //     };
-    // }
 
     // 9. Flex Layout Algorithm
 
@@ -317,7 +289,6 @@ fn compute_preliminary(
     // If our caller does not care about performing layout we are done now.
     if run_mode == RunMode::ComputeSize {
         let container_size = constants.container_size;
-        // *cache(tree, node, main_size) = Some(Cache { node_size: known_dimensions, parent_size, run_mode, size: container_size });
         return container_size;
     }
 
@@ -344,7 +315,6 @@ fn compute_preliminary(
     }
 
     let container_size = constants.container_size;
-    // *cache(tree, node, main_size) = Some(Cache { node_size: known_dimensions, parent_size, run_mode, size: container_size });
 
     container_size
 }
@@ -367,55 +337,6 @@ fn round_layout(tree: &mut impl LayoutTree, root: Node, abs_x: f32, abs_y: f32) 
         round_layout(tree, child, abs_x, abs_y);
     }
 }
-
-// /// Saves intermediate results to a [`Cache`]
-// fn cache(tree: &mut impl LayoutTree, node: Node, main_size: bool) -> &mut Option<Cache> {
-//     if main_size {
-//         tree.primary_cache(node)
-//     } else {
-//         tree.secondary_cache(node)
-//     }
-// }
-
-// /// Try to get the computation result from the cache.
-// #[inline]
-// fn compute_from_cache(
-//     tree: &mut impl LayoutTree,
-//     node: Node,
-//     node_size: Size<Option<f32>>,
-//     parent_size: Size<Option<f32>>,
-//     run_mode: RunMode,
-//     main_size: bool,
-// ) -> Option<Size<f32>> {
-//     if let Some(ref cache) = cache(tree, node, main_size) {
-//         // Cached ComputeSize results are not valid if we are running in PerformLayout mode
-//         if cache.run_mode == RunMode::ComputeSize && run_mode == RunMode::PeformLayout {
-//             return None;
-//         }
-
-//         let width_compatible = if let Some(width) = node_size.width {
-//             abs(width - cache.size.width) < f32::EPSILON
-//         } else {
-//             cache.node_size.width.is_none()
-//         };
-
-//         let height_compatible = if let Some(height) = node_size.height {
-//             abs(height - cache.size.height) < f32::EPSILON
-//         } else {
-//             cache.node_size.height.is_none()
-//         };
-
-//         if width_compatible && height_compatible {
-//             return Some(cache.size);
-//         }
-
-//         if cache.node_size == node_size && cache.parent_size == parent_size {
-//             return Some(cache.size);
-//         }
-//     }
-
-//     None
-// }
 
 /// Compute constants that can be reused during the flexbox algorithm.
 #[inline]

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -313,7 +313,7 @@ fn compute_preliminary(
     // Before returning we perform absolute layout on all absolutely positioned children
     #[cfg(feature = "debug")]
     NODE_LOGGER.log("perform_absolute_layout_on_absolute_children");
-    perform_absolute_layout_on_absolute_children(tree, node, &constants, available_space);
+    perform_absolute_layout_on_absolute_children(tree, node, &constants);
 
     #[cfg(feature = "debug")]
     NODE_LOGGER.log("hidden_layout");
@@ -1600,7 +1600,6 @@ fn perform_absolute_layout_on_absolute_children(
     tree: &mut impl LayoutTree,
     node: Node,
     constants: &AlgoConstants,
-    available_space: Size<AvailableSpace>,
 ) {
     // TODO: remove number of Vec<_> generated
     let candidates = tree

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -11,7 +11,7 @@ use crate::node::Node;
 use crate::resolve::{MaybeResolve, ResolveOrDefault};
 use crate::style::{AlignContent, AlignSelf, Dimension, Display, FlexWrap, JustifyContent, PositionType};
 use crate::style::{FlexDirection, FlexboxLayout};
-use crate::sys::{round, Vec};
+use crate::sys::Vec;
 use crate::tree::LayoutTree;
 
 #[cfg(feature = "debug")]
@@ -145,12 +145,12 @@ pub fn compute(
             node,
             known_dimensions.zip_map(clamped_first_pass_size, |known, first_pass| known.or(first_pass.into())),
             available_space,
-            RunMode::PeformLayout,
+            run_mode,
         )
     } else {
         #[cfg(feature = "debug")]
         NODE_LOGGER.log("FLEX: single-pass");
-        compute_preliminary(tree, node, known_dimensions.or(clamped_style_size), available_space, RunMode::PeformLayout)
+        compute_preliminary(tree, node, known_dimensions.or(clamped_style_size), available_space, run_mode)
     }
 }
 

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -143,7 +143,7 @@ pub fn compute(
         compute_preliminary(
             tree,
             node,
-            known_dimensions.zip_map(clamped_first_pass_size, |known, first_pass| known.or(first_pass.into())),
+            known_dimensions.zip_map(clamped_first_pass_size, |known, first_pass| known.or_else(|| first_pass.into())),
             available_space,
             run_mode,
         )
@@ -326,9 +326,7 @@ fn compute_preliminary(
         }
     }
 
-    let container_size = constants.container_size;
-
-    container_size
+    constants.container_size
 }
 
 /// Compute constants that can be reused during the flexbox algorithm.

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -146,13 +146,7 @@ pub fn compute(
         )
     } else {
         // NODE_LOGGER.log("FLEX: single-pass");
-        compute_preliminary(
-            tree,
-            node,
-            known_dimensions.or(clamped_style_size),
-            available_space,
-            RunMode::PeformLayout,
-        )
+        compute_preliminary(tree, node, known_dimensions.or(clamped_style_size), available_space, RunMode::PeformLayout)
     }
 }
 
@@ -164,7 +158,6 @@ fn compute_preliminary(
     parent_size: Size<AvailableSpace>,
     run_mode: RunMode,
 ) -> Size<f32> {
-
     // Define some general constants we will need for the remainder of the algorithm.
     let mut constants = compute_constants(tree.style(node), known_dimensions, parent_size);
 
@@ -589,10 +582,9 @@ fn determine_flex_base_size(
         .maybe_clamp(child.min_size.main(constants.dir), child.size.main(constants.dir))
         .into();
 
-        child.hypothetical_inner_size.set_main(
-            constants.dir,
-            child.flex_basis.maybe_clamp(min_main, child.max_size.main(constants.dir)),
-        );
+        child
+            .hypothetical_inner_size
+            .set_main(constants.dir, child.flex_basis.maybe_clamp(min_main, child.max_size.main(constants.dir)));
 
         child.hypothetical_outer_size.set_main(
             constants.dir,

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -128,7 +128,7 @@ pub fn compute(
         .zip_map(max_size, |size, max| size.maybe_min(max));
 
     if has_min_max_sizes {
-        NODE_LOGGER.log("FLEX: two-pass");
+        // NODE_LOGGER.log("FLEX: two-pass");
         let first_pass = compute_preliminary(
             tree,
             node,
@@ -152,7 +152,7 @@ pub fn compute(
             cache_slot == 0,//true,
         )
     } else {
-        NODE_LOGGER.log("FLEX: single-pass");
+        // NODE_LOGGER.log("FLEX: single-pass");
         compute_preliminary(
             tree,
             node,
@@ -212,31 +212,31 @@ fn compute_preliminary(
     // 9.1. Initial Setup
 
     // 1. Generate anonymous flex items as described in §4 Flex Items.
-    NODE_LOGGER.log("generate_anonymous_flex_items");
+    // NODE_LOGGER.log("generate_anonymous_flex_items");
     let mut flex_items = generate_anonymous_flex_items(tree, node, &constants);
 
     // 9.2. Line Length Determination
 
     // 2. Determine the available main and cross space for the flex items
-    NODE_LOGGER.log("determine_available_space");
+    // NODE_LOGGER.log("determine_available_space");
     let available_space = determine_available_space(known_dimensions, parent_size, &constants);
 
     let has_baseline_child =
         flex_items.iter().any(|child| tree.style(child.node).align_self(tree.style(node)) == AlignSelf::Baseline);
 
     // 3. Determine the flex base size and hypothetical main size of each item.
-    NODE_LOGGER.log("determine_flex_base_size");
+    // NODE_LOGGER.log("determine_flex_base_size");
     determine_flex_base_size(tree, node, known_dimensions, &constants, available_space, &mut flex_items);
 
     // TODO: Add step 4 according to spec: https://www.w3.org/TR/css-flexbox-1/#algo-main-container
     // 9.3. Main Size Determination
 
     // 5. Collect flex items into flex lines.
-    NODE_LOGGER.log("collect_flex_lines");
+    // NODE_LOGGER.log("collect_flex_lines");
     let mut flex_lines = collect_flex_lines(tree, node, &constants, available_space, &mut flex_items);
 
     // 6. Resolve the flexible lengths of all the flex items to find their used main size.
-    NODE_LOGGER.log("resolve_flexible_lengths");
+    // NODE_LOGGER.log("resolve_flexible_lengths");
     for line in &mut flex_lines {
         resolve_flexible_lengths(tree, line, &constants, available_space);
     }
@@ -267,7 +267,7 @@ fn compute_preliminary(
     // 9.4. Cross Size Determination
 
     // 7. Determine the hypothetical cross size of each item.
-    NODE_LOGGER.log("determine_hypothetical_cross_size");
+    // NODE_LOGGER.log("determine_hypothetical_cross_size");
     for line in &mut flex_lines {
         determine_hypothetical_cross_size(tree, line, &constants, available_space);
     }
@@ -275,16 +275,16 @@ fn compute_preliminary(
     // TODO - probably should move this somewhere else as it doesn't make a ton of sense here but we need it below
     // TODO - This is expensive and should only be done if we really require a baseline. aka, make it lazy
     if has_baseline_child {
-        NODE_LOGGER.log("calculate_children_base_lines");
+        // NODE_LOGGER.log("calculate_children_base_lines");
         calculate_children_base_lines(tree, node, known_dimensions, available_space, &mut flex_lines, &constants);
     }
 
     // 8. Calculate the cross size of each flex line.
-    NODE_LOGGER.log("calculate_cross_size");
+    // NODE_LOGGER.log("calculate_cross_size");
     calculate_cross_size(tree, &mut flex_lines, node, known_dimensions, &constants);
 
     // 9. Handle 'align-content: stretch'.
-    NODE_LOGGER.log("handle_align_content_stretch");
+    // NODE_LOGGER.log("handle_align_content_stretch");
     handle_align_content_stretch(tree, &mut flex_lines, node, known_dimensions, &constants);
 
     // 10. Collapse visibility:collapse items. If any flex items have visibility: collapse,
@@ -303,23 +303,23 @@ fn compute_preliminary(
     // TODO implement once (if ever) we support visibility:collapse
 
     // 11. Determine the used cross size of each flex item.
-    NODE_LOGGER.log("determine_used_cross_size");
+    // NODE_LOGGER.log("determine_used_cross_size");
     determine_used_cross_size(tree, &mut flex_lines, node, &constants);
 
     // 9.5. Main-Axis Alignment
 
     // 12. Distribute any remaining free space.
-    NODE_LOGGER.log("distribute_remaining_free_space");
+    // NODE_LOGGER.log("distribute_remaining_free_space");
     distribute_remaining_free_space(tree, &mut flex_lines, node, &constants);
 
     // 9.6. Cross-Axis Alignment
 
     // 13. Resolve cross-axis auto margins (also includes 14).
-    NODE_LOGGER.log("resolve_cross_axis_auto_margins");
+    // NODE_LOGGER.log("resolve_cross_axis_auto_margins");
     resolve_cross_axis_auto_margins(tree, &mut flex_lines, node, &constants);
 
     // 15. Determine the flex container’s used cross size.
-    NODE_LOGGER.log("determine_container_cross_size");
+    // NODE_LOGGER.log("determine_container_cross_size");
     let total_cross_size = determine_container_cross_size(&mut flex_lines, known_dimensions, &mut constants);
 
     // We have the container size.
@@ -331,18 +331,18 @@ fn compute_preliminary(
     }
 
     // 16. Align all flex lines per align-content.
-    NODE_LOGGER.log("align_flex_lines_per_align_content");
+    // NODE_LOGGER.log("align_flex_lines_per_align_content");
     align_flex_lines_per_align_content(tree, &mut flex_lines, node, &constants, total_cross_size);
 
     // Do a final layout pass and gather the resulting layouts
-    NODE_LOGGER.log("final_layout_pass");
+    // NODE_LOGGER.log("final_layout_pass");
     final_layout_pass(tree, node, &mut flex_lines, &constants);
 
     // Before returning we perform absolute layout on all absolutely positioned children
-    NODE_LOGGER.log("perform_absolute_layout_on_absolute_children");
+    // NODE_LOGGER.log("perform_absolute_layout_on_absolute_children");
     perform_absolute_layout_on_absolute_children(tree, node, &constants, available_space);
 
-    NODE_LOGGER.log("hidden_layout");
+    // NODE_LOGGER.log("hidden_layout");
     let len = tree.children(node).len();
     for order in 0..len {
         let child = tree.child(node, order);

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -627,28 +627,23 @@ fn determine_flex_base_size(
         //    is auto and not definite, in this calculation use fit-content as the
         //    flex item’s cross size. The flex base size is the item’s resulting main size.
 
-        let width: Option<f32> = if child.size.width.is_none()
-            && child_style.align_self(tree.style(node)) == AlignSelf::Stretch
-            && constants.is_column
-        {
-            available_space.width.as_option()
-        } else {
-            child.size.width
-        };
-
-        let height: Option<f32> = if child.size.height.is_none()
-            && child_style.align_self(tree.style(node)) == AlignSelf::Stretch
-            && constants.is_row
-        {
-            available_space.height.as_option()
-        } else {
-            child.size.height
+        let child_known_dimensions = {
+            let mut ckd = child.size;
+            if child_style.align_self(tree.style(node)) == AlignSelf::Stretch {
+                if constants.is_column && ckd.width.is_none() {
+                    ckd.width = available_space.width.as_option();
+                }
+                if constants.is_row && ckd.height.is_none() {
+                    ckd.height = available_space.height.as_option();
+                }
+            }
+            ckd
         };
 
         child.flex_basis = compute_node_layout(
             tree,
             child.node,
-            Size { width, height }.maybe_min(child.max_size),
+            child_known_dimensions.maybe_min(child.max_size),
             available_space,
             RunMode::ComputeSize,
             SizingMode::ContentSize,

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -1594,11 +1594,7 @@ fn final_layout_pass(tree: &mut impl LayoutTree, node: Node, flex_lines: &mut [F
 
 /// Perform absolute layout on all absolutely positioned children.
 #[inline]
-fn perform_absolute_layout_on_absolute_children(
-    tree: &mut impl LayoutTree,
-    node: Node,
-    constants: &AlgoConstants,
-) {
+fn perform_absolute_layout_on_absolute_children(tree: &mut impl LayoutTree, node: Node, constants: &AlgoConstants) {
     // TODO: remove number of Vec<_> generated
     let candidates = tree
         .children(node)

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -164,8 +164,6 @@ fn compute_preliminary(
     parent_size: Size<AvailableSpace>,
     run_mode: RunMode,
 ) -> Size<f32> {
-    // clear the dirtiness of the node now that we've computed it
-    tree.mark_dirty(node, false);
 
     // Define some general constants we will need for the remainder of the algorithm.
     let mut constants = compute_constants(tree.style(node), known_dimensions, parent_size);

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -331,25 +331,6 @@ fn compute_preliminary(
     container_size
 }
 
-/// Rounds the calculated [`NodeData`] according to the spec
-fn round_layout(tree: &mut impl LayoutTree, root: Node, abs_x: f32, abs_y: f32) {
-    let layout = tree.layout_mut(root);
-    let abs_x = abs_x + layout.location.x;
-    let abs_y = abs_y + layout.location.y;
-
-    layout.location.x = round(layout.location.x);
-    layout.location.y = round(layout.location.y);
-
-    layout.size.width = round(layout.size.width);
-    layout.size.height = round(layout.size.height);
-
-    // Satisfy the borrow checker here by re-indexing to shorten the lifetime to the loop scope
-    for x in 0..tree.children(root).len() {
-        let child = tree.child(root, x);
-        round_layout(tree, child, abs_x, abs_y);
-    }
-}
-
 /// Compute constants that can be reused during the flexbox algorithm.
 #[inline]
 fn compute_constants(

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -112,7 +112,6 @@ pub fn compute(
     known_dimensions: Size<Option<f32>>,
     available_space: Size<AvailableSpace>,
     run_mode: RunMode,
-    cache_slot: usize,
 ) -> Size<f32> {
     let style = tree.style(node);
     let has_min_max_sizes = style.min_size.width.is_defined()
@@ -134,7 +133,6 @@ pub fn compute(
             known_dimensions.zip_map(clamped_style_size, |known, style| known.or(style)),
             available_space,
             RunMode::ComputeSize,
-            cache_slot == 0, //true,
         );
 
         let clamped_first_pass_size = first_pass.maybe_clamp(min_size, max_size);
@@ -145,7 +143,6 @@ pub fn compute(
             known_dimensions.zip_map(clamped_first_pass_size, |known, first_pass| known.or(first_pass.into())),
             available_space,
             RunMode::PeformLayout,
-            cache_slot == 0, //true,
         )
     } else {
         // NODE_LOGGER.log("FLEX: single-pass");
@@ -155,7 +152,6 @@ pub fn compute(
             known_dimensions.or(clamped_style_size),
             available_space,
             RunMode::PeformLayout,
-            cache_slot == 0, //true,
         )
     }
 
@@ -171,7 +167,6 @@ fn compute_preliminary(
     known_dimensions: Size<Option<f32>>,
     parent_size: Size<AvailableSpace>,
     run_mode: RunMode,
-    main_size: bool,
 ) -> Size<f32> {
     // clear the dirtiness of the node now that we've computed it
     tree.mark_dirty(node, false);
@@ -647,7 +642,6 @@ fn determine_flex_base_size(
             available_space,
             RunMode::ComputeSize,
             SizingMode::ContentSize,
-            0,
         )
         .main(constants.dir)
         .maybe_min(child.max_size.main(constants.dir));
@@ -671,7 +665,6 @@ fn determine_flex_base_size(
             available_space,
             RunMode::ComputeSize,
             SizingMode::ContentSize,
-            1,
         )
         .main(constants.dir)
         .maybe_clamp(child.min_size.main(constants.dir), child.size.main(constants.dir))
@@ -785,7 +778,6 @@ fn resolve_flexible_lengths(
                     available_space,
                     RunMode::ComputeSize,
                     SizingMode::ContentSize,
-                    1,
                 )
                 .main(constants.dir)
                 .maybe_clamp(child.min_size.main(constants.dir), child.max_size.main(constants.dir)),
@@ -930,7 +922,6 @@ fn resolve_flexible_lengths(
                     available_space,
                     RunMode::ComputeSize,
                     SizingMode::ContentSize,
-                    1,
                 )
                 .width
                 .maybe_clamp(child.min_size.width, child.size.width)
@@ -1014,7 +1005,6 @@ fn determine_hypothetical_cross_size(
                 },
                 RunMode::ComputeSize,
                 SizingMode::ContentSize,
-                1,
             )
             .cross(constants.dir)
             .maybe_clamp(child.min_size.cross(constants.dir), child.max_size.cross(constants.dir)),
@@ -1086,7 +1076,6 @@ fn calculate_children_base_lines(
                 },
                 RunMode::PeformLayout,
                 SizingMode::ContentSize,
-                1,
             );
 
             child.baseline = calc_baseline(
@@ -1591,7 +1580,6 @@ fn calculate_flex_item(
         container_size.map(|s| s.into()),
         RunMode::PeformLayout,
         SizingMode::ContentSize,
-        1,
     );
 
     let offset_main = *total_offset_main
@@ -1761,7 +1749,6 @@ fn perform_absolute_layout_on_absolute_children(
             },
             RunMode::PeformLayout,
             SizingMode::ContentSize,
-            1,
         );
 
         // Satisfy the borrow checker by re-requesting the style from above.

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -341,9 +341,9 @@ fn compute_constants(
     let is_column = dir.is_column();
     let is_wrap_reverse = style.flex_wrap == FlexWrap::WrapReverse;
 
-    let margin = style.margin.resolve_or_default(parent_size.width.as_option());
-    let padding = style.padding.resolve_or_default(parent_size.width.as_option());
-    let border = style.border.resolve_or_default(parent_size.width.as_option());
+    let margin = style.margin.resolve_or_default(parent_size.width.into_option());
+    let padding = style.padding.resolve_or_default(parent_size.width.into_option());
+    let border = style.border.resolve_or_default(parent_size.width.into_option());
 
     let padding_border = Rect {
         start: padding.start + border.start,
@@ -538,10 +538,10 @@ fn determine_flex_base_size(
             let mut ckd = child.size;
             if child_style.align_self(tree.style(node)) == AlignSelf::Stretch {
                 if constants.is_column && ckd.width.is_none() {
-                    ckd.width = available_space.width.as_option();
+                    ckd.width = available_space.width.into_option();
                 }
                 if constants.is_row && ckd.height.is_none() {
-                    ckd.height = available_space.height.as_option();
+                    ckd.height = available_space.height.into_option();
                 }
             }
             ckd

--- a/src/compute/leaf.rs
+++ b/src/compute/leaf.rs
@@ -66,8 +66,8 @@ pub(crate) fn compute(
         return node_size.unwrap_or(measured_size).maybe_clamp(node_min_size, node_max_size);
     }
 
-    let padding = style.padding.resolve_or_default(available_space.width.as_option());
-    let border = style.border.resolve_or_default(available_space.width.as_option());
+    let padding = style.padding.resolve_or_default(available_space.width.into_option());
+    let border = style.border.resolve_or_default(available_space.width.into_option());
 
     Size {
         width: node_size

--- a/src/compute/leaf.rs
+++ b/src/compute/leaf.rs
@@ -1,3 +1,5 @@
+//! Computes size using styles and measure functions
+
 use crate::geometry::Size;
 use crate::layout::{AvailableSpace, RunMode, SizingMode};
 use crate::math::MaybeMath;
@@ -8,9 +10,7 @@ use crate::tree::LayoutTree;
 #[cfg(feature = "debug")]
 use crate::debug::NODE_LOGGER;
 
-// Define some general constants we will need for the remainder of the algorithm.
-// let mut constants = compute_constants(tree.style(node), node_size, available_space);
-
+/// Compute the size of a leaf node (node with no children)
 pub(crate) fn compute(
     tree: &mut impl LayoutTree,
     node: Node,

--- a/src/compute/leaf.rs
+++ b/src/compute/leaf.rs
@@ -28,10 +28,11 @@ pub(crate) fn compute(
             let node_min_size = Size::NONE;
             let node_max_size = Size::NONE;
             (node_size, node_min_size, node_max_size)
-        },
+        }
         SizingMode::InherentSize => {
             let style_size = style.size.maybe_resolve(available_space.as_options());
-            let node_size = style_size.zip_map(known_dimensions, |style_size, known_dimensions| known_dimensions.or(style_size));
+            let node_size =
+                style_size.zip_map(known_dimensions, |style_size, known_dimensions| known_dimensions.or(style_size));
             let node_min_size = style.min_size.maybe_resolve(available_space.as_options());
             let node_max_size = style.max_size.maybe_resolve(available_space.as_options());
             (node_size, node_min_size, node_max_size)
@@ -94,20 +95,17 @@ pub(crate) fn compute(
     };
 }
 
-fn maybe_clamp(size: Size<Option<f32>>, min_size: Size<Option<f32>>, max_size: Size<Option<f32>>, sizing_mode: SizingMode) -> Size<Option<f32>> {
+fn maybe_clamp(
+    size: Size<Option<f32>>,
+    min_size: Size<Option<f32>>,
+    max_size: Size<Option<f32>>,
+    sizing_mode: SizingMode,
+) -> Size<Option<f32>> {
     match sizing_mode {
         SizingMode::ContentSize => size,
-        SizingMode::InherentSize => {
-             Size {
-                width: size.
-                    width
-                    .maybe_max(min_size.width)
-                    .maybe_min(max_size.width),
-                height:size
-                    .height
-                    .maybe_max(min_size.height)
-                    .maybe_min(max_size.height),
-            }
-        }
+        SizingMode::InherentSize => Size {
+            width: size.width.maybe_max(min_size.width).maybe_min(max_size.width),
+            height: size.height.maybe_max(min_size.height).maybe_min(max_size.height),
+        },
     }
 }

--- a/src/compute/leaf.rs
+++ b/src/compute/leaf.rs
@@ -1,11 +1,12 @@
-use crate::debug::NODE_LOGGER;
 use crate::geometry::Size;
-use crate::layout::{AvailableSpace, Cache, RunMode, SizingMode};
+use crate::layout::{AvailableSpace, RunMode, SizingMode};
 use crate::math::MaybeMath;
 use crate::node::Node;
 use crate::resolve::{MaybeResolve, ResolveOrDefault};
-use crate::style::Dimension;
 use crate::tree::LayoutTree;
+
+#[cfg(feature = "debug")]
+use crate::debug::NODE_LOGGER;
 
 // Define some general constants we will need for the remainder of the algorithm.
 // let mut constants = compute_constants(tree.style(node), node_size, available_space);
@@ -38,10 +39,14 @@ pub(crate) fn compute(
         }
     };
 
-    // NODE_LOGGER.log("LEAF");
-    // NODE_LOGGER.debug_llog("node_size", node_size);
-    // NODE_LOGGER.debug_llog("min_size ", node_min_size);
-    // NODE_LOGGER.debug_llog("max_size ", node_max_size);
+    #[cfg(feature = "debug")]
+    NODE_LOGGER.log("LEAF");
+    #[cfg(feature = "debug")]
+    NODE_LOGGER.labelled_debug_log("node_size", node_size);
+    #[cfg(feature = "debug")]
+    NODE_LOGGER.labelled_debug_log("min_size ", node_min_size);
+    #[cfg(feature = "debug")]
+    NODE_LOGGER.labelled_debug_log("max_size ", node_max_size);
 
     // Return early if both width and height are known
     if let Size { width: Some(width), height: Some(height) } = node_size {

--- a/src/compute/leaf.rs
+++ b/src/compute/leaf.rs
@@ -44,10 +44,11 @@ pub(crate) fn compute(
     // NODE_LOGGER.debug_llog("min_size ", node_min_size);
     // NODE_LOGGER.debug_llog("max_size ", node_max_size);
 
-    if node_size.width.is_some() && node_size.height.is_some() {
+    // Return early if both width and height are known
+    if let Size { width: Some(width), height: Some(height) } = node_size {
         return Size {
-            width: node_size.width.maybe_max(node_min_size.width).maybe_min(node_max_size.width).unwrap_or(0.0),
-            height: node_size.height.maybe_max(node_min_size.height).maybe_min(node_max_size.height).unwrap_or(0.0),
+            width: width.maybe_max(node_min_size.width).maybe_min(node_max_size.width),
+            height: height.maybe_max(node_min_size.height).maybe_min(node_max_size.height),
         };
     };
 

--- a/src/compute/leaf.rs
+++ b/src/compute/leaf.rs
@@ -16,7 +16,7 @@ pub(crate) fn compute(
     node: Node,
     known_dimensions: Size<Option<f32>>,
     available_space: Size<AvailableSpace>,
-    run_mode: RunMode,
+    _run_mode: RunMode,
     sizing_mode: SizingMode,
 ) -> Size<f32> {
     let style = tree.style(node);

--- a/src/compute/leaf.rs
+++ b/src/compute/leaf.rs
@@ -38,10 +38,10 @@ pub(crate) fn compute(
         }
     };
 
-    NODE_LOGGER.log("LEAF");
-    NODE_LOGGER.debug_llog("node_size", node_size);
-    NODE_LOGGER.debug_llog("min_size ", node_min_size);
-    NODE_LOGGER.debug_llog("max_size ", node_max_size);
+    // NODE_LOGGER.log("LEAF");
+    // NODE_LOGGER.debug_llog("node_size", node_size);
+    // NODE_LOGGER.debug_llog("min_size ", node_min_size);
+    // NODE_LOGGER.debug_llog("max_size ", node_max_size);
 
     if node_size.width.is_some() && node_size.height.is_some() {
         return Size {

--- a/src/compute/leaf.rs
+++ b/src/compute/leaf.rs
@@ -81,14 +81,14 @@ pub(crate) fn compute(
     return Size {
         width: node_size
             .width
-            // .unwrap_or(0.0) + padding.horizontal_axis_sum() + border.horizontal_axis_sum(),
-            .unwrap_or(0.0 + padding.horizontal_axis_sum() + border.horizontal_axis_sum())
+            // .unwrap_or(0.0) + padding.horizontal_axis_sum() + border.horizontal_axis_sum(), // content-box
+            .unwrap_or(0.0 + padding.horizontal_axis_sum() + border.horizontal_axis_sum()) // border-box
             .maybe_max(node_min_size.width)
             .maybe_min(node_max_size.width),
         height: node_size
             .height
-            // .unwrap_or(0.0) + padding.horizontal_axis_sum() + border.horizontal_axis_sum(),
-            .unwrap_or(0.0 + padding.horizontal_axis_sum() + border.horizontal_axis_sum())
+            // .unwrap_or(0.0) + padding.horizontal_axis_sum() + border.horizontal_axis_sum(), // content-box
+            .unwrap_or(0.0 + padding.horizontal_axis_sum() + border.horizontal_axis_sum()) // border-box
             .maybe_max(node_min_size.height)
             .maybe_min(node_max_size.height),
     };

--- a/src/compute/leaf.rs
+++ b/src/compute/leaf.rs
@@ -1,0 +1,113 @@
+use crate::debug::NODE_LOGGER;
+use crate::geometry::Size;
+use crate::layout::{AvailableSpace, Cache, RunMode, SizingMode};
+use crate::math::MaybeMath;
+use crate::node::Node;
+use crate::resolve::{MaybeResolve, ResolveOrDefault};
+use crate::style::Dimension;
+use crate::tree::LayoutTree;
+
+// Define some general constants we will need for the remainder of the algorithm.
+// let mut constants = compute_constants(tree.style(node), node_size, available_space);
+
+pub(crate) fn compute(
+    tree: &mut impl LayoutTree,
+    node: Node,
+    known_dimensions: Size<Option<f32>>,
+    available_space: Size<AvailableSpace>,
+    run_mode: RunMode,
+    sizing_mode: SizingMode,
+) -> Size<f32> {
+    let style = tree.style(node);
+
+    // Resolve node's preferred/min/max sizes (width/heights) against the available space (percentages resolve to pixel values)
+    // For ContentSize mode, we pretend that the node has no size styles as these should be ignored.
+    let (node_size, node_min_size, node_max_size) = match sizing_mode {
+        SizingMode::ContentSize => {
+            let node_size = known_dimensions;
+            let node_min_size = Size::NONE;
+            let node_max_size = Size::NONE;
+            (node_size, node_min_size, node_max_size)
+        },
+        SizingMode::InherentSize => {
+            let style_size = style.size.maybe_resolve(available_space.as_options());
+            let node_size = style_size.zip_map(known_dimensions, |style_size, known_dimensions| known_dimensions.or(style_size));
+            let node_min_size = style.min_size.maybe_resolve(available_space.as_options());
+            let node_max_size = style.max_size.maybe_resolve(available_space.as_options());
+            (node_size, node_min_size, node_max_size)
+        }
+    };
+
+    NODE_LOGGER.log("LEAF");
+    NODE_LOGGER.debug_llog("node_size", node_size);
+    NODE_LOGGER.debug_llog("min_size ", node_min_size);
+    NODE_LOGGER.debug_llog("max_size ", node_max_size);
+
+    if node_size.width.is_some() && node_size.height.is_some() {
+        return Size {
+            width: node_size.width.maybe_max(node_min_size.width).maybe_min(node_max_size.width).unwrap_or(0.0),
+            height: node_size.height.maybe_max(node_min_size.height).maybe_min(node_max_size.height).unwrap_or(0.0),
+        };
+    };
+
+    if tree.needs_measure(node) {
+        // Compute available space
+        let available_space = Size {
+            width: available_space.width.maybe_set(node_size.width),
+            height: available_space.height.maybe_set(node_size.height),
+        };
+
+        // Measure node
+        let measured_size = tree.measure_node(node, known_dimensions, available_space);
+
+        let clamped_measured_size = Size {
+            width: node_size
+                .width
+                .unwrap_or(measured_size.width)
+                .maybe_max(node_min_size.width)
+                .maybe_min(node_max_size.width),
+            height: node_size
+                .height
+                .unwrap_or(measured_size.height)
+                .maybe_max(node_min_size.height)
+                .maybe_min(node_max_size.height),
+        };
+
+        return clamped_measured_size;
+    }
+
+    let padding = style.padding.resolve_or_default(available_space.width.as_option());
+    let border = style.border.resolve_or_default(available_space.width.as_option());
+    return Size {
+        width: node_size
+            .width
+            // .unwrap_or(0.0) + padding.horizontal_axis_sum() + border.horizontal_axis_sum(),
+            .unwrap_or(0.0 + padding.horizontal_axis_sum() + border.horizontal_axis_sum())
+            .maybe_max(node_min_size.width)
+            .maybe_min(node_max_size.width),
+        height: node_size
+            .height
+            // .unwrap_or(0.0) + padding.horizontal_axis_sum() + border.horizontal_axis_sum(),
+            .unwrap_or(0.0 + padding.horizontal_axis_sum() + border.horizontal_axis_sum())
+            .maybe_max(node_min_size.height)
+            .maybe_min(node_max_size.height),
+    };
+}
+
+fn maybe_clamp(size: Size<Option<f32>>, min_size: Size<Option<f32>>, max_size: Size<Option<f32>>, sizing_mode: SizingMode) -> Size<Option<f32>> {
+    match sizing_mode {
+        SizingMode::ContentSize => size,
+        SizingMode::InherentSize => {
+             Size {
+                width: size.
+                    width
+                    .maybe_max(min_size.width)
+                    .maybe_min(max_size.width),
+                height:size
+                    .height
+                    .maybe_max(min_size.height)
+                    .maybe_min(max_size.height),
+            }
+        }
+    }
+}

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -1,0 +1,1 @@
+pub (crate) mod flexbox;

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -52,7 +52,7 @@ fn compute_node_layout(
     
 
     // First we check if we have a cached result for the given input
-    if let Some(cached_size) = compute_from_cache(tree, node, known_dimensions, available_space) {
+    if let Some(cached_size) = compute_from_cache(tree, node, known_dimensions, available_space, run_mode) {
         NODE_LOGGER.debug_llog("CACHE", cached_size);
         NODE_LOGGER.pop_node();
         return cached_size;
@@ -123,11 +123,18 @@ fn compute_from_cache(
     node: Node,
     known_dimensions: Size<Option<f32>>,
     available_space: Size<AvailableSpace>,
+    run_mode: RunMode,
 ) -> Option<Size<f32>> {
     for idx in 0..4 {
         let entry = tree.cache_mut(node, idx);
         // NODE_LOGGER.debug_llog("cache_entry", &entry);
         if let Some(entry) = entry {
+
+            // Cached ComputeSize results are not valid if we are running in PerformLayout mode
+            if entry.run_mode == RunMode::ComputeSize && run_mode == RunMode::PeformLayout {
+                return None;
+            }
+
             if known_dimensions.width == entry.known_dimensions.width
                 && known_dimensions.height == entry.known_dimensions.height
             // if (known_dimensions.width == entry.known_dimensions.width || known_dimensions.width == Some(entry.cached_size.width))

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -112,6 +112,7 @@ fn compute_node_layout(
     };
 
     // Cache result
+    let cache_slot = (known_dimensions.width.is_some() as usize) + (known_dimensions.height.is_some() as usize * 2);
     *tree.cache_mut(node, cache_slot) =
         Some(Cache { known_dimensions, available_space, run_mode: cache_run_mode, cached_size: computed_size });
 

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -1,1 +1,167 @@
-pub (crate) mod flexbox;
+pub(crate) mod flexbox;
+pub(crate) mod leaf;
+
+use core::sync::atomic::AtomicU16;
+use std::env::consts;
+use slotmap::Key;
+
+use crate::error::TaffyError;
+use crate::geometry::{Point, Size};
+use crate::layout::{AvailableSpace, Cache, Layout, RunMode, SizingMode};
+use crate::math::MaybeMath;
+use crate::node::Node;
+use crate::resolve::MaybeResolve;
+use crate::style::Display;
+use crate::sys::round;
+use crate::tree::LayoutTree;
+use crate::debug::NODE_LOGGER;
+
+/// Updates the stored layout of the provided `node` and its children
+pub fn compute_layout(
+    tree: &mut impl LayoutTree,
+    root: Node,
+    available_space: Size<AvailableSpace>,
+) -> Result<(), TaffyError> {
+    // Recursively compute node layout
+    let size = compute_node_layout(tree, root, Size::NONE, available_space, RunMode::PeformLayout, SizingMode::InherentSize, 0);
+
+    let layout = Layout { order: 0, size, location: Point::ZERO };
+    *tree.layout_mut(root) = layout;
+
+    // Recursively round the layout's of this node and all children
+    round_layout(tree, root, 0.0, 0.0);
+
+    Ok(())
+}
+
+/// Updates the stored layout of the provided `node` and its children
+fn compute_node_layout(
+    tree: &mut impl LayoutTree,
+    node: Node,
+    known_dimensions: Size<Option<f32>>,
+    available_space: Size<AvailableSpace>,
+    run_mode: RunMode,
+    sizing_mode: SizingMode,
+    cache_slot: usize,
+) -> Size<f32> {
+    // clear the dirtiness of the node now that we've computed it
+    tree.mark_dirty(node, false);
+
+    NODE_LOGGER.push_node(node);
+    println!("");
+    
+
+    // First we check if we have a cached result for the given input
+    if let Some(cached_size) = compute_from_cache(tree, node, known_dimensions, available_space) {
+        NODE_LOGGER.debug_llog("CACHE", cached_size);
+        NODE_LOGGER.pop_node();
+        return cached_size;
+    }
+
+    NODE_LOGGER.log("COMPUTE");
+    NODE_LOGGER.debug_llog("run_mode", run_mode);
+    NODE_LOGGER.debug_llog("sizing_mode", sizing_mode);
+    NODE_LOGGER.debug_llog("known_dimensions", known_dimensions);
+    NODE_LOGGER.debug_llog("available_space", available_space);
+
+    // Attempt to shortcut size computation based on
+    //  - KnownSize sizing constraints
+    //  - The node's preferred sizes (width/heights) styles and AvailableSpace sizing constraints
+    // (percentages resolve to pixel values if there is a definite AvailableSpace sizing constraint)
+    // let style = tree.style(node);
+    // // let known_node_size = available_space.
+    // //     .zip_map(style.size, |constraint, style_size| style_size.maybe_resolve(constraint.as_option()));
+    // let known_node_size = style
+    //     .size
+    //     .maybe_resolve(available_space.as_options())
+    //     .zip_map(known_dimensions, |style_size, known_dimensions| known_dimensions.or(style_size));
+    // if run_mode == RunMode::ComputeSize && known_node_size.width.is_some() && known_node_size.height.is_some() {
+    //     let node_min_size = style.min_size.maybe_resolve(available_space.as_options());
+    //     let node_max_size = style.max_size.maybe_resolve(available_space.as_options());
+    //     return Size {
+    //         width: known_node_size.width.maybe_max(node_min_size.width).maybe_min(node_max_size.width).unwrap_or(0.0),
+    //         height: known_node_size
+    //             .height
+    //             .maybe_max(node_min_size.height)
+    //             .maybe_min(node_max_size.height)
+    //             .unwrap_or(0.0),
+    //     };
+    // }
+
+    // If this is a leaf node we can skip a lot of this function in some cases
+    let computed_size = if tree.children(node).is_empty() {
+        NODE_LOGGER.log("Algo: leaf");
+        self::leaf::compute(tree, node, known_dimensions, available_space, run_mode, sizing_mode)
+    } else {
+        // println!("match {:?}", tree.style(node).display);
+        match tree.style(node).display {
+            Display::Flex => {
+              NODE_LOGGER.log("Algo: flexbox");
+              self::flexbox::compute(tree, node, known_dimensions, available_space, run_mode, cache_slot)
+            },
+            Display::None => {
+              NODE_LOGGER.log("Algo: none");
+              Size { width: 0.0, height: 0.0 }
+            },
+        }
+    };
+
+    // Cache result
+    *tree.cache_mut(node, cache_slot) =
+        Some(Cache { known_dimensions, available_space, run_mode, cached_size: computed_size });
+
+    NODE_LOGGER.debug_llog("RESULT", computed_size);
+    NODE_LOGGER.pop_node();
+
+    computed_size
+}
+
+/// Try to get the computation result from the cache.
+#[inline]
+fn compute_from_cache(
+    tree: &mut impl LayoutTree,
+    node: Node,
+    known_dimensions: Size<Option<f32>>,
+    available_space: Size<AvailableSpace>,
+) -> Option<Size<f32>> {
+    for idx in 0..4 {
+        let entry = tree.cache_mut(node, idx);
+        // NODE_LOGGER.debug_llog("cache_entry", &entry);
+        if let Some(entry) = entry {
+            if known_dimensions.width == entry.known_dimensions.width
+                && known_dimensions.height == entry.known_dimensions.height
+            // if (known_dimensions.width == entry.known_dimensions.width || known_dimensions.width == Some(entry.cached_size.width))
+                // && (known_dimensions.height == entry.known_dimensions.height || known_dimensions.height == Some(entry.cached_size.height))
+                && entry.available_space.width.is_roughly_equal(available_space.width)
+                && entry.available_space.height.is_roughly_equal(available_space.height)
+                // && (known_dimensions.width.is_some() || entry.available_space.width.is_roughly_equal(available_space.width))
+                // && (known_dimensions.height.is_some() || entry.available_space.height.is_roughly_equal(available_space.height))
+                // && (entry.available_space.width.is_roughly_equal(available_space.width) || (available_space.width.is_definite() && available_space.width.unwrap() >= entry.cached_size.width))
+                // && (entry.available_space.height.is_roughly_equal(available_space.height) || (available_space.height.is_definite() && available_space.height.unwrap() >= entry.cached_size.height))
+            {
+                return Some(entry.cached_size);
+            }
+        }
+    }
+
+    None
+}
+
+/// Rounds the calculated [`NodeData`] according to the spec
+fn round_layout(tree: &mut impl LayoutTree, root: Node, abs_x: f32, abs_y: f32) {
+    let layout = tree.layout_mut(root);
+    let abs_x = abs_x + layout.location.x;
+    let abs_y = abs_y + layout.location.y;
+
+    layout.location.x = round(layout.location.x);
+    layout.location.y = round(layout.location.y);
+
+    layout.size.width = round(layout.size.width);
+    layout.size.height = round(layout.size.height);
+
+    // Satisfy the borrow checker here by re-indexing to shorten the lifetime to the loop scope
+    for x in 0..tree.children(root).len() {
+        let child = tree.child(root, x);
+        round_layout(tree, child, abs_x, abs_y);
+    }
+}

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -1,17 +1,11 @@
 pub(crate) mod flexbox;
 pub(crate) mod leaf;
 
-use core::sync::atomic::AtomicU16;
-use slotmap::Key;
-use std::env::consts;
-
 use crate::debug::NODE_LOGGER;
 use crate::error::TaffyError;
 use crate::geometry::{Point, Size};
 use crate::layout::{AvailableSpace, Cache, Layout, RunMode, SizingMode};
-use crate::math::MaybeMath;
 use crate::node::Node;
-use crate::resolve::MaybeResolve;
 use crate::style::Display;
 use crate::sys::round;
 use crate::tree::LayoutTree;

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -23,14 +23,8 @@ pub fn compute_layout(
     available_space: Size<AvailableSpace>,
 ) -> Result<(), TaffyError> {
     // Recursively compute node layout
-    let size = compute_node_layout(
-        tree,
-        root,
-        Size::NONE,
-        available_space,
-        RunMode::PeformLayout,
-        SizingMode::InherentSize,
-    );
+    let size =
+        compute_node_layout(tree, root, Size::NONE, available_space, RunMode::PeformLayout, SizingMode::InherentSize);
 
     let layout = Layout { order: 0, size, location: Point::ZERO };
     *tree.layout_mut(root) = layout;

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -47,27 +47,27 @@ fn compute_node_layout(
     // clear the dirtiness of the node now that we've computed it
     tree.mark_dirty(node, false);
 
-    NODE_LOGGER.push_node(node);
-    println!("");
+    // NODE_LOGGER.push_node(node);
+    // println!("");
     
 
     // First we check if we have a cached result for the given input
     let cache_run_mode = if tree.children(node).is_empty() { RunMode::PeformLayout } else { run_mode };
     if let Some(cached_size) = compute_from_cache(tree, node, known_dimensions, available_space, cache_run_mode, sizing_mode) {
-        NODE_LOGGER.debug_llog("CACHE", cached_size);
-        NODE_LOGGER.debug_llog("run_mode", run_mode);
-        NODE_LOGGER.debug_llog("sizing_mode", sizing_mode);
-        NODE_LOGGER.debug_llog("known_dimensions", known_dimensions);
-        NODE_LOGGER.debug_llog("available_space", available_space);
-        NODE_LOGGER.pop_node();
+        // NODE_LOGGER.debug_llog("CACHE", cached_size);
+        // NODE_LOGGER.debug_llog("run_mode", run_mode);
+        // NODE_LOGGER.debug_llog("sizing_mode", sizing_mode);
+        // NODE_LOGGER.debug_llog("known_dimensions", known_dimensions);
+        // NODE_LOGGER.debug_llog("available_space", available_space);
+        // NODE_LOGGER.pop_node();
         return cached_size;
     }
 
-    NODE_LOGGER.log("COMPUTE");
-    NODE_LOGGER.debug_llog("run_mode", run_mode);
-    NODE_LOGGER.debug_llog("sizing_mode", sizing_mode);
-    NODE_LOGGER.debug_llog("known_dimensions", known_dimensions);
-    NODE_LOGGER.debug_llog("available_space", available_space);
+    // NODE_LOGGER.log("COMPUTE");
+    // NODE_LOGGER.debug_llog("run_mode", run_mode);
+    // NODE_LOGGER.debug_llog("sizing_mode", sizing_mode);
+    // NODE_LOGGER.debug_llog("known_dimensions", known_dimensions);
+    // NODE_LOGGER.debug_llog("available_space", available_space);
 
     // Attempt to shortcut size computation based on
     //  - KnownSize sizing constraints
@@ -95,17 +95,17 @@ fn compute_node_layout(
 
     // If this is a leaf node we can skip a lot of this function in some cases
     let computed_size = if tree.children(node).is_empty() {
-        NODE_LOGGER.log("Algo: leaf");
+        // NODE_LOGGER.log("Algo: leaf");
         self::leaf::compute(tree, node, known_dimensions, available_space, run_mode, sizing_mode)
     } else {
         // println!("match {:?}", tree.style(node).display);
         match tree.style(node).display {
             Display::Flex => {
-              NODE_LOGGER.log("Algo: flexbox");
+              // NODE_LOGGER.log("Algo: flexbox");
               self::flexbox::compute(tree, node, known_dimensions, available_space, run_mode, cache_slot)
             },
             Display::None => {
-              NODE_LOGGER.log("Algo: none");
+              // NODE_LOGGER.log("Algo: none");
               Size { width: 0.0, height: 0.0 }
             },
         }
@@ -115,8 +115,8 @@ fn compute_node_layout(
     *tree.cache_mut(node, cache_slot) =
         Some(Cache { known_dimensions, available_space, run_mode: cache_run_mode, cached_size: computed_size });
 
-    NODE_LOGGER.debug_llog("RESULT", computed_size);
-    NODE_LOGGER.pop_node();
+    // NODE_LOGGER.debug_llog("RESULT", computed_size);
+    // NODE_LOGGER.pop_node();
 
     computed_size
 }

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -1,3 +1,5 @@
+//! The layout algorithms themselves
+
 pub(crate) mod flexbox;
 pub(crate) mod leaf;
 
@@ -46,7 +48,7 @@ fn compute_node_layout(
     #[cfg(feature = "debug")]
     NODE_LOGGER.push_node(node);
     #[cfg(feature = "debug")]
-    println!("");
+    println!();
 
     // First we check if we have a cached result for the given input
     let cache_run_mode = if tree.children(node).is_empty() { RunMode::PeformLayout } else { run_mode };

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -30,7 +30,6 @@ pub fn compute_layout(
         available_space,
         RunMode::PeformLayout,
         SizingMode::InherentSize,
-        0,
     );
 
     let layout = Layout { order: 0, size, location: Point::ZERO };
@@ -50,7 +49,6 @@ fn compute_node_layout(
     available_space: Size<AvailableSpace>,
     run_mode: RunMode,
     sizing_mode: SizingMode,
-    cache_slot: usize,
 ) -> Size<f32> {
     // clear the dirtiness of the node now that we've computed it
     tree.mark_dirty(node, false);
@@ -111,7 +109,7 @@ fn compute_node_layout(
         match tree.style(node).display {
             Display::Flex => {
                 // NODE_LOGGER.log("Algo: flexbox");
-                self::flexbox::compute(tree, node, known_dimensions, available_space, run_mode, cache_slot)
+                self::flexbox::compute(tree, node, known_dimensions, available_space, run_mode)
             }
             Display::None => {
                 // NODE_LOGGER.log("Algo: none");

--- a/src/data.rs
+++ b/src/data.rs
@@ -18,9 +18,7 @@ pub(crate) struct NodeData {
     pub(crate) needs_measure: bool,
 
     /// The primary cached results of the layout computation
-    pub(crate) main_size_layout_cache: Option<Cache>,
-    /// Secondary cached results of the layout computation
-    pub(crate) other_layout_cache: Option<Cache>,
+    pub(crate) size_cache: [Option<Cache>; 4],
     /// Does this node's layout need to be recomputed?
     pub(crate) is_dirty: bool,
 }
@@ -29,14 +27,7 @@ impl NodeData {
     /// Create the data for a new node
     #[must_use]
     pub const fn new(style: FlexboxLayout) -> Self {
-        Self {
-            style,
-            main_size_layout_cache: None,
-            other_layout_cache: None,
-            layout: Layout::new(),
-            is_dirty: true,
-            needs_measure: false,
-        }
+        Self { style, size_cache: [None; 4], layout: Layout::new(), is_dirty: true, needs_measure: false }
     }
 
     /// Marks a node and all of its parents (recursively) as dirty
@@ -44,8 +35,7 @@ impl NodeData {
     /// This clears any cached data and signals that the data must be recomputed.
     #[inline]
     pub fn mark_dirty(&mut self) {
-        self.main_size_layout_cache = None;
-        self.other_layout_cache = None;
+        self.size_cache = [None; 4];
         self.is_dirty = true;
     }
 }

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -7,7 +7,7 @@ use crate::tree::LayoutTree;
 
 #[doc(hidden)]
 pub fn print_tree(tree: &impl LayoutTree, root: Node) {
-    println!("");
+    println!();
     print_node(tree, root, 0);
 }
 

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -5,13 +5,12 @@ use std::sync::Mutex;
 use crate::node::Node;
 use crate::tree::LayoutTree;
 
-#[doc(hidden)]
+/// Prints a debug representation of the computed layout for a tree of nodes, starting with the passed root node.
 pub fn print_tree(tree: &impl LayoutTree, root: Node) {
     println!();
     print_node(tree, root, 0);
 }
 
-#[doc(hidden)]
 fn print_node(tree: &impl LayoutTree, node: Node, level: usize) {
     let layout = tree.layout(node);
     println!(

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -87,4 +87,5 @@ impl DebugLogger {
     }
 }
 
+#[cfg(feature = "debug")]
 pub(crate) static NODE_LOGGER: DebugLogger = DebugLogger::new();

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,0 +1,96 @@
+use core::fmt::{Debug, Display, Write};
+use core::sync::atomic::{Ordering, AtomicUsize};
+use std::sync::{Mutex, Arc};
+use slotmap::Key;
+
+use crate::node::Node;
+use crate::tree::LayoutTree;
+
+#[doc(hidden)]
+pub fn print_tree(tree: &impl LayoutTree, root: Node) {
+    println!("");
+    print_node(tree, root, 0);
+}
+
+#[doc(hidden)]
+fn print_node(tree: &impl LayoutTree, node: Node, level: usize) {
+    let layout = tree.layout(node);
+    println!(
+        "{space:leftpad$}{key:?} (x:{x}, y: {y}, width: {width}, height: {height})",
+        space = " ",
+        leftpad = level * 4,
+        key = node.data(),
+        x = layout.location.x,
+        y = layout.location.y, 
+        width = layout.size.width,
+        height = layout.size.height,
+    );
+
+    // Recurse into children
+    for child in tree.children(node) {
+      print_node(tree, *child, level + 1)
+    }
+}
+
+
+
+pub (crate) struct DebugLogger {
+  stack: Mutex<Vec<String>>,
+}
+
+static EMPTY_STRING : String = String::new();
+
+impl DebugLogger {
+
+  pub (crate) const fn new()  -> Self {
+    Self {
+      stack: Mutex::new(Vec::new())
+    }
+  }
+
+  pub (crate) fn push_node(&self, new_key: impl Key) {
+    let mut stack = self.stack.lock().unwrap();
+    let mut key_string = String::new();
+    write!(&mut key_string, "{:?}", new_key.data()).unwrap();
+    stack.push(key_string);
+  }
+
+  pub (crate) fn pop_node(&self) {
+    let mut stack = self.stack.lock().unwrap();
+    stack.pop();
+  }
+
+  pub (crate) fn log(&self, message: impl Display) {
+    let stack = self.stack.lock().unwrap();
+    let key = stack.last().unwrap_or(&EMPTY_STRING);
+    let level = stack.len() * 4;
+    let space = " ";
+    println!("{space:level$}{key}: {message}");
+  }
+
+  pub (crate) fn llog(&self, label: &str, message: impl Display) {
+    let stack = self.stack.lock().unwrap();
+    let key = stack.last().unwrap_or(&EMPTY_STRING);
+    let level = stack.len() * 4;
+    let space = " ";
+    println!("{space:level$}{key}: {label} {message}");
+  }
+
+  pub (crate) fn debug_log(&self, message: impl Debug) {
+    let stack = self.stack.lock().unwrap();
+    let key = stack.last().unwrap_or(&EMPTY_STRING);
+    let level = stack.len() * 4;
+    let space = " ";
+    println!("{space:level$}{key}: {message:?}");
+  }
+
+  pub (crate) fn debug_llog(&self, label: &str, message: impl Debug) {
+   let stack = self.stack.lock().unwrap();
+    let key = stack.last().unwrap_or(&EMPTY_STRING);
+    let level = stack.len() * 4;
+    let space = " ";
+    println!("{space:level$}{key}: {label} {message:?}");
+  }
+}
+
+pub (crate) static NODE_LOGGER : DebugLogger = DebugLogger::new();

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,7 +1,6 @@
 use core::fmt::{Debug, Display, Write};
-use core::sync::atomic::{AtomicUsize, Ordering};
 use slotmap::Key;
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
 use crate::node::Node;
 use crate::tree::LayoutTree;
@@ -32,30 +31,30 @@ fn print_node(tree: &impl LayoutTree, node: Node, level: usize) {
     }
 }
 
-pub(crate) struct DebugLogger {
+#[doc(hidden)]
+pub struct DebugLogger {
     stack: Mutex<Vec<String>>,
 }
 
 static EMPTY_STRING: String = String::new();
-
 impl DebugLogger {
-    pub(crate) const fn new() -> Self {
+    pub const fn new() -> Self {
         Self { stack: Mutex::new(Vec::new()) }
     }
 
-    pub(crate) fn push_node(&self, new_key: impl Key) {
+    pub fn push_node(&self, new_key: impl Key) {
         let mut stack = self.stack.lock().unwrap();
         let mut key_string = String::new();
         write!(&mut key_string, "{:?}", new_key.data()).unwrap();
         stack.push(key_string);
     }
 
-    pub(crate) fn pop_node(&self) {
+    pub fn pop_node(&self) {
         let mut stack = self.stack.lock().unwrap();
         stack.pop();
     }
 
-    pub(crate) fn log(&self, message: impl Display) {
+    pub fn log(&self, message: impl Display) {
         let stack = self.stack.lock().unwrap();
         let key = stack.last().unwrap_or(&EMPTY_STRING);
         let level = stack.len() * 4;
@@ -63,7 +62,7 @@ impl DebugLogger {
         println!("{space:level$}{key}: {message}");
     }
 
-    pub(crate) fn llog(&self, label: &str, message: impl Display) {
+    pub fn labelled_log(&self, label: &str, message: impl Display) {
         let stack = self.stack.lock().unwrap();
         let key = stack.last().unwrap_or(&EMPTY_STRING);
         let level = stack.len() * 4;
@@ -71,7 +70,7 @@ impl DebugLogger {
         println!("{space:level$}{key}: {label} {message}");
     }
 
-    pub(crate) fn debug_log(&self, message: impl Debug) {
+    pub fn debug_log(&self, message: impl Debug) {
         let stack = self.stack.lock().unwrap();
         let key = stack.last().unwrap_or(&EMPTY_STRING);
         let level = stack.len() * 4;
@@ -79,7 +78,7 @@ impl DebugLogger {
         println!("{space:level$}{key}: {message:?}");
     }
 
-    pub(crate) fn debug_llog(&self, label: &str, message: impl Debug) {
+    pub fn labelled_debug_log(&self, label: &str, message: impl Debug) {
         let stack = self.stack.lock().unwrap();
         let key = stack.last().unwrap_or(&EMPTY_STRING);
         let level = stack.len() * 4;

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,7 +1,7 @@
 use core::fmt::{Debug, Display, Write};
-use core::sync::atomic::{Ordering, AtomicUsize};
-use std::sync::{Mutex, Arc};
+use core::sync::atomic::{AtomicUsize, Ordering};
 use slotmap::Key;
+use std::sync::{Arc, Mutex};
 
 use crate::node::Node;
 use crate::tree::LayoutTree;
@@ -21,76 +21,71 @@ fn print_node(tree: &impl LayoutTree, node: Node, level: usize) {
         leftpad = level * 4,
         key = node.data(),
         x = layout.location.x,
-        y = layout.location.y, 
+        y = layout.location.y,
         width = layout.size.width,
         height = layout.size.height,
     );
 
     // Recurse into children
     for child in tree.children(node) {
-      print_node(tree, *child, level + 1)
+        print_node(tree, *child, level + 1)
     }
 }
 
-
-
-pub (crate) struct DebugLogger {
-  stack: Mutex<Vec<String>>,
+pub(crate) struct DebugLogger {
+    stack: Mutex<Vec<String>>,
 }
 
-static EMPTY_STRING : String = String::new();
+static EMPTY_STRING: String = String::new();
 
 impl DebugLogger {
-
-  pub (crate) const fn new()  -> Self {
-    Self {
-      stack: Mutex::new(Vec::new())
+    pub(crate) const fn new() -> Self {
+        Self { stack: Mutex::new(Vec::new()) }
     }
-  }
 
-  pub (crate) fn push_node(&self, new_key: impl Key) {
-    let mut stack = self.stack.lock().unwrap();
-    let mut key_string = String::new();
-    write!(&mut key_string, "{:?}", new_key.data()).unwrap();
-    stack.push(key_string);
-  }
+    pub(crate) fn push_node(&self, new_key: impl Key) {
+        let mut stack = self.stack.lock().unwrap();
+        let mut key_string = String::new();
+        write!(&mut key_string, "{:?}", new_key.data()).unwrap();
+        stack.push(key_string);
+    }
 
-  pub (crate) fn pop_node(&self) {
-    let mut stack = self.stack.lock().unwrap();
-    stack.pop();
-  }
+    pub(crate) fn pop_node(&self) {
+        let mut stack = self.stack.lock().unwrap();
+        stack.pop();
+    }
 
-  pub (crate) fn log(&self, message: impl Display) {
-    let stack = self.stack.lock().unwrap();
-    let key = stack.last().unwrap_or(&EMPTY_STRING);
-    let level = stack.len() * 4;
-    let space = " ";
-    println!("{space:level$}{key}: {message}");
-  }
+    pub(crate) fn log(&self, message: impl Display) {
+        let stack = self.stack.lock().unwrap();
+        let key = stack.last().unwrap_or(&EMPTY_STRING);
+        let level = stack.len() * 4;
+        let space = " ";
+        println!("{space:level$}{key}: {message}");
+    }
 
-  pub (crate) fn llog(&self, label: &str, message: impl Display) {
-    let stack = self.stack.lock().unwrap();
-    let key = stack.last().unwrap_or(&EMPTY_STRING);
-    let level = stack.len() * 4;
-    let space = " ";
-    println!("{space:level$}{key}: {label} {message}");
-  }
+    pub(crate) fn llog(&self, label: &str, message: impl Display) {
+        let stack = self.stack.lock().unwrap();
+        let key = stack.last().unwrap_or(&EMPTY_STRING);
+        let level = stack.len() * 4;
+        let space = " ";
+        println!("{space:level$}{key}: {label} {message}");
+    }
 
-  pub (crate) fn debug_log(&self, message: impl Debug) {
-    let stack = self.stack.lock().unwrap();
-    let key = stack.last().unwrap_or(&EMPTY_STRING);
-    let level = stack.len() * 4;
-    let space = " ";
-    println!("{space:level$}{key}: {message:?}");
-  }
+    pub(crate) fn debug_log(&self, message: impl Debug) {
+        let stack = self.stack.lock().unwrap();
+        let key = stack.last().unwrap_or(&EMPTY_STRING);
+        let level = stack.len() * 4;
+        let space = " ";
+        println!("{space:level$}{key}: {message:?}");
+    }
 
-  pub (crate) fn debug_llog(&self, label: &str, message: impl Debug) {
-   let stack = self.stack.lock().unwrap();
-    let key = stack.last().unwrap_or(&EMPTY_STRING);
-    let level = stack.len() * 4;
-    let space = " ";
-    println!("{space:level$}{key}: {label} {message:?}");
-  }
+    pub(crate) fn debug_llog(&self, label: &str, message: impl Debug) {
+        let stack = self.stack.lock().unwrap();
+        let key = stack.last().unwrap_or(&EMPTY_STRING);
+        let level = stack.len() * 4;
+        let space = " ";
+        println!("{space:level$}{key}: {label} {message:?}");
+    }
 }
 
-pub (crate) static NODE_LOGGER : DebugLogger = DebugLogger::new();
+pub(crate) static NODE_LOGGER: DebugLogger = DebugLogger::new();

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -163,12 +163,37 @@ pub struct Size<T> {
 impl<T> Size<T> {
     /// Applies the function `f` to both the width and height
     ///
-    /// This is used to transform a `Rect<T>` into a `Rect<R>`.
+    /// This is used to transform a `Size<T>` into a `Size<R>`.
     pub fn map<R, F>(self, f: F) -> Size<R>
     where
         F: Fn(T) -> R,
     {
         Size { width: f(self.width), height: f(self.height) }
+    }
+
+    /// Applies the function `f` to the width
+    pub fn map_width<F>(self, f: F) -> Size<T>
+    where
+        F: Fn(T) -> T,
+    {
+        Size { width: f(self.width), height: self.height }
+    }
+
+    /// Applies the function `f` to the height
+    pub fn map_height<F>(self, f: F) -> Size<T>
+    where
+        F: Fn(T) -> T,
+    {
+        Size { width: self.width, height: f(self.height) }
+    }
+
+    /// Applies the function `f` to both the width and height
+    /// of this value and another passed value
+    pub fn zip_map<Other, Ret, Func>(self, other: Size<Other>, f: Func) -> Size<Ret>
+    where
+        Func: Fn(T, Other) -> Ret,
+    {
+        Size { width: f(self.width, other.width), height: f(self.height, other.height) }
     }
 
     /// Sets the extent of the main layout axis

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -255,6 +255,16 @@ impl Size<Option<f32>> {
     pub const fn new(width: f32, height: f32) -> Self {
         Size { width: Some(width), height: Some(height) }
     }
+
+    /// Performs Option::unwrap_or on each component separately
+    pub fn unwrap_or(self, alt: Size<f32>) -> Size<f32> {
+        Size { width: self.width.unwrap_or(alt.width), height: self.height.unwrap_or(alt.height) }
+    }
+
+    /// Performs Option::or on each component separately
+    pub fn or(self, alt: Size<Option<f32>>) -> Size<Option<f32>> {
+        Size { width: self.width.or(alt.width), height: self.height.or(alt.height) }
+    }
 }
 
 impl Size<Dimension> {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1,6 +1,86 @@
 //! Final and cached data structures that represent the high-level UI layout
 
 use crate::geometry::{Point, Size};
+use crate::sys::abs;
+
+/// The amount of space available to a node in a given axis
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum AvailableSpace {
+    /// The amount of space available is the specified number of pixels
+    Definite(f32),
+    /// The amount of space available is indefinite and the node should be laid out under a min-content constraint
+    MinContent,
+    /// The amount of space available is indefinite and the node should be laid out under a max-content constraint
+    MaxContent,
+}
+
+impl AvailableSpace {
+    const ZERO: AvailableSpace = AvailableSpace::Definite(0.0);
+
+    /// Returns true for definite values, else false
+    pub fn is_definite(self) -> bool {
+        matches!(self, AvailableSpace::Definite(_))
+    }
+
+    /// Convert to Option
+    /// Definite values become Some(value). Contraints become None.
+    pub fn as_option(self) -> Option<f32> {
+        match self {
+            AvailableSpace::Definite(value) => Some(value),
+            _ => None,
+        }
+    }
+
+    /// Return the definite value or a default value
+    pub fn unwrap_or(self, default: f32) -> f32 {
+        self.as_option().unwrap_or(default)
+    }
+
+    /// Return the definite value. Panic is the value is not definite.
+    #[track_caller]
+    pub fn unwrap(self) -> f32 {
+        self.as_option().unwrap()
+    }
+
+    /// If passed value is Some then return AvailableSpace::Definite containing that value, else return self
+    pub fn maybe_set(self, value: Option<f32>) -> AvailableSpace {
+        match value {
+            Some(value) => AvailableSpace::Definite(value),
+            None => self,
+        }
+    }
+
+    /// Compare equality with another AvailableSpace, treating definite values
+    /// that are within f32::EPSILON of each other as equal
+    pub fn is_roughly_equal(self, other: AvailableSpace) -> bool {
+        use AvailableSpace::*;
+        match (self, other) {
+            (Definite(a), Definite(b)) => abs(a - b) < f32::EPSILON,
+            (MinContent, MinContent) => true,
+            (MaxContent, MaxContent) => true,
+            _ => false,
+        }
+    }
+}
+
+impl From<f32> for AvailableSpace {
+    fn from(value: f32) -> Self {
+        Self::Definite(value)
+    }
+}
+
+impl Size<AvailableSpace> {
+    /// A Size<AvailableSpace> containing a MaxContent constraint in both dimensions
+    const MAX_CONTENT : Size<AvailableSpace> = Size { width: AvailableSpace::MaxContent, height: AvailableSpace::MaxContent };
+
+    /// A Size<AvailableSpace> containing a MinContent constraint in both dimensions
+    const MIN_CONTENT : Size<AvailableSpace> = Size { width: AvailableSpace::MinContent, height: AvailableSpace::MinContent };
+
+    /// Convert Size<AvailableSpace> into Size<Option<f32>>
+    pub fn as_options(self) -> Size<Option<f32>> {
+        Size { width: self.width.as_option(), height: self.height.as_option() }
+    }
+}
 
 /// The final result of a layout algorithm for a single [`Node`](crate::node::Node).
 #[derive(Copy, Debug, Clone)]

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -3,6 +3,16 @@
 use crate::geometry::{Point, Size};
 use crate::sys::abs;
 
+/// Whether we are performing a full layout, or we merely need to size the node
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum RunMode {
+    /// A full layout for this node and all children should be computed
+    PeformLayout,
+    /// The layout algorithm should be executed such that an accurate container size for the node can be determined.
+    /// Layout steps that aren't necessary for determining the container size of the current node can be skipped.
+    ComputeSize,
+}
+
 /// The amount of space available to a node in a given axis
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum AvailableSpace {
@@ -125,7 +135,7 @@ pub struct Cache {
     /// The initial cached size of the parent's node
     pub(crate) parent_size: Size<Option<f32>>,
     /// Whether or not layout should be recomputed
-    pub(crate) perform_layout: bool,
+    pub(crate) run_mode: RunMode,
 
     /// The cached size of the item
     pub(crate) size: Size<f32>,

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -13,6 +13,15 @@ pub enum RunMode {
     ComputeSize,
 }
 
+/// Whether styles should be taken into account when computing size
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum SizingMode {
+    /// Only content contributions should be taken into account
+    ContentSize,
+    /// Inherent size styles should be taken into account in addition to content contributions
+    InherentSize,
+}
+
 /// The amount of space available to a node in a given axis
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum AvailableSpace {
@@ -81,10 +90,12 @@ impl From<f32> for AvailableSpace {
 
 impl Size<AvailableSpace> {
     /// A Size<AvailableSpace> containing a MaxContent constraint in both dimensions
-    const MAX_CONTENT : Size<AvailableSpace> = Size { width: AvailableSpace::MaxContent, height: AvailableSpace::MaxContent };
+    pub const MAX_CONTENT: Size<AvailableSpace> =
+        Size { width: AvailableSpace::MaxContent, height: AvailableSpace::MaxContent };
 
     /// A Size<AvailableSpace> containing a MinContent constraint in both dimensions
-    const MIN_CONTENT : Size<AvailableSpace> = Size { width: AvailableSpace::MinContent, height: AvailableSpace::MinContent };
+    pub const MIN_CONTENT: Size<AvailableSpace> =
+        Size { width: AvailableSpace::MinContent, height: AvailableSpace::MinContent };
 
     /// Convert Size<AvailableSpace> into Size<Option<f32>>
     pub fn as_options(self) -> Size<Option<f32>> {
@@ -128,15 +139,15 @@ impl Layout {
 }
 
 /// Cached intermediate layout results
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct Cache {
     /// The initial cached size of the node itself
-    pub(crate) node_size: Size<Option<f32>>,
+    pub(crate) known_dimensions: Size<Option<f32>>,
     /// The initial cached size of the parent's node
-    pub(crate) parent_size: Size<Option<f32>>,
+    pub(crate) available_space: Size<AvailableSpace>,
     /// Whether or not layout should be recomputed
     pub(crate) run_mode: RunMode,
 
     /// The cached size of the item
-    pub(crate) size: Size<f32>,
+    pub(crate) cached_size: Size<f32>,
 }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -44,7 +44,7 @@ impl AvailableSpace {
 
     /// Convert to Option
     /// Definite values become Some(value). Contraints become None.
-    pub fn as_option(self) -> Option<f32> {
+    pub fn into_option(self) -> Option<f32> {
         match self {
             AvailableSpace::Definite(value) => Some(value),
             _ => None,
@@ -53,13 +53,13 @@ impl AvailableSpace {
 
     /// Return the definite value or a default value
     pub fn unwrap_or(self, default: f32) -> f32 {
-        self.as_option().unwrap_or(default)
+        self.into_option().unwrap_or(default)
     }
 
     /// Return the definite value. Panic is the value is not definite.
     #[track_caller]
     pub fn unwrap(self) -> f32 {
-        self.as_option().unwrap()
+        self.into_option().unwrap()
     }
 
     /// If passed value is Some then return AvailableSpace::Definite containing that value, else return self
@@ -100,7 +100,7 @@ impl Size<AvailableSpace> {
 
     /// Convert Size<AvailableSpace> into Size<Option<f32>>
     pub fn as_options(self) -> Size<Option<f32>> {
-        Size { width: self.width.as_option(), height: self.height.as_option() }
+        Size { width: self.width.into_option(), height: self.height.into_option() }
     }
 }
 

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -34,7 +34,8 @@ pub enum AvailableSpace {
 }
 
 impl AvailableSpace {
-    const ZERO: AvailableSpace = AvailableSpace::Definite(0.0);
+    /// A definite available space of zero
+    pub const ZERO: AvailableSpace = AvailableSpace::Definite(0.0);
 
     /// Returns true for definite values, else false
     pub fn is_definite(self) -> bool {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -4,7 +4,7 @@ use crate::geometry::{Point, Size};
 use crate::sys::abs;
 
 /// Whether we are performing a full layout, or we merely need to size the node
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum RunMode {
     /// A full layout for this node and all children should be computed
     PeformLayout,
@@ -14,7 +14,7 @@ pub enum RunMode {
 }
 
 /// Whether styles should be taken into account when computing size
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum SizingMode {
     /// Only content contributions should be taken into account
     ContentSize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ pub mod tree;
 pub mod randomizable;
 
 mod data;
-mod flexbox;
+mod compute;
 mod resolve;
 mod sys;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,12 +26,14 @@ pub mod node;
 pub mod prelude;
 pub mod style;
 pub mod tree;
+#[doc(hidden)]
+pub mod debug;
 
 #[cfg(feature = "random")]
 pub mod randomizable;
 
-mod data;
 mod compute;
+mod data;
 mod resolve;
 mod sys;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@ extern crate alloc;
 #[cfg(feature = "serde")]
 extern crate serde;
 
+#[doc(hidden)]
+pub mod debug;
 pub mod error;
 pub mod geometry;
 pub mod layout;
@@ -26,8 +28,6 @@ pub mod node;
 pub mod prelude;
 pub mod style;
 pub mod tree;
-#[doc(hidden)]
-pub mod debug;
 
 #[cfg(feature = "random")]
 pub mod randomizable;

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,4 +1,5 @@
 //! Contains numerical helper traits and functions
+#![allow(clippy::manual_clamp)]
 
 use crate::geometry::Size;
 use crate::layout::AvailableSpace;

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,7 +1,7 @@
 //! Contains numerical helper traits and functions
 
-use crate::layout::AvailableSpace;
 use crate::geometry::Size;
+use crate::layout::AvailableSpace;
 
 /// A trait to conveniently calculate minimums and maximums when some data may not be defined
 ///
@@ -224,17 +224,11 @@ impl MaybeMath<Option<f32>, AvailableSpace> for AvailableSpace {
 
 impl<In, Out, T: MaybeMath<In, Out>> MaybeMath<Size<In>, Size<Out>> for Size<T> {
     fn maybe_min(self, rhs: Size<In>) -> Size<Out> {
-        Size {
-            width: self.width.maybe_min(rhs.width),
-            height: self.height.maybe_min(rhs.height),
-        }
+        Size { width: self.width.maybe_min(rhs.width), height: self.height.maybe_min(rhs.height) }
     }
 
     fn maybe_max(self, rhs: Size<In>) -> Size<Out> {
-        Size {
-            width: self.width.maybe_max(rhs.width),
-            height: self.height.maybe_max(rhs.height),
-        }
+        Size { width: self.width.maybe_max(rhs.width), height: self.height.maybe_max(rhs.height) }
     }
 
     fn maybe_clamp(self, min: Size<In>, max: Size<In>) -> Size<Out> {
@@ -245,17 +239,11 @@ impl<In, Out, T: MaybeMath<In, Out>> MaybeMath<Size<In>, Size<Out>> for Size<T> 
     }
 
     fn maybe_add(self, rhs: Size<In>) -> Size<Out> {
-        Size {
-            width: self.width.maybe_add(rhs.width),
-            height: self.height.maybe_add(rhs.height),
-        }
+        Size { width: self.width.maybe_add(rhs.width), height: self.height.maybe_add(rhs.height) }
     }
 
     fn maybe_sub(self, rhs: Size<In>) -> Size<Out> {
-        Size {
-            width: self.width.maybe_sub(rhs.width),
-            height: self.height.maybe_sub(rhs.height),
-        }
+        Size { width: self.width.maybe_sub(rhs.width), height: self.height.maybe_sub(rhs.height) }
     }
 }
 

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,6 +1,7 @@
 //! Contains numerical helper traits and functions
 
 use crate::layout::AvailableSpace;
+use crate::geometry::Size;
 
 /// A trait to conveniently calculate minimums and maximums when some data may not be defined
 ///
@@ -217,6 +218,43 @@ impl MaybeMath<Option<f32>, AvailableSpace> for AvailableSpace {
             (AvailableSpace::Definite(val), None) => AvailableSpace::Definite(val),
             (AvailableSpace::MinContent, _) => AvailableSpace::MinContent,
             (AvailableSpace::MaxContent, _) => AvailableSpace::MaxContent,
+        }
+    }
+}
+
+impl<In, Out, T: MaybeMath<In, Out>> MaybeMath<Size<In>, Size<Out>> for Size<T> {
+    fn maybe_min(self, rhs: Size<In>) -> Size<Out> {
+        Size {
+            width: self.width.maybe_min(rhs.width),
+            height: self.height.maybe_min(rhs.height),
+        }
+    }
+
+    fn maybe_max(self, rhs: Size<In>) -> Size<Out> {
+        Size {
+            width: self.width.maybe_max(rhs.width),
+            height: self.height.maybe_max(rhs.height),
+        }
+    }
+
+    fn maybe_clamp(self, min: Size<In>, max: Size<In>) -> Size<Out> {
+        Size {
+            width: self.width.maybe_clamp(min.width, max.width),
+            height: self.height.maybe_clamp(min.height, max.height),
+        }
+    }
+
+    fn maybe_add(self, rhs: Size<In>) -> Size<Out> {
+        Size {
+            width: self.width.maybe_add(rhs.width),
+            height: self.height.maybe_add(rhs.height),
+        }
+    }
+
+    fn maybe_sub(self, rhs: Size<In>) -> Size<Out> {
+        Size {
+            width: self.width.maybe_sub(rhs.width),
+            height: self.height.maybe_sub(rhs.height),
         }
     }
 }

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,5 +1,7 @@
 //! Contains numerical helper traits and functions
 
+use crate::layout::AvailableSpace;
+
 /// A trait to conveniently calculate minimums and maximums when some data may not be defined
 ///
 /// If the left-hand value is [`None`], these operations return [`None`].
@@ -100,6 +102,74 @@ impl MaybeMath<Option<f32>, f32> for f32 {
         match rhs {
             Some(val) => self - val,
             None => self,
+        }
+    }
+}
+
+impl MaybeMath<f32, AvailableSpace> for AvailableSpace {
+    fn maybe_min(self, rhs: f32) -> AvailableSpace {
+        match self {
+            AvailableSpace::Definite(val) => AvailableSpace::Definite(val.min(rhs)),
+            AvailableSpace::MinContent => AvailableSpace::Definite(rhs),
+            AvailableSpace::MaxContent => AvailableSpace::Definite(rhs),
+        }
+    }
+    fn maybe_max(self, rhs: f32) -> AvailableSpace {
+        match self {
+            AvailableSpace::Definite(val) => AvailableSpace::Definite(val.max(rhs)),
+            AvailableSpace::MinContent => AvailableSpace::MinContent,
+            AvailableSpace::MaxContent => AvailableSpace::MaxContent,
+        }
+    }
+    fn maybe_add(self, rhs: f32) -> AvailableSpace {
+        match self {
+            AvailableSpace::Definite(val) => AvailableSpace::Definite(val + rhs),
+            AvailableSpace::MinContent => AvailableSpace::MinContent,
+            AvailableSpace::MaxContent => AvailableSpace::MaxContent,
+        }
+    }
+    fn maybe_sub(self, rhs: f32) -> AvailableSpace {
+        match self {
+            AvailableSpace::Definite(val) => AvailableSpace::Definite(val - rhs),
+            AvailableSpace::MinContent => AvailableSpace::MinContent,
+            AvailableSpace::MaxContent => AvailableSpace::MaxContent,
+        }
+    }
+}
+
+impl MaybeMath<Option<f32>, AvailableSpace> for AvailableSpace {
+    fn maybe_min(self, rhs: Option<f32>) -> AvailableSpace {
+        match (self, rhs) {
+            (AvailableSpace::Definite(val), Some(rhs)) => AvailableSpace::Definite(val.min(rhs)),
+            (AvailableSpace::Definite(val), None) => AvailableSpace::Definite(val),
+            (AvailableSpace::MinContent, Some(rhs)) => AvailableSpace::Definite(rhs),
+            (AvailableSpace::MinContent, None) => AvailableSpace::MinContent,
+            (AvailableSpace::MaxContent, Some(rhs)) => AvailableSpace::Definite(rhs),
+            (AvailableSpace::MaxContent, None) => AvailableSpace::MaxContent,
+        }
+    }
+    fn maybe_max(self, rhs: Option<f32>) -> AvailableSpace {
+        match (self, rhs) {
+            (AvailableSpace::Definite(val), Some(rhs)) => AvailableSpace::Definite(val.max(rhs)),
+            (AvailableSpace::Definite(val), None) => AvailableSpace::Definite(val),
+            (AvailableSpace::MinContent, _) => AvailableSpace::MinContent,
+            (AvailableSpace::MaxContent, _) => AvailableSpace::MaxContent,
+        }
+    }
+    fn maybe_add(self, rhs: Option<f32>) -> AvailableSpace {
+        match (self, rhs) {
+            (AvailableSpace::Definite(val), Some(rhs)) => AvailableSpace::Definite(val + rhs),
+            (AvailableSpace::Definite(val), None) => AvailableSpace::Definite(val),
+            (AvailableSpace::MinContent, _) => AvailableSpace::MinContent,
+            (AvailableSpace::MaxContent, _) => AvailableSpace::MaxContent,
+        }
+    }
+    fn maybe_sub(self, rhs: Option<f32>) -> AvailableSpace {
+        match (self, rhs) {
+            (AvailableSpace::Definite(val), Some(rhs)) => AvailableSpace::Definite(val - rhs),
+            (AvailableSpace::Definite(val), None) => AvailableSpace::Definite(val),
+            (AvailableSpace::MinContent, _) => AvailableSpace::MinContent,
+            (AvailableSpace::MaxContent, _) => AvailableSpace::MaxContent,
         }
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -350,7 +350,7 @@ impl Taffy {
 
     /// Updates the stored layout of the provided `node` and its children
     pub fn compute_layout(&mut self, node: Node, size: Size<Option<f32>>) -> Result<(), TaffyError> {
-        crate::flexbox::compute(self, node, size);
+        crate::compute::flexbox::compute(self, node, size);
         // self.compute(node, size);
         Ok(())
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -8,7 +8,7 @@ pub type Node = slotmap::DefaultKey;
 
 use crate::error::{TaffyError, TaffyResult};
 use crate::geometry::Size;
-use crate::layout::{AvailableSpace, Cache, Layout, RunMode};
+use crate::layout::{AvailableSpace, Cache, Layout};
 use crate::prelude::LayoutTree;
 use crate::style::FlexboxLayout;
 #[cfg(any(feature = "std", feature = "alloc"))]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,7 +1,7 @@
 //! Commonly used types
 
 pub use crate::{
-    flexbox::compute as layout_flexbox,
+    compute::flexbox::compute as layout_flexbox,
     geometry::{Rect, Size},
     layout::Layout,
     node::{Node, Taffy},

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -3,7 +3,7 @@
 pub use crate::{
     compute::flexbox::compute as layout_flexbox,
     geometry::{Rect, Size},
-    layout::Layout,
+    layout::{AvailableSpace, Layout},
     node::{Node, Taffy},
     style::{
         AlignContent, AlignItems, AlignSelf, Dimension, Display, FlexDirection, FlexWrap, FlexboxLayout,

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -58,7 +58,6 @@ impl<In, Out, T: MaybeResolve<In, Out>> MaybeResolve<Size<In>, Size<Out>> for Si
     }
 }
 
-
 impl ResolveOrDefault<Option<f32>, f32> for Dimension {
     /// Will return a default value of result is evaluated to `None`
     fn resolve_or_default(self, context: Option<f32>) -> f32 {

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -17,12 +17,12 @@ pub(crate) trait ResolveOrDefault<TContext, TOutput> {
 /// a context-independent size or dimension.
 ///
 /// Will return a `None` if it unable to resolve.
-pub(crate) trait MaybeResolve<T> {
+pub(crate) trait MaybeResolve<In, Out> {
     /// Resolve a dimension that might be dependent on a context, with `None` as fallback value
-    fn maybe_resolve(self, context: T) -> T;
+    fn maybe_resolve(self, context: In) -> Out;
 }
 
-impl MaybeResolve<Option<f32>> for Dimension {
+impl MaybeResolve<Option<f32>, Option<f32>> for Dimension {
     /// Converts the given [`Dimension`] into a concrete value of points
     ///
     /// Can return `None`
@@ -36,12 +36,28 @@ impl MaybeResolve<Option<f32>> for Dimension {
     }
 }
 
-impl MaybeResolve<Size<Option<f32>>> for Size<Dimension> {
+impl MaybeResolve<f32, Option<f32>> for Dimension {
+    /// Converts the given [`Dimension`] into a concrete value of points
+    ///
+    /// Can return `None`
+    fn maybe_resolve(self, context: f32) -> Option<f32> {
+        match self {
+            Dimension::Points(points) => Some(points),
+            // parent_dim * percent
+            Dimension::Percent(percent) => Some(context * percent),
+            _ => None,
+        }
+    }
+}
+
+// Generic MaybeResolve for Size
+impl<In, Out, T: MaybeResolve<In, Out>> MaybeResolve<Size<In>, Size<Out>> for Size<T> {
     /// Converts any `parent`-relative values for size into an absolute size
-    fn maybe_resolve(self, context: Size<Option<f32>>) -> Size<Option<f32>> {
+    fn maybe_resolve(self, context: Size<In>) -> Size<Out> {
         Size { width: self.width.maybe_resolve(context.width), height: self.height.maybe_resolve(context.height) }
     }
 }
+
 
 impl ResolveOrDefault<Option<f32>, f32> for Dimension {
     /// Will return a default value of result is evaluated to `None`

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,7 +1,7 @@
 //! The baseline requirements of any UI Tree so Taffy can efficiently calculate the layout
 
 use crate::{
-    layout::{Cache, Layout},
+    layout::{AvailableSpace, Cache, Layout},
     prelude::*,
 };
 
@@ -35,25 +35,16 @@ pub trait LayoutTree {
     fn mark_dirty(&mut self, node: Node, dirty: bool);
 
     /// Measure a node. Taffy uses this to force reflows of things like text and overflowing content.
-    fn measure_node(&self, node: Node, node_size: Size<Option<f32>>) -> Size<f32>;
+    fn measure_node(
+        &self,
+        node: Node,
+        known_dimensions: Size<Option<f32>>,
+        available_space: Size<AvailableSpace>,
+    ) -> Size<f32>;
 
     /// Node needs to be measured
     fn needs_measure(&self, node: Node) -> bool;
 
-    /// Get the primary cache for this Node.
-    ///
-    /// Taffy caches results of computations for nodes to not need re-caculating nodes it already knows
-    ///
-    /// When a node does not have a cache, Taffy will layout that node appropriately.
-    fn primary_cache(&mut self, node: Node) -> &mut Option<Cache>;
-
-    /// Get the secondary cache for this Node.
-    ///
-    /// Taffy caches results of computations for nodes to not need re-caculating nodes it already knows
-    ///
-    /// When a node does not have a cache, Taffy will layout that node appropriately.
-    ///
-    /// The secondary cache is for nodes who have a main size already calculated, but need to calculate a secondary size.
-    /// This typically happens due to conflicting constraints.
-    fn secondary_cache(&mut self, node: Node) -> &mut Option<Cache>;
+    /// Get a cache entry for this Node by index
+    fn cache_mut(&mut self, node: Node, index: usize) -> &mut Option<Cache>;
 }

--- a/tests/generated/absolute_layout_align_items_and_justify_content_center.rs
+++ b/tests/generated/absolute_layout_align_items_and_justify_content_center.rs
@@ -30,7 +30,7 @@ fn absolute_layout_align_items_and_justify_content_center() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 110f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_align_items_and_justify_content_center_and_bottom_position.rs
+++ b/tests/generated/absolute_layout_align_items_and_justify_content_center_and_bottom_position.rs
@@ -34,7 +34,7 @@ fn absolute_layout_align_items_and_justify_content_center_and_bottom_position() 
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 110f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_align_items_and_justify_content_center_and_left_position.rs
+++ b/tests/generated/absolute_layout_align_items_and_justify_content_center_and_left_position.rs
@@ -31,7 +31,7 @@ fn absolute_layout_align_items_and_justify_content_center_and_left_position() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 110f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_align_items_and_justify_content_center_and_right_position.rs
+++ b/tests/generated/absolute_layout_align_items_and_justify_content_center_and_right_position.rs
@@ -31,7 +31,7 @@ fn absolute_layout_align_items_and_justify_content_center_and_right_position() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 110f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_align_items_and_justify_content_center_and_top_position.rs
+++ b/tests/generated/absolute_layout_align_items_and_justify_content_center_and_top_position.rs
@@ -31,7 +31,7 @@ fn absolute_layout_align_items_and_justify_content_center_and_top_position() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 110f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_align_items_and_justify_content_flex_end.rs
+++ b/tests/generated/absolute_layout_align_items_and_justify_content_flex_end.rs
@@ -30,7 +30,7 @@ fn absolute_layout_align_items_and_justify_content_flex_end() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 110f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_align_items_center.rs
+++ b/tests/generated/absolute_layout_align_items_center.rs
@@ -29,7 +29,7 @@ fn absolute_layout_align_items_center() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 110f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_align_items_center_on_child_only.rs
+++ b/tests/generated/absolute_layout_align_items_center_on_child_only.rs
@@ -29,7 +29,7 @@ fn absolute_layout_align_items_center_on_child_only() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 110f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_child_order.rs
+++ b/tests/generated/absolute_layout_child_order.rs
@@ -56,7 +56,7 @@ fn absolute_layout_child_order() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 110f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_child_order.rs
+++ b/tests/generated/absolute_layout_child_order.rs
@@ -57,9 +57,6 @@ fn absolute_layout_child_order() {
         )
         .unwrap();
     taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
-
-    taffy::debug::print_tree(&taffy, node);
-
     assert_eq!(taffy.layout(node).unwrap().size.width, 110f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_child_order.rs
+++ b/tests/generated/absolute_layout_child_order.rs
@@ -57,6 +57,9 @@ fn absolute_layout_child_order() {
         )
         .unwrap();
     taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
+
+    taffy::debug::print_tree(&taffy, node);
+
     assert_eq!(taffy.layout(node).unwrap().size.width, 110f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_in_wrap_reverse_column_container.rs
+++ b/tests/generated/absolute_layout_in_wrap_reverse_column_container.rs
@@ -30,7 +30,7 @@ fn absolute_layout_in_wrap_reverse_column_container() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_in_wrap_reverse_column_container_flex_end.rs
+++ b/tests/generated/absolute_layout_in_wrap_reverse_column_container_flex_end.rs
@@ -31,7 +31,7 @@ fn absolute_layout_in_wrap_reverse_column_container_flex_end() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_in_wrap_reverse_row_container.rs
+++ b/tests/generated/absolute_layout_in_wrap_reverse_row_container.rs
@@ -29,7 +29,7 @@ fn absolute_layout_in_wrap_reverse_row_container() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_in_wrap_reverse_row_container_flex_end.rs
+++ b/tests/generated/absolute_layout_in_wrap_reverse_row_container_flex_end.rs
@@ -30,7 +30,7 @@ fn absolute_layout_in_wrap_reverse_row_container_flex_end() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_justify_content_center.rs
+++ b/tests/generated/absolute_layout_justify_content_center.rs
@@ -29,7 +29,7 @@ fn absolute_layout_justify_content_center() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 110f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_no_size.rs
+++ b/tests/generated/absolute_layout_no_size.rs
@@ -20,7 +20,7 @@ fn absolute_layout_no_size() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_percentage_bottom_based_on_parent_height.rs
+++ b/tests/generated/absolute_layout_percentage_bottom_based_on_parent_height.rs
@@ -62,7 +62,7 @@ fn absolute_layout_percentage_bottom_based_on_parent_height() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_start_top_end_bottom.rs
+++ b/tests/generated/absolute_layout_start_top_end_bottom.rs
@@ -30,7 +30,7 @@ fn absolute_layout_start_top_end_bottom() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_width_height_end_bottom.rs
+++ b/tests/generated/absolute_layout_width_height_end_bottom.rs
@@ -33,7 +33,7 @@ fn absolute_layout_width_height_end_bottom() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_width_height_start_top.rs
+++ b/tests/generated/absolute_layout_width_height_start_top.rs
@@ -33,7 +33,7 @@ fn absolute_layout_width_height_start_top() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_width_height_start_top_end_bottom.rs
+++ b/tests/generated/absolute_layout_width_height_start_top_end_bottom.rs
@@ -35,7 +35,7 @@ fn absolute_layout_width_height_start_top_end_bottom() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/absolute_layout_within_border.rs
+++ b/tests/generated/absolute_layout_within_border.rs
@@ -118,7 +118,7 @@ fn absolute_layout_within_border() {
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_baseline.rs
+++ b/tests/generated/align_baseline.rs
@@ -41,7 +41,7 @@ fn align_baseline() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_baseline_child_multiline.rs
+++ b/tests/generated/align_baseline_child_multiline.rs
@@ -86,7 +86,7 @@ fn align_baseline_child_multiline() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 80f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_baseline_nested_child.rs
+++ b/tests/generated/align_baseline_nested_child.rs
@@ -55,7 +55,7 @@ fn align_baseline_nested_child() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_center_should_size_based_on_content.rs
+++ b/tests/generated/align_center_should_size_based_on_content.rs
@@ -45,7 +45,7 @@ fn align_center_should_size_based_on_content() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_content_space_around_single_line.rs
+++ b/tests/generated/align_content_space_around_single_line.rs
@@ -93,7 +93,7 @@ fn align_content_space_around_single_line() {
             &[node0, node1, node2, node3, node4, node5],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_content_space_around_wrapped.rs
+++ b/tests/generated/align_content_space_around_wrapped.rs
@@ -94,7 +94,7 @@ fn align_content_space_around_wrapped() {
             &[node0, node1, node2, node3, node4, node5],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_content_space_between_single_line.rs
+++ b/tests/generated/align_content_space_between_single_line.rs
@@ -93,7 +93,7 @@ fn align_content_space_between_single_line() {
             &[node0, node1, node2, node3, node4, node5],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_content_space_between_wrapped.rs
+++ b/tests/generated/align_content_space_between_wrapped.rs
@@ -94,7 +94,7 @@ fn align_content_space_between_wrapped() {
             &[node0, node1, node2, node3, node4, node5],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_content_space_evenly_single_line.rs
+++ b/tests/generated/align_content_space_evenly_single_line.rs
@@ -93,7 +93,7 @@ fn align_content_space_evenly_single_line() {
             &[node0, node1, node2, node3, node4, node5],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_content_space_evenly_wrapped.rs
+++ b/tests/generated/align_content_space_evenly_wrapped.rs
@@ -94,7 +94,7 @@ fn align_content_space_evenly_wrapped() {
             &[node0, node1, node2, node3, node4, node5],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_flex_start_with_shrinking_children.rs
+++ b/tests/generated/align_flex_start_with_shrinking_children.rs
@@ -32,7 +32,7 @@ fn align_flex_start_with_shrinking_children() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 500f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 500f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_flex_start_with_shrinking_children_with_stretch.rs
+++ b/tests/generated/align_flex_start_with_shrinking_children_with_stretch.rs
@@ -32,7 +32,7 @@ fn align_flex_start_with_shrinking_children_with_stretch() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 500f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 500f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_flex_start_with_stretching_children.rs
+++ b/tests/generated/align_flex_start_with_stretching_children.rs
@@ -27,7 +27,7 @@ fn align_flex_start_with_stretching_children() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 500f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 500f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_items_center.rs
+++ b/tests/generated/align_items_center.rs
@@ -28,7 +28,7 @@ fn align_items_center() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_items_center_child_with_margin_bigger_than_parent.rs
+++ b/tests/generated/align_items_center_child_with_margin_bigger_than_parent.rs
@@ -40,7 +40,7 @@ fn align_items_center_child_with_margin_bigger_than_parent() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 50f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_items_center_child_without_margin_bigger_than_parent.rs
+++ b/tests/generated/align_items_center_child_without_margin_bigger_than_parent.rs
@@ -35,7 +35,7 @@ fn align_items_center_child_without_margin_bigger_than_parent() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 50f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_items_center_with_child_margin.rs
+++ b/tests/generated/align_items_center_with_child_margin.rs
@@ -29,7 +29,7 @@ fn align_items_center_with_child_margin() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_items_center_with_child_top.rs
+++ b/tests/generated/align_items_center_with_child_top.rs
@@ -29,7 +29,7 @@ fn align_items_center_with_child_top() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_items_flex_end.rs
+++ b/tests/generated/align_items_flex_end.rs
@@ -28,7 +28,7 @@ fn align_items_flex_end() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_items_flex_end_child_with_margin_bigger_than_parent.rs
+++ b/tests/generated/align_items_flex_end_child_with_margin_bigger_than_parent.rs
@@ -40,7 +40,7 @@ fn align_items_flex_end_child_with_margin_bigger_than_parent() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 50f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_items_flex_end_child_without_margin_bigger_than_parent.rs
+++ b/tests/generated/align_items_flex_end_child_without_margin_bigger_than_parent.rs
@@ -35,7 +35,7 @@ fn align_items_flex_end_child_without_margin_bigger_than_parent() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 50f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_items_flex_start.rs
+++ b/tests/generated/align_items_flex_start.rs
@@ -28,7 +28,7 @@ fn align_items_flex_start() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_items_min_max.rs
+++ b/tests/generated/align_items_min_max.rs
@@ -33,7 +33,7 @@ fn align_items_min_max() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_items_stretch.rs
+++ b/tests/generated/align_items_stretch.rs
@@ -23,7 +23,7 @@ fn align_items_stretch() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_self_baseline.rs
+++ b/tests/generated/align_self_baseline.rs
@@ -55,7 +55,7 @@ fn align_self_baseline() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_self_center.rs
+++ b/tests/generated/align_self_center.rs
@@ -28,7 +28,7 @@ fn align_self_center() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_self_flex_end.rs
+++ b/tests/generated/align_self_flex_end.rs
@@ -28,7 +28,7 @@ fn align_self_flex_end() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_self_flex_end_override_flex_start.rs
+++ b/tests/generated/align_self_flex_end_override_flex_start.rs
@@ -29,7 +29,7 @@ fn align_self_flex_end_override_flex_start() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_self_flex_start.rs
+++ b/tests/generated/align_self_flex_start.rs
@@ -28,7 +28,7 @@ fn align_self_flex_start() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/align_strech_should_size_based_on_parent.rs
+++ b/tests/generated/align_strech_should_size_based_on_parent.rs
@@ -44,7 +44,7 @@ fn align_strech_should_size_based_on_parent() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/border_center_child.rs
+++ b/tests/generated/border_center_child.rs
@@ -34,7 +34,7 @@ fn border_center_child() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/border_flex_child.rs
+++ b/tests/generated/border_flex_child.rs
@@ -31,7 +31,7 @@ fn border_flex_child() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/border_no_child.rs
+++ b/tests/generated/border_no_child.rs
@@ -16,7 +16,7 @@ fn border_no_child() {
             &[],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 20f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 20f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/border_stretch_child.rs
+++ b/tests/generated/border_stretch_child.rs
@@ -30,7 +30,7 @@ fn border_stretch_child() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/child_min_max_width_flexing.rs
+++ b/tests/generated/child_min_max_width_flexing.rs
@@ -38,7 +38,7 @@ fn child_min_max_width_flexing() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 120f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/container_with_unsized_child.rs
+++ b/tests/generated/container_with_unsized_child.rs
@@ -15,7 +15,7 @@ fn container_with_unsized_child() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/display_none.rs
+++ b/tests/generated/display_none.rs
@@ -22,7 +22,7 @@ fn display_none() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/display_none_fixed_size.rs
+++ b/tests/generated/display_none_fixed_size.rs
@@ -30,7 +30,7 @@ fn display_none_fixed_size() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/display_none_with_child.rs
+++ b/tests/generated/display_none_with_child.rs
@@ -61,7 +61,7 @@ fn display_none_with_child() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/display_none_with_margin.rs
+++ b/tests/generated/display_none_with_margin.rs
@@ -37,7 +37,7 @@ fn display_none_with_margin() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/display_none_with_position.rs
+++ b/tests/generated/display_none_with_position.rs
@@ -27,7 +27,7 @@ fn display_none_with_position() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_and_main_dimen_set_when_flexing.rs
+++ b/tests/generated/flex_basis_and_main_dimen_set_when_flexing.rs
@@ -40,7 +40,7 @@ fn flex_basis_and_main_dimen_set_when_flexing() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_flex_grow_column.rs
+++ b/tests/generated/flex_basis_flex_grow_column.rs
@@ -27,7 +27,7 @@ fn flex_basis_flex_grow_column() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_flex_grow_row.rs
+++ b/tests/generated/flex_basis_flex_grow_row.rs
@@ -26,7 +26,7 @@ fn flex_basis_flex_grow_row() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_flex_shrink_column.rs
+++ b/tests/generated/flex_basis_flex_shrink_column.rs
@@ -27,7 +27,7 @@ fn flex_basis_flex_shrink_column() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_flex_shrink_row.rs
+++ b/tests/generated/flex_basis_flex_shrink_row.rs
@@ -26,7 +26,7 @@ fn flex_basis_flex_shrink_row() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_larger_than_content_column.rs
+++ b/tests/generated/flex_basis_larger_than_content_column.rs
@@ -34,7 +34,7 @@ fn flex_basis_larger_than_content_column() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_larger_than_content_row.rs
+++ b/tests/generated/flex_basis_larger_than_content_row.rs
@@ -33,7 +33,7 @@ fn flex_basis_larger_than_content_row() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_overrides_main_size.rs
+++ b/tests/generated/flex_basis_overrides_main_size.rs
@@ -45,7 +45,7 @@ fn flex_basis_overrides_main_size() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_slightly_smaller_then_content_with_flex_grow_large_size.rs
+++ b/tests/generated/flex_basis_slightly_smaller_then_content_with_flex_grow_large_size.rs
@@ -58,7 +58,7 @@ fn flex_basis_slightly_smaller_then_content_with_flex_grow_large_size() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_smaller_than_content_column.rs
+++ b/tests/generated/flex_basis_smaller_than_content_column.rs
@@ -34,7 +34,7 @@ fn flex_basis_smaller_than_content_column() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_smaller_than_content_row.rs
+++ b/tests/generated/flex_basis_smaller_than_content_row.rs
@@ -33,7 +33,7 @@ fn flex_basis_smaller_than_content_row() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_smaller_than_main_dimen_column.rs
+++ b/tests/generated/flex_basis_smaller_than_main_dimen_column.rs
@@ -25,7 +25,7 @@ fn flex_basis_smaller_than_main_dimen_column() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 50f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_smaller_than_main_dimen_row.rs
+++ b/tests/generated/flex_basis_smaller_than_main_dimen_row.rs
@@ -24,7 +24,7 @@ fn flex_basis_smaller_than_main_dimen_row() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_smaller_then_content_with_flex_grow_large_size.rs
+++ b/tests/generated/flex_basis_smaller_then_content_with_flex_grow_large_size.rs
@@ -58,7 +58,7 @@ fn flex_basis_smaller_then_content_with_flex_grow_large_size() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_smaller_then_content_with_flex_grow_small_size.rs
+++ b/tests/generated/flex_basis_smaller_then_content_with_flex_grow_small_size.rs
@@ -58,7 +58,7 @@ fn flex_basis_smaller_then_content_with_flex_grow_small_size() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 10f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_smaller_then_content_with_flex_grow_unconstraint_size.rs
+++ b/tests/generated/flex_basis_smaller_then_content_with_flex_grow_unconstraint_size.rs
@@ -50,7 +50,7 @@ fn flex_basis_smaller_then_content_with_flex_grow_unconstraint_size() {
         )
         .unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0, node1]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 90f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_smaller_then_content_with_flex_grow_very_large_size.rs
+++ b/tests/generated/flex_basis_smaller_then_content_with_flex_grow_very_large_size.rs
@@ -58,7 +58,7 @@ fn flex_basis_smaller_then_content_with_flex_grow_very_large_size() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_unconstraint_column.rs
+++ b/tests/generated/flex_basis_unconstraint_column.rs
@@ -17,7 +17,7 @@ fn flex_basis_unconstraint_column() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_basis_unconstraint_row.rs
+++ b/tests/generated/flex_basis_unconstraint_row.rs
@@ -12,7 +12,7 @@ fn flex_basis_unconstraint_row() {
         )
         .unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 0f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_direction_column.rs
+++ b/tests/generated/flex_direction_column.rs
@@ -42,7 +42,7 @@ fn flex_direction_column() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_direction_column_no_height.rs
+++ b/tests/generated/flex_direction_column_no_height.rs
@@ -38,7 +38,7 @@ fn flex_direction_column_no_height() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 30f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_direction_column_reverse.rs
+++ b/tests/generated/flex_direction_column_reverse.rs
@@ -42,7 +42,7 @@ fn flex_direction_column_reverse() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_direction_row.rs
+++ b/tests/generated/flex_direction_row.rs
@@ -41,7 +41,7 @@ fn flex_direction_row() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_direction_row_no_width.rs
+++ b/tests/generated/flex_direction_row_no_width.rs
@@ -37,7 +37,7 @@ fn flex_direction_row_no_width() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 30f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_direction_row_reverse.rs
+++ b/tests/generated/flex_direction_row_reverse.rs
@@ -42,7 +42,7 @@ fn flex_direction_row_reverse() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_grow_child.rs
+++ b/tests/generated/flex_grow_child.rs
@@ -13,7 +13,7 @@ fn flex_grow_child() {
         )
         .unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 0f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_grow_flex_basis_percent_min_max.rs
+++ b/tests/generated/flex_grow_flex_basis_percent_min_max.rs
@@ -40,7 +40,7 @@ fn flex_grow_flex_basis_percent_min_max() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 120f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 20f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_grow_height_maximized.rs
+++ b/tests/generated/flex_grow_height_maximized.rs
@@ -52,7 +52,7 @@ fn flex_grow_height_maximized() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 500f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_grow_in_at_most_container.rs
+++ b/tests/generated/flex_grow_in_at_most_container.rs
@@ -26,7 +26,7 @@ fn flex_grow_in_at_most_container() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_grow_less_than_factor_one.rs
+++ b/tests/generated/flex_grow_less_than_factor_one.rs
@@ -37,7 +37,7 @@ fn flex_grow_less_than_factor_one() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 500f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_grow_root_minimized.rs
+++ b/tests/generated/flex_grow_root_minimized.rs
@@ -56,7 +56,7 @@ fn flex_grow_root_minimized() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 300f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_grow_shrink_at_most.rs
+++ b/tests/generated/flex_grow_shrink_at_most.rs
@@ -21,7 +21,7 @@ fn flex_grow_shrink_at_most() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_grow_to_min.rs
+++ b/tests/generated/flex_grow_to_min.rs
@@ -34,7 +34,7 @@ fn flex_grow_to_min() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_grow_within_constrained_max_column.rs
+++ b/tests/generated/flex_grow_within_constrained_max_column.rs
@@ -34,7 +34,7 @@ fn flex_grow_within_constrained_max_column() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_grow_within_constrained_max_row.rs
+++ b/tests/generated/flex_grow_within_constrained_max_row.rs
@@ -43,7 +43,7 @@ fn flex_grow_within_constrained_max_row() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_grow_within_constrained_max_width.rs
+++ b/tests/generated/flex_grow_within_constrained_max_width.rs
@@ -37,7 +37,7 @@ fn flex_grow_within_constrained_max_width() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_grow_within_constrained_min_column.rs
+++ b/tests/generated/flex_grow_within_constrained_min_column.rs
@@ -25,7 +25,7 @@ fn flex_grow_within_constrained_min_column() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 0f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_grow_within_constrained_min_max_column.rs
+++ b/tests/generated/flex_grow_within_constrained_min_max_column.rs
@@ -24,7 +24,7 @@ fn flex_grow_within_constrained_min_max_column() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 0f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_grow_within_constrained_min_row.rs
+++ b/tests/generated/flex_grow_within_constrained_min_row.rs
@@ -25,7 +25,7 @@ fn flex_grow_within_constrained_min_row() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_grow_within_max_width.rs
+++ b/tests/generated/flex_grow_within_max_width.rs
@@ -37,7 +37,7 @@ fn flex_grow_within_max_width() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_root_ignored.rs
+++ b/tests/generated/flex_root_ignored.rs
@@ -38,7 +38,7 @@ fn flex_root_ignored() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 300f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_shrink_by_outer_margin_with_max_size.rs
+++ b/tests/generated/flex_shrink_by_outer_margin_with_max_size.rs
@@ -29,7 +29,7 @@ fn flex_shrink_by_outer_margin_with_max_size() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 20f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 80f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_shrink_flex_grow_child_flex_shrink_other_child.rs
+++ b/tests/generated/flex_shrink_flex_grow_child_flex_shrink_other_child.rs
@@ -44,7 +44,7 @@ fn flex_shrink_flex_grow_child_flex_shrink_other_child() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 500f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 500f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_shrink_flex_grow_row.rs
+++ b/tests/generated/flex_shrink_flex_grow_row.rs
@@ -44,7 +44,7 @@ fn flex_shrink_flex_grow_row() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 500f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 500f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_shrink_to_zero.rs
+++ b/tests/generated/flex_shrink_to_zero.rs
@@ -52,7 +52,7 @@ fn flex_shrink_to_zero() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 75f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_wrap_align_stretch_fits_one_row.rs
+++ b/tests/generated/flex_wrap_align_stretch_fits_one_row.rs
@@ -33,7 +33,7 @@ fn flex_wrap_align_stretch_fits_one_row() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 150f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_wrap_children_with_min_main_overriding_flex_basis.rs
+++ b/tests/generated/flex_wrap_children_with_min_main_overriding_flex_basis.rs
@@ -33,7 +33,7 @@ fn flex_wrap_children_with_min_main_overriding_flex_basis() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/flex_wrap_wrap_to_child_height.rs
+++ b/tests/generated/flex_wrap_wrap_to_child_height.rs
@@ -53,7 +53,7 @@ fn flex_wrap_wrap_to_child_height() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_column_center.rs
+++ b/tests/generated/justify_content_column_center.rs
@@ -43,7 +43,7 @@ fn justify_content_column_center() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_column_flex_end.rs
+++ b/tests/generated/justify_content_column_flex_end.rs
@@ -43,7 +43,7 @@ fn justify_content_column_flex_end() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_column_flex_start.rs
+++ b/tests/generated/justify_content_column_flex_start.rs
@@ -42,7 +42,7 @@ fn justify_content_column_flex_start() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_column_min_height_and_margin_bottom.rs
+++ b/tests/generated/justify_content_column_min_height_and_margin_bottom.rs
@@ -29,7 +29,7 @@ fn justify_content_column_min_height_and_margin_bottom() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 20f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_column_min_height_and_margin_top.rs
+++ b/tests/generated/justify_content_column_min_height_and_margin_top.rs
@@ -29,7 +29,7 @@ fn justify_content_column_min_height_and_margin_top() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 20f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_column_space_around.rs
+++ b/tests/generated/justify_content_column_space_around.rs
@@ -43,7 +43,7 @@ fn justify_content_column_space_around() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_column_space_between.rs
+++ b/tests/generated/justify_content_column_space_between.rs
@@ -43,7 +43,7 @@ fn justify_content_column_space_between() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_column_space_evenly.rs
+++ b/tests/generated/justify_content_column_space_evenly.rs
@@ -43,7 +43,7 @@ fn justify_content_column_space_evenly() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_min_max.rs
+++ b/tests/generated/justify_content_min_max.rs
@@ -33,7 +33,7 @@ fn justify_content_min_max() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_min_width_with_padding_child_width_greater_than_parent.rs
+++ b/tests/generated/justify_content_min_width_with_padding_child_width_greater_than_parent.rs
@@ -47,7 +47,7 @@ fn justify_content_min_width_with_padding_child_width_greater_than_parent() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 1000f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 1584f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_min_width_with_padding_child_width_lower_than_parent.rs
+++ b/tests/generated/justify_content_min_width_with_padding_child_width_lower_than_parent.rs
@@ -47,7 +47,7 @@ fn justify_content_min_width_with_padding_child_width_lower_than_parent() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 1080f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 1584f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_overflow_min_max.rs
+++ b/tests/generated/justify_content_overflow_min_max.rs
@@ -61,7 +61,7 @@ fn justify_content_overflow_min_max() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 50f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 110f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_row_center.rs
+++ b/tests/generated/justify_content_row_center.rs
@@ -42,7 +42,7 @@ fn justify_content_row_center() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_row_flex_end.rs
+++ b/tests/generated/justify_content_row_flex_end.rs
@@ -42,7 +42,7 @@ fn justify_content_row_flex_end() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_row_flex_start.rs
+++ b/tests/generated/justify_content_row_flex_start.rs
@@ -41,7 +41,7 @@ fn justify_content_row_flex_start() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_row_max_width_and_margin.rs
+++ b/tests/generated/justify_content_row_max_width_and_margin.rs
@@ -26,7 +26,7 @@ fn justify_content_row_max_width_and_margin() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 80f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 20f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_row_min_width_and_margin.rs
+++ b/tests/generated/justify_content_row_min_width_and_margin.rs
@@ -25,7 +25,7 @@ fn justify_content_row_min_width_and_margin() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 50f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 20f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_row_space_around.rs
+++ b/tests/generated/justify_content_row_space_around.rs
@@ -42,7 +42,7 @@ fn justify_content_row_space_around() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_row_space_between.rs
+++ b/tests/generated/justify_content_row_space_between.rs
@@ -42,7 +42,7 @@ fn justify_content_row_space_between() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/justify_content_row_space_evenly.rs
+++ b/tests/generated/justify_content_row_space_evenly.rs
@@ -42,7 +42,7 @@ fn justify_content_row_space_evenly() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_and_flex_column.rs
+++ b/tests/generated/margin_and_flex_column.rs
@@ -29,7 +29,7 @@ fn margin_and_flex_column() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_and_flex_row.rs
+++ b/tests/generated/margin_and_flex_row.rs
@@ -28,7 +28,7 @@ fn margin_and_flex_row() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_and_stretch_column.rs
+++ b/tests/generated/margin_and_stretch_column.rs
@@ -29,7 +29,7 @@ fn margin_and_stretch_column() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_and_stretch_row.rs
+++ b/tests/generated/margin_and_stretch_row.rs
@@ -28,7 +28,7 @@ fn margin_and_stretch_row() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_auto_bottom.rs
+++ b/tests/generated/margin_auto_bottom.rs
@@ -42,7 +42,7 @@ fn margin_auto_bottom() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_auto_bottom_and_top.rs
+++ b/tests/generated/margin_auto_bottom_and_top.rs
@@ -46,7 +46,7 @@ fn margin_auto_bottom_and_top() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_auto_bottom_and_top_justify_center.rs
+++ b/tests/generated/margin_auto_bottom_and_top_justify_center.rs
@@ -46,7 +46,7 @@ fn margin_auto_bottom_and_top_justify_center() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_auto_left.rs
+++ b/tests/generated/margin_auto_left.rs
@@ -42,7 +42,7 @@ fn margin_auto_left() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_auto_left_and_right.rs
+++ b/tests/generated/margin_auto_left_and_right.rs
@@ -45,7 +45,7 @@ fn margin_auto_left_and_right() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_auto_left_and_right_column.rs
+++ b/tests/generated/margin_auto_left_and_right_column.rs
@@ -46,7 +46,7 @@ fn margin_auto_left_and_right_column() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_auto_left_and_right_column_and_center.rs
+++ b/tests/generated/margin_auto_left_and_right_column_and_center.rs
@@ -46,7 +46,7 @@ fn margin_auto_left_and_right_column_and_center() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_auto_left_and_right_strech.rs
+++ b/tests/generated/margin_auto_left_and_right_strech.rs
@@ -45,7 +45,7 @@ fn margin_auto_left_and_right_strech() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_auto_left_child_bigger_than_parent.rs
+++ b/tests/generated/margin_auto_left_child_bigger_than_parent.rs
@@ -29,7 +29,7 @@ fn margin_auto_left_child_bigger_than_parent() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 52f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 52f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_auto_left_fix_right_child_bigger_than_parent.rs
+++ b/tests/generated/margin_auto_left_fix_right_child_bigger_than_parent.rs
@@ -33,7 +33,7 @@ fn margin_auto_left_fix_right_child_bigger_than_parent() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 52f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 52f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_auto_left_right_child_bigger_than_parent.rs
+++ b/tests/generated/margin_auto_left_right_child_bigger_than_parent.rs
@@ -33,7 +33,7 @@ fn margin_auto_left_right_child_bigger_than_parent() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 52f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 52f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_auto_left_stretching_child.rs
+++ b/tests/generated/margin_auto_left_stretching_child.rs
@@ -40,7 +40,7 @@ fn margin_auto_left_stretching_child() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_auto_mutiple_children_column.rs
+++ b/tests/generated/margin_auto_mutiple_children_column.rs
@@ -57,7 +57,7 @@ fn margin_auto_mutiple_children_column() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_auto_mutiple_children_row.rs
+++ b/tests/generated/margin_auto_mutiple_children_row.rs
@@ -56,7 +56,7 @@ fn margin_auto_mutiple_children_row() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_auto_right.rs
+++ b/tests/generated/margin_auto_right.rs
@@ -42,7 +42,7 @@ fn margin_auto_right() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_auto_top.rs
+++ b/tests/generated/margin_auto_top.rs
@@ -42,7 +42,7 @@ fn margin_auto_top() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_auto_top_and_bottom_strech.rs
+++ b/tests/generated/margin_auto_top_and_bottom_strech.rs
@@ -46,7 +46,7 @@ fn margin_auto_top_and_bottom_strech() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_auto_top_stretching_child.rs
+++ b/tests/generated/margin_auto_top_stretching_child.rs
@@ -40,7 +40,7 @@ fn margin_auto_top_stretching_child() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_bottom.rs
+++ b/tests/generated/margin_bottom.rs
@@ -26,7 +26,7 @@ fn margin_bottom() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_fix_left_auto_right_child_bigger_than_parent.rs
+++ b/tests/generated/margin_fix_left_auto_right_child_bigger_than_parent.rs
@@ -33,7 +33,7 @@ fn margin_fix_left_auto_right_child_bigger_than_parent() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 52f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 52f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_left.rs
+++ b/tests/generated/margin_left.rs
@@ -24,7 +24,7 @@ fn margin_left() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_right.rs
+++ b/tests/generated/margin_right.rs
@@ -25,7 +25,7 @@ fn margin_right() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_should_not_be_part_of_max_height.rs
+++ b/tests/generated/margin_should_not_be_part_of_max_height.rs
@@ -32,7 +32,7 @@ fn margin_should_not_be_part_of_max_height() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 250f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 250f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_should_not_be_part_of_max_width.rs
+++ b/tests/generated/margin_should_not_be_part_of_max_width.rs
@@ -32,7 +32,7 @@ fn margin_should_not_be_part_of_max_width() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 250f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 250f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_top.rs
+++ b/tests/generated/margin_top.rs
@@ -25,7 +25,7 @@ fn margin_top() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_with_sibling_column.rs
+++ b/tests/generated/margin_with_sibling_column.rs
@@ -27,7 +27,7 @@ fn margin_with_sibling_column() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/margin_with_sibling_row.rs
+++ b/tests/generated/margin_with_sibling_row.rs
@@ -26,7 +26,7 @@ fn margin_with_sibling_row() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/max_height.rs
+++ b/tests/generated/max_height.rs
@@ -27,7 +27,7 @@ fn max_height() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/max_height_overrides_height.rs
+++ b/tests/generated/max_height_overrides_height.rs
@@ -15,7 +15,7 @@ fn max_height_overrides_height() {
         )
         .unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 0f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/max_height_overrides_height_on_root.rs
+++ b/tests/generated/max_height_overrides_height_on_root.rs
@@ -14,7 +14,7 @@ fn max_height_overrides_height_on_root() {
             &[],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 0f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/max_width.rs
+++ b/tests/generated/max_width.rs
@@ -25,7 +25,7 @@ fn max_width() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/max_width_overrides_width.rs
+++ b/tests/generated/max_width_overrides_width.rs
@@ -15,7 +15,7 @@ fn max_width_overrides_width() {
         )
         .unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 0f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/max_width_overrides_width_on_root.rs
+++ b/tests/generated/max_width_overrides_width_on_root.rs
@@ -14,7 +14,7 @@ fn max_width_overrides_width_on_root() {
             &[],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 0f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/min_height.rs
+++ b/tests/generated/min_height.rs
@@ -30,7 +30,7 @@ fn min_height() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/min_height_overrides_height.rs
+++ b/tests/generated/min_height_overrides_height.rs
@@ -15,7 +15,7 @@ fn min_height_overrides_height() {
         )
         .unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 0f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/min_height_overrides_height_on_root.rs
+++ b/tests/generated/min_height_overrides_height_on_root.rs
@@ -14,7 +14,7 @@ fn min_height_overrides_height_on_root() {
             &[],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 0f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/min_max_percent_no_width_height.rs
+++ b/tests/generated/min_max_percent_no_width_height.rs
@@ -34,7 +34,7 @@ fn min_max_percent_no_width_height() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/min_width.rs
+++ b/tests/generated/min_width.rs
@@ -26,7 +26,7 @@ fn min_width() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/min_width.rs
+++ b/tests/generated/min_width.rs
@@ -27,6 +27,7 @@ fn min_width() {
         )
         .unwrap();
     taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
+
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/min_width.rs
+++ b/tests/generated/min_width.rs
@@ -27,7 +27,6 @@ fn min_width() {
         )
         .unwrap();
     taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
-
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/min_width_overrides_width.rs
+++ b/tests/generated/min_width_overrides_width.rs
@@ -15,7 +15,7 @@ fn min_width_overrides_width() {
         )
         .unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 0f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/min_width_overrides_width_on_root.rs
+++ b/tests/generated/min_width_overrides_width_on_root.rs
@@ -14,7 +14,7 @@ fn min_width_overrides_width_on_root() {
             &[],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 0f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/nested_overflowing_child.rs
+++ b/tests/generated/nested_overflowing_child.rs
@@ -28,7 +28,7 @@ fn nested_overflowing_child() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/nested_overflowing_child_in_constraint_parent.rs
+++ b/tests/generated/nested_overflowing_child_in_constraint_parent.rs
@@ -40,7 +40,7 @@ fn nested_overflowing_child_in_constraint_parent() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/overflow_cross_axis.rs
+++ b/tests/generated/overflow_cross_axis.rs
@@ -27,7 +27,7 @@ fn overflow_cross_axis() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/overflow_main_axis.rs
+++ b/tests/generated/overflow_main_axis.rs
@@ -24,7 +24,7 @@ fn overflow_main_axis() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/padding_align_end_child.rs
+++ b/tests/generated/padding_align_end_child.rs
@@ -36,7 +36,7 @@ fn padding_align_end_child() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/padding_center_child.rs
+++ b/tests/generated/padding_center_child.rs
@@ -36,7 +36,7 @@ fn padding_center_child() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/padding_flex_child.rs
+++ b/tests/generated/padding_flex_child.rs
@@ -31,7 +31,7 @@ fn padding_flex_child() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/padding_no_child.rs
+++ b/tests/generated/padding_no_child.rs
@@ -16,7 +16,7 @@ fn padding_no_child() {
             &[],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 20f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 20f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/padding_stretch_child.rs
+++ b/tests/generated/padding_stretch_child.rs
@@ -30,7 +30,7 @@ fn padding_stretch_child() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/parent_wrap_child_size_overflowing_parent.rs
+++ b/tests/generated/parent_wrap_child_size_overflowing_parent.rs
@@ -36,7 +36,7 @@ fn parent_wrap_child_size_overflowing_parent() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percent_absolute_position.rs
+++ b/tests/generated/percent_absolute_position.rs
@@ -51,7 +51,7 @@ fn percent_absolute_position() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 60f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percent_within_flex_grow.rs
+++ b/tests/generated/percent_within_flex_grow.rs
@@ -51,7 +51,7 @@ fn percent_within_flex_grow() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 350f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_absolute_position.rs
+++ b/tests/generated/percentage_absolute_position.rs
@@ -34,7 +34,7 @@ fn percentage_absolute_position() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_container_in_wrapping_container.rs
+++ b/tests/generated/percentage_container_in_wrapping_container.rs
@@ -59,7 +59,7 @@ fn percentage_container_in_wrapping_container() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_flex_basis.rs
+++ b/tests/generated/percentage_flex_basis.rs
@@ -34,7 +34,7 @@ fn percentage_flex_basis() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_flex_basis_cross.rs
+++ b/tests/generated/percentage_flex_basis_cross.rs
@@ -35,7 +35,7 @@ fn percentage_flex_basis_cross() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 400f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_flex_basis_cross_max_height.rs
+++ b/tests/generated/percentage_flex_basis_cross_max_height.rs
@@ -43,7 +43,7 @@ fn percentage_flex_basis_cross_max_height() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 400f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_flex_basis_cross_max_width.rs
+++ b/tests/generated/percentage_flex_basis_cross_max_width.rs
@@ -43,7 +43,7 @@ fn percentage_flex_basis_cross_max_width() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 400f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_flex_basis_cross_min_height.rs
+++ b/tests/generated/percentage_flex_basis_cross_min_height.rs
@@ -41,7 +41,7 @@ fn percentage_flex_basis_cross_min_height() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 400f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_flex_basis_cross_min_width.rs
+++ b/tests/generated/percentage_flex_basis_cross_min_width.rs
@@ -43,7 +43,7 @@ fn percentage_flex_basis_cross_min_width() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 400f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_flex_basis_main_max_height.rs
+++ b/tests/generated/percentage_flex_basis_main_max_height.rs
@@ -42,7 +42,7 @@ fn percentage_flex_basis_main_max_height() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 400f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_flex_basis_main_max_width.rs
+++ b/tests/generated/percentage_flex_basis_main_max_width.rs
@@ -42,7 +42,7 @@ fn percentage_flex_basis_main_max_width() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 400f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_flex_basis_main_min_width.rs
+++ b/tests/generated/percentage_flex_basis_main_min_width.rs
@@ -42,7 +42,7 @@ fn percentage_flex_basis_main_min_width() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 400f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_margin_should_calculate_based_only_on_width.rs
+++ b/tests/generated/percentage_margin_should_calculate_based_only_on_width.rs
@@ -45,7 +45,7 @@ fn percentage_margin_should_calculate_based_only_on_width() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_multiple_nested_with_padding_margin_and_percentage_values.rs
+++ b/tests/generated/percentage_multiple_nested_with_padding_margin_and_percentage_values.rs
@@ -105,7 +105,7 @@ fn percentage_multiple_nested_with_padding_margin_and_percentage_values() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_padding_should_calculate_based_only_on_width.rs
+++ b/tests/generated/percentage_padding_should_calculate_based_only_on_width.rs
@@ -45,7 +45,7 @@ fn percentage_padding_should_calculate_based_only_on_width() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_position_bottom_right.rs
+++ b/tests/generated/percentage_position_bottom_right.rs
@@ -32,7 +32,7 @@ fn percentage_position_bottom_right() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 500f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 500f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_position_left_top.rs
+++ b/tests/generated/percentage_position_left_top.rs
@@ -32,7 +32,7 @@ fn percentage_position_left_top() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 400f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 400f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_size_based_on_parent_inner_size.rs
+++ b/tests/generated/percentage_size_based_on_parent_inner_size.rs
@@ -35,7 +35,7 @@ fn percentage_size_based_on_parent_inner_size() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 400f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_size_of_flex_basis.rs
+++ b/tests/generated/percentage_size_of_flex_basis.rs
@@ -29,7 +29,7 @@ fn percentage_size_of_flex_basis() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_width_height.rs
+++ b/tests/generated/percentage_width_height.rs
@@ -27,7 +27,7 @@ fn percentage_width_height() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 400f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/percentage_width_height_undefined_parent_size.rs
+++ b/tests/generated/percentage_width_height_undefined_parent_size.rs
@@ -20,7 +20,7 @@ fn percentage_width_height_undefined_parent_size() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 0f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 0f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/relative_position_should_not_nudge_siblings.rs
+++ b/tests/generated/relative_position_should_not_nudge_siblings.rs
@@ -35,7 +35,7 @@ fn relative_position_should_not_nudge_siblings() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/rounding_flex_basis_flex_grow_row_prime_number_width.rs
+++ b/tests/generated/rounding_flex_basis_flex_grow_row_prime_number_width.rs
@@ -24,7 +24,7 @@ fn rounding_flex_basis_flex_grow_row_prime_number_width() {
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 113f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/rounding_flex_basis_flex_grow_row_width_of_100.rs
+++ b/tests/generated/rounding_flex_basis_flex_grow_row_width_of_100.rs
@@ -20,7 +20,7 @@ fn rounding_flex_basis_flex_grow_row_width_of_100() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/rounding_flex_basis_flex_shrink_row.rs
+++ b/tests/generated/rounding_flex_basis_flex_shrink_row.rs
@@ -36,7 +36,7 @@ fn rounding_flex_basis_flex_shrink_row() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 101f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/rounding_flex_basis_overrides_main_size.rs
+++ b/tests/generated/rounding_flex_basis_overrides_main_size.rs
@@ -46,7 +46,7 @@ fn rounding_flex_basis_overrides_main_size() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 113f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/rounding_fractial_input_1.rs
+++ b/tests/generated/rounding_fractial_input_1.rs
@@ -46,7 +46,7 @@ fn rounding_fractial_input_1() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 113f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/rounding_fractial_input_2.rs
+++ b/tests/generated/rounding_fractial_input_2.rs
@@ -46,7 +46,7 @@ fn rounding_fractial_input_2() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 114f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/rounding_fractial_input_3.rs
+++ b/tests/generated/rounding_fractial_input_3.rs
@@ -46,7 +46,7 @@ fn rounding_fractial_input_3() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 113f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/rounding_fractial_input_4.rs
+++ b/tests/generated/rounding_fractial_input_4.rs
@@ -46,7 +46,7 @@ fn rounding_fractial_input_4() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 113f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/rounding_total_fractial.rs
+++ b/tests/generated/rounding_total_fractial.rs
@@ -46,7 +46,7 @@ fn rounding_total_fractial() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 87f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 113f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/rounding_total_fractial_nested.rs
+++ b/tests/generated/rounding_total_fractial_nested.rs
@@ -74,7 +74,7 @@ fn rounding_total_fractial_nested() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 87f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 113f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/size_defined_by_child.rs
+++ b/tests/generated/size_defined_by_child.rs
@@ -15,7 +15,7 @@ fn size_defined_by_child() {
         )
         .unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/size_defined_by_child_with_border.rs
+++ b/tests/generated/size_defined_by_child_with_border.rs
@@ -29,7 +29,7 @@ fn size_defined_by_child_with_border() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 30f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 30f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/size_defined_by_child_with_padding.rs
+++ b/tests/generated/size_defined_by_child_with_padding.rs
@@ -29,7 +29,7 @@ fn size_defined_by_child_with_padding() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 30f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 30f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/size_defined_by_grand_child.rs
+++ b/tests/generated/size_defined_by_grand_child.rs
@@ -16,7 +16,7 @@ fn size_defined_by_grand_child() {
         .unwrap();
     let node0 = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node00]).unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/width_smaller_then_content_with_flex_grow_large_size.rs
+++ b/tests/generated/width_smaller_then_content_with_flex_grow_large_size.rs
@@ -58,7 +58,7 @@ fn width_smaller_then_content_with_flex_grow_large_size() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/width_smaller_then_content_with_flex_grow_small_size.rs
+++ b/tests/generated/width_smaller_then_content_with_flex_grow_small_size.rs
@@ -58,7 +58,7 @@ fn width_smaller_then_content_with_flex_grow_small_size() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 10f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/width_smaller_then_content_with_flex_grow_unconstraint_size.rs
+++ b/tests/generated/width_smaller_then_content_with_flex_grow_unconstraint_size.rs
@@ -50,7 +50,7 @@ fn width_smaller_then_content_with_flex_grow_unconstraint_size() {
         )
         .unwrap();
     let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[node0, node1]).unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 0f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/width_smaller_then_content_with_flex_grow_very_large_size.rs
+++ b/tests/generated/width_smaller_then_content_with_flex_grow_very_large_size.rs
@@ -58,7 +58,7 @@ fn width_smaller_then_content_with_flex_grow_very_large_size() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrap_column.rs
+++ b/tests/generated/wrap_column.rs
@@ -68,7 +68,7 @@ fn wrap_column() {
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrap_nodes_with_content_sizing_margin_cross.rs
+++ b/tests/generated/wrap_nodes_with_content_sizing_margin_cross.rs
@@ -67,7 +67,7 @@ fn wrap_nodes_with_content_sizing_margin_cross() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 500f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 500f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrap_nodes_with_content_sizing_overflowing_margin.rs
+++ b/tests/generated/wrap_nodes_with_content_sizing_overflowing_margin.rs
@@ -67,7 +67,7 @@ fn wrap_nodes_with_content_sizing_overflowing_margin() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 500f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 500f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrap_reverse_column.rs
+++ b/tests/generated/wrap_reverse_column.rs
@@ -68,7 +68,7 @@ fn wrap_reverse_column() {
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrap_reverse_column_fixed_size.rs
+++ b/tests/generated/wrap_reverse_column_fixed_size.rs
@@ -82,7 +82,7 @@ fn wrap_reverse_column_fixed_size() {
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrap_reverse_row.rs
+++ b/tests/generated/wrap_reverse_row.rs
@@ -63,7 +63,7 @@ fn wrap_reverse_row() {
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 60f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrap_reverse_row_align_content_center.rs
+++ b/tests/generated/wrap_reverse_row_align_content_center.rs
@@ -77,7 +77,7 @@ fn wrap_reverse_row_align_content_center() {
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 80f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrap_reverse_row_align_content_flex_start.rs
+++ b/tests/generated/wrap_reverse_row_align_content_flex_start.rs
@@ -77,7 +77,7 @@ fn wrap_reverse_row_align_content_flex_start() {
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 80f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrap_reverse_row_align_content_space_around.rs
+++ b/tests/generated/wrap_reverse_row_align_content_space_around.rs
@@ -77,7 +77,7 @@ fn wrap_reverse_row_align_content_space_around() {
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 80f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrap_reverse_row_align_content_stretch.rs
+++ b/tests/generated/wrap_reverse_row_align_content_stretch.rs
@@ -76,7 +76,7 @@ fn wrap_reverse_row_align_content_stretch() {
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 80f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrap_reverse_row_single_line_different_size.rs
+++ b/tests/generated/wrap_reverse_row_single_line_different_size.rs
@@ -77,7 +77,7 @@ fn wrap_reverse_row_single_line_different_size() {
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 300f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrap_row.rs
+++ b/tests/generated/wrap_row.rs
@@ -63,7 +63,7 @@ fn wrap_row() {
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 60f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrap_row_align_items_center.rs
+++ b/tests/generated/wrap_row_align_items_center.rs
@@ -64,7 +64,7 @@ fn wrap_row_align_items_center() {
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 60f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrap_row_align_items_flex_end.rs
+++ b/tests/generated/wrap_row_align_items_flex_end.rs
@@ -64,7 +64,7 @@ fn wrap_row_align_items_flex_end() {
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 60f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrapped_column_max_height.rs
+++ b/tests/generated/wrapped_column_max_height.rs
@@ -69,7 +69,7 @@ fn wrapped_column_max_height() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 700f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 500f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrapped_column_max_height_flex.rs
+++ b/tests/generated/wrapped_column_max_height_flex.rs
@@ -75,7 +75,7 @@ fn wrapped_column_max_height_flex() {
             &[node0, node1, node2],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 700f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 500f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrapped_row_within_align_items_center.rs
+++ b/tests/generated/wrapped_row_within_align_items_center.rs
@@ -48,7 +48,7 @@ fn wrapped_row_within_align_items_center() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrapped_row_within_align_items_flex_end.rs
+++ b/tests/generated/wrapped_row_within_align_items_flex_end.rs
@@ -48,7 +48,7 @@ fn wrapped_row_within_align_items_flex_end() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/generated/wrapped_row_within_align_items_flex_start.rs
+++ b/tests/generated/wrapped_row_within_align_items_flex_start.rs
@@ -48,7 +48,7 @@ fn wrapped_row_within_align_items_flex_start() {
             &[node0],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
     assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
     assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
     assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);

--- a/tests/measure.rs
+++ b/tests/measure.rs
@@ -8,14 +8,14 @@ mod measure {
         let node = taffy
             .new_leaf_with_measure(
                 taffy::style::FlexboxLayout { ..Default::default() },
-                MeasureFunc::Raw(|constraint| taffy::geometry::Size {
-                    width: constraint.width.unwrap_or(100.0),
-                    height: constraint.height.unwrap_or(100.0),
+                MeasureFunc::Raw(|known_dimensions, _available_space| taffy::geometry::Size {
+                    width: known_dimensions.width.unwrap_or(100.0),
+                    height: known_dimensions.height.unwrap_or(100.0),
                 }),
             )
             .unwrap();
 
-        taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 
         assert_eq!(taffy.layout(node).unwrap().size.width, 100.0);
         assert_eq!(taffy.layout(node).unwrap().size.height, 100.0);
@@ -28,15 +28,15 @@ mod measure {
         let child = taffy
             .new_leaf_with_measure(
                 taffy::style::FlexboxLayout { ..Default::default() },
-                MeasureFunc::Raw(|constraint| taffy::geometry::Size {
-                    width: constraint.width.unwrap_or(100.0),
-                    height: constraint.height.unwrap_or(100.0),
+                MeasureFunc::Raw(|known_dimensions, _available_space| taffy::geometry::Size {
+                    width: known_dimensions.width.unwrap_or(100.0),
+                    height: known_dimensions.height.unwrap_or(100.0),
                 }),
             )
             .unwrap();
 
         let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[child]).unwrap();
-        taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 
         assert_eq!(taffy.layout(node).unwrap().size.width, 100.0);
         assert_eq!(taffy.layout(node).unwrap().size.height, 100.0);
@@ -51,9 +51,9 @@ mod measure {
         let child = taffy
             .new_leaf_with_measure(
                 taffy::style::FlexboxLayout { ..Default::default() },
-                MeasureFunc::Raw(|constraint| taffy::geometry::Size {
-                    width: constraint.width.unwrap_or(100.0),
-                    height: constraint.height.unwrap_or(100.0),
+                MeasureFunc::Raw(|known_dimensions, _available_space| taffy::geometry::Size {
+                    width: known_dimensions.width.unwrap_or(100.0),
+                    height: known_dimensions.height.unwrap_or(100.0),
                 }),
             )
             .unwrap();
@@ -68,7 +68,7 @@ mod measure {
             )
             .unwrap();
 
-        taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 
         assert_eq!(taffy.layout(node).unwrap().size.width, 50.0);
         assert_eq!(taffy.layout(node).unwrap().size.height, 100.0);
@@ -83,9 +83,9 @@ mod measure {
         let child = taffy
             .new_leaf_with_measure(
                 taffy::style::FlexboxLayout { ..Default::default() },
-                MeasureFunc::Raw(|constraint| taffy::geometry::Size {
-                    width: constraint.width.unwrap_or(100.0),
-                    height: constraint.height.unwrap_or(100.0),
+                MeasureFunc::Raw(|known_dimensions, _available_space| taffy::geometry::Size {
+                    width: known_dimensions.width.unwrap_or(100.0),
+                    height: known_dimensions.height.unwrap_or(100.0),
                 }),
             )
             .unwrap();
@@ -105,7 +105,7 @@ mod measure {
                 &[child],
             )
             .unwrap();
-        taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 
         assert_eq!(taffy.layout(node).unwrap().size.width, 50.0);
         assert_eq!(taffy.layout(node).unwrap().size.height, 120.0);
@@ -130,9 +130,9 @@ mod measure {
         let child1 = taffy
             .new_leaf_with_measure(
                 taffy::style::FlexboxLayout { flex_grow: 1.0, ..Default::default() },
-                MeasureFunc::Raw(|constraint| taffy::geometry::Size {
-                    width: constraint.width.unwrap_or(10.0),
-                    height: constraint.height.unwrap_or(50.0),
+                MeasureFunc::Raw(|known_dimensions, _available_space| taffy::geometry::Size {
+                    width: known_dimensions.width.unwrap_or(10.0),
+                    height: known_dimensions.height.unwrap_or(50.0),
                 }),
             )
             .unwrap();
@@ -147,7 +147,7 @@ mod measure {
             )
             .unwrap();
 
-        taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 
         assert_eq!(taffy.layout(child1).unwrap().size.width, 50.0);
         assert_eq!(taffy.layout(child1).unwrap().size.height, 50.0);
@@ -170,9 +170,9 @@ mod measure {
         let child1 = taffy
             .new_leaf_with_measure(
                 taffy::style::FlexboxLayout { ..Default::default() },
-                MeasureFunc::Raw(|constraint| taffy::geometry::Size {
-                    width: constraint.width.unwrap_or(100.0),
-                    height: constraint.height.unwrap_or(50.0),
+                MeasureFunc::Raw(|known_dimensions, _available_space| taffy::geometry::Size {
+                    width: known_dimensions.width.unwrap_or(100.0),
+                    height: known_dimensions.height.unwrap_or(50.0),
                 }),
             )
             .unwrap();
@@ -187,7 +187,7 @@ mod measure {
             )
             .unwrap();
 
-        taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 
         assert_eq!(taffy.layout(child1).unwrap().size.width, 50.0);
         assert_eq!(taffy.layout(child1).unwrap().size.height, 50.0);
@@ -209,9 +209,9 @@ mod measure {
         let child1 = taffy
             .new_leaf_with_measure(
                 taffy::style::FlexboxLayout { flex_grow: 1.0, ..Default::default() },
-                MeasureFunc::Raw(|constraint| {
-                    let width = constraint.width.unwrap_or(10.0);
-                    let height = constraint.height.unwrap_or(width * 2.0);
+                MeasureFunc::Raw(|known_dimensions, _available_space| {
+                    let width = known_dimensions.width.unwrap_or(10.0);
+                    let height = known_dimensions.height.unwrap_or(width * 2.0);
                     taffy::geometry::Size { width, height }
                 }),
             )
@@ -228,7 +228,7 @@ mod measure {
             )
             .unwrap();
 
-        taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 
         assert_eq!(taffy.layout(child1).unwrap().size.width, 50.0);
         assert_eq!(taffy.layout(child1).unwrap().size.height, 100.0);
@@ -252,9 +252,9 @@ mod measure {
         let child1 = taffy
             .new_leaf_with_measure(
                 taffy::style::FlexboxLayout { ..Default::default() },
-                MeasureFunc::Raw(|constraint| {
-                    let width = constraint.width.unwrap_or(100.0);
-                    let height = constraint.height.unwrap_or(width * 2.0);
+                MeasureFunc::Raw(|known_dimensions, _available_space| {
+                    let width = known_dimensions.width.unwrap_or(100.0);
+                    let height = known_dimensions.height.unwrap_or(width * 2.0);
                     taffy::geometry::Size { width, height }
                 }),
             )
@@ -271,7 +271,7 @@ mod measure {
             )
             .unwrap();
 
-        taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 
         assert_eq!(taffy.layout(child1).unwrap().size.width, 50.0);
         assert_eq!(taffy.layout(child1).unwrap().size.height, 100.0);
@@ -284,9 +284,9 @@ mod measure {
         let child = taffy
             .new_leaf_with_measure(
                 taffy::style::FlexboxLayout { ..Default::default() },
-                MeasureFunc::Raw(|constraint| {
-                    let height = constraint.height.unwrap_or(50.0);
-                    let width = constraint.width.unwrap_or(height);
+                MeasureFunc::Raw(|known_dimensions, _available_space| {
+                    let height = known_dimensions.height.unwrap_or(50.0);
+                    let width = known_dimensions.width.unwrap_or(height);
                     taffy::geometry::Size { width, height }
                 }),
             )
@@ -305,7 +305,7 @@ mod measure {
             )
             .unwrap();
 
-        taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 
         assert_eq!(taffy.layout(child).unwrap().size.width, 100.0);
         assert_eq!(taffy.layout(child).unwrap().size.height, 100.0);
@@ -320,15 +320,15 @@ mod measure {
                     size: taffy::geometry::Size { width: taffy::style::Dimension::Points(50.0), ..Default::default() },
                     ..Default::default()
                 },
-                MeasureFunc::Raw(|constraint| taffy::geometry::Size {
-                    width: constraint.width.unwrap_or(100.0),
-                    height: constraint.height.unwrap_or(100.0),
+                MeasureFunc::Raw(|known_dimensions, _available_space| taffy::geometry::Size {
+                    width: known_dimensions.width.unwrap_or(100.0),
+                    height: known_dimensions.height.unwrap_or(100.0),
                 }),
             )
             .unwrap();
 
         let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[child]).unwrap();
-        taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 
         assert_eq!(taffy.layout(child).unwrap().size.width, 50.0);
         assert_eq!(taffy.layout(child).unwrap().size.height, 100.0);
@@ -343,15 +343,15 @@ mod measure {
                     size: taffy::geometry::Size { height: taffy::style::Dimension::Points(50.0), ..Default::default() },
                     ..Default::default()
                 },
-                MeasureFunc::Raw(|constraint| taffy::geometry::Size {
-                    width: constraint.width.unwrap_or(100.0),
-                    height: constraint.height.unwrap_or(100.0),
+                MeasureFunc::Raw(|known_dimensions, _available_space| taffy::geometry::Size {
+                    width: known_dimensions.width.unwrap_or(100.0),
+                    height: known_dimensions.height.unwrap_or(100.0),
                 }),
             )
             .unwrap();
 
         let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[child]).unwrap();
-        taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 
         assert_eq!(taffy.layout(child).unwrap().size.width, 100.0);
         assert_eq!(taffy.layout(child).unwrap().size.height, 50.0);
@@ -375,9 +375,9 @@ mod measure {
                     flex_grow: 1.0,
                     ..Default::default()
                 },
-                MeasureFunc::Raw(|constraint| taffy::geometry::Size {
-                    width: constraint.width.unwrap_or(100.0),
-                    height: constraint.height.unwrap_or(100.0),
+                MeasureFunc::Raw(|known_dimensions, _available_space| taffy::geometry::Size {
+                    width: known_dimensions.width.unwrap_or(100.0),
+                    height: known_dimensions.height.unwrap_or(100.0),
                 }),
             )
             .unwrap();
@@ -395,7 +395,7 @@ mod measure {
             )
             .unwrap();
 
-        taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 
         assert_eq!(taffy.layout(child0).unwrap().size.width, 100.0);
         assert_eq!(taffy.layout(child0).unwrap().size.height, 100.0);
@@ -409,9 +409,9 @@ mod measure {
         let child = taffy
             .new_leaf_with_measure(
                 taffy::style::FlexboxLayout { ..Default::default() },
-                MeasureFunc::Raw(|constraint| taffy::geometry::Size {
-                    width: constraint.width.unwrap_or(50.0),
-                    height: constraint.height.unwrap_or(50.0),
+                MeasureFunc::Raw(|known_dimensions, _available_space| taffy::geometry::Size {
+                    width: known_dimensions.width.unwrap_or(50.0),
+                    height: known_dimensions.height.unwrap_or(50.0),
                 }),
             )
             .unwrap();
@@ -429,7 +429,7 @@ mod measure {
             )
             .unwrap();
 
-        taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 
         assert_eq!(taffy.layout(child).unwrap().size.width, 50.0);
         assert_eq!(taffy.layout(child).unwrap().size.height, 100.0);
@@ -444,9 +444,9 @@ mod measure {
                     position_type: taffy::style::PositionType::Absolute,
                     ..Default::default()
                 },
-                MeasureFunc::Raw(|constraint| taffy::geometry::Size {
-                    width: constraint.width.unwrap_or(50.0),
-                    height: constraint.height.unwrap_or(50.0),
+                MeasureFunc::Raw(|known_dimensions, _available_space| taffy::geometry::Size {
+                    width: known_dimensions.width.unwrap_or(50.0),
+                    height: known_dimensions.height.unwrap_or(50.0),
                 }),
             )
             .unwrap();
@@ -464,7 +464,7 @@ mod measure {
             )
             .unwrap();
 
-        taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 
         assert_eq!(taffy.layout(child).unwrap().size.width, 50.0);
         assert_eq!(taffy.layout(child).unwrap().size.height, 50.0);
@@ -488,13 +488,14 @@ mod measure {
             )
             .unwrap();
 
-        taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 
         assert_eq!(taffy.layout(child).unwrap().size.width, 100.0);
         assert_eq!(taffy.layout(child).unwrap().size.height, 100.0);
     }
 
     #[test]
+    #[ignore]
     fn only_measure_once() {
         use std::sync::atomic;
 
@@ -504,11 +505,11 @@ mod measure {
         let grandchild = taffy
             .new_leaf_with_measure(
                 taffy::style::FlexboxLayout { ..Default::default() },
-                MeasureFunc::Raw(|constraint| {
-                    NUM_MEASURES.fetch_add(1, atomic::Ordering::Relaxed);
+                MeasureFunc::Raw(|known_dimensions, _available_space| {
+                    NUM_MEASURES.fetch_add(1, atomic::Ordering::SeqCst);
                     taffy::geometry::Size {
-                        width: constraint.width.unwrap_or(50.0),
-                        height: constraint.height.unwrap_or(50.0),
+                        width: known_dimensions.width.unwrap_or(50.0),
+                        height: known_dimensions.height.unwrap_or(50.0),
                     }
                 }),
             )
@@ -518,8 +519,8 @@ mod measure {
             taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[grandchild]).unwrap();
 
         let node = taffy.new_with_children(taffy::style::FlexboxLayout { ..Default::default() }, &[child]).unwrap();
-        taffy.compute_layout(node, taffy::geometry::Size::NONE).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
 
-        assert_eq!(NUM_MEASURES.load(atomic::Ordering::Relaxed), 2);
+        assert_eq!(NUM_MEASURES.load(atomic::Ordering::SeqCst), 1);
     }
 }

--- a/tests/measure.rs
+++ b/tests/measure.rs
@@ -495,7 +495,6 @@ mod measure {
     }
 
     #[test]
-    #[ignore]
     fn only_measure_once() {
         use std::sync::atomic;
 

--- a/tests/relayout.rs
+++ b/tests/relayout.rs
@@ -1,3 +1,4 @@
+use taffy::layout::AvailableSpace;
 use taffy::style::Dimension;
 
 #[test]
@@ -30,13 +31,26 @@ fn relayout() {
         )
         .unwrap();
     println!("0:");
-    taffy.compute_layout(node, taffy::geometry::Size { width: Some(100f32), height: Some(100f32) }).unwrap();
+    taffy
+        .compute_layout(
+            node,
+            taffy::geometry::Size { width: AvailableSpace::Definite(100f32), height: AvailableSpace::Definite(100f32) },
+        )
+        .unwrap();
     let initial = taffy.layout(node).unwrap().location;
     let initial0 = taffy.layout(node0).unwrap().location;
     let initial1 = taffy.layout(node1).unwrap().location;
     for i in 1..10 {
         println!("\n\n{i}:");
-        taffy.compute_layout(node, taffy::geometry::Size { width: Some(100f32), height: Some(100f32) }).unwrap();
+        taffy
+            .compute_layout(
+                node,
+                taffy::geometry::Size {
+                    width: AvailableSpace::Definite(100f32),
+                    height: AvailableSpace::Definite(100f32),
+                },
+            )
+            .unwrap();
         assert_eq!(taffy.layout(node).unwrap().location, initial);
         assert_eq!(taffy.layout(node0).unwrap().location, initial0);
         assert_eq!(taffy.layout(node1).unwrap().location, initial1);

--- a/tests/root_constraints.rs
+++ b/tests/root_constraints.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 mod root_constraints {
+    use taffy::layout::AvailableSpace;
 
     #[test]
     fn root_with_percentage_size() {
@@ -14,7 +15,15 @@ mod root_constraints {
             })
             .unwrap();
 
-        taffy.compute_layout(node, taffy::geometry::Size { width: Some(100.0), height: Some(200.0) }).unwrap();
+        taffy
+            .compute_layout(
+                node,
+                taffy::geometry::Size {
+                    width: AvailableSpace::Definite(100.0),
+                    height: AvailableSpace::Definite(200.0),
+                },
+            )
+            .unwrap();
         let layout = taffy.layout(node).unwrap();
 
         assert_eq!(layout.size.width, 100.0);
@@ -26,7 +35,15 @@ mod root_constraints {
         let mut taffy = taffy::node::Taffy::new();
         let node = taffy.new_leaf(taffy::style::FlexboxLayout { ..Default::default() }).unwrap();
 
-        taffy.compute_layout(node, taffy::geometry::Size { width: Some(100.0), height: Some(100.0) }).unwrap();
+        taffy
+            .compute_layout(
+                node,
+                taffy::geometry::Size {
+                    width: AvailableSpace::Definite(100.0),
+                    height: AvailableSpace::Definite(100.0),
+                },
+            )
+            .unwrap();
         let layout = taffy.layout(node).unwrap();
 
         assert_eq!(layout.size.width, 0.0);
@@ -46,7 +63,15 @@ mod root_constraints {
             })
             .unwrap();
 
-        taffy.compute_layout(node, taffy::geometry::Size { width: Some(100.0), height: Some(100.0) }).unwrap();
+        taffy
+            .compute_layout(
+                node,
+                taffy::geometry::Size {
+                    width: AvailableSpace::Definite(100.0),
+                    height: AvailableSpace::Definite(100.0),
+                },
+            )
+            .unwrap();
         let layout = taffy.layout(node).unwrap();
 
         assert_eq!(layout.size.width, 200.0);

--- a/tests/simple_child.rs
+++ b/tests/simple_child.rs
@@ -1,4 +1,4 @@
-use taffy::{geometry::Point, style::Dimension};
+use taffy::{geometry::Point, layout::AvailableSpace, style::Dimension};
 
 #[test]
 fn simple_child() {
@@ -51,7 +51,12 @@ fn simple_child() {
             &[node0, node1],
         )
         .unwrap();
-    taffy.compute_layout(node, taffy::geometry::Size { width: Some(100.), height: Some(100.) }).unwrap();
+    taffy
+        .compute_layout(
+            node,
+            taffy::geometry::Size { width: AvailableSpace::Definite(100.), height: AvailableSpace::Definite(100.) },
+        )
+        .unwrap();
     assert_eq!(taffy.layout(node).unwrap().location, Point { x: 0.0, y: 0.0 });
     assert_eq!(taffy.layout(node0).unwrap().location, Point { x: 0.0, y: 0.0 });
     assert_eq!(taffy.layout(node1).unwrap().location, Point { x: 10.0, y: 0.0 });


### PR DESCRIPTION
# Objective

- Lays the groundwork for #28 by splitting the "leaf" algorithm out from the flexbox algorithm ~and creating a trait that each algorithm implements~ (I now intend to make this a separate PR)

- Addresses #214 by adding an available_space parameter to MeasureFuncs. The `AvailableSpace` is also used for the flexbox parent size parameter.

- Dramatically improves performance on deep trees (17s -> 3ms) by improving caching. (Fixes #243)

-  Adds a debug module with support for printing a nested tree of logs when rendering a tree (todo: add a feature flag for outputting logs and default to off).

## Benchmark Results

Pay attention to units: there are all of seconds, milliseconds and microseconds in here.

| Benchmark | main (w/new benchmarks) | This Branch | % change | 
| --- | --- | --- | --- |
| big trees/10_000 nodes (2-level hierarchy) | 44.472 µs | 45.272 µs | no change |
| big trees/100_000 nodes (2-level hierarchy) | 4.2695 ms | 4.5856 ms | no change |
| big trees/100_000 nodes (7-level hierarchy) | 2.8302 s | 4.2983 ms | -99.738% |
| big trees/4000 nodes (12-level hierarchy)) | 10.988 s | 17.138 µs | -100.000% |
| big trees/10_000 nodes (14-level hierarchy) | 46.336 s | 3.3227 ms | -99.992% |
| big trees/100_000 nodes (17-level hierarchy) | gave up after 20 mins | 10.998 s | - |
| deep hierarchy/build  | 701.74 ns | 696.26 ns | no change |
| deep hierarchy/single | 6.8114 µs | 6.3035 µs | no change |
| deep hierarchy/relayout  | 4.1475 µs | 2.2235 µs | -46.389% |
| generated benchmarks  | 206.40 µs | 208.63 µs | no change |

## Context

Code is still WIP. Cleanup needed in a number of places. It is passing all tests though.

## Feedback wanted

Nothing specific, but general feedback welcome.
