### PR TITLE
Make CSS Grid feature a default feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,25 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --no-default-features --features alloc,grid
+
+  test-features-alloc-no-grod:
+    name: "Test Suite [Features: alloc (no grid)]"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
           args: --no-default-features --features alloc
 
-  test-features-default-with-grid:
-    name: "Test Suite [Features: default + experimental_grid]"
+  test-features-default-no-grid:
+    name: "Test Suite [Features: std (no grid)]"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -65,22 +80,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --features experimental_grid
-
-  test-features-alloc-with-grid:
-    name: "Test Suite [Features: alloc + experimental_grid]"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-default-features --features alloc,experimental_grid
+          args: --no-default-features --features std
 
   fmt:
     name: Rustfmt
@@ -112,7 +112,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --workspace --features experimental_grid -- -D warnings
+          args: --workspace -- -D warnings
 
   markdownlint:
     name: Markdown Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           command: test
           args: --no-default-features --features alloc,grid
 
-  test-features-alloc-no-grod:
+  test-features-alloc-no-grid:
     name: "Test Suite [Features: alloc (no grid)]"
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ grid = { version = "0.9.0", optional = true }
 
 [features]
 default = ["std"]
-experimental_grid = ["dep:grid"]
+grid = ["dep:grid"]
 alloc = []
 std = ["num-traits/std"]
 serde = ["dep:serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ slotmap = "1.0.6"
 grid = { version = "0.9.0", optional = true }
 
 [features]
-default = ["std"]
+default = ["std", "grid"]
 grid = ["dep:grid"]
 alloc = []
 std = ["num-traits/std"]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Currently Taffy implements only CSS based layout algorithms:
 
 - The stable `0.2.x` releases of Taffy implements the [flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/) layout algorithm.
-- Support for [CSS Grid](https://css-tricks.com/snippets/css/complete-guide-grid/) is in preview. If you wish to try this out then you should use the `0.3.x` alpha releases and enable the `experimental_grid` cargo feature. For information, see the [release notes](https://github.com/DioxusLabs/taffy/blob/main/RELEASES.md) and the [tracking issue](https://github.com/DioxusLabs/taffy/issues/204). Experimentation with the CSS Grid implementation is encouraged, and feedback and bug reports are welcomed.
+- Support for [CSS Grid](https://css-tricks.com/snippets/css/complete-guide-grid/) is in preview. If you wish to try this out then you should use the `0.3.x` alpha releases <del>and enable the `experimental_grid` cargo feature</del> (from `0.3.0-alpha2` the CSS Grid feature is enabled by default). For information, see the [release notes](https://github.com/DioxusLabs/taffy/blob/main/RELEASES.md) and the [tracking issue](https://github.com/DioxusLabs/taffy/issues/204). Experimentation with the CSS Grid implementation is encouraged, and feedback and bug reports are welcomed.
 
 Support for other paradigms [is planned](https://github.com/DioxusLabs/taffy/issues/28).
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Currently Taffy implements only CSS based layout algorithms:
 
 - The stable `0.2.x` releases of Taffy implements the [flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/) layout algorithm.
-- Support for [CSS Grid](https://css-tricks.com/snippets/css/complete-guide-grid/) is in preview. If you wish to try this out then you should use the `0.3.x` alpha releases <del>and enable the `experimental_grid` cargo feature</del> (from `0.3.0-alpha2` the CSS Grid feature is enabled by default). For information, see the [release notes](https://github.com/DioxusLabs/taffy/blob/main/RELEASES.md) and the [tracking issue](https://github.com/DioxusLabs/taffy/issues/204). Experimentation with the CSS Grid implementation is encouraged, and feedback and bug reports are welcomed.
+- Support for [CSS Grid](https://css-tricks.com/snippets/css/complete-guide-grid/) is in preview. If you wish to try this out then you should use the `0.3.x` alpha releases ~and enable the `experimental_grid` cargo feature~ (from `0.3.0-alpha2` the CSS Grid feature is enabled by default). For information, see the [release notes](https://github.com/DioxusLabs/taffy/blob/main/RELEASES.md) and the [tracking issue](https://github.com/DioxusLabs/taffy/issues/204). Experimentation with the CSS Grid implementation is encouraged, and feedback and bug reports are welcomed.
 
 Support for other paradigms [is planned](https://github.com/DioxusLabs/taffy/issues/28).
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -21,7 +21,7 @@
 
 This is the first in a series of planned alpha releases to allow users of Taffy to try out the new CSS Grid layout mode in advance of a stable release. We hope that by marking this is alpha release we are clearly communicating that this a pre-release and that the implementation is not yet of production quality. But we never-the-less encourage you to try it out. Feedback is welcome, and bug reports for the Grid implementation are being accepted as of this release.
 
-<del>**Note: CSS Grid support must be enabled using the `experimental_grid` feature. For the time being this feature is not enabled by default.**</del> From `0.3.0-alpha2`, the CSS Grid feature is now enabled by default.
+~**Note: CSS Grid support must be enabled using the `experimental_grid` feature. For the time being this feature is not enabled by default.**~ From `0.3.0-alpha2`, the CSS Grid feature is now enabled by default.
 
 ### New Feature: CSS Grid (Experimental)
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,11 @@
 
 ## 0.3.0-alpha2 (unreleased)
 
+### Changed
+
+- `experimental_grid` feature named to just `grid`
+- `grid` feature enabled by default
+
 ### Fixes
 
 - Flexbox nodes sized under a min-content constraint now size correctly (#291)
@@ -16,7 +21,7 @@
 
 This is the first in a series of planned alpha releases to allow users of Taffy to try out the new CSS Grid layout mode in advance of a stable release. We hope that by marking this is alpha release we are clearly communicating that this a pre-release and that the implementation is not yet of production quality. But we never-the-less encourage you to try it out. Feedback is welcome, and bug reports for the Grid implementation are being accepted as of this release.
 
-**Note: CSS Grid support must be enabled using the `experimental_grid` feature. For the time being this feature is not enabled by default.**
+<del>**Note: CSS Grid support must be enabled using the `experimental_grid` feature. For the time being this feature is not enabled by default.**</del> From `0.3.0-alpha2`, the CSS Grid feature is now enabled by default.
 
 ### New Feature: CSS Grid (Experimental)
 
@@ -90,7 +95,7 @@ The following properties and features are not supported, and there are no immedi
 See [examples/grid_holy_grail.rs](https://github.com/DioxusLabs/taffy/blob/main/examples/grid_holy_grail.rs) for an example using Taffy to implement the so-called [Holy Grail Layout](https://en.wikipedia.org/wiki/Holy_grail_(web_design)). If you want to run this example, the don't forget the enable the CSS Grid cargo feature:
 
 ```bash
-cargo run --example grid_holy_grail --features experimental_grid
+cargo run --example grid_holy_grail --features grid
 ```
 
 ### New Feature: Style Helpers

--- a/benches/generated/mod.rs
+++ b/benches/generated/mod.rs
@@ -184,209 +184,209 @@ mod gap_row_gap_align_items_stretch;
 mod gap_row_gap_column_child_margins;
 mod gap_row_gap_determines_parent_height;
 mod gap_row_gap_row_wrap_child_margins;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_align_self_sized_all;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_column_end;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_column_start;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_container_bottom_left;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_container_bottom_left_margin;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_container_left_overrides_right;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_container_left_right;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_container_left_right_margin;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_container_negative_position;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_container_negative_position_margin;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_container_top_bottom;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_container_top_bottom_margin;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_container_top_right;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_container_top_right_margin;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_justify_self_sized_all;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_row_end;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_row_start;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_top_overrides_bottom;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_with_padding;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_with_padding_and_margin;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_align_content_center;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_align_content_end;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_align_content_end_with_padding_border;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_align_content_space_around;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_align_content_space_around_with_padding_border;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_align_content_space_between;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_align_content_space_between_with_padding_border;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_align_content_space_evenly;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_align_content_space_evenly_with_padding_border;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_align_content_start;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_align_content_start_with_padding_border;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_align_items_sized_center;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_align_items_sized_end;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_align_items_sized_start;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_align_items_sized_stretch;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_align_self_sized_all;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_auto_columns_fixed_width;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_auto_fill_fixed_size;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_auto_fill_with_empty_auto_track;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_auto_fit_with_empty_auto_track;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_auto_single_item;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_auto_single_item_fixed_width;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_auto_single_item_fixed_width_with_definite_width;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_basic;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_basic_implicit_tracks;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_basic_with_overflow;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_basic_with_padding;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_fit_content_points_argument;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_fit_content_points_max_content;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_fit_content_points_min_content;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_fr_auto_no_sized_items;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_fr_auto_single_item;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_fr_fixed_size_no_content;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_fr_fixed_size_single_item;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_gap;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_hidden;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_justify_content_center;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_justify_content_center_with_padding_border;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_justify_content_end;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_justify_content_end_with_padding_border;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_justify_content_space_around;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_justify_content_space_around_with_padding_border;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_justify_content_space_between;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_justify_content_space_between_with_padding_border;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_justify_content_space_evenly;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_justify_content_space_evenly_with_padding_border;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_justify_content_start;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_justify_content_start_with_padding_border;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_justify_items_sized_center;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_justify_items_sized_end;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_justify_items_sized_start;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_justify_items_sized_stretch;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_justify_self_sized_all;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_margins_auto_margins;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_margins_auto_margins_override_stretch;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_margins_fixed_center;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_margins_fixed_end;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_margins_fixed_start;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_margins_fixed_stretch;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_margins_percent_center;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_margins_percent_end;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_margins_percent_start;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_margins_percent_stretch;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_max_content_maximum_single_item;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_max_content_single_item;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_max_content_single_item_margin_auto;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_max_content_single_item_margin_fixed;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_max_content_single_item_margin_percent;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_min_content_flex_column;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_min_content_flex_row;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_min_content_flex_single_item;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_min_content_flex_single_item_margin_auto;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_min_content_flex_single_item_margin_fixed;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_min_content_flex_single_item_margin_percent;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_min_content_maximum_single_item;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_min_content_single_item;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_min_max_column_auto;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_min_max_column_fixed_width_above_range;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_min_max_column_fixed_width_below_range;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_min_max_column_fixed_width_within_range;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_out_of_order_items;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_size_child_fixed_tracks;
 mod justify_content_column_center;
 mod justify_content_column_flex_end;
@@ -682,209 +682,209 @@ fn benchmark(c: &mut Criterion) {
             gap_row_gap_column_child_margins::compute();
             gap_row_gap_determines_parent_height::compute();
             gap_row_gap_row_wrap_child_margins::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_absolute_align_self_sized_all::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_absolute_column_end::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_absolute_column_start::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_absolute_container_bottom_left::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_absolute_container_bottom_left_margin::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_absolute_container_left_overrides_right::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_absolute_container_left_right::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_absolute_container_left_right_margin::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_absolute_container_negative_position::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_absolute_container_negative_position_margin::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_absolute_container_top_bottom::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_absolute_container_top_bottom_margin::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_absolute_container_top_right::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_absolute_container_top_right_margin::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_absolute_justify_self_sized_all::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_absolute_row_end::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_absolute_row_start::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_absolute_top_overrides_bottom::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_absolute_with_padding::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_absolute_with_padding_and_margin::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_align_content_center::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_align_content_end::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_align_content_end_with_padding_border::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_align_content_space_around::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_align_content_space_around_with_padding_border::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_align_content_space_between::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_align_content_space_between_with_padding_border::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_align_content_space_evenly::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_align_content_space_evenly_with_padding_border::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_align_content_start::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_align_content_start_with_padding_border::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_align_items_sized_center::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_align_items_sized_end::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_align_items_sized_start::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_align_items_sized_stretch::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_align_self_sized_all::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_auto_columns_fixed_width::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_auto_fill_fixed_size::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_auto_fill_with_empty_auto_track::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_auto_fit_with_empty_auto_track::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_auto_single_item::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_auto_single_item_fixed_width::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_auto_single_item_fixed_width_with_definite_width::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_basic::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_basic_implicit_tracks::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_basic_with_overflow::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_basic_with_padding::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_fit_content_points_argument::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_fit_content_points_max_content::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_fit_content_points_min_content::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_fr_auto_no_sized_items::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_fr_auto_single_item::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_fr_fixed_size_no_content::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_fr_fixed_size_single_item::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_gap::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_hidden::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_justify_content_center::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_justify_content_center_with_padding_border::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_justify_content_end::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_justify_content_end_with_padding_border::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_justify_content_space_around::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_justify_content_space_around_with_padding_border::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_justify_content_space_between::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_justify_content_space_between_with_padding_border::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_justify_content_space_evenly::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_justify_content_space_evenly_with_padding_border::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_justify_content_start::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_justify_content_start_with_padding_border::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_justify_items_sized_center::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_justify_items_sized_end::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_justify_items_sized_start::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_justify_items_sized_stretch::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_justify_self_sized_all::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_margins_auto_margins::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_margins_auto_margins_override_stretch::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_margins_fixed_center::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_margins_fixed_end::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_margins_fixed_start::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_margins_fixed_stretch::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_margins_percent_center::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_margins_percent_end::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_margins_percent_start::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_margins_percent_stretch::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_max_content_maximum_single_item::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_max_content_single_item::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_max_content_single_item_margin_auto::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_max_content_single_item_margin_fixed::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_max_content_single_item_margin_percent::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_min_content_flex_column::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_min_content_flex_row::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_min_content_flex_single_item::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_min_content_flex_single_item_margin_auto::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_min_content_flex_single_item_margin_fixed::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_min_content_flex_single_item_margin_percent::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_min_content_maximum_single_item::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_min_content_single_item::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_min_max_column_auto::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_min_max_column_fixed_width_above_range::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_min_max_column_fixed_width_below_range::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_min_max_column_fixed_width_within_range::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_out_of_order_items::compute();
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_size_child_fixed_tracks::compute();
             justify_content_column_center::compute();
             justify_content_column_flex_end::compute();

--- a/examples/grid_holy_grail.rs
+++ b/examples/grid_holy_grail.rs
@@ -1,21 +1,21 @@
 // This creates a so-called "holy grail" layout using the CSS Grid layout algorithm
 // See: https://en.wikipedia.org/wiki/Holy_grail_(web_design)
 
-// NOTE: This example requires the `experimental_grid` feature flag to be enabled.
+// NOTE: This example requires the `grid` feature flag to be enabled.
 
-#[cfg(not(feature = "experimental_grid"))]
+#[cfg(not(feature = "grid"))]
 fn main() {
-    println!("Error: this example requires the 'experimental_grid' feature to be enabled");
+    println!("Error: this example requires the 'grid' feature to be enabled");
     println!("Try:");
-    println!("    cargo run --example grid_holy_grail --features experimental_grid")
+    println!("    cargo run --example grid_holy_grail --features grid")
 }
 
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 fn default<T: Default>() -> T {
     Default::default()
 }
 
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 fn main() -> Result<(), taffy::error::TaffyError> {
     use taffy::prelude::*;
 

--- a/scripts/gentest/src/main.rs
+++ b/scripts/gentest/src/main.rs
@@ -82,7 +82,7 @@ async fn main() {
         .map(|(name, _)| {
             let bench_mod = Ident::new(name, Span::call_site());
             if name.starts_with("grid") {
-                quote!(#[cfg(feature = "experimental_grid")] #bench_mod::compute())
+                quote!(#[cfg(feature = "grid")] #bench_mod::compute())
             } else {
                 quote!(#bench_mod::compute())
             }
@@ -94,7 +94,7 @@ async fn main() {
         .map(|(name, _)| {
             let name_ident = Ident::new(name, Span::call_site());
             if name.starts_with("grid") {
-                quote!(#[cfg(feature = "experimental_grid")] mod #name_ident;)
+                quote!(#[cfg(feature = "grid")] mod #name_ident;)
             } else {
                 quote!(mod #name_ident;)
             }

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -4,7 +4,7 @@ pub(crate) mod common;
 pub(crate) mod flexbox;
 pub(crate) mod leaf;
 
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 pub(crate) mod grid;
 
 use crate::data::CACHE_SIZE;
@@ -120,7 +120,7 @@ fn compute_node_layout(
                 NODE_LOGGER.log("Algo: flexbox");
                 self::flexbox::compute(tree, node, known_dimensions, available_space, run_mode)
             }
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             Display::Grid => self::grid::compute(tree, node, available_space),
             Display::None => {
                 #[cfg(feature = "debug")]

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -22,7 +22,7 @@ fn print_node(tree: &impl LayoutTree, node: Node, has_sibling: bool, lines_strin
         (_, style::Display::None) => "NONE",
         (0, _) => "LEAF",
         (_, style::Display::Flex) => "FLEX",
-        #[cfg(feature = "experimental_grid")]
+        #[cfg(feature = "grid")]
         (_, style::Display::Grid) => "GRID",
     };
 

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -3,7 +3,7 @@
 use crate::style::{Dimension, FlexDirection};
 use core::ops::Add;
 
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 use crate::axis::AbstractAxis;
 
 /// An axis-aligned UI rectangle
@@ -332,7 +332,7 @@ impl<T> Size<T> {
 
     /// Gets the extent of the specified layout axis
     /// Whether this is the width or height depends on the `GridAxis` provided
-    #[cfg(feature = "experimental_grid")]
+    #[cfg(feature = "grid")]
     pub(crate) fn get(self, axis: AbstractAxis) -> T {
         match axis {
             AbstractAxis::Inline => self.width,
@@ -342,7 +342,7 @@ impl<T> Size<T> {
 
     /// Sets the extent of the specified layout axis
     /// Whether this is the width or height depends on the `GridAxis` provided
-    #[cfg(feature = "experimental_grid")]
+    #[cfg(feature = "grid")]
     pub(crate) fn set(&mut self, axis: AbstractAxis, value: T) {
         match axis {
             AbstractAxis::Inline => self.width = value,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ pub mod style;
 pub mod style_helpers;
 pub mod tree;
 
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod axis;
 #[cfg(feature = "random")]
 pub mod randomizable;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -16,10 +16,10 @@ pub use crate::{
     tree::LayoutTree,
 };
 
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 pub use crate::style::{
     GridAutoFlow, GridPlacement, GridTrackRepetition, MaxTrackSizingFunction, MinTrackSizingFunction,
     NonRepeatedTrackSizingFunction, TrackSizingFunction,
 };
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 pub use crate::style_helpers::{line, repeat, span, TaffyGridLine, TaffyGridSpan};

--- a/src/style/dimension.rs
+++ b/src/style/dimension.rs
@@ -141,7 +141,7 @@ impl Dimension {
     }
 
     /// Get Points value if value is Points variant
-    #[cfg(feature = "experimental_grid")]
+    #[cfg(feature = "grid")]
     pub(crate) fn into_option(self) -> Option<f32> {
         match self {
             Dimension::Points(value) => Some(value),

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -7,18 +7,18 @@ pub use self::alignment::{AlignContent, AlignItems, AlignSelf, JustifyContent, J
 pub use self::dimension::{AvailableSpace, Dimension, LengthPercentage, LengthPercentageAuto};
 pub use self::flex::{FlexDirection, FlexWrap};
 
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 pub use self::grid::{
     GridAutoFlow, GridPlacement, GridTrackRepetition, MaxTrackSizingFunction, MinTrackSizingFunction,
     NonRepeatedTrackSizingFunction, TrackSizingFunction,
 };
 use crate::geometry::{Rect, Size};
 
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 use crate::geometry::Line;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 use crate::sys::GridTrackVec;
 
 /// Sets the layout used for the children of this node
@@ -30,7 +30,7 @@ pub enum Display {
     /// The children will follow the flexbox layout algorithm
     Flex,
     /// The children will follow the CSS Grid layout algorithm
-    #[cfg(feature = "experimental_grid")]
+    #[cfg(feature = "grid")]
     Grid,
     /// The children will not be laid out, and will follow absolute positioning
     None,
@@ -125,7 +125,7 @@ pub struct Style {
     /// Falls back to the parents [`AlignItems`] if not set
     pub align_self: Option<AlignSelf>,
     /// How this node's children should be aligned in the inline axis
-    #[cfg(feature = "experimental_grid")]
+    #[cfg(feature = "grid")]
     pub justify_items: Option<AlignItems>,
     /// How this node should be aligned in the inline axis
     /// Falls back to the parents [`JustifyItems`] if not set
@@ -155,27 +155,27 @@ pub struct Style {
 
     // Grid container properies
     /// Defines the track sizing functions (widths) of the grid rows
-    #[cfg(feature = "experimental_grid")]
+    #[cfg(feature = "grid")]
     pub grid_template_rows: GridTrackVec<TrackSizingFunction>,
     /// Defines the track sizing functions (heights) of the grid columns
-    #[cfg(feature = "experimental_grid")]
+    #[cfg(feature = "grid")]
     pub grid_template_columns: GridTrackVec<TrackSizingFunction>,
     /// Defines the size of implicitly created rows
-    #[cfg(feature = "experimental_grid")]
+    #[cfg(feature = "grid")]
     pub grid_auto_rows: GridTrackVec<NonRepeatedTrackSizingFunction>,
     /// Defined the size of implicitly created columns
-    #[cfg(feature = "experimental_grid")]
+    #[cfg(feature = "grid")]
     pub grid_auto_columns: GridTrackVec<NonRepeatedTrackSizingFunction>,
     /// Controls how items get placed into the grid for auto-placed items
-    #[cfg(feature = "experimental_grid")]
+    #[cfg(feature = "grid")]
     pub grid_auto_flow: GridAutoFlow,
 
     // Grid child properties
     /// Defines which row in the grid the item should start and end at
-    #[cfg(feature = "experimental_grid")]
+    #[cfg(feature = "grid")]
     pub grid_row: Line<GridPlacement>,
     /// Defines which column in the grid the item should start and end at
-    #[cfg(feature = "experimental_grid")]
+    #[cfg(feature = "grid")]
     pub grid_column: Line<GridPlacement>,
 }
 
@@ -188,7 +188,7 @@ impl Style {
         flex_wrap: FlexWrap::NoWrap,
         align_items: None,
         align_self: None,
-        #[cfg(feature = "experimental_grid")]
+        #[cfg(feature = "grid")]
         justify_items: None,
         justify_self: None,
         align_content: None,
@@ -205,19 +205,19 @@ impl Style {
         min_size: Size::auto(),
         max_size: Size::auto(),
         aspect_ratio: None,
-        #[cfg(feature = "experimental_grid")]
+        #[cfg(feature = "grid")]
         grid_template_rows: GridTrackVec::new(),
-        #[cfg(feature = "experimental_grid")]
+        #[cfg(feature = "grid")]
         grid_template_columns: GridTrackVec::new(),
-        #[cfg(feature = "experimental_grid")]
+        #[cfg(feature = "grid")]
         grid_auto_rows: GridTrackVec::new(),
-        #[cfg(feature = "experimental_grid")]
+        #[cfg(feature = "grid")]
         grid_auto_columns: GridTrackVec::new(),
-        #[cfg(feature = "experimental_grid")]
+        #[cfg(feature = "grid")]
         grid_auto_flow: GridAutoFlow::Row,
-        #[cfg(feature = "experimental_grid")]
+        #[cfg(feature = "grid")]
         grid_row: Line { start: GridPlacement::Auto, end: GridPlacement::Auto },
-        #[cfg(feature = "experimental_grid")]
+        #[cfg(feature = "grid")]
         grid_column: Line { start: GridPlacement::Auto, end: GridPlacement::Auto },
     };
 }
@@ -235,7 +235,7 @@ mod tests {
 
     #[test]
     fn defaults_match() {
-        #[cfg(feature = "experimental_grid")]
+        #[cfg(feature = "grid")]
         use super::GridPlacement;
 
         let old_defaults = Style {
@@ -245,7 +245,7 @@ mod tests {
             flex_wrap: Default::default(),
             align_items: Default::default(),
             align_self: Default::default(),
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             justify_items: Default::default(),
             justify_self: Default::default(),
             align_content: Default::default(),
@@ -262,19 +262,19 @@ mod tests {
             min_size: Size::auto(),
             max_size: Size::auto(),
             aspect_ratio: Default::default(),
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_template_rows: Default::default(),
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_template_columns: Default::default(),
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_auto_rows: Default::default(),
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_auto_columns: Default::default(),
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_auto_flow: Default::default(),
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_row: Line { start: GridPlacement::Auto, end: GridPlacement::Auto },
-            #[cfg(feature = "experimental_grid")]
+            #[cfg(feature = "grid")]
             grid_column: Line { start: GridPlacement::Auto, end: GridPlacement::Auto },
         };
 

--- a/src/style_helpers.rs
+++ b/src/style_helpers.rs
@@ -4,11 +4,11 @@ use crate::{
     style::LengthPercentage,
 };
 
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 use crate::style::{GridTrackRepetition, NonRepeatedTrackSizingFunction, TrackSizingFunction};
 
 /// Returns an auto-repeated track definition
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 pub fn repeat(
     repetition_kind: GridTrackRepetition,
     track_list: Vec<NonRepeatedTrackSizingFunction>,

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -13,13 +13,13 @@ pub(crate) use self::alloc::*;
 pub(crate) use self::core::*;
 
 /// Returns the largest of two f32 values
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 pub(crate) fn f32_max(a: f32, b: f32) -> f32 {
     core::cmp::max_by(a, b, |a, b| a.total_cmp(b))
 }
 
 /// Returns the smallest of two f32 values
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 pub(crate) fn f32_min(a: f32, b: f32) -> f32 {
     core::cmp::min_by(a, b, |a, b| a.total_cmp(b))
 }
@@ -34,7 +34,7 @@ mod std {
     /// A vector of child nodes
     pub(crate) type ChildrenVec<A> = std::vec::Vec<A>;
     /// A vector of grid tracks
-    #[cfg(feature = "experimental_grid")]
+    #[cfg(feature = "grid")]
     pub(crate) type GridTrackVec<A> = std::vec::Vec<A>;
 
     /// Creates a new vector with the capacity for the specified number of items before it must be resized

--- a/tests/generated/mod.rs
+++ b/tests/generated/mod.rs
@@ -183,209 +183,209 @@ mod gap_row_gap_align_items_stretch;
 mod gap_row_gap_column_child_margins;
 mod gap_row_gap_determines_parent_height;
 mod gap_row_gap_row_wrap_child_margins;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_align_self_sized_all;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_column_end;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_column_start;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_container_bottom_left;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_container_bottom_left_margin;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_container_left_overrides_right;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_container_left_right;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_container_left_right_margin;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_container_negative_position;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_container_negative_position_margin;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_container_top_bottom;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_container_top_bottom_margin;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_container_top_right;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_container_top_right_margin;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_justify_self_sized_all;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_row_end;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_row_start;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_top_overrides_bottom;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_with_padding;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_absolute_with_padding_and_margin;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_align_content_center;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_align_content_end;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_align_content_end_with_padding_border;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_align_content_space_around;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_align_content_space_around_with_padding_border;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_align_content_space_between;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_align_content_space_between_with_padding_border;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_align_content_space_evenly;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_align_content_space_evenly_with_padding_border;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_align_content_start;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_align_content_start_with_padding_border;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_align_items_sized_center;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_align_items_sized_end;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_align_items_sized_start;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_align_items_sized_stretch;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_align_self_sized_all;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_auto_columns_fixed_width;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_auto_fill_fixed_size;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_auto_fill_with_empty_auto_track;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_auto_fit_with_empty_auto_track;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_auto_single_item;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_auto_single_item_fixed_width;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_auto_single_item_fixed_width_with_definite_width;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_basic;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_basic_implicit_tracks;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_basic_with_overflow;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_basic_with_padding;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_fit_content_points_argument;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_fit_content_points_max_content;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_fit_content_points_min_content;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_fr_auto_no_sized_items;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_fr_auto_single_item;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_fr_fixed_size_no_content;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_fr_fixed_size_single_item;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_gap;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_hidden;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_justify_content_center;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_justify_content_center_with_padding_border;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_justify_content_end;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_justify_content_end_with_padding_border;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_justify_content_space_around;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_justify_content_space_around_with_padding_border;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_justify_content_space_between;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_justify_content_space_between_with_padding_border;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_justify_content_space_evenly;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_justify_content_space_evenly_with_padding_border;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_justify_content_start;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_justify_content_start_with_padding_border;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_justify_items_sized_center;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_justify_items_sized_end;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_justify_items_sized_start;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_justify_items_sized_stretch;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_justify_self_sized_all;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_margins_auto_margins;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_margins_auto_margins_override_stretch;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_margins_fixed_center;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_margins_fixed_end;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_margins_fixed_start;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_margins_fixed_stretch;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_margins_percent_center;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_margins_percent_end;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_margins_percent_start;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_margins_percent_stretch;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_max_content_maximum_single_item;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_max_content_single_item;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_max_content_single_item_margin_auto;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_max_content_single_item_margin_fixed;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_max_content_single_item_margin_percent;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_min_content_flex_column;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_min_content_flex_row;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_min_content_flex_single_item;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_min_content_flex_single_item_margin_auto;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_min_content_flex_single_item_margin_fixed;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_min_content_flex_single_item_margin_percent;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_min_content_maximum_single_item;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_min_content_single_item;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_min_max_column_auto;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_min_max_column_fixed_width_above_range;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_min_max_column_fixed_width_below_range;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_min_max_column_fixed_width_within_range;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_out_of_order_items;
-#[cfg(feature = "experimental_grid")]
+#[cfg(feature = "grid")]
 mod grid_size_child_fixed_tracks;
 mod justify_content_column_center;
 mod justify_content_column_flex_end;


### PR DESCRIPTION
# Objective

Without this, development becomes difficult as development tools (from Rust Analyzer to cargo test) won't see modules by default. We don't intend to publish a new stable release until grid support is tested and ready anyway.