### PR TITLE
Change signature of mark_dirty method to match taffy 0.1

### DIFF
--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -42,9 +42,6 @@ fn compute_node_layout(
     run_mode: RunMode,
     sizing_mode: SizingMode,
 ) -> Size<f32> {
-    // clear the dirtiness of the node now that we've computed it
-    tree.mark_dirty(node, false);
-
     #[cfg(feature = "debug")]
     NODE_LOGGER.push_node(node);
     #[cfg(feature = "debug")]

--- a/src/data.rs
+++ b/src/data.rs
@@ -19,15 +19,13 @@ pub(crate) struct NodeData {
 
     /// The primary cached results of the layout computation
     pub(crate) size_cache: [Option<Cache>; 4],
-    /// Does this node's layout need to be recomputed?
-    pub(crate) is_dirty: bool,
 }
 
 impl NodeData {
     /// Create the data for a new node
     #[must_use]
     pub const fn new(style: Style) -> Self {
-        Self { style, size_cache: [None; 4], layout: Layout::new(), is_dirty: true, needs_measure: false }
+        Self { style, size_cache: [None; 4], layout: Layout::new(), needs_measure: false }
     }
 
     /// Marks a node and all of its parents (recursively) as dirty
@@ -36,6 +34,5 @@ impl NodeData {
     #[inline]
     pub fn mark_dirty(&mut self) {
         self.size_cache = [None; 4];
-        self.is_dirty = true;
     }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -3,6 +3,7 @@
 use crate::{
     layout::{AvailableSpace, Cache, Layout},
     prelude::*,
+    error::TaffyResult
 };
 
 /// Any item that implements the LayoutTree can be layed out using Taffy's algorithms.
@@ -32,7 +33,7 @@ pub trait LayoutTree {
     fn layout_mut(&mut self, node: Node) -> &mut Layout;
 
     /// Mark a node as finished
-    fn mark_dirty(&mut self, node: Node, dirty: bool);
+    fn mark_dirty(&mut self, node: Node) -> TaffyResult<()>;
 
     /// Measure a node. Taffy uses this to force reflows of things like text and overflowing content.
     fn measure_node(

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,9 +1,9 @@
 //! The baseline requirements of any UI Tree so Taffy can efficiently calculate the layout
 
 use crate::{
+    error::TaffyResult,
     layout::{AvailableSpace, Cache, Layout},
     prelude::*,
-    error::TaffyResult
 };
 
 /// Any item that implements the LayoutTree can be layed out using Taffy's algorithms.


### PR DESCRIPTION
# Objective

- Cargo semver picked up that the signature of `Taffy.mark_dirty()` had changed from `mark_dirty(&self, node: Node) -> TaffyResult<()>` to `mark_dirty(&self, node: Node, is_dirty: boolean)`. This seems like a needless breaking change which actually makes the API worse, so this PR undoes it.
- It also gets rid of the `is_dirty` flag internally (as it wasn't being read except to respond to the public `.dirty()` method). `mark_dirty()` now simply clears all cache entries, and `.dirty()` returns true if all cache entries are `None`.
- Finally it corrects an issue where the wrong `mark_dirty` method was being called (there was both a trait method and an inherent impl), which would cause the marking to happen only to the specified node, and not recursively up the tree.