### PR TITLE
Re-export compute::compute_layout at the top level

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,4 +37,5 @@ mod data;
 mod resolve;
 mod sys;
 
+pub use crate::compute::compute_layout;
 pub use crate::node::Taffy;


### PR DESCRIPTION
# Objective

Fixes #263

## Feedback wanted

We should potentially backport and release this in a `0.2.1` release, along with #262? I'm not sure how much effort the actual release process is, but the backport should be straightforward.