### PR TITLE
Make tree debug printing more readable

### DIFF
--- a/src/debug.rs
+++ b/src/debug.rs
@@ -7,26 +7,32 @@ use crate::tree::LayoutTree;
 
 /// Prints a debug representation of the computed layout for a tree of nodes, starting with the passed root node.
 pub fn print_tree(tree: &impl LayoutTree, root: Node) {
-    println!();
-    print_node(tree, root, 0);
+    println!("TREE");
+    print_node(tree, root, 0, false, String::new());
 }
 
-fn print_node(tree: &impl LayoutTree, node: Node, level: usize) {
+fn print_node(tree: &impl LayoutTree, node: Node, level: usize, has_sibling: bool, lines_string: String) {
     let layout = tree.layout(node);
+
+    let num_children = tree.child_count(node);
+
+    let fork_string = if has_sibling { "├── " } else { "└── " };
     println!(
-        "{space:leftpad$}{key:?} (x:{x}, y: {y}, width: {width}, height: {height})",
-        space = " ",
-        leftpad = level * 4,
-        key = node.data(),
+        "{lines}{fork}[x: {x}, y: {y}, width: {width}, height: {height}]",
+        lines = lines_string,
+        fork = fork_string,
         x = layout.location.x,
         y = layout.location.y,
         width = layout.size.width,
         height = layout.size.height,
     );
+    let bar = if has_sibling { "│   " } else { "    " };
+    let new_string = lines_string + bar;
 
     // Recurse into children
-    for child in tree.children(node) {
-        print_node(tree, *child, level + 1)
+    for (index, child) in tree.children(node).enumerate() {
+        let has_sibling = index < num_children - 1;
+        print_node(tree, *child, level + 1, has_sibling, new_string.clone());
     }
 }
 

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -8,10 +8,10 @@ use crate::tree::LayoutTree;
 /// Prints a debug representation of the computed layout for a tree of nodes, starting with the passed root node.
 pub fn print_tree(tree: &impl LayoutTree, root: Node) {
     println!("TREE");
-    print_node(tree, root, 0, false, String::new());
+    print_node(tree, root, false, String::new());
 }
 
-fn print_node(tree: &impl LayoutTree, node: Node, level: usize, has_sibling: bool, lines_string: String) {
+fn print_node(tree: &impl LayoutTree, node: Node, has_sibling: bool, lines_string: String) {
     let layout = tree.layout(node);
 
     let num_children = tree.child_count(node);
@@ -32,7 +32,7 @@ fn print_node(tree: &impl LayoutTree, node: Node, level: usize, has_sibling: boo
     // Recurse into children
     for (index, child) in tree.children(node).enumerate() {
         let has_sibling = index < num_children - 1;
-        print_node(tree, *child, level + 1, has_sibling, new_string.clone());
+        print_node(tree, *child, has_sibling, new_string.clone());
     }
 }
 


### PR DESCRIPTION
Small change but I thought it might be useful to better visualise the tree when debug printing. As an example:
```
TREE
└── [x: 0, y: 0, width: 50, height: 20]
    ├── [x: 0, y: 0, width: 20, height: 20]
    │   ├── [x: 0, y: 0, width: 7, height: 20]
    │   ├── [x: 7, y: 0, width: 7, height: 20]
    │   └── [x: 13, y: 0, width: 7, height: 20]
    └── [x: 30, y: 0, width: 20, height: 20]
```
(this looks even better with a font that supports ligatures)

I was going to add the node number but it's not accessible. I could probably add one using a counter passed to the recursive `print_node` function but I don't know if that would be desired or not. 