### PR TITLE
Don't specify explicit version for dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,9 @@ criterion = "0.4"
 rstest = "0.15.0"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
-# We need to explicitly set a version here so that cargo deny doesn't complain
-# Don't forget to update this when bumping the version of taffy!
-taffy = { path = ".", version = "0.2.0", features = ["random"] }
+
+# Enable example and test-specific features
+taffy = { path = ".", features = ["random"] }
 
 [profile.release]
 lto = true

--- a/deny.toml
+++ b/deny.toml
@@ -26,7 +26,10 @@ wildcards = "deny"
 highlight = "all"
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
-    { name = "itoa", version = "1.0.2" }
+    { name = "itoa", version = "1.0.2" },
+    # Bypass problems with wildcard dependencies for dev-dependncies.
+    # Proper fix requires https://github.com/EmbarkStudios/cargo-deny/issues/448
+    { name = "taffy" }
 ]
 
 [sources]

--- a/deny.toml
+++ b/deny.toml
@@ -26,7 +26,6 @@ wildcards = "deny"
 highlight = "all"
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
-    { name = "itoa", version = "1.0.2" },
     # Bypass problems with wildcard dependencies for dev-dependncies.
     # Proper fix requires https://github.com/EmbarkStudios/cargo-deny/issues/448
     { name = "taffy" }

--- a/deny.toml
+++ b/deny.toml
@@ -6,7 +6,7 @@ unmaintained = "deny"
 yanked = "deny"
 notice = "deny"
 ignore = [
-    "RUSTSEC-2021-0127" # from serde_cbor
+    "RUSTSEC-2021-0145" # from criterion, used only for benchmarking
 ]
 
 [licenses]


### PR DESCRIPTION
Once this PR is merged, I intend to release taffy 0.2.

Testing the release currently fails:

> alice@pop-os:~/Documents/Code/taffy$ cargo publish --dry-run
>     Updating crates.io index
>    Packaging taffy v0.2.0 (/home/alice/Documents/Code/taffy)
> error: failed to prepare local package for uploading
> 
> Caused by:
>   failed to select a version for the requirement `taffy = "^0.2.0"`
>   candidate versions found which didn't match: 0.1.0
>   location searched: crates.io index
>   required by package `taffy v0.2.0 (/home/alice/Documents/Code/taffy)`

Removing the explicit version causes this to pass correctly. It's currently unclear how this worked before. EDIT: it never has :(