### PR TITLE
Remove unused abs_x/abs_y variables from round_layout function

### DIFF
--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -40,7 +40,7 @@ pub fn compute_layout(
     *tree.layout_mut(root) = layout;
 
     // Recursively round the layout's of this node and all children
-    round_layout(tree, root, 0.0, 0.0);
+    round_layout(tree, root);
 
     Ok(())
 }
@@ -231,10 +231,8 @@ fn perform_hidden_layout(tree: &mut impl LayoutTree, node: Node) -> Size<f32> {
 }
 
 /// Rounds the calculated [`NodeData`] according to the spec
-fn round_layout(tree: &mut impl LayoutTree, root: Node, abs_x: f32, abs_y: f32) {
+fn round_layout(tree: &mut impl LayoutTree, root: Node) {
     let layout = tree.layout_mut(root);
-    let abs_x = abs_x + layout.location.x;
-    let abs_y = abs_y + layout.location.y;
 
     layout.location.x = round(layout.location.x);
     layout.location.y = round(layout.location.y);
@@ -245,7 +243,7 @@ fn round_layout(tree: &mut impl LayoutTree, root: Node, abs_x: f32, abs_y: f32) 
     // Satisfy the borrow checker here by re-indexing to shorten the lifetime to the loop scope
     for x in 0..tree.child_count(root) {
         let child = tree.child(root, x);
-        round_layout(tree, child, abs_x, abs_y);
+        round_layout(tree, child);
     }
 }
 


### PR DESCRIPTION
These variables are unused, but the compiler doesn't warn about them because they're passed into a recursive call.

I've validated my change by running `cargo fmt` and `cargo test`.

## Objective

I noticed this while reviewing the code (I was curious about some flexbox rounding behavior), and figured I'd submit a PR to fix it. I'm not currently using taffy.

## Context

It looks like stretch rounded positions based on their absolute positions. It sounds like taffy intentionally does not do this:

> Fixed rounding of fractional values to follow latest Chrome - values are now rounded the same regardless of their position

https://github.com/DioxusLabs/taffy/blob/main/RELEASES.md#fixes-4
