### PR TITLE
WIP: Refactor the `LayoutTree` trait

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,145 @@
+//! A cache for storing the results of layout computation
+use crate::geometry::Size;
+use crate::layout::{RunMode, SizeAndBaselines, SizingMode};
+use crate::style::AvailableSpace;
+
+/// The number of cache entries for each node in the tree
+pub(crate) const CACHE_SIZE: usize = 7;
+
+/// Cached intermediate layout results
+#[derive(Debug, Clone, Copy)]
+pub struct CacheEntry {
+    /// The initial cached size of the node itself
+    known_dimensions: Size<Option<f32>>,
+    /// The initial cached size of the parent's node
+    available_space: Size<AvailableSpace>,
+    /// Whether or not layout should be recomputed
+    run_mode: RunMode,
+
+    /// The cached size and baselines of the item
+    cached_size_and_baselines: SizeAndBaselines,
+}
+
+/// A cache for caching the results of a sizing a Grid Item or Flexbox Item
+pub struct Cache {
+    /// An array of entries in the cache
+    entries: [Option<CacheEntry>; CACHE_SIZE],
+}
+
+impl Cache {
+    /// Create a new empty cache
+    pub const fn new() -> Self {
+        Self { entries: [None; CACHE_SIZE] }
+    }
+
+    /// Return the cache slot to cache the current computed result in
+    ///
+    /// ## Caching Strategy
+    ///
+    /// We need multiple cache slots, because a node's size is often queried by it's parent multiple times in the course of the layout
+    /// process, and we don't want later results to clobber earlier ones.
+    ///
+    /// The two variables that we care about when determining cache slot are:
+    ///
+    ///   - How many "known_dimensions" are set. In the worst case, a node may be called first with neither dimensions known known_dimensions,
+    ///     then with one dimension known (either width of height - which doesn't matter for our purposes here), and then with both dimensions
+    ///     known.
+    ///   - Whether unknown dimensions are being sized under a min-content or a max-content available space constraint (definite available space
+    ///     shares a cache slot with max-content because a node will generally be sized under one or the other but not both).
+    ///
+    /// ## Cache slots:
+    ///
+    /// - Slot 0: Both known_dimensions were set
+    /// - Slot 1: 1 of 2 known_dimensions were set and the other dimension was either a MaxContent or Definite available space constraint
+    /// - Slot 2: 1 of 2 known_dimensions were set and the other dimension was a MinContent constraint
+    /// - Slot 3: Neither known_dimensions were set and we are sizing under a MaxContent or Definite available space constraint
+    /// - Slot 4: Neither known_dimensions were set and we are sizing under a MinContent constraint
+    #[inline]
+    fn compute_cache_slot(known_dimensions: Size<Option<f32>>, available_space: Size<AvailableSpace>) -> usize {
+        let has_known_width = known_dimensions.width.is_some();
+        let has_known_height = known_dimensions.height.is_some();
+
+        // Slot 0: Both known_dimensions were set
+        if has_known_width && has_known_height {
+            return 0;
+        }
+
+        // Slot 1: width but not height known_dimension was set and the other dimension was either a MaxContent or Definite available space constraint
+        // Slot 2: width but not height known_dimension was set and the other dimension was a MinContent constraint
+        if has_known_width && !has_known_height {
+            return 1 + (available_space.height == AvailableSpace::MinContent) as usize;
+        }
+
+        // Slot 3: height but not width known_dimension was set and the other dimension was either a MaxContent or Definite available space constraint
+        // Slot 4: height but not width known_dimension was set and the other dimension was a MinContent constraint
+        if !has_known_width && has_known_height {
+            return 3 + (available_space.width == AvailableSpace::MinContent) as usize;
+        }
+
+        // Slot 5: Neither known_dimensions were set and we are sizing under a MaxContent or Definite available space constraint
+        // Slot 6: Neither known_dimensions were set and we are sizing under a MinContent constraint
+        5 + (available_space.width == AvailableSpace::MinContent) as usize
+    }
+
+    /// Try to retrieve a cached result from the cache
+    #[inline]
+    pub fn get(
+        &self,
+        known_dimensions: Size<Option<f32>>,
+        available_space: Size<AvailableSpace>,
+        run_mode: RunMode,
+        sizing_mode: SizingMode,
+    ) -> Option<SizeAndBaselines> {
+        for entry in self.entries.iter().flatten() {
+            // Cached ComputeSize results are not valid if we are running in PerformLayout mode
+            if entry.run_mode == RunMode::ComputeSize && run_mode == RunMode::PeformLayout {
+                continue;
+            }
+
+            let cached_size = entry.cached_size_and_baselines.size;
+
+            if (known_dimensions.width == entry.known_dimensions.width
+                || known_dimensions.width == Some(cached_size.width))
+                && (known_dimensions.height == entry.known_dimensions.height
+                    || known_dimensions.height == Some(cached_size.height))
+                && (known_dimensions.width.is_some()
+                    || entry.available_space.width.is_roughly_equal(available_space.width)
+                    || (sizing_mode == SizingMode::ContentSize
+                        && available_space.width.is_definite()
+                        && available_space.width.unwrap() >= cached_size.width))
+                && (known_dimensions.height.is_some()
+                    || entry.available_space.height.is_roughly_equal(available_space.height)
+                    || (sizing_mode == SizingMode::ContentSize
+                        && available_space.height.is_definite()
+                        && available_space.height.unwrap() >= cached_size.height))
+            {
+                return Some(entry.cached_size_and_baselines);
+            }
+        }
+
+        None
+    }
+
+    /// Store a computed size in the cache
+    pub fn store(
+        &mut self,
+        known_dimensions: Size<Option<f32>>,
+        available_space: Size<AvailableSpace>,
+        run_mode: RunMode,
+        cached_size_and_baselines: SizeAndBaselines,
+    ) {
+        let cache_slot = Self::compute_cache_slot(known_dimensions, available_space);
+        self.entries[cache_slot] =
+            Some(CacheEntry { known_dimensions, available_space, run_mode, cached_size_and_baselines });
+    }
+
+    /// Clear all cache entries
+    pub fn clear(&mut self) {
+        self.entries = [None; CACHE_SIZE];
+    }
+
+    /// Returns true if all cache entries are None, else false
+    pub fn is_empty(&self) -> bool {
+        !self.entries.iter().any(|entry| entry.is_some())
+    }
+}

--- a/src/compute/grid/alignment.rs
+++ b/src/compute/grid/alignment.rs
@@ -2,11 +2,9 @@
 use super::types::GridTrack;
 use crate::axis::InBothAbsAxis;
 use crate::compute::common::alignment::compute_alignment_offset;
-use crate::compute::{GenericAlgorithm, LayoutAlgorithm};
 use crate::geometry::{Line, Point, Rect, Size};
 use crate::layout::{Layout, SizingMode};
 use crate::math::MaybeMath;
-use crate::node::Node;
 use crate::resolve::MaybeResolve;
 use crate::style::{AlignContent, AlignItems, AlignSelf, AvailableSpace, Position};
 use crate::sys::{f32_max, f32_min};
@@ -72,9 +70,9 @@ pub(super) fn align_tracks(
 }
 
 /// Align and size a grid item into it's final position
-pub(super) fn align_and_position_item(
-    tree: &mut impl LayoutTree,
-    node: Node,
+pub(super) fn align_and_position_item<Tree: LayoutTree>(
+    tree: &mut Tree,
+    node: Tree::ChildId,
     order: u32,
     grid_area: Rect<f32>,
     container_alignment_styles: InBothAbsAxis<Option<AlignItems>>,
@@ -82,7 +80,7 @@ pub(super) fn align_and_position_item(
 ) {
     let grid_area_size = Size { width: grid_area.right - grid_area.left, height: grid_area.bottom - grid_area.top };
 
-    let style = tree.style(node);
+    let style = tree.child_style(node);
     let aspect_ratio = style.aspect_ratio;
     let justify_self = style.justify_self;
     let align_self = style.align_self;
@@ -180,8 +178,7 @@ pub(super) fn align_and_position_item(
     let Size { width, height } = Size { width, height }.maybe_clamp(min_size, max_size);
 
     // Layout node
-    let measured_size_and_baselines = GenericAlgorithm::perform_layout(
-        tree,
+    let measured_size_and_baselines = tree.perform_child_layout(
         node,
         Size { width, height },
         grid_area_size.map(Option::Some),
@@ -212,7 +209,7 @@ pub(super) fn align_and_position_item(
         baseline_shim,
     );
 
-    *tree.layout_mut(node) = Layout { order, size: Size { width, height }, location: Point { x, y } };
+    *tree.child_layout_mut(node) = Layout { order, size: Size { width, height }, location: Point { x, y } };
 }
 
 /// Align and size a grid item along a single axis

--- a/src/compute/grid/placement.rs
+++ b/src/compute/grid/placement.rs
@@ -4,23 +4,23 @@ use super::types::{CellOccupancyMatrix, CellOccupancyState, GridItem};
 use super::OriginZeroLine;
 use crate::axis::{AbsoluteAxis, InBothAbsAxis};
 use crate::geometry::Line;
-use crate::node::Node;
 use crate::style::{AlignItems, GridAutoFlow, OriginZeroGridPlacement, Style};
 use crate::sys::Vec;
+use crate::tree::LayoutTree;
 
 /// 8.5. Grid Item Placement Algorithm
 /// Place items into the grid, generating new rows/column into the implicit grid as required
 ///
 /// [Specification](https://www.w3.org/TR/css-grid-2/#auto-placement-algo)
-pub(super) fn place_grid_items<'a, ChildIter>(
+pub(super) fn place_grid_items<'a, ChildIter, Tree: LayoutTree>(
     cell_occupancy_matrix: &mut CellOccupancyMatrix,
-    items: &mut Vec<GridItem>,
+    items: &mut Vec<GridItem<Tree>>,
     children_iter: impl Fn() -> ChildIter,
     grid_auto_flow: GridAutoFlow,
     align_items: AlignItems,
     justify_items: AlignItems,
 ) where
-    ChildIter: Iterator<Item = (usize, Node, &'a Style)>,
+    ChildIter: Iterator<Item = (usize, Tree::ChildId, &'a Style)>,
 {
     let primary_axis = grid_auto_flow.primary_axis();
     let secondary_axis = primary_axis.other_axis();
@@ -28,7 +28,7 @@ pub(super) fn place_grid_items<'a, ChildIter>(
     let map_child_style_to_origin_zero_placement = {
         let explicit_col_count = cell_occupancy_matrix.track_counts(AbsoluteAxis::Horizontal).explicit;
         let explicit_row_count = cell_occupancy_matrix.track_counts(AbsoluteAxis::Vertical).explicit;
-        move |(index, node, style): (usize, Node, &'a Style)| -> (_, _, _, &'a Style) {
+        move |(index, node, style): (usize, Tree::ChildId, &'a Style)| -> (_, _, _, &'a Style) {
             let origin_zero_placement = InBothAbsAxis {
                 horizontal: style.grid_column.map(|placement| placement.into_origin_zero_placement(explicit_col_count)),
                 vertical: style.grid_row.map(|placement| placement.into_origin_zero_placement(explicit_row_count)),
@@ -294,10 +294,10 @@ fn place_indefinitely_positioned_item(
 /// Record the grid item in both CellOccupancyMatric and the GridItems list
 /// once a definite placement has been determined
 #[allow(clippy::too_many_arguments)]
-fn record_grid_placement(
+fn record_grid_placement<Tree: LayoutTree>(
     cell_occupancy_matrix: &mut CellOccupancyMatrix,
-    items: &mut Vec<GridItem>,
-    node: Node,
+    items: &mut Vec<GridItem<Tree>>,
+    node: Tree::ChildId,
     index: usize,
     style: &Style,
     parent_align_items: AlignItems,
@@ -346,9 +346,10 @@ mod tests {
 
     mod test_placement_algorithm {
         use crate::compute::grid::implicit_grid::compute_grid_size_estimate;
-        use crate::compute::grid::types::TrackCounts;
+        use crate::compute::grid::types::{GridItem, TrackCounts};
         use crate::compute::grid::util::*;
         use crate::compute::grid::CellOccupancyMatrix;
+        use crate::node::TaffyNodeRef;
         use crate::prelude::*;
         use crate::style::GridAutoFlow;
         use slotmap::SlotMap;
@@ -369,7 +370,7 @@ mod tests {
             let children_iter = || children.iter().map(|(index, node, style, _)| (*index, *node, style));
             let child_styles_iter = children.iter().map(|(_, _, style, _)| style);
             let estimated_sizes = compute_grid_size_estimate(explicit_col_count, explicit_row_count, child_styles_iter);
-            let mut items = Vec::new();
+            let mut items: Vec<GridItem<TaffyNodeRef>> = Vec::new();
             let mut cell_occupancy_matrix =
                 CellOccupancyMatrix::with_track_counts(estimated_sizes.0, estimated_sizes.1);
 

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -11,26 +11,20 @@ use crate::data::CACHE_SIZE;
 use crate::error::TaffyError;
 use crate::geometry::{Point, Size};
 use crate::layout::{Cache, Layout, RunMode, SizeAndBaselines, SizingMode};
-use crate::node::Node;
+use crate::node::{Node, Taffy};
 use crate::style::{AvailableSpace, Display};
-use crate::sys::round;
 use crate::tree::LayoutTree;
 
 use self::flexbox::FlexboxAlgorithm;
 use self::grid::CssGridAlgorithm;
-use self::leaf::LeafAlgorithm;
 
 #[cfg(any(feature = "debug", feature = "profile"))]
 use crate::debug::NODE_LOGGER;
 
 /// Updates the stored layout of the provided `node` and its children
-pub fn compute_layout(
-    tree: &mut impl LayoutTree,
-    root: Node,
-    available_space: Size<AvailableSpace>,
-) -> Result<(), TaffyError> {
+pub fn compute_layout(tree: &mut Taffy, root: Node, available_space: Size<AvailableSpace>) -> Result<(), TaffyError> {
     // Recursively compute node layout
-    let size_and_baselines = GenericAlgorithm::perform_layout(
+    let size_and_baselines = perform_layout(
         tree,
         root,
         Size::NONE,
@@ -40,23 +34,22 @@ pub fn compute_layout(
     );
 
     let layout = Layout { order: 0, size: size_and_baselines.size, location: Point::ZERO };
-    *tree.layout_mut(root) = layout;
+    tree.nodes[root].layout = layout;
 
     // Recursively round the layout's of this node and all children
-    round_layout(tree, root);
+    recursively_round_layout(tree, root);
 
     Ok(())
 }
 
 /// A common interface that all Taffy layout algorithms conform to
-pub(crate) trait LayoutAlgorithm {
+pub trait LayoutAlgorithm {
     /// The name of the algorithm (mainly used for debug purposes)
     const NAME: &'static str;
 
     /// Compute the size of the node given the specified constraints
     fn measure_size(
         tree: &mut impl LayoutTree,
-        node: Node,
         known_dimensions: Size<Option<f32>>,
         parent_size: Size<Option<f32>>,
         available_space: Size<AvailableSpace>,
@@ -66,7 +59,6 @@ pub(crate) trait LayoutAlgorithm {
     /// Perform a full layout on the node given the specified constraints
     fn perform_layout(
         tree: &mut impl LayoutTree,
-        node: Node,
         known_dimensions: Size<Option<f32>>,
         parent_size: Size<Option<f32>>,
         available_space: Size<AvailableSpace>,
@@ -74,55 +66,36 @@ pub(crate) trait LayoutAlgorithm {
     ) -> SizeAndBaselines;
 }
 
-/// The public interface to a generic algorithm that abstracts over all of Taffy's algorithms
-/// and applies the correct one based on the `Display` style
-pub struct GenericAlgorithm;
-impl LayoutAlgorithm for GenericAlgorithm {
-    const NAME: &'static str = "GENERIC";
+/// Compute the size of the node given the specified constraints
+#[inline(always)]
+pub(crate) fn perform_layout(
+    tree: &mut Taffy,
+    node: Node,
+    known_dimensions: Size<Option<f32>>,
+    parent_size: Size<Option<f32>>,
+    available_space: Size<AvailableSpace>,
+    sizing_mode: SizingMode,
+) -> SizeAndBaselines {
+    compute_node_layout(tree, node, known_dimensions, parent_size, available_space, RunMode::PeformLayout, sizing_mode)
+}
 
-    fn perform_layout(
-        tree: &mut impl LayoutTree,
-        node: Node,
-        known_dimensions: Size<Option<f32>>,
-        parent_size: Size<Option<f32>>,
-        available_space: Size<AvailableSpace>,
-        sizing_mode: SizingMode,
-    ) -> SizeAndBaselines {
-        compute_node_layout(
-            tree,
-            node,
-            known_dimensions,
-            parent_size,
-            available_space,
-            RunMode::PeformLayout,
-            sizing_mode,
-        )
-    }
-
-    fn measure_size(
-        tree: &mut impl LayoutTree,
-        node: Node,
-        known_dimensions: Size<Option<f32>>,
-        parent_size: Size<Option<f32>>,
-        available_space: Size<AvailableSpace>,
-        sizing_mode: SizingMode,
-    ) -> Size<f32> {
-        compute_node_layout(
-            tree,
-            node,
-            known_dimensions,
-            parent_size,
-            available_space,
-            RunMode::ComputeSize,
-            sizing_mode,
-        )
+/// Perform a full layout on the node given the specified constraints
+#[inline(always)]
+pub(crate) fn measure_size(
+    tree: &mut Taffy,
+    node: Node,
+    known_dimensions: Size<Option<f32>>,
+    parent_size: Size<Option<f32>>,
+    available_space: Size<AvailableSpace>,
+    sizing_mode: SizingMode,
+) -> Size<f32> {
+    compute_node_layout(tree, node, known_dimensions, parent_size, available_space, RunMode::ComputeSize, sizing_mode)
         .size
-    }
 }
 
 /// Updates the stored layout of the provided `node` and its children
 fn compute_node_layout(
-    tree: &mut impl LayoutTree,
+    tree: &mut Taffy,
     node: Node,
     known_dimensions: Size<Option<f32>>,
     parent_size: Size<Option<f32>>,
@@ -135,10 +108,12 @@ fn compute_node_layout(
     #[cfg(feature = "debug")]
     println!();
 
+    let child_count = tree.children[node].len();
+
     // First we check if we have a cached result for the given input
-    let cache_run_mode = if tree.is_childless(node) { RunMode::PeformLayout } else { run_mode };
+    let cache_run_mode = if child_count == 0 { RunMode::PeformLayout } else { run_mode };
     if let Some(cached_size_and_baselines) =
-        compute_from_cache(tree, node, known_dimensions, available_space, cache_run_mode, sizing_mode)
+        compute_from_cache(&tree.nodes[node].size_cache, known_dimensions, available_space, cache_run_mode, sizing_mode)
     {
         #[cfg(feature = "debug")]
         NODE_LOGGER.labelled_debug_log("CACHE", cached_size_and_baselines.size);
@@ -156,7 +131,6 @@ fn compute_node_layout(
     #[inline(always)]
     fn perform_computations<Algorithm: LayoutAlgorithm>(
         tree: &mut impl LayoutTree,
-        node: Node,
         known_dimensions: Size<Option<f32>>,
         parent_size: Size<Option<f32>>,
         available_space: Size<AvailableSpace>,
@@ -168,31 +142,32 @@ fn compute_node_layout(
 
         match run_mode {
             RunMode::PeformLayout => {
-                Algorithm::perform_layout(tree, node, known_dimensions, parent_size, available_space, sizing_mode)
+                Algorithm::perform_layout(tree, known_dimensions, parent_size, available_space, sizing_mode)
             }
             RunMode::ComputeSize => {
-                let size =
-                    Algorithm::measure_size(tree, node, known_dimensions, parent_size, available_space, sizing_mode);
+                let size = Algorithm::measure_size(tree, known_dimensions, parent_size, available_space, sizing_mode);
                 SizeAndBaselines { size, first_baselines: Point::NONE }
             }
         }
     }
 
-    let computed_size_and_baselines = if tree.is_childless(node) {
-        perform_computations::<LeafAlgorithm>(
-            tree,
-            node,
-            known_dimensions,
-            parent_size,
-            available_space,
-            run_mode,
-            sizing_mode,
-        )
+    let computed_size_and_baselines = if child_count == 0 {
+        #[cfg(feature = "debug")]
+        NODE_LOGGER.log("LEAF");
+
+        match run_mode {
+            RunMode::PeformLayout => {
+                leaf::perform_layout(tree, node, known_dimensions, parent_size, available_space, sizing_mode)
+            }
+            RunMode::ComputeSize => {
+                let size = leaf::measure_size(tree, node, known_dimensions, parent_size, available_space, sizing_mode);
+                SizeAndBaselines { size, first_baselines: Point::NONE }
+            }
+        }
     } else {
-        match tree.style(node).display {
+        match tree.nodes[node].style.display {
             Display::Flex => perform_computations::<FlexboxAlgorithm>(
-                tree,
-                node,
+                &mut tree.node_ref_mut(node).unwrap(),
                 known_dimensions,
                 parent_size,
                 available_space,
@@ -201,29 +176,28 @@ fn compute_node_layout(
             ),
             #[cfg(feature = "grid")]
             Display::Grid => perform_computations::<CssGridAlgorithm>(
-                tree,
-                node,
+                &mut tree.node_ref_mut(node).unwrap(),
                 known_dimensions,
                 parent_size,
                 available_space,
                 run_mode,
                 sizing_mode,
             ),
-            Display::None => perform_computations::<HiddenAlgorithm>(
-                tree,
-                node,
-                known_dimensions,
-                parent_size,
-                available_space,
-                run_mode,
-                sizing_mode,
-            ),
+            Display::None => {
+                tree.nodes[node].layout = Layout::with_order(0);
+                for index in 0..child_count {
+                    let child_id = tree.children[node][index];
+                    let node_ref = &mut tree.node_ref_mut(node).unwrap();
+                    node_ref.perform_child_hidden_layout(child_id, index as _)
+                }
+                SizeAndBaselines { size: Size::ZERO, first_baselines: Point::NONE }
+            }
         }
     };
 
     // Cache result
     let cache_slot = compute_cache_slot(known_dimensions, available_space);
-    *tree.cache_mut(node, cache_slot) = Some(Cache {
+    tree.nodes[node].size_cache[cache_slot] = Some(Cache {
         known_dimensions,
         available_space,
         run_mode: cache_run_mode,
@@ -249,6 +223,7 @@ fn debug_log_node(
     NODE_LOGGER.debug_log(run_mode);
     NODE_LOGGER.labelled_debug_log("sizing_mode", sizing_mode);
     NODE_LOGGER.labelled_debug_log("known_dimensions", known_dimensions);
+    NODE_LOGGER.labelled_debug_log("parent_size", parent_size);
     NODE_LOGGER.labelled_debug_log("available_space", available_space);
 }
 
@@ -304,144 +279,96 @@ fn compute_cache_slot(known_dimensions: Size<Option<f32>>, available_space: Size
 /// Try to get the computation result from the cache.
 #[inline]
 fn compute_from_cache(
-    tree: &mut impl LayoutTree,
-    node: Node,
+    cache: &[Option<Cache>; CACHE_SIZE],
     known_dimensions: Size<Option<f32>>,
     available_space: Size<AvailableSpace>,
     run_mode: RunMode,
     sizing_mode: SizingMode,
 ) -> Option<SizeAndBaselines> {
-    for idx in 0..CACHE_SIZE {
-        let entry = tree.cache_mut(node, idx);
-        if let Some(entry) = entry {
-            // Cached ComputeSize results are not valid if we are running in PerformLayout mode
-            if entry.run_mode == RunMode::ComputeSize && run_mode == RunMode::PeformLayout {
-                return None;
-            }
+    for entry in cache.iter().flatten() {
+        // Cached ComputeSize results are not valid if we are running in PerformLayout mode
+        if entry.run_mode == RunMode::ComputeSize && run_mode == RunMode::PeformLayout {
+            return None;
+        }
 
-            let cached_size = entry.cached_size_and_baselines.size;
+        let cached_size = entry.cached_size_and_baselines.size;
 
-            if (known_dimensions.width == entry.known_dimensions.width
-                || known_dimensions.width == Some(cached_size.width))
-                && (known_dimensions.height == entry.known_dimensions.height
-                    || known_dimensions.height == Some(cached_size.height))
-                && (known_dimensions.width.is_some()
-                    || entry.available_space.width.is_roughly_equal(available_space.width)
-                    || (sizing_mode == SizingMode::ContentSize
-                        && available_space.width.is_definite()
-                        && available_space.width.unwrap() >= cached_size.width))
-                && (known_dimensions.height.is_some()
-                    || entry.available_space.height.is_roughly_equal(available_space.height)
-                    || (sizing_mode == SizingMode::ContentSize
-                        && available_space.height.is_definite()
-                        && available_space.height.unwrap() >= cached_size.height))
-            {
-                return Some(entry.cached_size_and_baselines);
-            }
+        if (known_dimensions.width == entry.known_dimensions.width || known_dimensions.width == Some(cached_size.width))
+            && (known_dimensions.height == entry.known_dimensions.height
+                || known_dimensions.height == Some(cached_size.height))
+            && (known_dimensions.width.is_some()
+                || entry.available_space.width.is_roughly_equal(available_space.width)
+                || (sizing_mode == SizingMode::ContentSize
+                    && available_space.width.is_definite()
+                    && available_space.width.unwrap() >= cached_size.width))
+            && (known_dimensions.height.is_some()
+                || entry.available_space.height.is_roughly_equal(available_space.height)
+                || (sizing_mode == SizingMode::ContentSize
+                    && available_space.height.is_definite()
+                    && available_space.height.unwrap() >= cached_size.height))
+        {
+            return Some(entry.cached_size_and_baselines);
         }
     }
 
     None
 }
 
-/// The public interface to Taffy's hidden node algorithm implementation
-struct HiddenAlgorithm;
-impl LayoutAlgorithm for HiddenAlgorithm {
-    const NAME: &'static str = "NONE";
-
-    fn perform_layout(
-        tree: &mut impl LayoutTree,
-        node: Node,
-        _known_dimensions: Size<Option<f32>>,
-        _parent_size: Size<Option<f32>>,
-        _available_space: Size<AvailableSpace>,
-        _sizing_mode: SizingMode,
-    ) -> SizeAndBaselines {
-        perform_hidden_layout(tree, node);
-        SizeAndBaselines { size: Size::ZERO, first_baselines: Point::NONE }
-    }
-
-    fn measure_size(
-        _tree: &mut impl LayoutTree,
-        _node: Node,
-        _known_dimensions: Size<Option<f32>>,
-        _parent_size: Size<Option<f32>>,
-        _available_space: Size<AvailableSpace>,
-        _sizing_mode: SizingMode,
-    ) -> Size<f32> {
-        Size::ZERO
-    }
-}
-
 /// Creates a layout for this node and its children, recursively.
 /// Each hidden node has zero size and is placed at the origin
-fn perform_hidden_layout(tree: &mut impl LayoutTree, node: Node) {
-    /// Recursive function to apply hidden layout to all descendents
-    fn perform_hidden_layout_inner(tree: &mut impl LayoutTree, node: Node, order: u32) {
-        *tree.layout_mut(node) = Layout::with_order(order);
-        for order in 0..tree.child_count(node) {
-            perform_hidden_layout_inner(tree, tree.child(node, order), order as _);
-        }
-    }
-
-    for order in 0..tree.child_count(node) {
-        perform_hidden_layout_inner(tree, tree.child(node, order), order as _);
+pub(crate) fn recursively_perform_hidden_layout(tree: &mut Taffy, node: Node, order: u32) {
+    tree.nodes[node].layout = Layout::with_order(order);
+    for index in 0..tree.children[node].len() {
+        recursively_perform_hidden_layout(tree, tree.children[node][index], index as _);
     }
 }
 
 /// Rounds the calculated [`NodeData`] according to the spec
-fn round_layout(tree: &mut impl LayoutTree, root: Node) {
-    let layout = tree.layout_mut(root);
-
-    layout.location.x = round(layout.location.x);
-    layout.location.y = round(layout.location.y);
-
-    layout.size.width = round(layout.size.width);
-    layout.size.height = round(layout.size.height);
+fn recursively_round_layout(tree: &mut Taffy, node: Node) {
+    tree.nodes[node].layout.round();
 
     // Satisfy the borrow checker here by re-indexing to shorten the lifetime to the loop scope
-    for x in 0..tree.child_count(root) {
-        let child = tree.child(root, x);
-        round_layout(tree, child);
+    for index in 0..tree.children[node].len() {
+        recursively_round_layout(tree, tree.children[node][index]);
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::perform_hidden_layout;
-    use crate::geometry::{Point, Size};
-    use crate::style::{Display, Style};
-    use crate::Taffy;
+// #[cfg(test)]
+// mod tests {
+//     use super::perform_hidden_layout;
+//     use crate::geometry::{Point, Size};
+//     use crate::style::{Display, Style};
+//     use crate::Taffy;
 
-    #[test]
-    fn hidden_layout_should_hide_recursively() {
-        let mut taffy = Taffy::new();
+//     #[test]
+//     fn hidden_layout_should_hide_recursively() {
+//         let mut taffy = Taffy::new();
 
-        let style: Style = Style { display: Display::Flex, size: Size::from_points(50.0, 50.0), ..Default::default() };
+//         let style: Style = Style { display: Display::Flex, size: Size::from_points(50.0, 50.0), ..Default::default() };
 
-        let grandchild_00 = taffy.new_leaf(style.clone()).unwrap();
-        let grandchild_01 = taffy.new_leaf(style.clone()).unwrap();
-        let child_00 = taffy.new_with_children(style.clone(), &[grandchild_00, grandchild_01]).unwrap();
+//         let grandchild_00 = taffy.new_leaf(style.clone()).unwrap();
+//         let grandchild_01 = taffy.new_leaf(style.clone()).unwrap();
+//         let child_00 = taffy.new_with_children(style.clone(), &[grandchild_00, grandchild_01]).unwrap();
 
-        let grandchild_02 = taffy.new_leaf(style.clone()).unwrap();
-        let child_01 = taffy.new_with_children(style.clone(), &[grandchild_02]).unwrap();
+//         let grandchild_02 = taffy.new_leaf(style.clone()).unwrap();
+//         let child_01 = taffy.new_with_children(style.clone(), &[grandchild_02]).unwrap();
 
-        let root = taffy
-            .new_with_children(
-                Style { display: Display::None, size: Size::from_points(50.0, 50.0), ..Default::default() },
-                &[child_00, child_01],
-            )
-            .unwrap();
+//         let root = taffy
+//             .new_with_children(
+//                 Style { display: Display::None, size: Size::from_points(50.0, 50.0), ..Default::default() },
+//                 &[child_00, child_01],
+//             )
+//             .unwrap();
 
-        perform_hidden_layout(&mut taffy, root);
+//         perform_hidden_layout(&mut taffy, root);
 
-        // Whatever size and display-mode the nodes had previously,
-        // all layouts should resolve to ZERO due to the root's DISPLAY::NONE
-        for (node, _) in taffy.nodes.iter().filter(|(node, _)| *node != root) {
-            if let Ok(layout) = taffy.layout(node) {
-                assert_eq!(layout.size, Size::zero());
-                assert_eq!(layout.location, Point::zero());
-            }
-        }
-    }
-}
+//         // Whatever size and display-mode the nodes had previously,
+//         // all layouts should resolve to ZERO due to the root's DISPLAY::NONE
+//         for (node, _) in taffy.nodes.iter().filter(|(node, _)| *node != root) {
+//             if let Ok(layout) = taffy.layout(node) {
+//                 assert_eq!(layout.size, Size::zero());
+//                 assert_eq!(layout.location, Point::zero());
+//             }
+//         }
+//     }
+// }

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -7,10 +7,9 @@ pub(crate) mod leaf;
 #[cfg(feature = "grid")]
 pub(crate) mod grid;
 
-use crate::data::CACHE_SIZE;
 use crate::error::TaffyError;
 use crate::geometry::{Point, Size};
-use crate::layout::{Cache, Layout, RunMode, SizeAndBaselines, SizingMode};
+use crate::layout::{Layout, RunMode, SizeAndBaselines, SizingMode};
 use crate::node::{Node, Taffy};
 use crate::style::{AvailableSpace, Display};
 use crate::tree::LayoutTree;
@@ -112,9 +111,8 @@ fn compute_node_layout(
 
     // First we check if we have a cached result for the given input
     let cache_run_mode = if child_count == 0 { RunMode::PeformLayout } else { run_mode };
-    if let Some(cached_size_and_baselines) =
-        compute_from_cache(&tree.nodes[node].size_cache, known_dimensions, available_space, cache_run_mode, sizing_mode)
-    {
+    let cached_size = tree.nodes[node].cache.get(known_dimensions, available_space, cache_run_mode, sizing_mode);
+    if let Some(cached_size_and_baselines) = cached_size {
         #[cfg(feature = "debug")]
         NODE_LOGGER.labelled_debug_log("CACHE", cached_size_and_baselines.size);
         #[cfg(feature = "debug")]
@@ -196,13 +194,7 @@ fn compute_node_layout(
     };
 
     // Cache result
-    let cache_slot = compute_cache_slot(known_dimensions, available_space);
-    tree.nodes[node].size_cache[cache_slot] = Some(Cache {
-        known_dimensions,
-        available_space,
-        run_mode: cache_run_mode,
-        cached_size_and_baselines: computed_size_and_baselines,
-    });
+    tree.nodes[node].cache.store(known_dimensions, available_space, cache_run_mode, computed_size_and_baselines);
 
     #[cfg(feature = "debug")]
     NODE_LOGGER.labelled_debug_log("RESULT", computed_size_and_baselines.size);
@@ -225,93 +217,6 @@ fn debug_log_node(
     NODE_LOGGER.labelled_debug_log("known_dimensions", known_dimensions);
     NODE_LOGGER.labelled_debug_log("parent_size", parent_size);
     NODE_LOGGER.labelled_debug_log("available_space", available_space);
-}
-
-/// Return the cache slot to cache the current computed result in
-///
-/// ## Caching Strategy
-///
-/// We need multiple cache slots, because a node's size is often queried by it's parent multiple times in the course of the layout
-/// process, and we don't want later results to clobber earlier ones.
-///
-/// The two variables that we care about when determining cache slot are:
-///
-///   - How many "known_dimensions" are set. In the worst case, a node may be called first with neither dimensions known known_dimensions,
-///     then with one dimension known (either width of height - which doesn't matter for our purposes here), and then with both dimensions
-///     known.
-///   - Whether unknown dimensions are being sized under a min-content or a max-content available space constraint (definite available space
-///     shares a cache slot with max-content because a node will generally be sized under one or the other but not both).
-///
-/// ## Cache slots:
-///
-/// - Slot 0: Both known_dimensions were set
-/// - Slot 1: 1 of 2 known_dimensions were set and the other dimension was either a MaxContent or Definite available space constraint
-/// - Slot 2: 1 of 2 known_dimensions were set and the other dimension was a MinContent constraint
-/// - Slot 3: Neither known_dimensions were set and we are sizing under a MaxContent or Definite available space constraint
-/// - Slot 4: Neither known_dimensions were set and we are sizing under a MinContent constraint
-#[inline]
-fn compute_cache_slot(known_dimensions: Size<Option<f32>>, available_space: Size<AvailableSpace>) -> usize {
-    let has_known_width = known_dimensions.width.is_some();
-    let has_known_height = known_dimensions.height.is_some();
-
-    // Slot 0: Both known_dimensions were set
-    if has_known_width && has_known_height {
-        return 0;
-    }
-
-    // Slot 1: width but not height known_dimension was set and the other dimension was either a MaxContent or Definite available space constraint
-    // Slot 2: width but not height known_dimension was set and the other dimension was a MinContent constraint
-    if has_known_width && !has_known_height {
-        return 1 + (available_space.height == AvailableSpace::MinContent) as usize;
-    }
-
-    // Slot 3: height but not width known_dimension was set and the other dimension was either a MaxContent or Definite available space constraint
-    // Slot 4: height but not width known_dimension was set and the other dimension was a MinContent constraint
-    if !has_known_width && has_known_height {
-        return 3 + (available_space.width == AvailableSpace::MinContent) as usize;
-    }
-
-    // Slot 5: Neither known_dimensions were set and we are sizing under a MaxContent or Definite available space constraint
-    // Slot 6: Neither known_dimensions were set and we are sizing under a MinContent constraint
-    5 + (available_space.width == AvailableSpace::MinContent) as usize
-}
-
-/// Try to get the computation result from the cache.
-#[inline]
-fn compute_from_cache(
-    cache: &[Option<Cache>; CACHE_SIZE],
-    known_dimensions: Size<Option<f32>>,
-    available_space: Size<AvailableSpace>,
-    run_mode: RunMode,
-    sizing_mode: SizingMode,
-) -> Option<SizeAndBaselines> {
-    for entry in cache.iter().flatten() {
-        // Cached ComputeSize results are not valid if we are running in PerformLayout mode
-        if entry.run_mode == RunMode::ComputeSize && run_mode == RunMode::PeformLayout {
-            return None;
-        }
-
-        let cached_size = entry.cached_size_and_baselines.size;
-
-        if (known_dimensions.width == entry.known_dimensions.width || known_dimensions.width == Some(cached_size.width))
-            && (known_dimensions.height == entry.known_dimensions.height
-                || known_dimensions.height == Some(cached_size.height))
-            && (known_dimensions.width.is_some()
-                || entry.available_space.width.is_roughly_equal(available_space.width)
-                || (sizing_mode == SizingMode::ContentSize
-                    && available_space.width.is_definite()
-                    && available_space.width.unwrap() >= cached_size.width))
-            && (known_dimensions.height.is_some()
-                || entry.available_space.height.is_roughly_equal(available_space.height)
-                || (sizing_mode == SizingMode::ContentSize
-                    && available_space.height.is_definite()
-                    && available_space.height.unwrap() >= cached_size.height))
-        {
-            return Some(entry.cached_size_and_baselines);
-        }
-    }
-
-    None
 }
 
 /// Creates a layout for this node and its children, recursively.

--- a/src/data.rs
+++ b/src/data.rs
@@ -2,11 +2,9 @@
 //!
 //! Used to compute layout for Taffy trees
 //!
-use crate::layout::{Cache, Layout};
+use crate::cache::Cache;
+use crate::layout::Layout;
 use crate::style::Style;
-
-/// The number of cache entries for each node in the tree
-pub(crate) const CACHE_SIZE: usize = 7;
 
 /// Layout information for a given [`Node`](crate::node::Node)
 ///
@@ -20,15 +18,15 @@ pub(crate) struct NodeData {
     /// Should we try and measure this node?
     pub(crate) needs_measure: bool,
 
-    /// The primary cached results of the layout computation
-    pub(crate) size_cache: [Option<Cache>; CACHE_SIZE],
+    /// The cached results of the layout computation
+    pub(crate) cache: Cache,
 }
 
 impl NodeData {
     /// Create the data for a new node
     #[must_use]
     pub const fn new(style: Style) -> Self {
-        Self { style, size_cache: [None; CACHE_SIZE], layout: Layout::new(), needs_measure: false }
+        Self { style, cache: Cache::new(), layout: Layout::new(), needs_measure: false }
     }
 
     /// Marks a node and all of its parents (recursively) as dirty
@@ -36,6 +34,6 @@ impl NodeData {
     /// This clears any cached data and signals that the data must be recomputed.
     #[inline]
     pub fn mark_dirty(&mut self) {
-        self.size_cache = [None; CACHE_SIZE];
+        self.cache.clear();
     }
 }

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -4,19 +4,19 @@ use std::sync::Mutex;
 
 use crate::node::Node;
 use crate::style;
-use crate::tree::LayoutTree;
+use crate::Taffy;
 
 /// Prints a debug representation of the computed layout for a tree of nodes, starting with the passed root node.
-pub fn print_tree(tree: &impl LayoutTree, root: Node) {
+pub fn print_tree(tree: &Taffy, root: Node) {
     println!("TREE");
     print_node(tree, root, false, String::new());
 }
 
-fn print_node(tree: &impl LayoutTree, node: Node, has_sibling: bool, lines_string: String) {
-    let layout = tree.layout(node);
-    let style = tree.style(node);
+fn print_node(tree: &Taffy, node: Node, has_sibling: bool, lines_string: String) {
+    let layout = tree.layout(node).unwrap();
+    let style = tree.style(node).unwrap();
 
-    let num_children = tree.child_count(node);
+    let num_children = tree.child_count(node).unwrap();
 
     let display = match (num_children, style.display) {
         (_, style::Display::None) => "NONE",
@@ -42,7 +42,7 @@ fn print_node(tree: &impl LayoutTree, node: Node, has_sibling: bool, lines_strin
     let new_string = lines_string + bar;
 
     // Recurse into children
-    for (index, child) in tree.children(node).enumerate() {
+    for (index, child) in tree.children(node).unwrap().iter().enumerate() {
         let has_sibling = index < num_children - 1;
         print_node(tree, *child, has_sibling, new_string.clone());
     }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -2,6 +2,7 @@
 
 use crate::geometry::{Point, Size};
 use crate::style::AvailableSpace;
+use crate::sys::round;
 
 /// Whether we are performing a full layout, or we merely need to size the node
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -74,6 +75,14 @@ impl Layout {
     #[must_use]
     pub const fn with_order(order: u32) -> Self {
         Self { order, size: Size::zero(), location: Point::ZERO }
+    }
+
+    /// Round layout to integer values
+    pub fn round(&mut self) {
+        self.location.x = round(self.location.x);
+        self.location.y = round(self.location.y);
+        self.size.width = round(self.size.width);
+        self.size.height = round(self.size.height);
     }
 }
 

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1,7 +1,6 @@
-//! Final and cached data structures that represent the high-level UI layout
+//! Types that are either inputs to or outputs from the layout computation
 
 use crate::geometry::{Point, Size};
-use crate::style::AvailableSpace;
 use crate::sys::round;
 
 /// Whether we are performing a full layout, or we merely need to size the node
@@ -84,18 +83,4 @@ impl Layout {
         self.size.width = round(self.size.width);
         self.size.height = round(self.size.height);
     }
-}
-
-/// Cached intermediate layout results
-#[derive(Debug, Clone, Copy)]
-pub struct Cache {
-    /// The initial cached size of the node itself
-    pub(crate) known_dimensions: Size<Option<f32>>,
-    /// The initial cached size of the parent's node
-    pub(crate) available_space: Size<AvailableSpace>,
-    /// Whether or not layout should be recomputed
-    pub(crate) run_mode: RunMode,
-
-    /// The cached size and baselines of the item
-    pub(crate) cached_size_and_baselines: SizeAndBaselines,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,4 +40,7 @@ mod resolve;
 mod sys;
 
 pub use crate::compute::compute_layout;
+pub use crate::compute::flexbox::FlexboxAlgorithm;
+pub use crate::compute::grid::CssGridAlgorithm;
+pub use crate::compute::LayoutAlgorithm;
 pub use crate::node::Taffy;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ extern crate alloc;
 extern crate serde;
 
 pub mod axis;
+pub mod cache;
 #[doc(hidden)]
 pub mod debug;
 pub mod error;

--- a/src/node.rs
+++ b/src/node.rs
@@ -9,7 +9,7 @@ pub type Node = slotmap::DefaultKey;
 use crate::compute::{self, recursively_perform_hidden_layout};
 use crate::error::{TaffyError, TaffyResult};
 use crate::geometry::Size;
-use crate::layout::{Cache, Layout};
+use crate::layout::{Layout};
 use crate::style::{AvailableSpace, Style};
 #[cfg(any(feature = "std", feature = "alloc"))]
 use crate::sys::Box;
@@ -135,11 +135,6 @@ impl<'tree> LayoutTree for TaffyNodeRef<'tree> {
     #[inline(always)]
     fn child_layout_mut(&mut self, child_node_id: Node) -> &mut Layout {
         &mut self.tree.nodes[child_node_id].layout
-    }
-
-    #[inline(always)]
-    fn cache_mut(&mut self, index: usize) -> &mut Option<Cache> {
-        &mut self.node_data_mut().size_cache[index]
     }
 
     #[inline(always)]

--- a/src/node.rs
+++ b/src/node.rs
@@ -9,7 +9,7 @@ pub type Node = slotmap::DefaultKey;
 use crate::compute::{self, recursively_perform_hidden_layout};
 use crate::error::{TaffyError, TaffyResult};
 use crate::geometry::Size;
-use crate::layout::{Layout};
+use crate::layout::Layout;
 use crate::style::{AvailableSpace, Style};
 #[cfg(any(feature = "std", feature = "alloc"))]
 use crate::sys::Box;
@@ -418,7 +418,7 @@ impl Taffy {
 
     /// Indicates whether the layout of this node (and its children) need to be recomputed
     pub fn dirty(&self, node: Node) -> TaffyResult<bool> {
-        Ok(self.nodes[node].size_cache.iter().all(|entry| entry.is_none()))
+        Ok(self.nodes[node].cache.is_empty())
     }
 
     /// Updates the stored layout of the provided `node` and its children

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -7,7 +7,6 @@ use crate::layout::{SizeAndBaselines, SizingMode};
 #[inline(always)]
 pub fn layout_flexbox(
     tree: &mut impl LayoutTree,
-    node: Node,
     known_dimensions: Size<Option<f32>>,
     parent_size: Size<Option<f32>>,
     available_space: Size<AvailableSpace>,
@@ -15,7 +14,6 @@ pub fn layout_flexbox(
 ) -> SizeAndBaselines {
     crate::compute::flexbox::FlexboxAlgorithm::perform_layout(
         tree,
-        node,
         known_dimensions,
         parent_size,
         available_space,

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -1,6 +1,7 @@
 //! Helper trait to calculate dimensions during layout resolution
 
-use crate::prelude::{Dimension, LengthPercentage, LengthPercentageAuto, Rect, Size};
+use crate::geometry::{Rect, Size};
+use crate::style::{Dimension, LengthPercentage, LengthPercentageAuto};
 use crate::style_helpers::TaffyZero;
 
 /// Trait to encapsulate behaviour where we need to resolve from a

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,66 +1,73 @@
 //! The baseline requirements of any UI Tree so Taffy can efficiently calculate the layout
 
-use slotmap::DefaultKey;
-
 use crate::{
-    error::TaffyResult,
-    layout::{Cache, Layout},
+    layout::{Cache, Layout, SizeAndBaselines, SizingMode},
     prelude::*,
 };
+use core::fmt::Debug;
 
 /// Any item that implements the LayoutTree can be layed out using Taffy's algorithms.
 ///
 /// Generally, Taffy expects your Node tree to be indexable by stable indices. A "stable" index means that the Node's ID
 /// remains the same between re-layouts.
 pub trait LayoutTree {
+    /// Type of an id that represents a child of the current node
+    /// This can be a usize if you are storing children in a vector
+    type ChildId: Copy + PartialEq + Debug;
+
     /// Type representing an iterator of the children of a node
-    type ChildIter<'a>: Iterator<Item = &'a DefaultKey>
+    type ChildIter<'a>: Iterator<Item = Self::ChildId>
     where
         Self: 'a;
 
-    /// Get the list of children IDs for the given node
-    fn children(&self, node: Node) -> Self::ChildIter<'_>;
+    // Current node methods
 
-    /// Get the number of children for the given node
-    fn child_count(&self, node: Node) -> usize;
-
-    /// Returns true if the node has no children
-    fn is_childless(&self, node: Node) -> bool;
-
-    /// Get a specific child of a node, where the index represents the nth child
-    fn child(&self, node: Node, index: usize) -> Node;
-
-    /// Get any available parent for this node
-    fn parent(&self, node: Node) -> Option<Node>;
-
-    // todo: allow abstractions over this so we don't prescribe how layout works
-    // for reference, CSS cascades require context, and storing a full flexbox layout for each node could be inefficient
-    //
     /// Get the [`Style`] for this Node.
-    fn style(&self, node: Node) -> &Style;
-
-    /// Get the node's output "Final Layout"
-    fn layout(&self, node: Node) -> &Layout;
+    fn style(&self) -> &Style;
 
     /// Modify the node's output layout
-    fn layout_mut(&mut self, node: Node) -> &mut Layout;
-
-    /// Mark a node as dirty to tell Taffy that something has changed and it needs to be recomputed.
-    ///
-    /// Commonly done if the style of the node has changed.
-    fn mark_dirty(&mut self, node: Node) -> TaffyResult<()>;
-
-    /// Measure a node. Taffy uses this to force reflows of things like text and overflowing content.
-    fn measure_node(
-        &self,
-        node: Node,
-        known_dimensions: Size<Option<f32>>,
-        available_space: Size<AvailableSpace>,
-    ) -> Size<f32>;
-
-    /// Node needs to be measured
-    fn needs_measure(&self, node: Node) -> bool;
+    fn layout_mut(&mut self) -> &mut Layout;
 
     /// Get a cache entry for this Node by index
-    fn cache_mut(&mut self, node: Node, index: usize) -> &mut Option<Cache>;
+    fn cache_mut(&mut self, index: usize) -> &mut Option<Cache>;
+
+    // Child methods
+
+    /// Get the list of children IDs for the given node
+    fn children(&self) -> Self::ChildIter<'_>;
+
+    /// Get the number of children for the given node
+    fn child_count(&self) -> usize;
+
+    /// Get a specific child of a node, where the index represents the nth child
+    fn child(&self, index: usize) -> Self::ChildId;
+
+    /// Get the [`Style`] for this child.
+    fn child_style(&self, child_node_id: Self::ChildId) -> &Style;
+
+    /// Modify the child's output layout
+    fn child_layout_mut(&mut self, child_node_id: Self::ChildId) -> &mut Layout;
+
+    /// Compute the size of the node given the specified constraints
+    fn measure_child_size(
+        &mut self,
+        child_node_id: Self::ChildId,
+        known_dimensions: Size<Option<f32>>,
+        parent_size: Size<Option<f32>>,
+        available_space: Size<AvailableSpace>,
+        sizing_mode: SizingMode,
+    ) -> Size<f32>;
+
+    /// Perform a full layout on the node given the specified constraints
+    fn perform_child_layout(
+        &mut self,
+        child_node_id: Self::ChildId,
+        known_dimensions: Size<Option<f32>>,
+        parent_size: Size<Option<f32>>,
+        available_space: Size<AvailableSpace>,
+        sizing_mode: SizingMode,
+    ) -> SizeAndBaselines;
+
+    /// Perform a hidden layout (mark the node as invisible)
+    fn perform_child_hidden_layout(&mut self, child_node_id: Self::ChildId, order: u32);
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,7 +1,7 @@
 //! The baseline requirements of any UI Tree so Taffy can efficiently calculate the layout
 
 use crate::{
-    layout::{Cache, Layout, SizeAndBaselines, SizingMode},
+    layout::{Layout, SizeAndBaselines, SizingMode},
     prelude::*,
 };
 use core::fmt::Debug;
@@ -27,9 +27,6 @@ pub trait LayoutTree {
 
     /// Modify the node's output layout
     fn layout_mut(&mut self) -> &mut Layout;
-
-    /// Get a cache entry for this Node by index
-    fn cache_mut(&mut self, index: usize) -> &mut Option<Cache>;
 
     // Child methods
 


### PR DESCRIPTION
# Objective

Fix #28 by adding child measurement functions to the `LayoutTree` trait.

- [x] Add `measure_child_size` and `perform_child_layout` methods to the `LayoutTree` trait, and trampoline all calls to size children through the LayoutTree trait (fixes #28)
- [x] Remove `parent` method (unused - we only ever traverse down the tree)
- [x] Remove `mark_dirty` method (unused - layout algorithms never need to mark nodes as dirty)
- [x] Remove `layout` method (unused - we only ever use `layout_mut`)
- [x] Remove the `is_childless` method (no need to make implementors implement another method when we can just use `child_count() == 0`)
- [x] Refactor such that `impl LayoutTree` represents a single node rather an entire hierarchy. Add `child_style` and `child_layout_mut` methods.
- [x] Make `ChildId` an ~associated~ generic type
- [x] Remove `needs_measure` and `measure_child` methods (if you're implementing LayoutTree then you don't need measure_funcs or the Leaf layout more).

## Remaining Issues

- [x] **Caching**. Currently the `LayoutTree` trait still has a `cache_mut` method, but the standalone Flexbox and CSS Grid implementations don't use it (in the high-level API caching is implemented in the generic method that switches between the modes). There are a couple of options here:
   - We could remove the `cache_mut` method from the trait. This simplifies the trait, but requires that implementors implement caching themselves. This is entirely possible with the current caching strategy, and we could provide an standalone cache type that encapsulates the storage and actual cache logic for people who want to use it. But it does preclude things like storing more of the internal state of the Flexbox/Grid algorithms in future (although we could of course just reintroduce a cache method to the trait at that point).
   - Alternatively we could move caching into the individual algorithms. This adds complexity, but might be a good idea from a perspective of having maximum information available when choosing what to cache. However, it would be quite hard to design a general purpose caching strategy. For example, in the `Taffy` struct where we are in control of the whole tree it doesn't make sense for the flexbox implementation to cache the sizes of it's children, because those children can cache their own sizes and this avoids us doubling up on caches. I suppose perhaps we could have nodes only cache their children, but that relies on making sure we have stable node references (reordering children shouldn't end up with them getting each other's cached values!)

   I'm definitely leaning towards removing caching entirely for those implementing `LayoutTree` themselves for the time being (on the basis that it's better to have no abstraction than a leaky abstraction), but I'd value other perspectives on this.
   
- [ ] **Performance**. I'm currently seeing a 10%-16% decrease in performance from this PR.  I'm not sure what's causing the slowdown, but I feel like I'd be willing to accept this for the increased flexibility (thoughts?). For the "deep tree" benchmarks we're still quite a bit faster than Taffy 0.2 due to earlier optimisations that have already been merged to main (for the "wide tree" benchmarks we seem to be a bit slower - I'm not sure why, but I'm not going to worry too much about this as a single node with 1000 direct (non-absolutely positioned) children doesn't seem like a very likely use case).

- [ ] **Children/Child methods**. There are a few related issues here:
    - The `ChildIter` associated type and `children` method aren't strictly necessary. We could make do with `child_count` and `child`. This would simplify the implementation of the trait, but would make things slightly less efficient. In some cases we're using `child_count` and `child` anyway to get around borrow checking restrictions.
    - The `ChildId` associated type and `child` methods are not strictly necessary. We could just always refer to children by index. Again, this would be less efficient (for some storage methods that actually have a meaningful child key - like Taffy's own storage), but would simplify the trait implementation.
   
- [ ] **Reference Nesting**. The layout algorithms currently take `&mut impl LayoutTree` like they did before this PR. However, prior to this PR the `impl LayoutTree` was an instance of the `Taffy` struct (so there was only one level of indirection), but in the new implementation `impl LayoutTree` is an instance of `TaffyNodeRef<'a>`, which is a small struct which itself contains an `&mut Taffy` and a node id (so there are now two levels of indirection). It's possible to remove the outer layer by making the layout algorithms take `impl LayoutTree` instead of `&mut LayoutTree`, and I've implemented this in https://github.com/nicoburns/taffy/commits/reborrow-layout-tree (see most recent 2 commits).

  In theory this should be more efficient (*assuming that struct implementing `LayoutTree` are as small as the two I've created so far*). However:
    - It requires implementers of `LayoutTree` to [implement an additional reborrow method](https://github.com/nicoburns/taffy/commit/93fdaa4422a55575ed311f473268c51feeaef74e)
    - It didn't seem to make much difference in benchmarks.
    
  I'm currently leaning towards leaving this as it is.
   
- [ ] **Naming**. The trait is called `LayoutTree`, and that makes sense in the current version of Taffy because it represents a whole tree. But with the changes in this PR it only represents a single node in the tree (and it's direct children). As such, I'm thinking it makes sense to rename the trait. Some options:
  - `LayoutNode`
  - `LayoutNodeRef`
  -  `Node`
  - `NodeRef`

  The "ref" bit is because in both the implementations of the new `LayoutTree` I have written so far (the one in this PR, and the one in `iced_taffy`), the type implementing `LayoutTree` has ended up being a wrapper around a reference back to the



## Context

See https://github.com/DioxusLabs/taffy/issues/28#issuecomment-1374941635
Blocked on #325, which is blocked on #320.

## New `LayoutTree` trait

```rust
pub trait LayoutTree {
    /// Type of an id that represents a child of the current node
    /// This can be a usize if you are storing children in a vector
    type ChildId: Copy + PartialEq + Debug;

    /// Type representing an iterator of the children of a node
    type ChildIter<'a>: Iterator<Item = Self::ChildId>
    where
        Self: 'a;

    // Current node methods

    /// Get the [`Style`] for this Node.
    fn style(&self) -> &Style;

    /// Modify the node's output layout
    fn layout_mut(&mut self) -> &mut Layout;

    // Child methods

    /// Get the list of children IDs for the given node
    fn children(&self) -> Self::ChildIter<'_>;

    /// Get the number of children for the given node
    fn child_count(&self) -> usize;

    /// Get a specific child of a node, where the index represents the nth child
    fn child(&self, index: usize) -> Self::ChildId;

    /// Get the [`Style`] for this child.
    fn child_style(&self, child_node_id: Self::ChildId) -> &Style;

    /// Modify the child's output layout
    fn child_layout_mut(&mut self, child_node_id: Self::ChildId) -> &mut Layout;

    /// Compute the size of the node given the specified constraints
    fn measure_child_size(
        &mut self,
        child_node_id: Self::ChildId,
        known_dimensions: Size<Option<f32>>,
        parent_size: Size<Option<f32>>,
        available_space: Size<AvailableSpace>,
        sizing_mode: SizingMode,
    ) -> Size<f32>;

    /// Perform a full layout on the node given the specified constraints
    fn perform_child_layout(
        &mut self,
        child_node_id: Self::ChildId,
        known_dimensions: Size<Option<f32>>,
        parent_size: Size<Option<f32>>,
        available_space: Size<AvailableSpace>,
        sizing_mode: SizingMode,
    ) -> SizeAndBaselines;

    /// Perform a hidden layout (mark the node as invisible)
    fn perform_child_hidden_layout(&mut self, child_node_id: Self::ChildId, order: u32);
}
```