### PR TITLE
Reinstate FlexStart and FlexEnd alignment variants

### DIFF
--- a/benches/generated/absolute_layout_align_items_and_justify_content_flex_end.rs
+++ b/benches/generated/absolute_layout_align_items_and_justify_content_flex_end.rs
@@ -15,8 +15,8 @@ pub fn compute() {
     let node = taffy
         .new_with_children(
             taffy::style::Style {
-                align_items: Some(taffy::style::AlignItems::End),
-                justify_content: Some(taffy::style::JustifyContent::End),
+                align_items: Some(taffy::style::AlignItems::FlexEnd),
+                justify_content: Some(taffy::style::JustifyContent::FlexEnd),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(110f32),
                     height: taffy::style::Dimension::Points(100f32),

--- a/benches/generated/absolute_layout_in_wrap_reverse_column_container_flex_end.rs
+++ b/benches/generated/absolute_layout_in_wrap_reverse_column_container_flex_end.rs
@@ -5,7 +5,7 @@ pub fn compute() {
     let node0 = taffy
         .new_leaf(taffy::style::Style {
             position: taffy::style::Position::Absolute,
-            align_self: Some(taffy::style::AlignSelf::End),
+            align_self: Some(taffy::style::AlignSelf::FlexEnd),
             size: taffy::geometry::Size {
                 width: taffy::style::Dimension::Points(20f32),
                 height: taffy::style::Dimension::Points(20f32),

--- a/benches/generated/absolute_layout_in_wrap_reverse_row_container_flex_end.rs
+++ b/benches/generated/absolute_layout_in_wrap_reverse_row_container_flex_end.rs
@@ -5,7 +5,7 @@ pub fn compute() {
     let node0 = taffy
         .new_leaf(taffy::style::Style {
             position: taffy::style::Position::Absolute,
-            align_self: Some(taffy::style::AlignSelf::End),
+            align_self: Some(taffy::style::AlignSelf::FlexEnd),
             size: taffy::geometry::Size {
                 width: taffy::style::Dimension::Points(20f32),
                 height: taffy::style::Dimension::Points(20f32),

--- a/benches/generated/absolute_margin_bottom_left.rs
+++ b/benches/generated/absolute_margin_bottom_left.rs
@@ -22,7 +22,7 @@ pub fn compute() {
         .new_with_children(
             taffy::style::Style {
                 flex_direction: taffy::style::FlexDirection::Column,
-                justify_content: Some(taffy::style::JustifyContent::End),
+                justify_content: Some(taffy::style::JustifyContent::FlexEnd),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(100f32),
                     height: taffy::style::Dimension::Points(100f32),

--- a/benches/generated/align_content_flex_end.rs
+++ b/benches/generated/align_content_flex_end.rs
@@ -52,7 +52,7 @@ pub fn compute() {
             taffy::style::Style {
                 flex_direction: taffy::style::FlexDirection::Column,
                 flex_wrap: taffy::style::FlexWrap::Wrap,
-                align_content: Some(taffy::style::AlignContent::End),
+                align_content: Some(taffy::style::AlignContent::FlexEnd),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(100f32),
                     height: taffy::style::Dimension::Points(100f32),

--- a/benches/generated/align_content_flex_start.rs
+++ b/benches/generated/align_content_flex_start.rs
@@ -51,7 +51,7 @@ pub fn compute() {
         .new_with_children(
             taffy::style::Style {
                 flex_wrap: taffy::style::FlexWrap::Wrap,
-                align_content: Some(taffy::style::AlignContent::Start),
+                align_content: Some(taffy::style::AlignContent::FlexStart),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(130f32),
                     height: taffy::style::Dimension::Points(100f32),

--- a/benches/generated/align_content_flex_start_with_flex.rs
+++ b/benches/generated/align_content_flex_start_with_flex.rs
@@ -49,7 +49,7 @@ pub fn compute() {
             taffy::style::Style {
                 flex_direction: taffy::style::FlexDirection::Column,
                 flex_wrap: taffy::style::FlexWrap::Wrap,
-                align_content: Some(taffy::style::AlignContent::Start),
+                align_content: Some(taffy::style::AlignContent::FlexStart),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(100f32),
                     height: taffy::style::Dimension::Points(120f32),

--- a/benches/generated/align_content_flex_start_without_height_on_children.rs
+++ b/benches/generated/align_content_flex_start_without_height_on_children.rs
@@ -43,7 +43,7 @@ pub fn compute() {
             taffy::style::Style {
                 flex_direction: taffy::style::FlexDirection::Column,
                 flex_wrap: taffy::style::FlexWrap::Wrap,
-                align_content: Some(taffy::style::AlignContent::Start),
+                align_content: Some(taffy::style::AlignContent::FlexStart),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(100f32),
                     height: taffy::style::Dimension::Points(100f32),

--- a/benches/generated/align_content_not_stretch_with_align_items_stretch.rs
+++ b/benches/generated/align_content_not_stretch_with_align_items_stretch.rs
@@ -36,7 +36,7 @@ pub fn compute() {
         .new_with_children(
             taffy::style::Style {
                 flex_wrap: taffy::style::FlexWrap::Wrap,
-                align_content: Some(taffy::style::AlignContent::Start),
+                align_content: Some(taffy::style::AlignContent::FlexStart),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(328f32),
                     height: taffy::style::Dimension::Points(52f32),

--- a/benches/generated/align_flex_start_with_shrinking_children.rs
+++ b/benches/generated/align_flex_start_with_shrinking_children.rs
@@ -9,7 +9,7 @@ pub fn compute() {
         .unwrap();
     let node0 = taffy
         .new_with_children(
-            taffy::style::Style { align_items: Some(taffy::style::AlignItems::Start), ..Default::default() },
+            taffy::style::Style { align_items: Some(taffy::style::AlignItems::FlexStart), ..Default::default() },
             &[node00],
         )
         .unwrap();

--- a/benches/generated/align_flex_start_with_shrinking_children_with_stretch.rs
+++ b/benches/generated/align_flex_start_with_shrinking_children_with_stretch.rs
@@ -17,7 +17,7 @@ pub fn compute() {
         .unwrap();
     let node0 = taffy
         .new_with_children(
-            taffy::style::Style { align_items: Some(taffy::style::AlignItems::Start), ..Default::default() },
+            taffy::style::Style { align_items: Some(taffy::style::AlignItems::FlexStart), ..Default::default() },
             &[node00],
         )
         .unwrap();

--- a/benches/generated/align_items_flex_end.rs
+++ b/benches/generated/align_items_flex_end.rs
@@ -14,7 +14,7 @@ pub fn compute() {
     let node = taffy
         .new_with_children(
             taffy::style::Style {
-                align_items: Some(taffy::style::AlignItems::End),
+                align_items: Some(taffy::style::AlignItems::FlexEnd),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(100f32),
                     height: taffy::style::Dimension::Points(100f32),

--- a/benches/generated/align_items_flex_end_child_with_margin_bigger_than_parent.rs
+++ b/benches/generated/align_items_flex_end_child_with_margin_bigger_than_parent.rs
@@ -19,7 +19,7 @@ pub fn compute() {
         .unwrap();
     let node0 = taffy
         .new_with_children(
-            taffy::style::Style { align_items: Some(taffy::style::AlignItems::End), ..Default::default() },
+            taffy::style::Style { align_items: Some(taffy::style::AlignItems::FlexEnd), ..Default::default() },
             &[node00],
         )
         .unwrap();

--- a/benches/generated/align_items_flex_end_child_without_margin_bigger_than_parent.rs
+++ b/benches/generated/align_items_flex_end_child_without_margin_bigger_than_parent.rs
@@ -13,7 +13,7 @@ pub fn compute() {
         .unwrap();
     let node0 = taffy
         .new_with_children(
-            taffy::style::Style { align_items: Some(taffy::style::AlignItems::End), ..Default::default() },
+            taffy::style::Style { align_items: Some(taffy::style::AlignItems::FlexEnd), ..Default::default() },
             &[node00],
         )
         .unwrap();

--- a/benches/generated/align_items_flex_start.rs
+++ b/benches/generated/align_items_flex_start.rs
@@ -14,7 +14,7 @@ pub fn compute() {
     let node = taffy
         .new_with_children(
             taffy::style::Style {
-                align_items: Some(taffy::style::AlignItems::Start),
+                align_items: Some(taffy::style::AlignItems::FlexStart),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(100f32),
                     height: taffy::style::Dimension::Points(100f32),

--- a/benches/generated/align_self_flex_end.rs
+++ b/benches/generated/align_self_flex_end.rs
@@ -4,7 +4,7 @@ pub fn compute() {
     let mut taffy = taffy::Taffy::new();
     let node0 = taffy
         .new_leaf(taffy::style::Style {
-            align_self: Some(taffy::style::AlignSelf::End),
+            align_self: Some(taffy::style::AlignSelf::FlexEnd),
             size: taffy::geometry::Size {
                 width: taffy::style::Dimension::Points(10f32),
                 height: taffy::style::Dimension::Points(10f32),

--- a/benches/generated/align_self_flex_end_override_flex_start.rs
+++ b/benches/generated/align_self_flex_end_override_flex_start.rs
@@ -4,7 +4,7 @@ pub fn compute() {
     let mut taffy = taffy::Taffy::new();
     let node0 = taffy
         .new_leaf(taffy::style::Style {
-            align_self: Some(taffy::style::AlignSelf::End),
+            align_self: Some(taffy::style::AlignSelf::FlexEnd),
             size: taffy::geometry::Size {
                 width: taffy::style::Dimension::Points(10f32),
                 height: taffy::style::Dimension::Points(10f32),
@@ -15,7 +15,7 @@ pub fn compute() {
     let node = taffy
         .new_with_children(
             taffy::style::Style {
-                align_items: Some(taffy::style::AlignItems::Start),
+                align_items: Some(taffy::style::AlignItems::FlexStart),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(100f32),
                     height: taffy::style::Dimension::Points(100f32),

--- a/benches/generated/align_self_flex_start.rs
+++ b/benches/generated/align_self_flex_start.rs
@@ -4,7 +4,7 @@ pub fn compute() {
     let mut taffy = taffy::Taffy::new();
     let node0 = taffy
         .new_leaf(taffy::style::Style {
-            align_self: Some(taffy::style::AlignSelf::Start),
+            align_self: Some(taffy::style::AlignSelf::FlexStart),
             size: taffy::geometry::Size {
                 width: taffy::style::Dimension::Points(10f32),
                 height: taffy::style::Dimension::Points(10f32),

--- a/benches/generated/android_news_feed.rs
+++ b/benches/generated/android_news_feed.rs
@@ -63,7 +63,7 @@ pub fn compute() {
     let node0000 = taffy
         .new_with_children(
             taffy::style::Style {
-                align_items: Some(taffy::style::AlignItems::Start),
+                align_items: Some(taffy::style::AlignItems::FlexStart),
                 align_content: Some(taffy::style::AlignContent::Stretch),
                 margin: taffy::geometry::Rect {
                     left: taffy::style::LengthPercentageAuto::Points(36f32),
@@ -147,7 +147,7 @@ pub fn compute() {
     let node0010 = taffy
         .new_with_children(
             taffy::style::Style {
-                align_items: Some(taffy::style::AlignItems::Start),
+                align_items: Some(taffy::style::AlignItems::FlexStart),
                 align_content: Some(taffy::style::AlignContent::Stretch),
                 margin: taffy::geometry::Rect {
                     left: taffy::style::LengthPercentageAuto::Points(174f32),

--- a/benches/generated/child_with_padding_align_end.rs
+++ b/benches/generated/child_with_padding_align_end.rs
@@ -21,8 +21,8 @@ pub fn compute() {
         .new_with_children(
             taffy::style::Style {
                 flex_direction: taffy::style::FlexDirection::Column,
-                align_items: Some(taffy::style::AlignItems::End),
-                justify_content: Some(taffy::style::JustifyContent::End),
+                align_items: Some(taffy::style::AlignItems::FlexEnd),
+                justify_content: Some(taffy::style::JustifyContent::FlexEnd),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(200f32),
                     height: taffy::style::Dimension::Points(200f32),

--- a/benches/generated/flex_grow_in_at_most_container.rs
+++ b/benches/generated/flex_grow_in_at_most_container.rs
@@ -13,7 +13,7 @@ pub fn compute() {
     let node = taffy
         .new_with_children(
             taffy::style::Style {
-                align_items: Some(taffy::style::AlignItems::Start),
+                align_items: Some(taffy::style::AlignItems::FlexStart),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(100f32),
                     height: taffy::style::Dimension::Points(100f32),

--- a/benches/generated/flex_wrap_wrap_to_child_height.rs
+++ b/benches/generated/flex_wrap_wrap_to_child_height.rs
@@ -25,7 +25,7 @@ pub fn compute() {
         .new_with_children(
             taffy::style::Style {
                 flex_wrap: taffy::style::FlexWrap::Wrap,
-                align_items: Some(taffy::style::AlignItems::Start),
+                align_items: Some(taffy::style::AlignItems::FlexStart),
                 ..Default::default()
             },
             &[node00],

--- a/benches/generated/gap_column_gap_justify_flex_end.rs
+++ b/benches/generated/gap_column_gap_justify_flex_end.rs
@@ -23,7 +23,7 @@ pub fn compute() {
     let node = taffy
         .new_with_children(
             taffy::style::Style {
-                justify_content: Some(taffy::style::JustifyContent::End),
+                justify_content: Some(taffy::style::JustifyContent::FlexEnd),
                 gap: taffy::geometry::Size { width: taffy::style::LengthPercentage::Points(10f32), height: zero() },
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(100f32),

--- a/benches/generated/gap_column_gap_justify_flex_start.rs
+++ b/benches/generated/gap_column_gap_justify_flex_start.rs
@@ -23,7 +23,7 @@ pub fn compute() {
     let node = taffy
         .new_with_children(
             taffy::style::Style {
-                justify_content: Some(taffy::style::JustifyContent::Start),
+                justify_content: Some(taffy::style::JustifyContent::FlexStart),
                 gap: taffy::geometry::Size { width: taffy::style::LengthPercentage::Points(10f32), height: zero() },
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(100f32),

--- a/benches/generated/gap_column_gap_wrap_align_flex_end.rs
+++ b/benches/generated/gap_column_gap_wrap_align_flex_end.rs
@@ -60,7 +60,7 @@ pub fn compute() {
         .new_with_children(
             taffy::style::Style {
                 flex_wrap: taffy::style::FlexWrap::Wrap,
-                align_content: Some(taffy::style::AlignContent::End),
+                align_content: Some(taffy::style::AlignContent::FlexEnd),
                 gap: taffy::geometry::Size {
                     width: taffy::style::LengthPercentage::Points(10f32),
                     height: taffy::style::LengthPercentage::Points(20f32),

--- a/benches/generated/gap_column_gap_wrap_align_flex_start.rs
+++ b/benches/generated/gap_column_gap_wrap_align_flex_start.rs
@@ -60,7 +60,7 @@ pub fn compute() {
         .new_with_children(
             taffy::style::Style {
                 flex_wrap: taffy::style::FlexWrap::Wrap,
-                align_content: Some(taffy::style::AlignContent::Start),
+                align_content: Some(taffy::style::AlignContent::FlexStart),
                 gap: taffy::geometry::Size {
                     width: taffy::style::LengthPercentage::Points(10f32),
                     height: taffy::style::LengthPercentage::Points(20f32),

--- a/benches/generated/gap_row_gap_align_items_end.rs
+++ b/benches/generated/gap_row_gap_align_items_end.rs
@@ -42,7 +42,7 @@ pub fn compute() {
         .new_with_children(
             taffy::style::Style {
                 flex_wrap: taffy::style::FlexWrap::Wrap,
-                align_items: Some(taffy::style::AlignItems::End),
+                align_items: Some(taffy::style::AlignItems::FlexEnd),
                 gap: taffy::geometry::Size {
                     width: taffy::style::LengthPercentage::Points(10f32),
                     height: taffy::style::LengthPercentage::Points(20f32),

--- a/benches/generated/justify_content_column_flex_end.rs
+++ b/benches/generated/justify_content_column_flex_end.rs
@@ -24,7 +24,7 @@ pub fn compute() {
         .new_with_children(
             taffy::style::Style {
                 flex_direction: taffy::style::FlexDirection::Column,
-                justify_content: Some(taffy::style::JustifyContent::End),
+                justify_content: Some(taffy::style::JustifyContent::FlexEnd),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(100f32),
                     height: taffy::style::Dimension::Points(100f32),

--- a/benches/generated/justify_content_column_flex_start.rs
+++ b/benches/generated/justify_content_column_flex_start.rs
@@ -24,7 +24,7 @@ pub fn compute() {
         .new_with_children(
             taffy::style::Style {
                 flex_direction: taffy::style::FlexDirection::Column,
-                justify_content: Some(taffy::style::JustifyContent::Start),
+                justify_content: Some(taffy::style::JustifyContent::FlexStart),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(100f32),
                     height: taffy::style::Dimension::Points(100f32),

--- a/benches/generated/justify_content_row_flex_end.rs
+++ b/benches/generated/justify_content_row_flex_end.rs
@@ -23,7 +23,7 @@ pub fn compute() {
     let node = taffy
         .new_with_children(
             taffy::style::Style {
-                justify_content: Some(taffy::style::JustifyContent::End),
+                justify_content: Some(taffy::style::JustifyContent::FlexEnd),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(100f32),
                     height: taffy::style::Dimension::Points(100f32),

--- a/benches/generated/justify_content_row_flex_start.rs
+++ b/benches/generated/justify_content_row_flex_start.rs
@@ -23,7 +23,7 @@ pub fn compute() {
     let node = taffy
         .new_with_children(
             taffy::style::Style {
-                justify_content: Some(taffy::style::JustifyContent::Start),
+                justify_content: Some(taffy::style::JustifyContent::FlexStart),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(100f32),
                     height: taffy::style::Dimension::Points(100f32),

--- a/benches/generated/margin_bottom.rs
+++ b/benches/generated/margin_bottom.rs
@@ -18,7 +18,7 @@ pub fn compute() {
         .new_with_children(
             taffy::style::Style {
                 flex_direction: taffy::style::FlexDirection::Column,
-                justify_content: Some(taffy::style::JustifyContent::End),
+                justify_content: Some(taffy::style::JustifyContent::FlexEnd),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(100f32),
                     height: taffy::style::Dimension::Points(100f32),

--- a/benches/generated/margin_right.rs
+++ b/benches/generated/margin_right.rs
@@ -17,7 +17,7 @@ pub fn compute() {
     let node = taffy
         .new_with_children(
             taffy::style::Style {
-                justify_content: Some(taffy::style::JustifyContent::End),
+                justify_content: Some(taffy::style::JustifyContent::FlexEnd),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(100f32),
                     height: taffy::style::Dimension::Points(100f32),

--- a/benches/generated/min_height_with_nested_fixed_height.rs
+++ b/benches/generated/min_height_with_nested_fixed_height.rs
@@ -15,7 +15,7 @@ pub fn compute() {
         .new_with_children(
             taffy::style::Style {
                 flex_direction: taffy::style::FlexDirection::Column,
-                align_self: Some(taffy::style::AlignSelf::Start),
+                align_self: Some(taffy::style::AlignSelf::FlexStart),
                 flex_shrink: 0f32,
                 min_size: taffy::geometry::Size { width: auto(), height: taffy::style::Dimension::Points(28f32) },
                 margin: taffy::geometry::Rect {

--- a/benches/generated/min_max_percent_different_width_height.rs
+++ b/benches/generated/min_max_percent_different_width_height.rs
@@ -31,7 +31,7 @@ pub fn compute() {
         .new_with_children(
             taffy::style::Style {
                 flex_direction: taffy::style::FlexDirection::Column,
-                align_items: Some(taffy::style::AlignItems::Start),
+                align_items: Some(taffy::style::AlignItems::FlexStart),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(100f32),
                     height: taffy::style::Dimension::Points(200f32),

--- a/benches/generated/min_max_percent_no_width_height.rs
+++ b/benches/generated/min_max_percent_no_width_height.rs
@@ -19,7 +19,7 @@ pub fn compute() {
         .new_with_children(
             taffy::style::Style {
                 flex_direction: taffy::style::FlexDirection::Column,
-                align_items: Some(taffy::style::AlignItems::Start),
+                align_items: Some(taffy::style::AlignItems::FlexStart),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(100f32),
                     height: taffy::style::Dimension::Points(100f32),

--- a/benches/generated/padding_align_end_child.rs
+++ b/benches/generated/padding_align_end_child.rs
@@ -20,8 +20,8 @@ pub fn compute() {
     let node = taffy
         .new_with_children(
             taffy::style::Style {
-                align_items: Some(taffy::style::AlignItems::End),
-                justify_content: Some(taffy::style::JustifyContent::End),
+                align_items: Some(taffy::style::AlignItems::FlexEnd),
+                justify_content: Some(taffy::style::JustifyContent::FlexEnd),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(200f32),
                     height: taffy::style::Dimension::Points(200f32),

--- a/benches/generated/percentage_main_max_height.rs
+++ b/benches/generated/percentage_main_max_height.rs
@@ -16,7 +16,7 @@ pub fn compute() {
         .new_with_children(
             taffy::style::Style {
                 flex_direction: taffy::style::FlexDirection::Column,
-                align_items: Some(taffy::style::AlignItems::Start),
+                align_items: Some(taffy::style::AlignItems::FlexStart),
                 size: taffy::geometry::Size { width: auto(), height: taffy::style::Dimension::Points(151f32) },
                 ..Default::default()
             },

--- a/benches/generated/wrap_reverse_row_align_content_flex_start.rs
+++ b/benches/generated/wrap_reverse_row_align_content_flex_start.rs
@@ -51,7 +51,7 @@ pub fn compute() {
         .new_with_children(
             taffy::style::Style {
                 flex_wrap: taffy::style::FlexWrap::WrapReverse,
-                align_content: Some(taffy::style::AlignContent::Start),
+                align_content: Some(taffy::style::AlignContent::FlexStart),
                 size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), height: auto() },
                 ..Default::default()
             },

--- a/benches/generated/wrap_reverse_row_single_line_different_size.rs
+++ b/benches/generated/wrap_reverse_row_single_line_different_size.rs
@@ -51,7 +51,7 @@ pub fn compute() {
         .new_with_children(
             taffy::style::Style {
                 flex_wrap: taffy::style::FlexWrap::WrapReverse,
-                align_content: Some(taffy::style::AlignContent::Start),
+                align_content: Some(taffy::style::AlignContent::FlexStart),
                 size: taffy::geometry::Size { width: taffy::style::Dimension::Points(300f32), height: auto() },
                 ..Default::default()
             },

--- a/benches/generated/wrap_row_align_items_flex_end.rs
+++ b/benches/generated/wrap_row_align_items_flex_end.rs
@@ -42,7 +42,7 @@ pub fn compute() {
         .new_with_children(
             taffy::style::Style {
                 flex_wrap: taffy::style::FlexWrap::Wrap,
-                align_items: Some(taffy::style::AlignItems::End),
+                align_items: Some(taffy::style::AlignItems::FlexEnd),
                 size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), height: auto() },
                 ..Default::default()
             },

--- a/benches/generated/wrapped_row_within_align_items_flex_end.rs
+++ b/benches/generated/wrapped_row_within_align_items_flex_end.rs
@@ -30,7 +30,7 @@ pub fn compute() {
         .new_with_children(
             taffy::style::Style {
                 flex_direction: taffy::style::FlexDirection::Column,
-                align_items: Some(taffy::style::AlignItems::End),
+                align_items: Some(taffy::style::AlignItems::FlexEnd),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(200f32),
                     height: taffy::style::Dimension::Points(200f32),

--- a/benches/generated/wrapped_row_within_align_items_flex_start.rs
+++ b/benches/generated/wrapped_row_within_align_items_flex_start.rs
@@ -30,7 +30,7 @@ pub fn compute() {
         .new_with_children(
             taffy::style::Style {
                 flex_direction: taffy::style::FlexDirection::Column,
-                align_items: Some(taffy::style::AlignItems::Start),
+                align_items: Some(taffy::style::AlignItems::FlexStart),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(200f32),
                     height: taffy::style::Dimension::Points(200f32),

--- a/scripts/gentest/src/main.rs
+++ b/scripts/gentest/src/main.rs
@@ -410,8 +410,10 @@ fn generate_node(ident: &str, node: &Value) -> TokenStream {
 
     let align_items = match style["alignItems"] {
         Value::String(ref value) => match value.as_ref() {
-            "flex-start" | "start" => quote!(align_items: Some(taffy::style::AlignItems::Start),),
-            "flex-end" | "end" => quote!(align_items: Some(taffy::style::AlignItems::End),),
+            "start" => quote!(align_items: Some(taffy::style::AlignItems::Start),),
+            "end" => quote!(align_items: Some(taffy::style::AlignItems::End),),
+            "flex-start" => quote!(align_items: Some(taffy::style::AlignItems::FlexStart),),
+            "flex-end" => quote!(align_items: Some(taffy::style::AlignItems::FlexEnd),),
             "center" => quote!(align_items: Some(taffy::style::AlignItems::Center),),
             "baseline" => quote!(align_items: Some(taffy::style::AlignItems::Baseline),),
             "stretch" => quote!(align_items: Some(taffy::style::AlignItems::Stretch),),
@@ -422,8 +424,10 @@ fn generate_node(ident: &str, node: &Value) -> TokenStream {
 
     let align_self = match style["alignSelf"] {
         Value::String(ref value) => match value.as_ref() {
-            "flex-start" | "start" => quote!(align_self: Some(taffy::style::AlignSelf::Start),),
-            "flex-end" | "end" => quote!(align_self: Some(taffy::style::AlignSelf::End),),
+            "start" => quote!(align_self: Some(taffy::style::AlignSelf::Start),),
+            "end" => quote!(align_self: Some(taffy::style::AlignSelf::End),),
+            "flex-start" => quote!(align_self: Some(taffy::style::AlignSelf::FlexStart),),
+            "flex-end" => quote!(align_self: Some(taffy::style::AlignSelf::FlexEnd),),
             "center" => quote!(align_self: Some(taffy::style::AlignSelf::Center),),
             "baseline" => quote!(align_self: Some(taffy::style::AlignSelf::Baseline),),
             "stretch" => quote!(align_self: Some(taffy::style::AlignSelf::Stretch),),
@@ -434,8 +438,10 @@ fn generate_node(ident: &str, node: &Value) -> TokenStream {
 
     let justify_items = match style["justifyItems"] {
         Value::String(ref value) => match value.as_ref() {
-            "flex-start" | "start" => quote!(justify_items: Some(taffy::style::JustifyItems::Start),),
-            "flex-end" | "end" => quote!(justify_items: Some(taffy::style::JustifyItems::End),),
+            "start" => quote!(justify_items: Some(taffy::style::JustifyItems::Start),),
+            "end" => quote!(justify_items: Some(taffy::style::JustifyItems::End),),
+            "flex-start" => quote!(justify_items: Some(taffy::style::JustifyItems::FlexStart),),
+            "flex-end" => quote!(justify_items: Some(taffy::style::JustifyItems::FlexEnd),),
             "center" => quote!(justify_items: Some(taffy::style::JustifyItems::Center),),
             "baseline" => quote!(justify_items: Some(taffy::style::JustifyItems::Baseline),),
             "stretch" => quote!(justify_items: Some(taffy::style::JustifyItems::Stretch),),
@@ -446,8 +452,10 @@ fn generate_node(ident: &str, node: &Value) -> TokenStream {
 
     let justify_self = match style["justifySelf"] {
         Value::String(ref value) => match value.as_ref() {
-            "flex-start" | "start" => quote!(justify_self: Some(taffy::style::JustifySelf::Start),),
-            "flex-end" | "end" => quote!(justify_self: Some(taffy::style::JustifySelf::End),),
+            "start" => quote!(justify_self: Some(taffy::style::JustifySelf::Start),),
+            "end" => quote!(justify_self: Some(taffy::style::JustifySelf::End),),
+            "flex-start" => quote!(justify_self: Some(taffy::style::JustifySelf::FlexStart),),
+            "flex-end" => quote!(justify_self: Some(taffy::style::JustifySelf::FlexEnd),),
             "center" => quote!(justify_self: Some(taffy::style::JustifySelf::Center),),
             "baseline" => quote!(justify_self: Some(taffy::style::JustifySelf::Baseline),),
             "stretch" => quote!(justify_self: Some(taffy::style::JustifySelf::Stretch),),
@@ -458,8 +466,10 @@ fn generate_node(ident: &str, node: &Value) -> TokenStream {
 
     let align_content = match style["alignContent"] {
         Value::String(ref value) => match value.as_ref() {
-            "flex-start" | "start" => quote!(align_content: Some(taffy::style::AlignContent::Start),),
-            "flex-end" | "end" => quote!(align_content: Some(taffy::style::AlignContent::End),),
+            "start" => quote!(align_content: Some(taffy::style::AlignContent::Start),),
+            "end" => quote!(align_content: Some(taffy::style::AlignContent::End),),
+            "flex-start" => quote!(align_content: Some(taffy::style::AlignContent::FlexStart),),
+            "flex-end" => quote!(align_content: Some(taffy::style::AlignContent::FlexEnd),),
             "center" => quote!(align_content: Some(taffy::style::AlignContent::Center),),
             "stretch" => quote!(align_content: Some(taffy::style::AlignContent::Stretch),),
             "space-between" => quote!(align_content: Some(taffy::style::AlignContent::SpaceBetween),),
@@ -472,10 +482,12 @@ fn generate_node(ident: &str, node: &Value) -> TokenStream {
 
     let justify_content = match style["justifyContent"] {
         Value::String(ref value) => match value.as_ref() {
-            "flex-start" | "start" => quote!(justify_content: Some(taffy::style::JustifyContent::Start),),
-            "flex-end" | "end" => quote!(justify_content: Some(taffy::style::JustifyContent::End),),
+            "start" => quote!(justify_content: Some(taffy::style::JustifyContent::Start),),
+            "end" => quote!(justify_content: Some(taffy::style::JustifyContent::End),),
+            "flex-start" => quote!(justify_content: Some(taffy::style::JustifyContent::FlexStart),),
+            "flex-end" => quote!(justify_content: Some(taffy::style::JustifyContent::FlexEnd),),
             "center" => quote!(justify_content: Some(taffy::style::JustifyContent::Center),),
-            "stretch" => quote!(align_content: Some(taffy::style::AlignContent::Stretch),),
+            "stretch" => quote!(justify_content: Some(taffy::style::AlignContent::Stretch),),
             "space-between" => quote!(justify_content: Some(taffy::style::JustifyContent::SpaceBetween),),
             "space-around" => quote!(justify_content: Some(taffy::style::JustifyContent::SpaceAround),),
             "space-evenly" => quote!(justify_content: Some(taffy::style::JustifyContent::SpaceEvenly),),

--- a/src/compute/common/alignment.rs
+++ b/src/compute/common/alignment.rs
@@ -11,66 +11,44 @@ pub(crate) fn compute_alignment_offset(
     num_items: usize,
     gap: f32,
     alignment_mode: AlignContent,
-    layout_is_reversed: bool,
+    layout_is_flex_reversed: bool,
     is_first: bool,
 ) -> f32 {
-    match alignment_mode {
-        AlignContent::Start => {
-            if is_first {
-                if layout_is_reversed {
+    if is_first {
+        match alignment_mode {
+            AlignContent::Start => 0.0,
+            AlignContent::FlexStart => {
+                if layout_is_flex_reversed {
                     free_space
                 } else {
                     0.0
                 }
-            } else {
-                gap
             }
-        }
-        AlignContent::End => {
-            if is_first {
-                if !layout_is_reversed {
-                    free_space
-                } else {
+            AlignContent::End => free_space,
+            AlignContent::FlexEnd => {
+                if layout_is_flex_reversed {
                     0.0
+                } else {
+                    free_space
                 }
-            } else {
-                gap
             }
+            AlignContent::Center => free_space / 2.0,
+            AlignContent::Stretch => 0.0,
+            AlignContent::SpaceBetween => 0.0,
+            AlignContent::SpaceAround => (free_space / num_items as f32) / 2.0,
+            AlignContent::SpaceEvenly => free_space / (num_items + 1) as f32,
         }
-        AlignContent::Center => {
-            if is_first {
-                free_space / 2.0
-            } else {
-                gap
-            }
-        }
-        AlignContent::Stretch => {
-            if is_first {
-                0.0
-            } else {
-                gap
-            }
-        }
-        AlignContent::SpaceBetween => {
-            if is_first {
-                0.0
-            } else {
-                gap + (free_space / (num_items - 1) as f32)
-            }
-        }
-        AlignContent::SpaceAround => {
-            if is_first {
-                (free_space / num_items as f32) / 2.0
-            } else {
-                gap + (free_space / num_items as f32)
-            }
-        }
-        AlignContent::SpaceEvenly => {
-            if is_first {
-                free_space / (num_items + 1) as f32
-            } else {
-                gap + (free_space / (num_items + 1) as f32)
-            }
+    } else {
+        gap + match alignment_mode {
+            AlignContent::Start => 0.0,
+            AlignContent::FlexStart => 0.0,
+            AlignContent::End => 0.0,
+            AlignContent::FlexEnd => 0.0,
+            AlignContent::Center => 0.0,
+            AlignContent::Stretch => 0.0,
+            AlignContent::SpaceBetween => free_space / (num_items - 1) as f32,
+            AlignContent::SpaceAround => free_space / num_items as f32,
+            AlignContent::SpaceEvenly => free_space / (num_items + 1) as f32,
         }
     }
 }

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -1310,7 +1310,7 @@ fn distribute_remaining_free_space(
             let layout_reverse = constants.dir.is_reverse();
             let gap = constants.gap.main(constants.dir);
             let justify_content_mode: JustifyContent =
-                tree.style(node).justify_content.unwrap_or(JustifyContent::Start);
+                tree.style(node).justify_content.unwrap_or(JustifyContent::FlexStart);
 
             let justify_item = |(i, child): (usize, &mut FlexItem)| {
                 child.offset_main =
@@ -1392,14 +1392,16 @@ fn align_flex_items_along_cross_axis(
     constants: &AlgoConstants,
 ) -> f32 {
     match child.align_self {
-        AlignSelf::Start => {
+        AlignSelf::Start => 0.0,
+        AlignSelf::FlexStart => {
             if constants.is_wrap_reverse {
                 free_space
             } else {
                 0.0
             }
         }
-        AlignSelf::End => {
+        AlignSelf::End => free_space,
+        AlignSelf::FlexEnd => {
             if constants.is_wrap_reverse {
                 0.0
             } else {
@@ -1408,11 +1410,11 @@ fn align_flex_items_along_cross_axis(
         }
         AlignSelf::Center => free_space / 2.0,
         AlignSelf::Baseline => {
+            // Until we support vertical writing modes, baseline alignment only makes sense if
+            // the constants.direction is row, so we treat it as flex-start alignment in columns.
             if constants.is_row {
                 max_baseline - child.baseline
             } else {
-                // baseline alignment only makes sense if the constants.direction is row
-                // we treat it as flex-start alignment in columns.
                 if constants.is_wrap_reverse {
                     free_space
                 } else {
@@ -1753,19 +1755,26 @@ fn perform_absolute_layout_on_absolute_children(tree: &mut impl LayoutTree, node
                 - end
                 - resolved_margin.main_end(constants.dir)
         } else {
-            match tree.style(node).justify_content.unwrap_or(JustifyContent::Start) {
-                // Stretch is an invalid value for justify_content in the flexbox algorithm, so we
-                // treat it as if it wasn't set (and thus we default to FlexStart behaviour)
-                JustifyContent::SpaceBetween | JustifyContent::Start | JustifyContent::Stretch => {
+            // Stretch is an invalid value for justify_content in the flexbox algorithm, so we
+            // treat it as if it wasn't set (and thus we default to FlexStart behaviour)
+            match (tree.style(node).justify_content.unwrap_or(JustifyContent::Start), constants.is_wrap_reverse) {
+                (JustifyContent::SpaceBetween, _)
+                | (JustifyContent::Start, _)
+                | (JustifyContent::Stretch, false)
+                | (JustifyContent::FlexStart, false)
+                | (JustifyContent::FlexEnd, true) => {
                     constants.padding_border.main_start(constants.dir) + resolved_margin.main_start(constants.dir)
                 }
-                JustifyContent::End => {
+                (JustifyContent::End, _)
+                | (JustifyContent::FlexEnd, false)
+                | (JustifyContent::FlexStart, true)
+                | (JustifyContent::Stretch, true) => {
                     constants.container_size.main(constants.dir)
                         - constants.padding_border.main_end(constants.dir)
                         - final_size.main(constants.dir)
                         - resolved_margin.main_end(constants.dir)
                 }
-                JustifyContent::SpaceEvenly | JustifyContent::SpaceAround | JustifyContent::Center => {
+                (JustifyContent::SpaceEvenly, _) | (JustifyContent::SpaceAround, _) | (JustifyContent::Center, _) => {
                     (constants.container_size.main(constants.dir) + constants.padding_border.main_start(constants.dir)
                         - constants.padding_border.main_end(constants.dir)
                         - final_size.main(constants.dir)
@@ -1791,10 +1800,14 @@ fn perform_absolute_layout_on_absolute_children(tree: &mut impl LayoutTree, node
                 // Stretch alignment does not apply to absolutely positioned items
                 // See "Example 3" at https://www.w3.org/TR/css-flexbox-1/#abspos-items
                 // Note: Stretch should be FlexStart not Start when we support both
-                (AlignSelf::Baseline | AlignSelf::Stretch | AlignSelf::Start, false) | (AlignSelf::End, true) => {
+                (AlignSelf::Start, _)
+                | (AlignSelf::Baseline | AlignSelf::Stretch | AlignSelf::FlexStart, false)
+                | (AlignSelf::FlexEnd, true) => {
                     constants.padding_border.cross_start(constants.dir) + resolved_margin.cross_start(constants.dir)
                 }
-                (AlignSelf::Baseline | AlignSelf::Stretch | AlignSelf::Start, true) | (AlignSelf::End, false) => {
+                (AlignSelf::End, _)
+                | (AlignSelf::Baseline | AlignSelf::Stretch | AlignSelf::FlexStart, true)
+                | (AlignSelf::FlexEnd, false) => {
                     constants.container_size.cross(constants.dir)
                         - constants.padding_border.cross_end(constants.dir)
                         - final_size.cross(constants.dir)

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -1410,11 +1410,11 @@ fn align_flex_items_along_cross_axis(
         }
         AlignSelf::Center => free_space / 2.0,
         AlignSelf::Baseline => {
-            // Until we support vertical writing modes, baseline alignment only makes sense if
-            // the constants.direction is row, so we treat it as flex-start alignment in columns.
             if constants.is_row {
                 max_baseline - child.baseline
             } else {
+                // Until we support vertical writing modes, baseline alignment only makes sense if
+                // the constants.direction is row, so we treat it as flex-start alignment in columns.
                 if constants.is_wrap_reverse {
                     free_space
                 } else {

--- a/src/compute/grid/alignment.rs
+++ b/src/compute/grid/alignment.rs
@@ -33,7 +33,9 @@ pub(super) fn align_tracks(
         + border.start
         + match track_alignment_style {
             AlignContent::Start => 0.0,
+            AlignContent::FlexStart => 0.0,
             AlignContent::End => overflow,
+            AlignContent::FlexEnd => overflow,
             AlignContent::Center => overflow / 2.0,
             AlignContent::Stretch => 0.0,
             AlignContent::SpaceBetween => 0.0,
@@ -231,8 +233,8 @@ pub(super) fn align_item_within_area(
 
     // Compute offset in the axis
     let alignment_based_offset = match alignment_style {
-        AlignSelf::Start => resolved_margin.start,
-        AlignSelf::End => grid_area_size - resolved_size - resolved_margin.end,
+        AlignSelf::Start | AlignSelf::FlexStart => resolved_margin.start,
+        AlignSelf::End | AlignSelf::FlexEnd => grid_area_size - resolved_size - resolved_margin.end,
         AlignSelf::Center => (grid_area_size - resolved_size + resolved_margin.start - resolved_margin.end) / 2.0,
         // TODO: Add support for baseline alignment. For now we treat it as "start".
         AlignSelf::Baseline => resolved_margin.start,

--- a/src/compute/grid/track_sizing.rs
+++ b/src/compute/grid/track_sizing.rs
@@ -98,7 +98,9 @@ pub(super) fn compute_alignment_gutter_adjustment(
     // AlignContent::Start and AlignContent::End the same
     let outer_gutter_weight = match alignment {
         AlignContent::Start => 1,
+        AlignContent::FlexStart => 1,
         AlignContent::End => 1,
+        AlignContent::FlexEnd => 1,
         AlignContent::Center => 1,
         AlignContent::Stretch => 0,
         AlignContent::SpaceBetween => 0,
@@ -107,7 +109,9 @@ pub(super) fn compute_alignment_gutter_adjustment(
     };
 
     let inner_gutter_weight = match alignment {
+        AlignContent::FlexStart => 0,
         AlignContent::Start => 0,
+        AlignContent::FlexEnd => 0,
         AlignContent::End => 0,
         AlignContent::Center => 0,
         AlignContent::Stretch => 0,

--- a/src/style/alignment.rs
+++ b/src/style/alignment.rs
@@ -8,10 +8,20 @@
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum AlignItems {
-    /// Items are packed toward the start of the cross axis
+    /// Items are packed toward the start of the axis
     Start,
-    /// Items are packed toward the end of the cross axis
+    /// Items are packed toward the end of the axis
     End,
+    /// Items are packed towards the flex-relative start of the axis.
+    ///
+    /// For flex containers with flex_direction RowReverse of ColumnReverse this is equivalent
+    /// to End. In all other cases it is equivalent to Start.
+    FlexStart,
+    /// Items are packed towards the flex-relative end of the axis.
+    ///
+    /// For flex containers with flex_direction RowReverse of ColumnReverse this is equivalent
+    /// to Start. In all other cases it is equivalent to End.
+    FlexEnd,
     /// Items are packed along the center of the cross axis
     Center,
     /// Items are aligned such as their baselines align
@@ -52,6 +62,16 @@ pub enum AlignContent {
     Start,
     /// Items are packed toward the end of the axis
     End,
+    /// Items are packed towards the flex-relative start of the axis.
+    ///
+    /// For flex containers with flex_direction RowReverse of ColumnReverse this is equivalent
+    /// to End. In all other cases it is equivalent to Start.
+    FlexStart,
+    /// Items are packed towards the flex-relative end of the axis.
+    ///
+    /// For flex containers with flex_direction RowReverse of ColumnReverse this is equivalent
+    /// to Start. In all other cases it is equivalent to End.
+    FlexEnd,
     /// Items are centered around the middle of the axis
     Center,
     /// Items are stretched to fill the container

--- a/tests/generated/absolute_layout_align_items_and_justify_content_flex_end.rs
+++ b/tests/generated/absolute_layout_align_items_and_justify_content_flex_end.rs
@@ -17,8 +17,8 @@ fn absolute_layout_align_items_and_justify_content_flex_end() {
     let node = taffy
         .new_with_children(
             taffy::style::Style {
-                align_items: Some(taffy::style::AlignItems::End),
-                justify_content: Some(taffy::style::JustifyContent::End),
+                align_items: Some(taffy::style::AlignItems::FlexEnd),
+                justify_content: Some(taffy::style::JustifyContent::FlexEnd),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(110f32),
                     height: taffy::style::Dimension::Points(100f32),

--- a/tests/generated/absolute_layout_in_wrap_reverse_column_container_flex_end.rs
+++ b/tests/generated/absolute_layout_in_wrap_reverse_column_container_flex_end.rs
@@ -7,7 +7,7 @@ fn absolute_layout_in_wrap_reverse_column_container_flex_end() {
     let node0 = taffy
         .new_leaf(taffy::style::Style {
             position: taffy::style::Position::Absolute,
-            align_self: Some(taffy::style::AlignSelf::End),
+            align_self: Some(taffy::style::AlignSelf::FlexEnd),
             size: taffy::geometry::Size {
                 width: taffy::style::Dimension::Points(20f32),
                 height: taffy::style::Dimension::Points(20f32),

--- a/tests/generated/absolute_layout_in_wrap_reverse_row_container_flex_end.rs
+++ b/tests/generated/absolute_layout_in_wrap_reverse_row_container_flex_end.rs
@@ -7,7 +7,7 @@ fn absolute_layout_in_wrap_reverse_row_container_flex_end() {
     let node0 = taffy
         .new_leaf(taffy::style::Style {
             position: taffy::style::Position::Absolute,
-            align_self: Some(taffy::style::AlignSelf::End),
+            align_self: Some(taffy::style::AlignSelf::FlexEnd),
             size: taffy::geometry::Size {
                 width: taffy::style::Dimension::Points(20f32),
                 height: taffy::style::Dimension::Points(20f32),

--- a/tests/generated/absolute_margin_bottom_left.rs
+++ b/tests/generated/absolute_margin_bottom_left.rs
@@ -24,7 +24,7 @@ fn absolute_margin_bottom_left() {
         .new_with_children(
             taffy::style::Style {
                 flex_direction: taffy::style::FlexDirection::Column,
-                justify_content: Some(taffy::style::JustifyContent::End),
+                justify_content: Some(taffy::style::JustifyContent::FlexEnd),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(100f32),
                     height: taffy::style::Dimension::Points(100f32),

--- a/tests/generated/align_content_flex_end.rs
+++ b/tests/generated/align_content_flex_end.rs
@@ -54,7 +54,7 @@ fn align_content_flex_end() {
             taffy::style::Style {
                 flex_direction: taffy::style::FlexDirection::Column,
                 flex_wrap: taffy::style::FlexWrap::Wrap,
-                align_content: Some(taffy::style::AlignContent::End),
+                align_content: Some(taffy::style::AlignContent::FlexEnd),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(100f32),
                     height: taffy::style::Dimension::Points(100f32),

--- a/tests/generated/align_content_flex_start.rs
+++ b/tests/generated/align_content_flex_start.rs
@@ -53,7 +53,7 @@ fn align_content_flex_start() {
         .new_with_children(
             taffy::style::Style {
                 flex_wrap: taffy::style::FlexWrap::Wrap,
-                align_content: Some(taffy::style::AlignContent::Start),
+                align_content: Some(taffy::style::AlignContent::FlexStart),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(130f32),
                     height: taffy::style::Dimension::Points(100f32),

--- a/tests/generated/align_content_flex_start_with_flex.rs
+++ b/tests/generated/align_content_flex_start_with_flex.rs
@@ -51,7 +51,7 @@ fn align_content_flex_start_with_flex() {
             taffy::style::Style {
                 flex_direction: taffy::style::FlexDirection::Column,
                 flex_wrap: taffy::style::FlexWrap::Wrap,
-                align_content: Some(taffy::style::AlignContent::Start),
+                align_content: Some(taffy::style::AlignContent::FlexStart),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(100f32),
                     height: taffy::style::Dimension::Points(120f32),

--- a/tests/generated/align_content_flex_start_without_height_on_children.rs
+++ b/tests/generated/align_content_flex_start_without_height_on_children.rs
@@ -45,7 +45,7 @@ fn align_content_flex_start_without_height_on_children() {
             taffy::style::Style {
                 flex_direction: taffy::style::FlexDirection::Column,
                 flex_wrap: taffy::style::FlexWrap::Wrap,
-                align_content: Some(taffy::style::AlignContent::Start),
+                align_content: Some(taffy::style::AlignContent::FlexStart),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(100f32),
                     height: taffy::style::Dimension::Points(100f32),

--- a/tests/generated/align_content_not_stretch_with_align_items_stretch.rs
+++ b/tests/generated/align_content_not_stretch_with_align_items_stretch.rs
@@ -38,7 +38,7 @@ fn align_content_not_stretch_with_align_items_stretch() {
         .new_with_children(
             taffy::style::Style {
                 flex_wrap: taffy::style::FlexWrap::Wrap,
-                align_content: Some(taffy::style::AlignContent::Start),
+                align_content: Some(taffy::style::AlignContent::FlexStart),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(328f32),
                     height: taffy::style::Dimension::Points(52f32),

--- a/tests/generated/align_flex_start_with_shrinking_children.rs
+++ b/tests/generated/align_flex_start_with_shrinking_children.rs
@@ -11,7 +11,7 @@ fn align_flex_start_with_shrinking_children() {
         .unwrap();
     let node0 = taffy
         .new_with_children(
-            taffy::style::Style { align_items: Some(taffy::style::AlignItems::Start), ..Default::default() },
+            taffy::style::Style { align_items: Some(taffy::style::AlignItems::FlexStart), ..Default::default() },
             &[node00],
         )
         .unwrap();

--- a/tests/generated/align_flex_start_with_shrinking_children_with_stretch.rs
+++ b/tests/generated/align_flex_start_with_shrinking_children_with_stretch.rs
@@ -19,7 +19,7 @@ fn align_flex_start_with_shrinking_children_with_stretch() {
         .unwrap();
     let node0 = taffy
         .new_with_children(
-            taffy::style::Style { align_items: Some(taffy::style::AlignItems::Start), ..Default::default() },
+            taffy::style::Style { align_items: Some(taffy::style::AlignItems::FlexStart), ..Default::default() },
             &[node00],
         )
         .unwrap();

--- a/tests/generated/align_items_flex_end.rs
+++ b/tests/generated/align_items_flex_end.rs
@@ -16,7 +16,7 @@ fn align_items_flex_end() {
     let node = taffy
         .new_with_children(
             taffy::style::Style {
-                align_items: Some(taffy::style::AlignItems::End),
+                align_items: Some(taffy::style::AlignItems::FlexEnd),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(100f32),
                     height: taffy::style::Dimension::Points(100f32),

--- a/tests/generated/align_items_flex_end_child_with_margin_bigger_than_parent.rs
+++ b/tests/generated/align_items_flex_end_child_with_margin_bigger_than_parent.rs
@@ -21,7 +21,7 @@ fn align_items_flex_end_child_with_margin_bigger_than_parent() {
         .unwrap();
     let node0 = taffy
         .new_with_children(
-            taffy::style::Style { align_items: Some(taffy::style::AlignItems::End), ..Default::default() },
+            taffy::style::Style { align_items: Some(taffy::style::AlignItems::FlexEnd), ..Default::default() },
             &[node00],
         )
         .unwrap();

--- a/tests/generated/align_items_flex_end_child_without_margin_bigger_than_parent.rs
+++ b/tests/generated/align_items_flex_end_child_without_margin_bigger_than_parent.rs
@@ -15,7 +15,7 @@ fn align_items_flex_end_child_without_margin_bigger_than_parent() {
         .unwrap();
     let node0 = taffy
         .new_with_children(
-            taffy::style::Style { align_items: Some(taffy::style::AlignItems::End), ..Default::default() },
+            taffy::style::Style { align_items: Some(taffy::style::AlignItems::FlexEnd), ..Default::default() },
             &[node00],
         )
         .unwrap();

--- a/tests/generated/align_items_flex_start.rs
+++ b/tests/generated/align_items_flex_start.rs
@@ -16,7 +16,7 @@ fn align_items_flex_start() {
     let node = taffy
         .new_with_children(
             taffy::style::Style {
-                align_items: Some(taffy::style::AlignItems::Start),
+                align_items: Some(taffy::style::AlignItems::FlexStart),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(100f32),
                     height: taffy::style::Dimension::Points(100f32),

--- a/tests/generated/align_self_flex_end.rs
+++ b/tests/generated/align_self_flex_end.rs
@@ -6,7 +6,7 @@ fn align_self_flex_end() {
     let mut taffy = taffy::Taffy::new();
     let node0 = taffy
         .new_leaf(taffy::style::Style {
-            align_self: Some(taffy::style::AlignSelf::End),
+            align_self: Some(taffy::style::AlignSelf::FlexEnd),
             size: taffy::geometry::Size {
                 width: taffy::style::Dimension::Points(10f32),
                 height: taffy::style::Dimension::Points(10f32),

--- a/tests/generated/align_self_flex_end_override_flex_start.rs
+++ b/tests/generated/align_self_flex_end_override_flex_start.rs
@@ -6,7 +6,7 @@ fn align_self_flex_end_override_flex_start() {
     let mut taffy = taffy::Taffy::new();
     let node0 = taffy
         .new_leaf(taffy::style::Style {
-            align_self: Some(taffy::style::AlignSelf::End),
+            align_self: Some(taffy::style::AlignSelf::FlexEnd),
             size: taffy::geometry::Size {
                 width: taffy::style::Dimension::Points(10f32),
                 height: taffy::style::Dimension::Points(10f32),
@@ -17,7 +17,7 @@ fn align_self_flex_end_override_flex_start() {
     let node = taffy
         .new_with_children(
             taffy::style::Style {
-                align_items: Some(taffy::style::AlignItems::Start),
+                align_items: Some(taffy::style::AlignItems::FlexStart),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(100f32),
                     height: taffy::style::Dimension::Points(100f32),

--- a/tests/generated/align_self_flex_start.rs
+++ b/tests/generated/align_self_flex_start.rs
@@ -6,7 +6,7 @@ fn align_self_flex_start() {
     let mut taffy = taffy::Taffy::new();
     let node0 = taffy
         .new_leaf(taffy::style::Style {
-            align_self: Some(taffy::style::AlignSelf::Start),
+            align_self: Some(taffy::style::AlignSelf::FlexStart),
             size: taffy::geometry::Size {
                 width: taffy::style::Dimension::Points(10f32),
                 height: taffy::style::Dimension::Points(10f32),

--- a/tests/generated/android_news_feed.rs
+++ b/tests/generated/android_news_feed.rs
@@ -65,7 +65,7 @@ fn android_news_feed() {
     let node0000 = taffy
         .new_with_children(
             taffy::style::Style {
-                align_items: Some(taffy::style::AlignItems::Start),
+                align_items: Some(taffy::style::AlignItems::FlexStart),
                 align_content: Some(taffy::style::AlignContent::Stretch),
                 margin: taffy::geometry::Rect {
                     left: taffy::style::LengthPercentageAuto::Points(36f32),
@@ -149,7 +149,7 @@ fn android_news_feed() {
     let node0010 = taffy
         .new_with_children(
             taffy::style::Style {
-                align_items: Some(taffy::style::AlignItems::Start),
+                align_items: Some(taffy::style::AlignItems::FlexStart),
                 align_content: Some(taffy::style::AlignContent::Stretch),
                 margin: taffy::geometry::Rect {
                     left: taffy::style::LengthPercentageAuto::Points(174f32),

--- a/tests/generated/child_with_padding_align_end.rs
+++ b/tests/generated/child_with_padding_align_end.rs
@@ -23,8 +23,8 @@ fn child_with_padding_align_end() {
         .new_with_children(
             taffy::style::Style {
                 flex_direction: taffy::style::FlexDirection::Column,
-                align_items: Some(taffy::style::AlignItems::End),
-                justify_content: Some(taffy::style::JustifyContent::End),
+                align_items: Some(taffy::style::AlignItems::FlexEnd),
+                justify_content: Some(taffy::style::JustifyContent::FlexEnd),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(200f32),
                     height: taffy::style::Dimension::Points(200f32),

--- a/tests/generated/flex_grow_in_at_most_container.rs
+++ b/tests/generated/flex_grow_in_at_most_container.rs
@@ -15,7 +15,7 @@ fn flex_grow_in_at_most_container() {
     let node = taffy
         .new_with_children(
             taffy::style::Style {
-                align_items: Some(taffy::style::AlignItems::Start),
+                align_items: Some(taffy::style::AlignItems::FlexStart),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(100f32),
                     height: taffy::style::Dimension::Points(100f32),

--- a/tests/generated/flex_wrap_wrap_to_child_height.rs
+++ b/tests/generated/flex_wrap_wrap_to_child_height.rs
@@ -27,7 +27,7 @@ fn flex_wrap_wrap_to_child_height() {
         .new_with_children(
             taffy::style::Style {
                 flex_wrap: taffy::style::FlexWrap::Wrap,
-                align_items: Some(taffy::style::AlignItems::Start),
+                align_items: Some(taffy::style::AlignItems::FlexStart),
                 ..Default::default()
             },
             &[node00],

--- a/tests/generated/gap_column_gap_justify_flex_end.rs
+++ b/tests/generated/gap_column_gap_justify_flex_end.rs
@@ -25,7 +25,7 @@ fn gap_column_gap_justify_flex_end() {
     let node = taffy
         .new_with_children(
             taffy::style::Style {
-                justify_content: Some(taffy::style::JustifyContent::End),
+                justify_content: Some(taffy::style::JustifyContent::FlexEnd),
                 gap: taffy::geometry::Size { width: taffy::style::LengthPercentage::Points(10f32), height: zero() },
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(100f32),

--- a/tests/generated/gap_column_gap_justify_flex_start.rs
+++ b/tests/generated/gap_column_gap_justify_flex_start.rs
@@ -25,7 +25,7 @@ fn gap_column_gap_justify_flex_start() {
     let node = taffy
         .new_with_children(
             taffy::style::Style {
-                justify_content: Some(taffy::style::JustifyContent::Start),
+                justify_content: Some(taffy::style::JustifyContent::FlexStart),
                 gap: taffy::geometry::Size { width: taffy::style::LengthPercentage::Points(10f32), height: zero() },
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(100f32),

--- a/tests/generated/gap_column_gap_wrap_align_flex_end.rs
+++ b/tests/generated/gap_column_gap_wrap_align_flex_end.rs
@@ -62,7 +62,7 @@ fn gap_column_gap_wrap_align_flex_end() {
         .new_with_children(
             taffy::style::Style {
                 flex_wrap: taffy::style::FlexWrap::Wrap,
-                align_content: Some(taffy::style::AlignContent::End),
+                align_content: Some(taffy::style::AlignContent::FlexEnd),
                 gap: taffy::geometry::Size {
                     width: taffy::style::LengthPercentage::Points(10f32),
                     height: taffy::style::LengthPercentage::Points(20f32),

--- a/tests/generated/gap_column_gap_wrap_align_flex_start.rs
+++ b/tests/generated/gap_column_gap_wrap_align_flex_start.rs
@@ -62,7 +62,7 @@ fn gap_column_gap_wrap_align_flex_start() {
         .new_with_children(
             taffy::style::Style {
                 flex_wrap: taffy::style::FlexWrap::Wrap,
-                align_content: Some(taffy::style::AlignContent::Start),
+                align_content: Some(taffy::style::AlignContent::FlexStart),
                 gap: taffy::geometry::Size {
                     width: taffy::style::LengthPercentage::Points(10f32),
                     height: taffy::style::LengthPercentage::Points(20f32),

--- a/tests/generated/gap_row_gap_align_items_end.rs
+++ b/tests/generated/gap_row_gap_align_items_end.rs
@@ -44,7 +44,7 @@ fn gap_row_gap_align_items_end() {
         .new_with_children(
             taffy::style::Style {
                 flex_wrap: taffy::style::FlexWrap::Wrap,
-                align_items: Some(taffy::style::AlignItems::End),
+                align_items: Some(taffy::style::AlignItems::FlexEnd),
                 gap: taffy::geometry::Size {
                     width: taffy::style::LengthPercentage::Points(10f32),
                     height: taffy::style::LengthPercentage::Points(20f32),

--- a/tests/generated/justify_content_column_flex_end.rs
+++ b/tests/generated/justify_content_column_flex_end.rs
@@ -26,7 +26,7 @@ fn justify_content_column_flex_end() {
         .new_with_children(
             taffy::style::Style {
                 flex_direction: taffy::style::FlexDirection::Column,
-                justify_content: Some(taffy::style::JustifyContent::End),
+                justify_content: Some(taffy::style::JustifyContent::FlexEnd),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(100f32),
                     height: taffy::style::Dimension::Points(100f32),

--- a/tests/generated/justify_content_column_flex_start.rs
+++ b/tests/generated/justify_content_column_flex_start.rs
@@ -26,7 +26,7 @@ fn justify_content_column_flex_start() {
         .new_with_children(
             taffy::style::Style {
                 flex_direction: taffy::style::FlexDirection::Column,
-                justify_content: Some(taffy::style::JustifyContent::Start),
+                justify_content: Some(taffy::style::JustifyContent::FlexStart),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(100f32),
                     height: taffy::style::Dimension::Points(100f32),

--- a/tests/generated/justify_content_row_flex_end.rs
+++ b/tests/generated/justify_content_row_flex_end.rs
@@ -25,7 +25,7 @@ fn justify_content_row_flex_end() {
     let node = taffy
         .new_with_children(
             taffy::style::Style {
-                justify_content: Some(taffy::style::JustifyContent::End),
+                justify_content: Some(taffy::style::JustifyContent::FlexEnd),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(100f32),
                     height: taffy::style::Dimension::Points(100f32),

--- a/tests/generated/justify_content_row_flex_start.rs
+++ b/tests/generated/justify_content_row_flex_start.rs
@@ -25,7 +25,7 @@ fn justify_content_row_flex_start() {
     let node = taffy
         .new_with_children(
             taffy::style::Style {
-                justify_content: Some(taffy::style::JustifyContent::Start),
+                justify_content: Some(taffy::style::JustifyContent::FlexStart),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(100f32),
                     height: taffy::style::Dimension::Points(100f32),

--- a/tests/generated/margin_bottom.rs
+++ b/tests/generated/margin_bottom.rs
@@ -20,7 +20,7 @@ fn margin_bottom() {
         .new_with_children(
             taffy::style::Style {
                 flex_direction: taffy::style::FlexDirection::Column,
-                justify_content: Some(taffy::style::JustifyContent::End),
+                justify_content: Some(taffy::style::JustifyContent::FlexEnd),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(100f32),
                     height: taffy::style::Dimension::Points(100f32),

--- a/tests/generated/margin_right.rs
+++ b/tests/generated/margin_right.rs
@@ -19,7 +19,7 @@ fn margin_right() {
     let node = taffy
         .new_with_children(
             taffy::style::Style {
-                justify_content: Some(taffy::style::JustifyContent::End),
+                justify_content: Some(taffy::style::JustifyContent::FlexEnd),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(100f32),
                     height: taffy::style::Dimension::Points(100f32),

--- a/tests/generated/min_height_with_nested_fixed_height.rs
+++ b/tests/generated/min_height_with_nested_fixed_height.rs
@@ -17,7 +17,7 @@ fn min_height_with_nested_fixed_height() {
         .new_with_children(
             taffy::style::Style {
                 flex_direction: taffy::style::FlexDirection::Column,
-                align_self: Some(taffy::style::AlignSelf::Start),
+                align_self: Some(taffy::style::AlignSelf::FlexStart),
                 flex_shrink: 0f32,
                 min_size: taffy::geometry::Size { width: auto(), height: taffy::style::Dimension::Points(28f32) },
                 margin: taffy::geometry::Rect {

--- a/tests/generated/min_max_percent_different_width_height.rs
+++ b/tests/generated/min_max_percent_different_width_height.rs
@@ -33,7 +33,7 @@ fn min_max_percent_different_width_height() {
         .new_with_children(
             taffy::style::Style {
                 flex_direction: taffy::style::FlexDirection::Column,
-                align_items: Some(taffy::style::AlignItems::Start),
+                align_items: Some(taffy::style::AlignItems::FlexStart),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(100f32),
                     height: taffy::style::Dimension::Points(200f32),

--- a/tests/generated/min_max_percent_no_width_height.rs
+++ b/tests/generated/min_max_percent_no_width_height.rs
@@ -21,7 +21,7 @@ fn min_max_percent_no_width_height() {
         .new_with_children(
             taffy::style::Style {
                 flex_direction: taffy::style::FlexDirection::Column,
-                align_items: Some(taffy::style::AlignItems::Start),
+                align_items: Some(taffy::style::AlignItems::FlexStart),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(100f32),
                     height: taffy::style::Dimension::Points(100f32),

--- a/tests/generated/padding_align_end_child.rs
+++ b/tests/generated/padding_align_end_child.rs
@@ -22,8 +22,8 @@ fn padding_align_end_child() {
     let node = taffy
         .new_with_children(
             taffy::style::Style {
-                align_items: Some(taffy::style::AlignItems::End),
-                justify_content: Some(taffy::style::JustifyContent::End),
+                align_items: Some(taffy::style::AlignItems::FlexEnd),
+                justify_content: Some(taffy::style::JustifyContent::FlexEnd),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(200f32),
                     height: taffy::style::Dimension::Points(200f32),

--- a/tests/generated/percentage_main_max_height.rs
+++ b/tests/generated/percentage_main_max_height.rs
@@ -18,7 +18,7 @@ fn percentage_main_max_height() {
         .new_with_children(
             taffy::style::Style {
                 flex_direction: taffy::style::FlexDirection::Column,
-                align_items: Some(taffy::style::AlignItems::Start),
+                align_items: Some(taffy::style::AlignItems::FlexStart),
                 size: taffy::geometry::Size { width: auto(), height: taffy::style::Dimension::Points(151f32) },
                 ..Default::default()
             },

--- a/tests/generated/wrap_reverse_row_align_content_flex_start.rs
+++ b/tests/generated/wrap_reverse_row_align_content_flex_start.rs
@@ -53,7 +53,7 @@ fn wrap_reverse_row_align_content_flex_start() {
         .new_with_children(
             taffy::style::Style {
                 flex_wrap: taffy::style::FlexWrap::WrapReverse,
-                align_content: Some(taffy::style::AlignContent::Start),
+                align_content: Some(taffy::style::AlignContent::FlexStart),
                 size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), height: auto() },
                 ..Default::default()
             },

--- a/tests/generated/wrap_reverse_row_single_line_different_size.rs
+++ b/tests/generated/wrap_reverse_row_single_line_different_size.rs
@@ -53,7 +53,7 @@ fn wrap_reverse_row_single_line_different_size() {
         .new_with_children(
             taffy::style::Style {
                 flex_wrap: taffy::style::FlexWrap::WrapReverse,
-                align_content: Some(taffy::style::AlignContent::Start),
+                align_content: Some(taffy::style::AlignContent::FlexStart),
                 size: taffy::geometry::Size { width: taffy::style::Dimension::Points(300f32), height: auto() },
                 ..Default::default()
             },

--- a/tests/generated/wrap_row_align_items_flex_end.rs
+++ b/tests/generated/wrap_row_align_items_flex_end.rs
@@ -44,7 +44,7 @@ fn wrap_row_align_items_flex_end() {
         .new_with_children(
             taffy::style::Style {
                 flex_wrap: taffy::style::FlexWrap::Wrap,
-                align_items: Some(taffy::style::AlignItems::End),
+                align_items: Some(taffy::style::AlignItems::FlexEnd),
                 size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), height: auto() },
                 ..Default::default()
             },

--- a/tests/generated/wrapped_row_within_align_items_flex_end.rs
+++ b/tests/generated/wrapped_row_within_align_items_flex_end.rs
@@ -32,7 +32,7 @@ fn wrapped_row_within_align_items_flex_end() {
         .new_with_children(
             taffy::style::Style {
                 flex_direction: taffy::style::FlexDirection::Column,
-                align_items: Some(taffy::style::AlignItems::End),
+                align_items: Some(taffy::style::AlignItems::FlexEnd),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(200f32),
                     height: taffy::style::Dimension::Points(200f32),

--- a/tests/generated/wrapped_row_within_align_items_flex_start.rs
+++ b/tests/generated/wrapped_row_within_align_items_flex_start.rs
@@ -32,7 +32,7 @@ fn wrapped_row_within_align_items_flex_start() {
         .new_with_children(
             taffy::style::Style {
                 flex_direction: taffy::style::FlexDirection::Column,
-                align_items: Some(taffy::style::AlignItems::Start),
+                align_items: Some(taffy::style::AlignItems::FlexStart),
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(200f32),
                     height: taffy::style::Dimension::Points(200f32),


### PR DESCRIPTION
# Objective

Fixes #307 (regression from Taffy 0.2). Taffy now has both `Start`/`End` and `FlexStart`/`FlexEnd` as per the spec.
We probably ought to duplicate all our alignment tests to test all 4 properties. But we do have at least some coverage of both sets of properties.