### PR TITLE
Vertical border and padding percentage values are multiplied by available_space.width

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -11,6 +11,10 @@
 - Added `child_count`  method to `LayoutTree` for querying the number of children of a node. Required because the `children` method now returns an iterator instead of an array.
 - Added `is_childless` method to `LayoutTree` for querying whether a node has no children.
 
+### Fixes
+
+- Border or padding on the horizontal axis could, in some cases, increase the height of nodes.
+
 ## 0.2.1
 
 ### Fixes

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -14,6 +14,7 @@
 ### Fixes
 
 - Border or padding on the horizontal axis could, in some cases, increase the height of nodes.
+- Vertical `border` and `padding` percentage values incorrectly multiplied by `available_space.width` instead of `height`.
 
 ## 0.2.1
 

--- a/src/compute/leaf.rs
+++ b/src/compute/leaf.rs
@@ -78,7 +78,7 @@ pub(crate) fn compute(
         height: node_size
             .height
             // .unwrap_or(0.0) + padding.horizontal_axis_sum() + border.horizontal_axis_sum(), // content-box
-            .unwrap_or(0.0 + padding.horizontal_axis_sum() + border.horizontal_axis_sum()) // border-box
+            .unwrap_or(0.0 + padding.vertical_axis_sum() + border.vertical_axis_sum()) // border-box
             .maybe_clamp(node_min_size.height, node_max_size.height),
     }
 }

--- a/src/compute/leaf.rs
+++ b/src/compute/leaf.rs
@@ -66,8 +66,8 @@ pub(crate) fn compute(
         return node_size.unwrap_or(measured_size).maybe_clamp(node_min_size, node_max_size);
     }
 
-    let padding = style.padding.resolve_or_zero(available_space.width.into_option());
-    let border = style.border.resolve_or_zero(available_space.width.into_option());
+    let padding = style.padding.resolve_or_zero(available_space.as_options());
+    let border = style.border.resolve_or_zero(available_space.as_options());
 
     Size {
         width: node_size

--- a/tests/border_and_padding.rs
+++ b/tests/border_and_padding.rs
@@ -1,0 +1,79 @@
+use taffy::prelude::*;
+use taffy::style_helpers::TaffyZero;
+
+fn arr_to_rect<T: Copy>(items: [T; 4]) -> Rect<T> {
+    Rect { left: items[0], right: items[1], top: items[2], bottom: items[3] }
+}
+
+#[test]
+fn border_on_a_single_axis_doesnt_increase_size() {
+    for i in 0..4 {
+        let mut taffy = Taffy::new();
+        let node = taffy.new_leaf(Style {
+            border: {
+                let mut lengths = [LengthPercentage::ZERO; 4];
+                lengths[i] = LengthPercentage::Points(10.);
+                arr_to_rect(lengths)
+            },
+            ..Default::default()
+        }).unwrap();
+        
+        taffy.compute_layout(
+            node, 
+            Size { height: AvailableSpace::Definite(100.0), width: AvailableSpace::Definite(100.0) }
+        )
+        .ok();
+
+        let layout = taffy.layout(node).unwrap();
+        assert_eq!(layout.size.width * layout.size.height, 0.);
+    }
+}
+
+#[test]
+fn padding_on_a_single_axis_doesnt_increase_size() {
+    for i in 0..4 {
+        let mut taffy = Taffy::new();
+        let node = taffy.new_leaf(Style {
+            border: {
+                let mut lengths = [LengthPercentage::ZERO; 4];
+                lengths[i] = LengthPercentage::Points(10.);
+                arr_to_rect(lengths)
+            },
+            ..Default::default()
+        }).unwrap();
+        
+        taffy.compute_layout(
+            node, 
+            Size { height: AvailableSpace::Definite(100.0), width: AvailableSpace::Definite(100.0) }
+        )
+        .ok();
+
+        let layout = taffy.layout(node).unwrap();
+        assert_eq!(layout.size.width * layout.size.height, 0.);
+    }
+}
+
+#[test]
+fn border_and_padding_on_a_single_axis_doesnt_increase_size() {
+    for i in 0..4 {
+        let mut taffy = Taffy::new();
+        let rect = {
+             let mut lengths = [LengthPercentage::ZERO; 4];
+            lengths[i] = LengthPercentage::Points(10.);
+            arr_to_rect(lengths)
+        };
+        let node = taffy.new_leaf(Style {
+            border: rect,
+            padding: rect,
+            ..Default::default()
+        }).unwrap();
+        
+        taffy.compute_layout(
+            node, 
+            Size { height: AvailableSpace::Definite(100.0), width: AvailableSpace::Definite(100.0) }
+        )
+        .ok();
+        let layout = taffy.layout(node).unwrap();
+        assert_eq!(layout.size.width * layout.size.height, 0.);
+    }
+}

--- a/tests/border_and_padding.rs
+++ b/tests/border_and_padding.rs
@@ -80,3 +80,23 @@ fn border_and_padding_on_a_single_axis_doesnt_increase_size() {
         assert_eq!(layout.size.width * layout.size.height, 0.);
     }
 }
+
+#[test]
+fn vertical_border_and_padding_percentage_values_use_available_space_correctly() {
+    let mut taffy = Taffy::new();
+
+    let node = taffy
+        .new_leaf(Style {
+            padding: Rect { left: LengthPercentage::Percent(1.0), top: LengthPercentage::Percent(1.0), ..Rect::zero() },
+            ..Default::default()
+        })
+        .unwrap();
+
+    taffy
+        .compute_layout(node, Size { width: AvailableSpace::Definite(200.0), height: AvailableSpace::Definite(100.0) })
+        .ok();
+
+    let layout = taffy.layout(node).unwrap();
+    assert_eq!(layout.size.width, 200.0);
+    assert_eq!(layout.size.height, 100.0);
+}

--- a/tests/border_and_padding.rs
+++ b/tests/border_and_padding.rs
@@ -9,20 +9,23 @@ fn arr_to_rect<T: Copy>(items: [T; 4]) -> Rect<T> {
 fn border_on_a_single_axis_doesnt_increase_size() {
     for i in 0..4 {
         let mut taffy = Taffy::new();
-        let node = taffy.new_leaf(Style {
-            border: {
-                let mut lengths = [LengthPercentage::ZERO; 4];
-                lengths[i] = LengthPercentage::Points(10.);
-                arr_to_rect(lengths)
-            },
-            ..Default::default()
-        }).unwrap();
-        
-        taffy.compute_layout(
-            node, 
-            Size { height: AvailableSpace::Definite(100.0), width: AvailableSpace::Definite(100.0) }
-        )
-        .ok();
+        let node = taffy
+            .new_leaf(Style {
+                border: {
+                    let mut lengths = [LengthPercentage::ZERO; 4];
+                    lengths[i] = LengthPercentage::Points(10.);
+                    arr_to_rect(lengths)
+                },
+                ..Default::default()
+            })
+            .unwrap();
+
+        taffy
+            .compute_layout(
+                node,
+                Size { height: AvailableSpace::Definite(100.0), width: AvailableSpace::Definite(100.0) },
+            )
+            .ok();
 
         let layout = taffy.layout(node).unwrap();
         assert_eq!(layout.size.width * layout.size.height, 0.);
@@ -33,20 +36,23 @@ fn border_on_a_single_axis_doesnt_increase_size() {
 fn padding_on_a_single_axis_doesnt_increase_size() {
     for i in 0..4 {
         let mut taffy = Taffy::new();
-        let node = taffy.new_leaf(Style {
-            border: {
-                let mut lengths = [LengthPercentage::ZERO; 4];
-                lengths[i] = LengthPercentage::Points(10.);
-                arr_to_rect(lengths)
-            },
-            ..Default::default()
-        }).unwrap();
-        
-        taffy.compute_layout(
-            node, 
-            Size { height: AvailableSpace::Definite(100.0), width: AvailableSpace::Definite(100.0) }
-        )
-        .ok();
+        let node = taffy
+            .new_leaf(Style {
+                border: {
+                    let mut lengths = [LengthPercentage::ZERO; 4];
+                    lengths[i] = LengthPercentage::Points(10.);
+                    arr_to_rect(lengths)
+                },
+                ..Default::default()
+            })
+            .unwrap();
+
+        taffy
+            .compute_layout(
+                node,
+                Size { height: AvailableSpace::Definite(100.0), width: AvailableSpace::Definite(100.0) },
+            )
+            .ok();
 
         let layout = taffy.layout(node).unwrap();
         assert_eq!(layout.size.width * layout.size.height, 0.);
@@ -58,21 +64,18 @@ fn border_and_padding_on_a_single_axis_doesnt_increase_size() {
     for i in 0..4 {
         let mut taffy = Taffy::new();
         let rect = {
-             let mut lengths = [LengthPercentage::ZERO; 4];
+            let mut lengths = [LengthPercentage::ZERO; 4];
             lengths[i] = LengthPercentage::Points(10.);
             arr_to_rect(lengths)
         };
-        let node = taffy.new_leaf(Style {
-            border: rect,
-            padding: rect,
-            ..Default::default()
-        }).unwrap();
-        
-        taffy.compute_layout(
-            node, 
-            Size { height: AvailableSpace::Definite(100.0), width: AvailableSpace::Definite(100.0) }
-        )
-        .ok();
+        let node = taffy.new_leaf(Style { border: rect, padding: rect, ..Default::default() }).unwrap();
+
+        taffy
+            .compute_layout(
+                node,
+                Size { height: AvailableSpace::Definite(100.0), width: AvailableSpace::Definite(100.0) },
+            )
+            .ok();
         let layout = taffy.layout(node).unwrap();
         assert_eq!(layout.size.width * layout.size.height, 0.);
     }


### PR DESCRIPTION
## Context

Fixes:

If the top and bottom border and padding fields are set to percentage values then they are multiplied by `available_space.width`, instead of `.height`:

```rust
use taffy::prelude::*;

fn main() {
    let mut taffy = Taffy::new();

    let node = taffy.new_leaf(Style {
        padding: Rect {
            left: LengthPercentage::Percent(1.0), 
            top: LengthPercentage::Percent(1.0),
            ..Rect::zero()
        },
        ..Default::default()
    }).unwrap();
    
    taffy.compute_layout(
            node, 
            Size { width: AvailableSpace::Definite(200.0),  height: AvailableSpace::Definite(100.0) }
        )
        .ok();

    println!("{:?}", taffy.layout(node).unwrap().size);   
}
```
output:
```
Size { width: 200.0, height: 200.0 }
```

should be:
```
Size { width: 200.0, height: 100.0 }
```
