### PR TITLE
Add style size test + update style-properties.md with sizes

### DIFF
--- a/docs/style-properties.md
+++ b/docs/style-properties.md
@@ -9,7 +9,7 @@ N = Supported in spec but not implemented in Taffy
 | Property                 | Flex | Grid | Type                                  | Stack | Heap   | Description                                                                                 |
 | ---                      | ---  | ---  | ---                                   | ---   | -      | ---                                                                                         |
 | **Layout Mode**          |      |      |                                       |       |        |                                                                                             |
-| `display`                | Y    | Y    | Display                               | 1     | -      | What layout strategy should be used?                                                        |
+| `display`                | Y    | Y    | `Display`                             | 1     | -      | What layout strategy should be used?                                                        |
 | **Position**             |      |      |                                       |       | -      |                                                                                             |
 | `position`               | Y    | Y    | `Position`                            | 1     | -      | Absolute vs. in-flow position                                                               |
 | `inset`                  | Y    | Y    | `Rect<LengthPercentageAuto>`          | 32    | -      | How should the position of this element be tweaked relative to the layout defined?          |

--- a/docs/style-properties.md
+++ b/docs/style-properties.md
@@ -6,48 +6,44 @@ N = Supported in spec but not implemented in Taffy
 \- = Not applicable to layout mode
 1-5 = Priorities for a phased implementation of CSS Grid
 
-| Property                 | Flex | Grid | Description                                                                                 |
-| ---                      | ---  | ---  | ---                                                                                         |
-| **Layout Mode**          |      |      |                                                                                             |
-| `display`                | Y    | Y    | What layout strategy should be used?                                                        |
-| **Position**             |      |      |                                                                                             |
-| `position_type`          | Y    | 2    | Absolute vs. in-flow position                                                               |
-| `position`               | Y    | 2    | How should the position of this element be tweaked relative to the layout defined?          |
-| **Item size**            |      |      |                                                                                             |
-| `size`                   | Y    | Y    | The nominal height and width of item                                                        |
-| `min_size`               | Y    | Y    | The minimum height and width of the item                                                    |
-| `max_size`               | Y    | Y    | The maximum height and width of the item                                                    |
-| `aspect_ratio`           | Y    | 3    | The preferred aspect ratio (calculated as width divided by height)                          |
-| **Item spacing**         |      |      |                                                                                             |
-| `padding`                | Y    | ~Y   | How large should the padding be on each side?                                               |
-| `border`                 | Y    | ~Y   | How large should the border be on each side?                                                |
-| `margin`                 | Y    | ~Y   | How large should the margin be on each side?                                                |
-| `gap`                    | Y    | Y    | The size of the vertical and horizontal gaps between flex items / grid rows                 |
-| **Alignment**            |      |      |                                                                                             |
-| `align_items`            | Y    | Y    | How should items be aligned relative to the cross axis?                                     |
-| `align_self`             | Y    | Y    | Should this item violate the cross axis alignment specified by its parent's [`AlignItems`]? |
-| `align_content`          | Y    | Y    | How should content contained within this item be aligned relative to the cross axis?        |
-| `justify_items`          | -    | Y    | How should items be aligned relative to the main axis?                                      |
-| `justify_self`           | -    | Y    | Should this item violate the main axis alignment specified by its parent's [`AlignItems`]?  |
-| `justify_content`        | Y    | Y    | How should content contained within this item be aligned relative to the main axis?         |
-| **Flexbox**              |      |      |                                                                                             |
-| `flex_direction`         | Y    | -    | Which direction does the main axis flow in?                                                 |
-| `flex_wrap`              | Y    | -    | Should elements wrap, or stay in a single line?                                             |
-| `flex_basis`             | Y    | -    | Sets the initial main axis size of the item                                                 |
-| `flex_grow`              | Y    | -    | The relative rate at which this item grows when it is expanding to fill space               |
-| `flex_shrink`            | Y    | -    | The relative rate at which this item shrinks when it is contracting to fit into space       |
-| **CSS Grid (Container)** |      |      |                                                                                             |
-| `grid-template-columns`  | -    | Y    | The track sizing functions of the grid's explicit columns                                   |
-| `grid-template-rows`     | -    | Y    | The track sizing functions of the grid's explicit rows                                      |
-| `grid-template-areas`    | -    | 5    | Defines named grid areas                                                                    |
-| `grid-auto-rows`         | -    | Y    | Track sizing functions for the grid's implicitly generated rows                             |
-| `grid-auto-columns`      | -    | Y    | Track sizing functions for the grid's implicitly generated columns                          |
-| `grid-auto-flow`         | -    | Y    | Whether auto-placed items are placed row-wise or column-wise. And sparsely or densely.      |
-| **CSS Grid (Child)**     |      |      |                                                                                             |
-| `grid-row-start`         | -    | Y    | The (row) grid line the item starts at (or a span)                                          |
-| `grid-row-end`           | -    | Y    | The (row) grid line the item ends at (or a span)                                            |
-| `grid-column-start`      | -    | Y    | The (column) grid line the item starts at (or a span)                                       |
-| `grid-column-end`        | -    | Y    | The (column) grid line the item end at (or a span)                                          |
-| `grid-column`            | -    | 4    | Shorthand for grid-column-start/grid-column-end                                             |
-| `grid-row`               | -    | 4    | Shorthand for grid-row-start/grid-row-end                                                   |
-| `grid-area`              | -    | 5    | Accepts either shorthand row/column-start/end or a named grid area                          |
+| Property                 | Flex | Grid | Type                                  | Stack | Heap   | Description                                                                                 |
+| ---                      | ---  | ---  | ---                                   | ---   | -      | ---                                                                                         |
+| **Layout Mode**          |      |      |                                       |       |        |                                                                                             |
+| `display`                | Y    | Y    | Display                               | 1     | -      | What layout strategy should be used?                                                        |
+| **Position**             |      |      |                                       |       | -      |                                                                                             |
+| `position`               | Y    | Y    | `Position`                            | 1     | -      | Absolute vs. in-flow position                                                               |
+| `inset`                  | Y    | Y    | `Rect<LengthPercentageAuto>`          | 32    | -      | How should the position of this element be tweaked relative to the layout defined?          |
+| **Item size**            |      |      |                                       |       |        |                                                                                             |
+| `size`                   | Y    | Y    | `Size<Dimension>`                     | 16    | -      | The nominal height and width of item                                                        |
+| `min_size`               | Y    | Y    | `Size<Dimension>`                     | 16    | -      | The minimum height and width of the item                                                    |
+| `max_size`               | Y    | Y    | `Size<Dimension>`                     | 16    | -      | The maximum height and width of the item                                                    |
+| `aspect_ratio`           | Y    | 3    | `f32`                                 | 4     | -      | The preferred aspect ratio (calculated as width divided by height)                          |
+| **Item spacing**         |      |      |                                       |       |        |                                                                                             |
+| `padding`                | Y    | ~Y   | `Rect<LengthPercentage>`              | 32    | -      | How large should the padding be on each side?                                               |
+| `border`                 | Y    | ~Y   | `Rect<LengthPercentage>`              | 32    | -      | How large should the border be on each side?                                                |
+| `margin`                 | Y    | ~Y   | `Rect<LengthPercentageAuto>`          | 32    | -      | How large should the margin be on each side?                                                |
+| `gap`                    | Y    | Y    | `Size<LengthPercentage>`              | 16    | -      | The size of the vertical and horizontal gaps between flex items / grid rows                 |
+| **Alignment**            |      |      |                                       |       |        |                                                                                             |
+| `align_content`          | Y    | Y    | `AlignContent`                        | 1     | -      | How should content contained within this item be aligned relative to the cross axis?        |
+| `justify_content`        | Y    | Y    | `AlignContent`                        | 1     | -      | How should content contained within this item be aligned relative to the main axis?         |
+| `align_items`            | Y    | Y    | `AlignItems`                          | 1     | -      | How should items be aligned relative to the cross axis?                                     |
+| `align_self`             | Y    | Y    | `Option<AlignItems>`                  | 1     | -      | Should this item violate the cross axis alignment specified by its parent's [`AlignItems`]? |
+| `justify_items`          | -    | Y    | `AlignItems`                          | 1     | -      | How should items be aligned relative to the main axis?                                      |
+| `justify_self`           | -    | Y    | `Option<AlignItems>`                  | 1     | -      | Should this item violate the main axis alignment specified by its parent's [`AlignItems`]?  |
+| **Flexbox**              |      |      |                                       |       |        |                                                                                             |
+| `flex_direction`         | Y    | -    | `FlexDirection`                       | 1     | -      | Which direction does the main axis flow in?                                                 |
+| `flex_wrap`              | Y    | -    | `FlexWrap`                            | 1     | -      | Should elements wrap, or stay in a single line?                                             |
+| `flex_basis`             | Y    | -    | `Dimension`                           | 8     | -      | Sets the initial main axis size of the item                                                 |
+| `flex_grow`              | Y    | -    | `f32`                                 | 4     | -      | The relative rate at which this item grows when it is expanding to fill space               |
+| `flex_shrink`            | Y    | -    | `f32`                                 | 4     | -      | The relative rate at which this item shrinks when it is contracting to fit into space       |
+| **CSS Grid (Container)** |      |      |                                       |       |        |                                                                                             |
+| `grid_template_columns`  | -    | Y    | `Vec<TrackSizingFunction>`            | 24    | 32 * N | The track sizing functions of the grid's explicit columns                                   |
+| `grid_template_rows`     | -    | Y    | `Vec<TrackSizingFunction>`            | 24    | 32 * N | The track sizing functions of the grid's explicit rows                                      |
+| `grid_template_areas`    | -    | 5    | -                                     | -     | -      | Defines named grid areas                                                                    |
+| `grid_auto_rows`         | -    | Y    | `Vec<NonRepeatedTrackSizingFunction>` | 24    | 20 * N | Track sizing functions for the grid's implicitly generated rows                             |
+| `grid_auto_columns`      | -    | Y    | `Vec<NonRepeatedTrackSizingFunction>` | 24    | 20 * N | Track sizing functions for the grid's implicitly generated columns                          |
+| `grid_auto_flow`         | -    | Y    | `GridAutoFlow`                        | 1     | -      | Whether auto-placed items are placed row-wise or column-wise. And sparsely or densely.      |
+| **CSS Grid (Child)**     |      |      |                                       |       |        |                                                                                             |
+| `grid_row`               | -    | Y    | `Line<GridPlacement>`                 | 8     | -      | The vertical (row) placement of a grid item                                                 |
+| `grid_column`            | -    | Y    | `Line<GridPlacement>`                 | 8     | -      | The horizontal (row) placement of a grid item                                               |
+| `grid_area`              | -    | 5    | -                                     | -     | -      | Accepts either shorthand row/column-start/end or a named grid area                          |

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -281,4 +281,72 @@ mod tests {
         assert_eq!(Style::DEFAULT, Style::default());
         assert_eq!(Style::DEFAULT, old_defaults);
     }
+
+    // NOTE: Please feel free the update the sizes in this test as required. This test is here to prevent unintentional size changes
+    // and to serve as accurate up-to-date documentation on the sizes.
+    #[test]
+    fn style_sizes() {
+        use super::*;
+
+        fn assert_type_size<T>(expected_size: usize) {
+
+            let name = ::core::any::type_name::<T>();
+            let name = name.replace("taffy::geometry::", "");
+            let name = name.replace("taffy::style::dimension::", "");
+            let name = name.replace("taffy::style::alignment::", "");
+            let name = name.replace("taffy::style::flex::", "");
+            let name = name.replace("taffy::style::grid::", "");
+
+            assert_eq!(
+                ::core::mem::size_of::<T>(),
+                expected_size,
+                "Expected {} for be {} byte(s) but it was {} byte(s)",
+                name,
+                expected_size,
+                ::core::mem::size_of::<T>(),
+            );
+        }
+
+        // Display and Position
+        assert_type_size::<Display>(1);
+        assert_type_size::<Position>(1);
+
+        // Dimensions and aggregations of Dimensions
+        assert_type_size::<f32>(4);
+        assert_type_size::<LengthPercentage>(8);
+        assert_type_size::<LengthPercentageAuto>(8);
+        assert_type_size::<Dimension>(8);
+        assert_type_size::<Size<LengthPercentage>>(16);
+        assert_type_size::<Size<LengthPercentageAuto>>(16);
+        assert_type_size::<Size<Dimension>>(16);
+        assert_type_size::<Rect<LengthPercentage>>(32);
+        assert_type_size::<Rect<LengthPercentageAuto>>(32);
+        assert_type_size::<Rect<Dimension>>(32);
+
+        // Alignment
+        assert_type_size::<AlignContent>(1);
+        assert_type_size::<AlignItems>(1);
+        assert_type_size::<Option<AlignItems>>(1);
+
+        // Flexbox Container
+        assert_type_size::<FlexDirection>(1);
+        assert_type_size::<FlexWrap>(1);
+
+        // CSS Grid Container
+        assert_type_size::<GridAutoFlow>(1);
+        assert_type_size::<MinTrackSizingFunction>(8);
+        assert_type_size::<MaxTrackSizingFunction>(12);
+        assert_type_size::<NonRepeatedTrackSizingFunction>(20);
+        assert_type_size::<TrackSizingFunction>(32);
+        assert_type_size::<Vec<NonRepeatedTrackSizingFunction>>(24);
+        assert_type_size::<Vec<TrackSizingFunction>>(24);
+
+        // CSS Grid Item
+        assert_type_size::<GridPlacement>(4);
+        assert_type_size::<Line<GridPlacement>>(8);
+
+        // Overall
+        assert_type_size::<Style>(344);
+
+    }
 }

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -289,7 +289,6 @@ mod tests {
         use super::*;
 
         fn assert_type_size<T>(expected_size: usize) {
-
             let name = ::core::any::type_name::<T>();
             let name = name.replace("taffy::geometry::", "");
             let name = name.replace("taffy::style::dimension::", "");
@@ -347,6 +346,5 @@ mod tests {
 
         // Overall
         assert_type_size::<Style>(344);
-
     }
 }


### PR DESCRIPTION
# Objective

Document the size of each style as a first step in thinking about optimising memory use, and as a useful data point for when thinking about how we might want to split up the `Style` struct.

## Analysis

IMO most interesting thing to come out of this is how big `LengthPercentage`, `LengthPercentageAuto`, and `Dimension` are (8 bytes each). These would be the obvious thing to target if we wanted optimise memory usage:
- I believe we could shave `72` bytes out of the total `344` by switching these types to use `NonNaNf32` rather than `f32` (enabling niche optimisation on the containing enum).
- We could also consider creating a custom `f24` format (truncated `f32`) if we really wanted to.