### PR TITLE
Return iterator for children for `LayoutTree`

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## 0.3.0
+
+### Breaking API changes
+
+#### Changes to `LayoutTree`
+- Added generic associated type to `LayoutTree` for a `ChildIter`, an iterator on the children of a given node.
+- Changed the `children` method of `LayoutTree` to return the `ChildIter` generic associated type to allow for custom tree storage implementations which do not store the children of a node contiguously.
+- Added `child_count`  method to `LayoutTree` for querying the number of children of a node. Required because the `children` method now returns an iterator instead of an array.
+- Added `is_childless` method to `LayoutTree` for querying whether a node has no children.
+
 ## 0.2.0
 
 ### New features

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -5,6 +5,7 @@
 ### Breaking API changes
 
 #### Changes to `LayoutTree`
+
 - Added generic associated type to `LayoutTree` for a `ChildIter`, an iterator on the children of a given node.
 - Changed the `children` method of `LayoutTree` to return the `ChildIter` generic associated type to allow for custom tree storage implementations which do not store the children of a node contiguously.
 - Added `child_count`  method to `LayoutTree` for querying the number of children of a node. Required because the `children` method now returns an iterator instead of an array.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## 0.3.0
+## 0.3.0 (Unreleased)
 
 ### Breaking API changes
 

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -332,7 +332,7 @@ fn compute_preliminary(
 
     #[cfg(feature = "debug")]
     NODE_LOGGER.log("hidden_layout");
-    let len = tree.num_children(node);
+    let len = tree.child_count(node);
     for order in 0..len {
         let child = tree.child(node, order);
         if tree.style(child).display == Display::None {
@@ -973,20 +973,12 @@ fn calculate_children_base_lines(
 ) {
     /// Recursively calculates the baseline for children
     fn calc_baseline(db: &impl LayoutTree, node: Node, layout: &Layout) -> f32 {
-        if db.num_children(node) == 0 {
-            layout.size.height
-        } else {
-            // Safe to unwrap because we already checked that the num_children > 0
-            let first_child = db.children(node).nth(0).unwrap();
+        if let Some(first_child) = db.children(node).next() {
             let layout = db.layout(*first_child);
             calc_baseline(db, *first_child, layout)
+        } else {
+            layout.size.height
         }
-        // if db.children[node].is_empty() {
-        //     layout.size.height
-        // } else {
-        //     let child = db.children[node][0];
-        //     calc_baseline(db, child, &db.nodes[child].layout)
-        // }
     }
 
     for line in flex_lines {
@@ -1829,7 +1821,7 @@ fn perform_absolute_layout_on_absolute_children(tree: &mut impl LayoutTree, node
 fn hidden_layout(tree: &mut impl LayoutTree, node: Node, order: u32) {
     *tree.layout_mut(node) = Layout::with_order(order);
 
-    let len = tree.num_children(node);
+    let len = tree.child_count(node);
     for order in 0..len {
         hidden_layout(tree, tree.child(node, order), order as _);
     }

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -48,7 +48,7 @@ fn compute_node_layout(
     println!();
 
     // First we check if we have a cached result for the given input
-    let cache_run_mode = if tree.num_children(node) == 0 { RunMode::PeformLayout } else { run_mode };
+    let cache_run_mode = if tree.is_childless(node) { RunMode::PeformLayout } else { run_mode };
     if let Some(cached_size) =
         compute_from_cache(tree, node, known_dimensions, available_space, cache_run_mode, sizing_mode)
     {
@@ -103,7 +103,7 @@ fn compute_node_layout(
     // }
 
     // If this is a leaf node we can skip a lot of this function in some cases
-    let computed_size = if tree.num_children(node) == 0 {
+    let computed_size = if tree.is_childless(node) {
         #[cfg(feature = "debug")]
         NODE_LOGGER.log("Algo: leaf");
         self::leaf::compute(tree, node, known_dimensions, available_space, run_mode, sizing_mode)
@@ -196,7 +196,7 @@ fn round_layout(tree: &mut impl LayoutTree, root: Node, abs_x: f32, abs_y: f32) 
     layout.size.height = round(layout.size.height);
 
     // Satisfy the borrow checker here by re-indexing to shorten the lifetime to the loop scope
-    for x in 0..tree.num_children(root) {
+    for x in 0..tree.child_count(root) {
         let child = tree.child(root, x);
         round_layout(tree, child, abs_x, abs_y);
     }

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -48,7 +48,7 @@ fn compute_node_layout(
     println!();
 
     // First we check if we have a cached result for the given input
-    let cache_run_mode = if tree.children(node).is_empty() { RunMode::PeformLayout } else { run_mode };
+    let cache_run_mode = if tree.num_children(node) == 0 { RunMode::PeformLayout } else { run_mode };
     if let Some(cached_size) =
         compute_from_cache(tree, node, known_dimensions, available_space, cache_run_mode, sizing_mode)
     {
@@ -103,7 +103,7 @@ fn compute_node_layout(
     // }
 
     // If this is a leaf node we can skip a lot of this function in some cases
-    let computed_size = if tree.children(node).is_empty() {
+    let computed_size = if tree.num_children(node) == 0 {
         #[cfg(feature = "debug")]
         NODE_LOGGER.log("Algo: leaf");
         self::leaf::compute(tree, node, known_dimensions, available_space, run_mode, sizing_mode)
@@ -196,7 +196,7 @@ fn round_layout(tree: &mut impl LayoutTree, root: Node, abs_x: f32, abs_y: f32) 
     layout.size.height = round(layout.size.height);
 
     // Satisfy the borrow checker here by re-indexing to shorten the lifetime to the loop scope
-    for x in 0..tree.children(root).len() {
+    for x in 0..tree.num_children(root) {
         let child = tree.child(root, x);
         round_layout(tree, child, abs_x, abs_y);
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,7 +1,7 @@
 //! UI [`Node`] types and related data structures.
 //!
 //! Layouts are composed of multiple nodes, which live in a tree-like data structure.
-use slotmap::{SlotMap, SparseSecondaryMap};
+use slotmap::{DefaultKey, SlotMap, SparseSecondaryMap};
 
 /// A node in a layout.
 pub type Node = slotmap::DefaultKey;
@@ -58,8 +58,14 @@ impl Default for Taffy {
 }
 
 impl LayoutTree for Taffy {
-    fn children(&self, node: Node) -> &[Node] {
-        &self.children[node]
+    type ChildIter<'a> = std::slice::Iter<'a, DefaultKey>;
+
+    fn children<'a>(&'a self, node: Node) -> Self::ChildIter<'a> {
+        self.children[node].iter()
+    }
+
+    fn num_children(&self, node: Node) -> usize {
+        self.children[node].len()
     }
 
     fn parent(&self, node: Node) -> Option<Node> {

--- a/src/node.rs
+++ b/src/node.rs
@@ -64,8 +64,12 @@ impl LayoutTree for Taffy {
         self.children[node].iter()
     }
 
-    fn num_children(&self, node: Node) -> usize {
+    fn child_count(&self, node: Node) -> usize {
         self.children[node].len()
+    }
+
+    fn is_childless(&self, node: Node) -> bool {
+        self.children[node].len() == 0
     }
 
     fn parent(&self, node: Node) -> Option<Node> {

--- a/src/node.rs
+++ b/src/node.rs
@@ -60,7 +60,7 @@ impl Default for Taffy {
 impl LayoutTree for Taffy {
     type ChildIter<'a> = std::slice::Iter<'a, DefaultKey>;
 
-    fn children<'a>(&'a self, node: Node) -> Self::ChildIter<'a> {
+    fn children(&self, node: Node) -> Self::ChildIter<'_> {
         self.children[node].iter()
     }
 
@@ -69,7 +69,7 @@ impl LayoutTree for Taffy {
     }
 
     fn is_childless(&self, node: Node) -> bool {
-        self.children[node].len() == 0
+        self.children[node].is_empty()
     }
 
     fn parent(&self, node: Node) -> Option<Node> {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -13,12 +13,13 @@ use crate::{
 /// Generally, Taffy expects your Node tree to be indexable by stable indices. A "stable" index means that the Node's ID
 /// remains the same between re-layouts.
 pub trait LayoutTree {
+    /// Type representing an iterator of the children of a node
     type ChildIter<'a>: Iterator<Item = &'a DefaultKey>
     where
         Self: 'a;
 
     /// Get the list of children IDs for the given node
-    fn children<'a>(&'a self, node: Node) -> Self::ChildIter<'a>;
+    fn children(&self, node: Node) -> Self::ChildIter<'_>;
 
     /// Get the number of children for the given node
     fn child_count(&self, node: Node) -> usize;

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,5 +1,7 @@
 //! The baseline requirements of any UI Tree so Taffy can efficiently calculate the layout
 
+use slotmap::DefaultKey;
+
 use crate::{
     error::TaffyResult,
     layout::{AvailableSpace, Cache, Layout},
@@ -11,8 +13,15 @@ use crate::{
 /// Generally, Taffy expects your Node tree to be indexable by stable indices. A "stable" index means that the Node's ID
 /// remains the same between re-layouts.
 pub trait LayoutTree {
+    type ChildIter<'a>: Iterator<Item = &'a DefaultKey>
+    where
+        Self: 'a;
+
     /// Get the list of children IDs for the given node
-    fn children(&self, node: Node) -> &[Node];
+    fn children<'a>(&'a self, node: Node) -> Self::ChildIter<'a>;
+
+    /// Get the number of children for the given node
+    fn num_children(&self, node: Node) -> usize;
 
     /// Get a specific child of a node, where the index represents the nth child
     fn child(&self, node: Node, index: usize) -> Node;

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -21,7 +21,10 @@ pub trait LayoutTree {
     fn children<'a>(&'a self, node: Node) -> Self::ChildIter<'a>;
 
     /// Get the number of children for the given node
-    fn num_children(&self, node: Node) -> usize;
+    fn child_count(&self, node: Node) -> usize;
+
+    /// Returns true if the node has no children
+    fn is_childless(&self, node: Node) -> bool;
 
     /// Get a specific child of a node, where the index represents the nth child
     fn child(&self, node: Node, index: usize) -> Node;


### PR DESCRIPTION
# Objective

Why did you make this PR?

The current approach of returning `&[Node]` only works if the tree stores the children contiguously. Returning an iterator allows the tree to completely abstract the method of storage. 

## Context

Related to #222 

## Feedback wanted

I'm not completely sure about the lifetimes for the iterator. I didn't want to force a copy when the children actually are stored contiguously so I used a GAT to allow returning a borrowing iterator. However, this now ties the lifetime of the iterator to the lifetime of the tree. However, I think this is correct but thought I'd mention it in acse anyone can think of a situation where this wouldn't be the case.

I'm not sure if this change is necessary until work on implementing another layout system, such as [morphorm](https://github.com/vizia/morphorm), into taffy is attempted, so I'm opening this as a draft PR for now.
