### PR TITLE
Fix sizing of flexbox nodes under a min-content constraint

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.3.0-alpha2 (unreleased)
+
+### Fixes
+
+- Flexbox nodes sized under a min-content constraint now size correctly (#291)
+
 ## 0.3.0-alpha1
 
 This is the first in a series of planned alpha releases to allow users of Taffy to try out the new CSS Grid layout mode in advance of a stable release. We hope that by marking this is alpha release we are clearly communicating that this a pre-release and that the implementation is not yet of production quality. But we never-the-less encourage you to try it out. Feedback is welcome, and bug reports for the Grid implementation are being accepted as of this release.

--- a/benches/generated/grid_min_content_flex_column.rs
+++ b/benches/generated/grid_min_content_flex_column.rs
@@ -1,0 +1,54 @@
+pub fn compute() {
+    #[allow(unused_imports)]
+    use taffy::prelude::*;
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
+        .new_leaf_with_measure(
+            taffy::style::Style { ..Default::default() },
+            taffy::node::MeasureFunc::Raw(|known_dimensions, available_space| {
+                const TEXT: &str = "HH\u{200b}HH";
+                super::measure_standard_text(known_dimensions, available_space, TEXT)
+            }),
+        )
+        .unwrap();
+    let node01 = taffy
+        .new_leaf_with_measure(
+            taffy::style::Style { ..Default::default() },
+            taffy::node::MeasureFunc::Raw(|known_dimensions, available_space| {
+                const TEXT: &str = "HH\u{200b}HH";
+                super::measure_standard_text(known_dimensions, available_space, TEXT)
+            }),
+        )
+        .unwrap();
+    let node02 = taffy
+        .new_leaf_with_measure(
+            taffy::style::Style { ..Default::default() },
+            taffy::node::MeasureFunc::Raw(|known_dimensions, available_space| {
+                const TEXT: &str = "HH\u{200b}HH";
+                super::measure_standard_text(known_dimensions, available_space, TEXT)
+            }),
+        )
+        .unwrap();
+    let node0 = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Flex,
+                flex_direction: taffy::style::FlexDirection::Column,
+                ..Default::default()
+            },
+            &[node00, node01, node02],
+        )
+        .unwrap();
+    let node = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Grid,
+                grid_template_rows: vec![points(40f32)],
+                grid_template_columns: vec![min_content()],
+                ..Default::default()
+            },
+            &[node0],
+        )
+        .unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
+}

--- a/benches/generated/grid_min_content_flex_row.rs
+++ b/benches/generated/grid_min_content_flex_row.rs
@@ -1,0 +1,50 @@
+pub fn compute() {
+    #[allow(unused_imports)]
+    use taffy::prelude::*;
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
+        .new_leaf_with_measure(
+            taffy::style::Style { ..Default::default() },
+            taffy::node::MeasureFunc::Raw(|known_dimensions, available_space| {
+                const TEXT: &str = "HH\u{200b}HH";
+                super::measure_standard_text(known_dimensions, available_space, TEXT)
+            }),
+        )
+        .unwrap();
+    let node01 = taffy
+        .new_leaf_with_measure(
+            taffy::style::Style { ..Default::default() },
+            taffy::node::MeasureFunc::Raw(|known_dimensions, available_space| {
+                const TEXT: &str = "HH\u{200b}HH";
+                super::measure_standard_text(known_dimensions, available_space, TEXT)
+            }),
+        )
+        .unwrap();
+    let node02 = taffy
+        .new_leaf_with_measure(
+            taffy::style::Style { ..Default::default() },
+            taffy::node::MeasureFunc::Raw(|known_dimensions, available_space| {
+                const TEXT: &str = "HH\u{200b}HH";
+                super::measure_standard_text(known_dimensions, available_space, TEXT)
+            }),
+        )
+        .unwrap();
+    let node0 = taffy
+        .new_with_children(
+            taffy::style::Style { display: taffy::style::Display::Flex, ..Default::default() },
+            &[node00, node01, node02],
+        )
+        .unwrap();
+    let node = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Grid,
+                grid_template_rows: vec![points(40f32)],
+                grid_template_columns: vec![min_content()],
+                ..Default::default()
+            },
+            &[node0],
+        )
+        .unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
+}

--- a/benches/generated/mod.rs
+++ b/benches/generated/mod.rs
@@ -359,6 +359,10 @@ mod grid_max_content_single_item_margin_fixed;
 #[cfg(feature = "experimental_grid")]
 mod grid_max_content_single_item_margin_percent;
 #[cfg(feature = "experimental_grid")]
+mod grid_min_content_flex_column;
+#[cfg(feature = "experimental_grid")]
+mod grid_min_content_flex_row;
+#[cfg(feature = "experimental_grid")]
 mod grid_min_content_flex_single_item;
 #[cfg(feature = "experimental_grid")]
 mod grid_min_content_flex_single_item_margin_auto;
@@ -838,6 +842,10 @@ fn benchmark(c: &mut Criterion) {
             grid_max_content_single_item_margin_fixed::compute();
             #[cfg(feature = "experimental_grid")]
             grid_max_content_single_item_margin_percent::compute();
+            #[cfg(feature = "experimental_grid")]
+            grid_min_content_flex_column::compute();
+            #[cfg(feature = "experimental_grid")]
+            grid_min_content_flex_row::compute();
             #[cfg(feature = "experimental_grid")]
             grid_min_content_flex_single_item::compute();
             #[cfg(feature = "experimental_grid")]

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -594,7 +594,6 @@ fn determine_flex_base_size(
             SizingMode::ContentSize,
         )
         .main(constants.dir);
-        // .maybe_min(child.max_size.main(constants.dir))
     }
 
     // The hypothetical main size is the item’s flex base size clamped according to its

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -9,7 +9,7 @@ use crate::geometry::{Point, Rect, Size};
 use crate::layout::{Layout, RunMode, SizingMode};
 use crate::math::MaybeMath;
 use crate::node::Node;
-use crate::prelude::TaffyMaxContent;
+use crate::prelude::{TaffyMaxContent, TaffyMinContent};
 use crate::resolve::{MaybeResolve, ResolveOrZero};
 use crate::style::{
     AlignContent, AlignItems, AlignSelf, AvailableSpace, Dimension, Display, FlexWrap, JustifyContent,
@@ -35,6 +35,10 @@ struct FlexItem {
     max_size: Size<Option<f32>>,
     /// The cross-alignment of this item
     align_self: AlignSelf,
+
+    /// The minimum size of the item. This differs from min_size above because it also
+    /// takes into account content based automatic minimum sizes
+    resolved_minimum_size: Size<f32>,
 
     /// The final offset of this item
     position: Rect<Option<f32>>,
@@ -201,6 +205,15 @@ fn compute_preliminary(
     #[cfg(feature = "debug")]
     NODE_LOGGER.log("determine_flex_base_size");
     determine_flex_base_size(tree, known_dimensions, &constants, available_space, &mut flex_items);
+
+    #[cfg(feature = "debug")]
+    for item in flex_items.iter() {
+        NODE_LOGGER.labelled_log("item.flex_basis", item.flex_basis);
+        NODE_LOGGER.labelled_log("item.inner_flex_basis", item.inner_flex_basis);
+        NODE_LOGGER.labelled_debug_log("item.hypothetical_outer_size", item.hypothetical_outer_size);
+        NODE_LOGGER.labelled_debug_log("item.hypothetical_inner_size", item.hypothetical_inner_size);
+        NODE_LOGGER.labelled_debug_log("item.resolved_minimum_size", item.resolved_minimum_size);
+    }
 
     // TODO: Add step 4 according to spec: https://www.w3.org/TR/css-flexbox-1/#algo-main-container
     // 9.3. Main Size Determination
@@ -431,6 +444,7 @@ fn generate_anonymous_flex_items(tree: &impl LayoutTree, node: Node, constants: 
             violation: 0.0,
             frozen: false,
 
+            resolved_minimum_size: Size::zero(),
             hypothetical_inner_size: Size::zero(),
             hypothetical_outer_size: Size::zero(),
             target_size: Size::zero(),
@@ -565,13 +579,8 @@ fn determine_flex_base_size(
 
         let child_known_dimensions = {
             let mut ckd = child.size;
-            if child.align_self == AlignSelf::Stretch {
-                if constants.is_column && ckd.width.is_none() {
-                    ckd.width = available_space.width.into_option();
-                }
-                if constants.is_row && ckd.height.is_none() {
-                    ckd.height = available_space.height.into_option();
-                }
+            if child.align_self == AlignSelf::Stretch && ckd.cross(constants.dir).is_none() {
+                ckd.set_cross(constants.dir, available_space.cross(constants.dir).into_option());
             }
             ckd
         };
@@ -579,13 +588,13 @@ fn determine_flex_base_size(
         child.flex_basis = compute_node_layout(
             tree,
             child.node,
-            child_known_dimensions.maybe_min(child.max_size),
+            child_known_dimensions,
             available_space,
             RunMode::ComputeSize,
             SizingMode::ContentSize,
         )
-        .main(constants.dir)
-        .maybe_min(child.max_size.main(constants.dir));
+        .main(constants.dir);
+        // .maybe_min(child.max_size.main(constants.dir))
     }
 
     // The hypothetical main size is the item’s flex base size clamped according to its
@@ -595,26 +604,36 @@ fn determine_flex_base_size(
         child.inner_flex_basis =
             child.flex_basis - child.padding.main_axis_sum(constants.dir) - child.border.main_axis_sum(constants.dir);
 
-        // TODO - not really spec abiding but needs to be done somewhere. probably somewhere else though.
-        // The following logic was developed not from the spec but by trail and error looking into how
-        // webkit handled various scenarios. Can probably be solved better by passing in
-        // min-content max-content constraints from the top
-        let min_main = compute_node_layout(
+        let child_known_dimensions = {
+            let mut ckd = Size::NONE;
+            if child.align_self == AlignSelf::Stretch && ckd.cross(constants.dir).is_none() {
+                ckd.set_cross(constants.dir, available_space.cross(constants.dir).into_option());
+            }
+            ckd
+        };
+
+        let min_content_size = compute_node_layout(
             tree,
             child.node,
-            Size::NONE,
-            available_space,
+            child_known_dimensions, // Should possibly also be Size::NONE
+            Size::MIN_CONTENT,
             RunMode::ComputeSize,
             SizingMode::ContentSize,
-        )
-        .main(constants.dir)
-        .maybe_clamp(child.min_size.main(constants.dir), child.size.main(constants.dir))
-        .into();
+        );
 
-        child
-            .hypothetical_inner_size
-            .set_main(constants.dir, child.flex_basis.maybe_clamp(min_main, child.max_size.main(constants.dir)));
+        // 4.5. Automatic Minimum Size of Flex Items
+        // https://www.w3.org/TR/css-flexbox-1/#min-size-auto
+        let specified = child.size.maybe_min(child.max_size);
+        child.resolved_minimum_size = child.min_size.unwrap_or(min_content_size.maybe_min(specified));
 
+        let hypothetical_inner_min_main = min_content_size
+            .main(constants.dir)
+            .maybe_clamp(child.resolved_minimum_size.main(constants.dir).into(), child.size.main(constants.dir))
+            .into();
+        child.hypothetical_inner_size.set_main(
+            constants.dir,
+            child.flex_basis.maybe_clamp(hypothetical_inner_min_main, child.max_size.main(constants.dir)),
+        );
         child.hypothetical_outer_size.set_main(
             constants.dir,
             child.hypothetical_inner_size.main(constants.dir) + child.margin.main_axis_sum(constants.dir),
@@ -770,7 +789,7 @@ fn resolve_flexible_lengths(
             .iter()
             .map(|child| {
                 child.margin.main_axis_sum(constants.dir)
-                    + if child.frozen { child.target_size.main(constants.dir) } else { child.flex_basis }
+                    + if child.frozen { child.outer_target_size.main(constants.dir) } else { child.flex_basis }
             })
             .sum::<f32>();
 
@@ -798,7 +817,7 @@ fn resolve_flexible_lengths(
                 .iter()
                 .map(|child| {
                     child.margin.main_axis_sum(constants.dir)
-                        + if child.frozen { child.target_size.main(constants.dir) } else { child.flex_basis }
+                        + if child.frozen { child.outer_target_size.main(constants.dir) } else { child.flex_basis }
                 })
                 .sum::<f32>();
 
@@ -870,29 +889,9 @@ fn resolve_flexible_lengths(
         //    If the item’s target main size was made larger by this, it’s a min violation.
 
         let total_violation = unfrozen.iter_mut().fold(0.0, |acc, child| -> f32 {
-            // TODO - not really spec abiding but needs to be done somewhere. probably somewhere else though.
-            // The following logic was developed not from the spec but by trial and error looking into how
-            // webkit handled various scenarios. Can probably be solved better by passing in
-            // min-content max-content constraints from the top. Need to figure out correct thing to do here as
-            // just piling on more conditionals.
-            let min_main = if constants.is_row && !tree.needs_measure(child.node) {
-                compute_node_layout(
-                    tree,
-                    child.node,
-                    Size::NONE,
-                    available_space,
-                    RunMode::ComputeSize,
-                    SizingMode::ContentSize,
-                )
-                .width
-                .maybe_clamp(child.min_size.width, child.size.width)
-                .into()
-            } else {
-                child.min_size.main(constants.dir)
-            };
-
+            let resolved_min_main: Option<f32> = child.resolved_minimum_size.main(constants.dir).into();
             let max_main = child.max_size.main(constants.dir);
-            let clamped = child.target_size.main(constants.dir).maybe_clamp(min_main, max_main).max(0.0);
+            let clamped = child.target_size.main(constants.dir).maybe_clamp(resolved_min_main, max_main).max(0.0);
             child.violation = clamped - child.target_size.main(constants.dir);
             child.target_size.set_main(constants.dir, clamped);
             child.outer_target_size.set_main(

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -135,14 +135,12 @@ fn compute_node_layout(
     let has_known_height = known_dimensions.height.is_some();
     let cache_slot = if has_known_width && has_known_height {
         0
+    } else if has_known_width {
+        1 + (available_space.height == AvailableSpace::MinContent) as usize
+    } else if has_known_height {
+        1 + (available_space.width == AvailableSpace::MinContent) as usize
     } else {
-        if has_known_width {
-            1 + (available_space.height == AvailableSpace::MinContent) as usize
-        } else if has_known_height {
-            1 + (available_space.width == AvailableSpace::MinContent) as usize
-        } else {
-            3 + (available_space.width == AvailableSpace::MinContent) as usize
-        }
+        3 + (available_space.width == AvailableSpace::MinContent) as usize
     };
 
     // Cache result

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -143,7 +143,6 @@ fn compute_node_layout(
     computed_size
 }
 
-
 /// Return the cache slot to cache the current computed result in
 ///
 /// ## Caching Strategy
@@ -208,18 +207,20 @@ fn compute_from_cache(
                 return None;
             }
 
-            if (known_dimensions.width == entry.known_dimensions.width || known_dimensions.width == Some(entry.cached_size.width))
-                && (known_dimensions.height == entry.known_dimensions.height || known_dimensions.height == Some(entry.cached_size.height))
-                && (
-                  known_dimensions.width.is_some()
-                  || entry.available_space.width.is_roughly_equal(available_space.width)
-                  || (sizing_mode == SizingMode::ContentSize && available_space.width.is_definite() && available_space.width.unwrap() >= entry.cached_size.width)
-                )
-                && (
-                  known_dimensions.height.is_some()
-                  || entry.available_space.height.is_roughly_equal(available_space.height)
-                  || (sizing_mode == SizingMode::ContentSize && available_space.height.is_definite() && available_space.height.unwrap() >= entry.cached_size.height)
-                )
+            if (known_dimensions.width == entry.known_dimensions.width
+                || known_dimensions.width == Some(entry.cached_size.width))
+                && (known_dimensions.height == entry.known_dimensions.height
+                    || known_dimensions.height == Some(entry.cached_size.height))
+                && (known_dimensions.width.is_some()
+                    || entry.available_space.width.is_roughly_equal(available_space.width)
+                    || (sizing_mode == SizingMode::ContentSize
+                        && available_space.width.is_definite()
+                        && available_space.width.unwrap() >= entry.cached_size.width))
+                && (known_dimensions.height.is_some()
+                    || entry.available_space.height.is_roughly_equal(available_space.height)
+                    || (sizing_mode == SizingMode::ContentSize
+                        && available_space.height.is_definite()
+                        && available_space.height.unwrap() >= entry.cached_size.height))
             {
                 return Some(entry.cached_size);
             }

--- a/src/data.rs
+++ b/src/data.rs
@@ -5,6 +5,8 @@
 use crate::layout::{Cache, Layout};
 use crate::style::Style;
 
+pub(crate) const CACHE_SIZE: usize = 5;
+
 /// Layout information for a given [`Node`](crate::node::Node)
 ///
 /// Stored in a [`Taffy`].
@@ -18,14 +20,14 @@ pub(crate) struct NodeData {
     pub(crate) needs_measure: bool,
 
     /// The primary cached results of the layout computation
-    pub(crate) size_cache: [Option<Cache>; 4],
+    pub(crate) size_cache: [Option<Cache>; CACHE_SIZE],
 }
 
 impl NodeData {
     /// Create the data for a new node
     #[must_use]
     pub const fn new(style: Style) -> Self {
-        Self { style, size_cache: [None; 4], layout: Layout::new(), needs_measure: false }
+        Self { style, size_cache: [None; CACHE_SIZE], layout: Layout::new(), needs_measure: false }
     }
 
     /// Marks a node and all of its parents (recursively) as dirty
@@ -33,6 +35,6 @@ impl NodeData {
     /// This clears any cached data and signals that the data must be recomputed.
     #[inline]
     pub fn mark_dirty(&mut self) {
-        self.size_cache = [None; 4];
+        self.size_cache = [None; CACHE_SIZE];
     }
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -5,6 +5,7 @@
 use crate::layout::{Cache, Layout};
 use crate::style::Style;
 
+/// The number of cache entries for each node in the tree
 pub(crate) const CACHE_SIZE: usize = 5;
 
 /// Layout information for a given [`Node`](crate::node::Node)

--- a/test_fixtures/grid_min_content_flex_column.html
+++ b/test_fixtures/grid_min_content_flex_column.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+<head/>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-columns: min-content;grid-template-rows: 40px">
+  <div style="display: flex;flex-direction: column">
+    <div>HH&ZeroWidthSpace;HH</div>
+    <div>HH&ZeroWidthSpace;HH</div>
+    <div>HH&ZeroWidthSpace;HH</div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid_min_content_flex_row.html
+++ b/test_fixtures/grid_min_content_flex_row.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+<head/>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-columns: min-content;grid-template-rows: 40px">
+  <div style="display: flex;flex-direction: row">
+    <div>HH&ZeroWidthSpace;HH</div>
+    <div>HH&ZeroWidthSpace;HH</div>
+    <div>HH&ZeroWidthSpace;HH</div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/generated/grid_min_content_flex_column.rs
+++ b/tests/generated/grid_min_content_flex_column.rs
@@ -1,0 +1,84 @@
+#[test]
+fn grid_min_content_flex_column() {
+    use slotmap::Key;
+    #[allow(unused_imports)]
+    use taffy::{layout::Layout, prelude::*};
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
+        .new_leaf_with_measure(
+            taffy::style::Style { ..Default::default() },
+            taffy::node::MeasureFunc::Raw(|known_dimensions, available_space| {
+                const TEXT: &str = "HH\u{200b}HH";
+                super::measure_standard_text(known_dimensions, available_space, TEXT)
+            }),
+        )
+        .unwrap();
+    let node01 = taffy
+        .new_leaf_with_measure(
+            taffy::style::Style { ..Default::default() },
+            taffy::node::MeasureFunc::Raw(|known_dimensions, available_space| {
+                const TEXT: &str = "HH\u{200b}HH";
+                super::measure_standard_text(known_dimensions, available_space, TEXT)
+            }),
+        )
+        .unwrap();
+    let node02 = taffy
+        .new_leaf_with_measure(
+            taffy::style::Style { ..Default::default() },
+            taffy::node::MeasureFunc::Raw(|known_dimensions, available_space| {
+                const TEXT: &str = "HH\u{200b}HH";
+                super::measure_standard_text(known_dimensions, available_space, TEXT)
+            }),
+        )
+        .unwrap();
+    let node0 = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Flex,
+                flex_direction: taffy::style::FlexDirection::Column,
+                ..Default::default()
+            },
+            &[node00, node01, node02],
+        )
+        .unwrap();
+    let node = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Grid,
+                grid_template_rows: vec![points(40f32)],
+                grid_template_columns: vec![min_content()],
+                ..Default::default()
+            },
+            &[node0],
+        )
+        .unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
+    println!("\nComputed tree:");
+    taffy::debug::print_tree(&taffy, node);
+    println!();
+    let Layout { size, location, .. } = taffy.layout(node).unwrap();
+    assert_eq!(size.width, 20f32, "width of node {:?}. Expected {}. Actual {}", node.data(), 20f32, size.width);
+    assert_eq!(size.height, 40f32, "height of node {:?}. Expected {}. Actual {}", node.data(), 40f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node0).unwrap();
+    assert_eq!(size.width, 20f32, "width of node {:?}. Expected {}. Actual {}", node0.data(), 20f32, size.width);
+    assert_eq!(size.height, 40f32, "height of node {:?}. Expected {}. Actual {}", node0.data(), 40f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node00).unwrap();
+    assert_eq!(size.width, 20f32, "width of node {:?}. Expected {}. Actual {}", node00.data(), 20f32, size.width);
+    assert_eq!(size.height, 20f32, "height of node {:?}. Expected {}. Actual {}", node00.data(), 20f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node00.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node00.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node01).unwrap();
+    assert_eq!(size.width, 20f32, "width of node {:?}. Expected {}. Actual {}", node01.data(), 20f32, size.width);
+    assert_eq!(size.height, 20f32, "height of node {:?}. Expected {}. Actual {}", node01.data(), 20f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node01.data(), 0f32, location.x);
+    assert_eq!(location.y, 20f32, "y of node {:?}. Expected {}. Actual {}", node01.data(), 20f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node02).unwrap();
+    assert_eq!(size.width, 20f32, "width of node {:?}. Expected {}. Actual {}", node02.data(), 20f32, size.width);
+    assert_eq!(size.height, 20f32, "height of node {:?}. Expected {}. Actual {}", node02.data(), 20f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node02.data(), 0f32, location.x);
+    assert_eq!(location.y, 40f32, "y of node {:?}. Expected {}. Actual {}", node02.data(), 40f32, location.y);
+}

--- a/tests/generated/grid_min_content_flex_row.rs
+++ b/tests/generated/grid_min_content_flex_row.rs
@@ -1,0 +1,80 @@
+#[test]
+fn grid_min_content_flex_row() {
+    use slotmap::Key;
+    #[allow(unused_imports)]
+    use taffy::{layout::Layout, prelude::*};
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
+        .new_leaf_with_measure(
+            taffy::style::Style { ..Default::default() },
+            taffy::node::MeasureFunc::Raw(|known_dimensions, available_space| {
+                const TEXT: &str = "HH\u{200b}HH";
+                super::measure_standard_text(known_dimensions, available_space, TEXT)
+            }),
+        )
+        .unwrap();
+    let node01 = taffy
+        .new_leaf_with_measure(
+            taffy::style::Style { ..Default::default() },
+            taffy::node::MeasureFunc::Raw(|known_dimensions, available_space| {
+                const TEXT: &str = "HH\u{200b}HH";
+                super::measure_standard_text(known_dimensions, available_space, TEXT)
+            }),
+        )
+        .unwrap();
+    let node02 = taffy
+        .new_leaf_with_measure(
+            taffy::style::Style { ..Default::default() },
+            taffy::node::MeasureFunc::Raw(|known_dimensions, available_space| {
+                const TEXT: &str = "HH\u{200b}HH";
+                super::measure_standard_text(known_dimensions, available_space, TEXT)
+            }),
+        )
+        .unwrap();
+    let node0 = taffy
+        .new_with_children(
+            taffy::style::Style { display: taffy::style::Display::Flex, ..Default::default() },
+            &[node00, node01, node02],
+        )
+        .unwrap();
+    let node = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Grid,
+                grid_template_rows: vec![points(40f32)],
+                grid_template_columns: vec![min_content()],
+                ..Default::default()
+            },
+            &[node0],
+        )
+        .unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
+    println!("\nComputed tree:");
+    taffy::debug::print_tree(&taffy, node);
+    println!();
+    let Layout { size, location, .. } = taffy.layout(node).unwrap();
+    assert_eq!(size.width, 60f32, "width of node {:?}. Expected {}. Actual {}", node.data(), 60f32, size.width);
+    assert_eq!(size.height, 40f32, "height of node {:?}. Expected {}. Actual {}", node.data(), 40f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node0).unwrap();
+    assert_eq!(size.width, 60f32, "width of node {:?}. Expected {}. Actual {}", node0.data(), 60f32, size.width);
+    assert_eq!(size.height, 40f32, "height of node {:?}. Expected {}. Actual {}", node0.data(), 40f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node00).unwrap();
+    assert_eq!(size.width, 20f32, "width of node {:?}. Expected {}. Actual {}", node00.data(), 20f32, size.width);
+    assert_eq!(size.height, 40f32, "height of node {:?}. Expected {}. Actual {}", node00.data(), 40f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node00.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node00.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node01).unwrap();
+    assert_eq!(size.width, 20f32, "width of node {:?}. Expected {}. Actual {}", node01.data(), 20f32, size.width);
+    assert_eq!(size.height, 40f32, "height of node {:?}. Expected {}. Actual {}", node01.data(), 40f32, size.height);
+    assert_eq!(location.x, 20f32, "x of node {:?}. Expected {}. Actual {}", node01.data(), 20f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node01.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node02).unwrap();
+    assert_eq!(size.width, 20f32, "width of node {:?}. Expected {}. Actual {}", node02.data(), 20f32, size.width);
+    assert_eq!(size.height, 40f32, "height of node {:?}. Expected {}. Actual {}", node02.data(), 40f32, size.height);
+    assert_eq!(location.x, 40f32, "x of node {:?}. Expected {}. Actual {}", node02.data(), 40f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node02.data(), 0f32, location.y);
+}

--- a/tests/generated/mod.rs
+++ b/tests/generated/mod.rs
@@ -358,6 +358,10 @@ mod grid_max_content_single_item_margin_fixed;
 #[cfg(feature = "experimental_grid")]
 mod grid_max_content_single_item_margin_percent;
 #[cfg(feature = "experimental_grid")]
+mod grid_min_content_flex_column;
+#[cfg(feature = "experimental_grid")]
+mod grid_min_content_flex_row;
+#[cfg(feature = "experimental_grid")]
 mod grid_min_content_flex_single_item;
 #[cfg(feature = "experimental_grid")]
 mod grid_min_content_flex_single_item_margin_auto;

--- a/tests/measure.rs
+++ b/tests/measure.rs
@@ -68,10 +68,11 @@ mod measure {
 
         taffy.compute_layout(node, Size::MAX_CONTENT).unwrap();
 
+        // Parent
         assert_eq!(taffy.layout(node).unwrap().size.width, 50.0);
         assert_eq!(taffy.layout(node).unwrap().size.height, 100.0);
-
-        assert_eq!(taffy.layout(child).unwrap().size.width, 50.0);
+        // Child
+        assert_eq!(taffy.layout(child).unwrap().size.width, 100.0);
         assert_eq!(taffy.layout(child).unwrap().size.height, 100.0);
     }
 
@@ -105,10 +106,14 @@ mod measure {
             .unwrap();
         taffy.compute_layout(node, Size::MAX_CONTENT).unwrap();
 
+        assert_eq!(taffy.layout(node).unwrap().location.x, 0.0);
+        assert_eq!(taffy.layout(node).unwrap().location.y, 0.0);
         assert_eq!(taffy.layout(node).unwrap().size.width, 50.0);
         assert_eq!(taffy.layout(node).unwrap().size.height, 120.0);
 
-        assert_eq!(taffy.layout(child).unwrap().size.width, 30.0);
+        assert_eq!(taffy.layout(child).unwrap().location.x, 10.0);
+        assert_eq!(taffy.layout(child).unwrap().location.y, 10.0);
+        assert_eq!(taffy.layout(child).unwrap().size.width, 100.0);
         assert_eq!(taffy.layout(child).unwrap().size.height, 100.0);
     }
 
@@ -175,7 +180,7 @@ mod measure {
 
         taffy.compute_layout(node, Size::MAX_CONTENT).unwrap();
 
-        assert_eq!(taffy.layout(child1).unwrap().size.width, 50.0);
+        assert_eq!(taffy.layout(child1).unwrap().size.width, 100.0);
         assert_eq!(taffy.layout(child1).unwrap().size.height, 50.0);
     }
 
@@ -253,8 +258,8 @@ mod measure {
 
         taffy.compute_layout(node, Size::MAX_CONTENT).unwrap();
 
-        assert_eq!(taffy.layout(child1).unwrap().size.width, 50.0);
-        assert_eq!(taffy.layout(child1).unwrap().size.height, 100.0);
+        assert_eq!(taffy.layout(child1).unwrap().size.width, 100.0);
+        assert_eq!(taffy.layout(child1).unwrap().size.height, 200.0);
     }
 
     #[test]

--- a/tests/measure.rs
+++ b/tests/measure.rs
@@ -459,10 +459,6 @@ mod measure {
                 Style { ..Default::default() },
                 MeasureFunc::Raw(|known_dimensions, _available_space| {
                     NUM_MEASURES.fetch_add(1, Ordering::SeqCst);
-
-                    println!("\n{}", NUM_MEASURES.load(Ordering::SeqCst));
-                    dbg!(known_dimensions);
-                    dbg!(_available_space);
                     Size {
                         width: known_dimensions.width.unwrap_or(50.0),
                         height: known_dimensions.height.unwrap_or(50.0),

--- a/tests/measure.rs
+++ b/tests/measure.rs
@@ -444,16 +444,20 @@ mod measure {
 
     #[test]
     fn only_measure_once() {
-        use std::sync::atomic;
+        use std::sync::atomic::{AtomicU32, Ordering};
 
         let mut taffy = Taffy::new();
-        static NUM_MEASURES: atomic::AtomicU32 = atomic::AtomicU32::new(0);
+        static NUM_MEASURES: AtomicU32 = AtomicU32::new(0);
 
         let grandchild = taffy
             .new_leaf_with_measure(
                 Style { ..Default::default() },
                 MeasureFunc::Raw(|known_dimensions, _available_space| {
-                    NUM_MEASURES.fetch_add(1, atomic::Ordering::SeqCst);
+                    NUM_MEASURES.fetch_add(1, Ordering::SeqCst);
+
+                    println!("\n{}", NUM_MEASURES.load(Ordering::SeqCst));
+                    dbg!(known_dimensions);
+                    dbg!(_available_space);
                     Size {
                         width: known_dimensions.width.unwrap_or(50.0),
                         height: known_dimensions.height.unwrap_or(50.0),
@@ -467,6 +471,6 @@ mod measure {
         let node = taffy.new_with_children(Style { ..Default::default() }, &[child]).unwrap();
         taffy.compute_layout(node, Size::MAX_CONTENT).unwrap();
 
-        assert_eq!(NUM_MEASURES.load(atomic::Ordering::SeqCst), 1);
+        assert_eq!(NUM_MEASURES.load(Ordering::SeqCst), 2);
     }
 }


### PR DESCRIPTION
# Objective

Nesting a flexbox row inside a grid column with a min-content width was giving incorrect results.

## Context

This was discovered in testing Grid/Flexbox interaction, although I believe it was a pre-existing bug in the Flexbox implementation that was exposed by the Grid implementation implementing `min-content`.

## Changes made

- Compute flex children's "minimum size" according to the spec
- Updated cache implementation to avoid thrashing the cache with the new implementation (which happens because we now sometimes need to size a node under both a min-content and a max-content constraint). This bumps the cache size from 4 to 5. I think a similar change would be required for decent Grid perf anyway (we just haven't started measuring this yet).
- Added tests to cover failing cases.
- Updated measure.rs test values (these were incorrectly enforcing our previous buggy implementation - I've verified the new values against Chrome).
