### PR TITLE
Grid: Rename Flex to Fraction

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,6 +9,7 @@
 - `GridPlacement::Line` now stores a `GridLine` newtype wrapper around an `i16` rather than a raw `i16`. If you are using the style helpers then this change will not affect you.
 - *BREAKING:* `Position` is now renamed to `Inset` and is now in line with [CSS inset specs](https://developer.mozilla.org/en-US/docs/Web/CSS/inset)
 - *BREAKING:* `PositionType` is now renamed to `Position` and is now in line with [CSS position specs](https://developer.mozilla.org/en-US/docs/Web/CSS/position)
+- `MaxTrackSizingFunction::Flex` is now called `MaxTrackSizingFunction::Fraction`. The `flex()` helper is now called `fr()`. A new `flex()` helper has been added which create a `minmax(0, Nfr)` track.
 
 ### Fixes
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,10 @@
 
 ## 0.3.0-alpha2 (unreleased)
 
+### Added
+
+- A new style helper `evenly_sized_tracks(count: u16)` has been added which creates a grid template containing `count` evenly sized tracks (rows or columns)
+
 ### Changed
 
 - `experimental_grid` feature named to just `grid`

--- a/benches/big_tree_grid.rs
+++ b/benches/big_tree_grid.rs
@@ -20,9 +20,9 @@ fn random_grid_track<R: Rng>(rng: &mut R) -> TrackSizingFunction {
     } else if switch < 0.3 {
         max_content()
     } else if switch < 0.5 {
-        flex(1.0)
+        fr(1.0)
     } else if switch < 0.6 {
-        minmax(points(0.0), flex(1.0))
+        minmax(points(0.0), fr(1.0))
     } else if switch < 0.8 {
         points(40.0)
     } else {

--- a/benches/generated/grid_auto_takes_precedence_over_fr.rs
+++ b/benches/generated/grid_auto_takes_precedence_over_fr.rs
@@ -9,7 +9,7 @@ pub fn compute() {
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
                 grid_template_rows: vec![points(40f32)],
-                grid_template_columns: vec![auto(), flex(1f32)],
+                grid_template_columns: vec![auto(), fr(1f32)],
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(200f32),
                     height: taffy::style::Dimension::Points(200f32),

--- a/benches/generated/grid_fr_fixed_size_no_content_proportions.rs
+++ b/benches/generated/grid_fr_fixed_size_no_content_proportions.rs
@@ -10,7 +10,7 @@ pub fn compute() {
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
                 grid_template_rows: vec![points(40f32)],
-                grid_template_columns: vec![flex(1f32), flex(2f32), flex(3f32)],
+                grid_template_columns: vec![fr(1f32), fr(2f32), fr(3f32)],
                 size: taffy::geometry::Size { width: taffy::style::Dimension::Points(200f32), height: auto() },
                 ..Default::default()
             },

--- a/benches/generated/grid_fr_fixed_size_no_content_proportions_sub_1_sum.rs
+++ b/benches/generated/grid_fr_fixed_size_no_content_proportions_sub_1_sum.rs
@@ -9,7 +9,7 @@ pub fn compute() {
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
                 grid_template_rows: vec![points(40f32)],
-                grid_template_columns: vec![flex(0.3f32), flex(0.2f32)],
+                grid_template_columns: vec![fr(0.3f32), fr(0.2f32)],
                 size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), height: auto() },
                 ..Default::default()
             },

--- a/benches/generated/grid_fr_fixed_size_single_item.rs
+++ b/benches/generated/grid_fr_fixed_size_single_item.rs
@@ -20,8 +20,8 @@ pub fn compute() {
         .new_with_children(
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
-                grid_template_rows: vec![points(40f32), flex(1f32), flex(1f32)],
-                grid_template_columns: vec![points(40f32), flex(1f32), flex(1f32)],
+                grid_template_rows: vec![points(40f32), fr(1f32), fr(1f32)],
+                grid_template_columns: vec![points(40f32), fr(1f32), fr(1f32)],
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(200f32),
                     height: taffy::style::Dimension::Points(200f32),

--- a/benches/generated/grid_fr_no_sized_items_indefinite.rs
+++ b/benches/generated/grid_fr_no_sized_items_indefinite.rs
@@ -15,8 +15,8 @@ pub fn compute() {
         .new_with_children(
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
-                grid_template_rows: vec![points(40f32), flex(1f32), flex(1f32)],
-                grid_template_columns: vec![points(40f32), flex(1f32), flex(1f32)],
+                grid_template_rows: vec![points(40f32), fr(1f32), fr(1f32)],
+                grid_template_columns: vec![points(40f32), fr(1f32), fr(1f32)],
                 ..Default::default()
             },
             &[node0, node1, node2, node3, node4, node5, node6, node7, node8],

--- a/benches/generated/grid_fr_single_item_indefinite.rs
+++ b/benches/generated/grid_fr_single_item_indefinite.rs
@@ -20,8 +20,8 @@ pub fn compute() {
         .new_with_children(
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
-                grid_template_rows: vec![points(40f32), flex(1f32), flex(1f32)],
-                grid_template_columns: vec![points(40f32), flex(1f32), flex(1f32)],
+                grid_template_rows: vec![points(40f32), fr(1f32), fr(1f32)],
+                grid_template_columns: vec![points(40f32), fr(1f32), fr(1f32)],
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Auto,
                     height: taffy::style::Dimension::Auto,

--- a/benches/generated/grid_fr_span_2_proportion.rs
+++ b/benches/generated/grid_fr_span_2_proportion.rs
@@ -19,7 +19,7 @@ pub fn compute() {
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
                 grid_template_rows: vec![points(40f32), points(40f32)],
-                grid_template_columns: vec![flex(1f32), flex(2f32)],
+                grid_template_columns: vec![fr(1f32), fr(2f32)],
                 ..Default::default()
             },
             &[node0, node1, node2],

--- a/benches/generated/grid_fr_span_2_proportion_sub_1_sum.rs
+++ b/benches/generated/grid_fr_span_2_proportion_sub_1_sum.rs
@@ -19,7 +19,7 @@ pub fn compute() {
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
                 grid_template_rows: vec![points(40f32), points(40f32)],
-                grid_template_columns: vec![flex(0.2f32), flex(0.3f32)],
+                grid_template_columns: vec![fr(0.2f32), fr(0.3f32)],
                 ..Default::default()
             },
             &[node0, node1, node2],

--- a/benches/generated/grid_fr_span_2_proportion_with_non_spanned_track.rs
+++ b/benches/generated/grid_fr_span_2_proportion_with_non_spanned_track.rs
@@ -21,7 +21,7 @@ pub fn compute() {
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
                 grid_template_rows: vec![points(40f32), points(40f32)],
-                grid_template_columns: vec![flex(1f32), flex(2f32), flex(3f32)],
+                grid_template_columns: vec![fr(1f32), fr(2f32), fr(3f32)],
                 ..Default::default()
             },
             &[node0, node1, node2, node3, node4],

--- a/benches/generated/grid_fr_span_2_proportion_zero_sum.rs
+++ b/benches/generated/grid_fr_span_2_proportion_zero_sum.rs
@@ -19,7 +19,7 @@ pub fn compute() {
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
                 grid_template_rows: vec![points(40f32), points(40f32)],
-                grid_template_columns: vec![flex(0f32), flex(0f32)],
+                grid_template_columns: vec![fr(0f32), fr(0f32)],
                 ..Default::default()
             },
             &[node0, node1, node2],

--- a/benches/generated/grid_fr_span_2_proportion_zero_sum_with_non_spanned_track.rs
+++ b/benches/generated/grid_fr_span_2_proportion_zero_sum_with_non_spanned_track.rs
@@ -21,7 +21,7 @@ pub fn compute() {
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
                 grid_template_rows: vec![points(40f32), points(40f32)],
-                grid_template_columns: vec![flex(0f32), flex(0f32), flex(0f32)],
+                grid_template_columns: vec![fr(0f32), fr(0f32), fr(0f32)],
                 ..Default::default()
             },
             &[node0, node1, node2, node3, node4],

--- a/benches/generated/grid_min_content_flex_single_item.rs
+++ b/benches/generated/grid_min_content_flex_single_item.rs
@@ -40,7 +40,7 @@ pub fn compute() {
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
                 grid_template_rows: vec![points(40f32), points(40f32), points(40f32)],
-                grid_template_columns: vec![points(40f32), min_content(), flex(1f32)],
+                grid_template_columns: vec![points(40f32), min_content(), fr(1f32)],
                 ..Default::default()
             },
             &[node0, node1, node2, node3, node4, node5, node6, node7],

--- a/benches/generated/grid_min_content_flex_single_item_margin_auto.rs
+++ b/benches/generated/grid_min_content_flex_single_item_margin_auto.rs
@@ -52,7 +52,7 @@ pub fn compute() {
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
                 grid_template_rows: vec![points(40f32), points(40f32), points(40f32)],
-                grid_template_columns: vec![points(40f32), min_content(), flex(1f32)],
+                grid_template_columns: vec![points(40f32), min_content(), fr(1f32)],
                 ..Default::default()
             },
             &[node0, node1, node2, node3, node4, node5, node6, node7],

--- a/benches/generated/grid_min_content_flex_single_item_margin_fixed.rs
+++ b/benches/generated/grid_min_content_flex_single_item_margin_fixed.rs
@@ -52,7 +52,7 @@ pub fn compute() {
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
                 grid_template_rows: vec![points(40f32), points(40f32), points(40f32)],
-                grid_template_columns: vec![points(40f32), min_content(), flex(1f32)],
+                grid_template_columns: vec![points(40f32), min_content(), fr(1f32)],
                 ..Default::default()
             },
             &[node0, node1, node2, node3, node4, node5, node6, node7],

--- a/benches/generated/grid_min_content_flex_single_item_margin_percent.rs
+++ b/benches/generated/grid_min_content_flex_single_item_margin_percent.rs
@@ -52,7 +52,7 @@ pub fn compute() {
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
                 grid_template_rows: vec![points(40f32), points(40f32), points(40f32)],
-                grid_template_columns: vec![points(40f32), min_content(), flex(1f32)],
+                grid_template_columns: vec![points(40f32), min_content(), fr(1f32)],
                 ..Default::default()
             },
             &[node0, node1, node2, node3, node4, node5, node6, node7],

--- a/benches/generated/grid_minmax_column_with_fr_fixed.rs
+++ b/benches/generated/grid_minmax_column_with_fr_fixed.rs
@@ -9,7 +9,7 @@ pub fn compute() {
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
                 grid_template_rows: vec![points(40f32)],
-                grid_template_columns: vec![minmax(points(20f32), points(40f32)), flex(1f32)],
+                grid_template_columns: vec![minmax(points(20f32), points(40f32)), fr(1f32)],
                 size: taffy::geometry::Size { width: taffy::style::Dimension::Points(60f32), height: auto() },
                 ..Default::default()
             },

--- a/benches/generated/grid_minmax_max_content_1fr.rs
+++ b/benches/generated/grid_minmax_max_content_1fr.rs
@@ -22,7 +22,7 @@ pub fn compute() {
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
                 grid_template_rows: vec![points(40f32)],
-                grid_template_columns: vec![minmax(max_content(), flex(1f32))],
+                grid_template_columns: vec![minmax(max_content(), fr(1f32))],
                 ..Default::default()
             },
             &[node0],

--- a/benches/generated/grid_minmax_min_content_1fr.rs
+++ b/benches/generated/grid_minmax_min_content_1fr.rs
@@ -22,7 +22,7 @@ pub fn compute() {
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
                 grid_template_rows: vec![points(40f32)],
-                grid_template_columns: vec![minmax(min_content(), flex(1f32))],
+                grid_template_columns: vec![minmax(min_content(), fr(1f32))],
                 ..Default::default()
             },
             &[node0],

--- a/benches/generated/grid_percent_items_nested_with_padding_margin.rs
+++ b/benches/generated/grid_percent_items_nested_with_padding_margin.rs
@@ -69,7 +69,7 @@ pub fn compute() {
         .new_with_children(
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
-                grid_template_rows: vec![flex(1f32), flex(4f32)],
+                grid_template_rows: vec![fr(1f32), fr(4f32)],
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(200f32),
                     height: taffy::style::Dimension::Points(200f32),

--- a/benches/generated/grid_span_8_all_track_types_indefinite.rs
+++ b/benches/generated/grid_span_8_all_track_types_indefinite.rs
@@ -40,8 +40,8 @@ pub fn compute() {
                     auto(),
                     points(10f32),
                     percent(0.2f32),
-                    flex(1f32),
-                    flex(2f32),
+                    fr(1f32),
+                    fr(2f32),
                 ],
                 ..Default::default()
             },

--- a/benches/generated/gridflex_column_integration.rs
+++ b/benches/generated/gridflex_column_integration.rs
@@ -66,8 +66,8 @@ pub fn compute() {
         .new_with_children(
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
-                grid_template_rows: vec![flex(1f32), flex(1f32)],
-                grid_template_columns: vec![flex(1f32), flex(1f32)],
+                grid_template_rows: vec![fr(1f32), fr(1f32)],
+                grid_template_columns: vec![fr(1f32), fr(1f32)],
                 ..Default::default()
             },
             &[node00, node01, node02, node03],

--- a/benches/generated/gridflex_kitchen_sink.rs
+++ b/benches/generated/gridflex_kitchen_sink.rs
@@ -88,8 +88,8 @@ pub fn compute() {
         .new_with_children(
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
-                grid_template_rows: vec![flex(1f32), flex(1f32)],
-                grid_template_columns: vec![flex(1f32), flex(1f32)],
+                grid_template_rows: vec![fr(1f32), fr(1f32)],
+                grid_template_columns: vec![fr(1f32), fr(1f32)],
                 ..Default::default()
             },
             &[node00, node01, node02, node03],

--- a/benches/generated/gridflex_kitchen_sink_minimise.rs
+++ b/benches/generated/gridflex_kitchen_sink_minimise.rs
@@ -14,7 +14,7 @@ pub fn compute() {
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
                 grid_template_rows: vec![points(20f32)],
-                grid_template_columns: vec![flex(1f32), flex(1f32)],
+                grid_template_columns: vec![fr(1f32), fr(1f32)],
                 ..Default::default()
             },
             &[node00, node01],

--- a/benches/generated/gridflex_row_integration.rs
+++ b/benches/generated/gridflex_row_integration.rs
@@ -66,8 +66,8 @@ pub fn compute() {
         .new_with_children(
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
-                grid_template_rows: vec![flex(1f32), flex(1f32)],
-                grid_template_columns: vec![flex(1f32), flex(1f32)],
+                grid_template_rows: vec![fr(1f32), fr(1f32)],
+                grid_template_columns: vec![fr(1f32), fr(1f32)],
                 ..Default::default()
             },
             &[node00, node01, node02, node03],

--- a/examples/grid_holy_grail.rs
+++ b/examples/grid_holy_grail.rs
@@ -25,8 +25,8 @@ fn main() -> Result<(), taffy::error::TaffyError> {
     let root_style = Style {
         display: Display::Grid,
         size: Size { width: points(800.0), height: points(600.0) },
-        grid_template_columns: vec![points(250.0), flex(1.0), points(250.0)],
-        grid_template_rows: vec![points(150.0), flex(1.0), points(150.0)],
+        grid_template_columns: vec![points(250.0), fr(1.0), points(250.0)],
+        grid_template_rows: vec![points(150.0), fr(1.0), points(150.0)],
         ..default()
     };
 

--- a/scripts/gentest/src/main.rs
+++ b/scripts/gentest/src/main.rs
@@ -830,7 +830,7 @@ fn generate_scalar_definition(track_definition: &serde_json::Map<String, Value>)
             match unit() {
                 "points" => quote!(points(#value)),
                 "percent" => quote!(percent(#value)),
-                "fraction" => quote!(flex(#value)),
+                "fraction" => quote!(fr(#value)),
                 _ => unreachable!(),
             }
         }

--- a/src/compute/grid/explicit_grid.rs
+++ b/src/compute/grid/explicit_grid.rs
@@ -455,7 +455,7 @@ mod test {
         let px100 = LengthPercentage::Points(100.0);
 
         // Setup test
-        let track_template = vec![points(100.0), minmax(points(100.0), flex(2.0)), flex(1.0)];
+        let track_template = vec![points(100.0), minmax(points(100.0), fr(2.0)), fr(1.0)];
         let track_counts =
             TrackCounts { negative_implicit: 3, explicit: track_template.len() as u16, positive_implicit: 3 };
         let auto_tracks = vec![auto(), points(100.0)];
@@ -479,9 +479,9 @@ mod test {
             // Explicit tracks
             (GridTrackKind::Track, MinTrackSizingFunction::Fixed(px100), MaxTrackSizingFunction::Fixed(px100)),
             (GridTrackKind::Gutter, MinTrackSizingFunction::Fixed(px20), MaxTrackSizingFunction::Fixed(px20)),
-            (GridTrackKind::Track, MinTrackSizingFunction::Fixed(px100), MaxTrackSizingFunction::Flex(2.0)), // Note: separate min-max functions
+            (GridTrackKind::Track, MinTrackSizingFunction::Fixed(px100), MaxTrackSizingFunction::Fraction(2.0)), // Note: separate min-max functions
             (GridTrackKind::Gutter, MinTrackSizingFunction::Fixed(px20), MaxTrackSizingFunction::Fixed(px20)),
-            (GridTrackKind::Track, MinTrackSizingFunction::Auto, MaxTrackSizingFunction::Flex(1.0)), // Note: min sizing function of flex sizing functions is auto
+            (GridTrackKind::Track, MinTrackSizingFunction::Auto, MaxTrackSizingFunction::Fraction(1.0)), // Note: min sizing function of flex sizing functions is auto
             (GridTrackKind::Gutter, MinTrackSizingFunction::Fixed(px20), MaxTrackSizingFunction::Fixed(px20)),
             // Positive implict tracks
             (GridTrackKind::Track, MinTrackSizingFunction::Auto, MaxTrackSizingFunction::Auto),

--- a/src/compute/grid/track_sizing.rs
+++ b/src/compute/grid/track_sizing.rs
@@ -1146,7 +1146,7 @@ fn expand_flexible_tracks(
             let hypothetical_grid_size: f32 = axis_tracks
                 .iter()
                 .map(|track| match track.max_track_sizing_function {
-                    MaxTrackSizingFunction::Flex(track_flex_factor) => {
+                    MaxTrackSizingFunction::Fraction(track_flex_factor) => {
                         f32_max(track.base_size, track_flex_factor * flex_fraction)
                     }
                     _ => track.base_size,
@@ -1167,7 +1167,7 @@ fn expand_flexible_tracks(
     // For each flexible track, if the product of the used flex fraction and the track’s flex factor is greater
     // than the track’s base size, set its base size to that product.
     for track in axis_tracks.iter_mut() {
-        if let MaxTrackSizingFunction::Flex(track_flex_factor) = track.max_track_sizing_function {
+        if let MaxTrackSizingFunction::Fraction(track_flex_factor) = track.max_track_sizing_function {
             track.base_size = f32_max(track.base_size, track_flex_factor * flex_fraction);
         }
     }
@@ -1199,7 +1199,9 @@ fn find_size_of_fr(tracks: &[GridTrack], space_to_fill: f32) -> f32 {
         for track in tracks.iter() {
             match track.max_track_sizing_function {
                 // Tracks for which flex_factor * hypothetical_fr_size < track.base_size are treated as inflexible
-                MaxTrackSizingFunction::Flex(flex_factor) if flex_factor * hypothetical_fr_size >= track.base_size => {
+                MaxTrackSizingFunction::Fraction(flex_factor)
+                    if flex_factor * hypothetical_fr_size >= track.base_size =>
+                {
                     naive_flex_factor_sum += flex_factor;
                 }
                 _ => used_space += track.base_size,
@@ -1216,7 +1218,7 @@ fn find_size_of_fr(tracks: &[GridTrack], space_to_fill: f32) -> f32 {
         // restart this algorithm treating all such tracks as inflexible.
         // We keep track of the hypothetical_fr_size
         let hypotherical_fr_size_is_valid = tracks.iter().all(|track| match track.max_track_sizing_function {
-            MaxTrackSizingFunction::Flex(flex_factor) => {
+            MaxTrackSizingFunction::Fraction(flex_factor) => {
                 flex_factor * hypothetical_fr_size >= track.base_size
                     || flex_factor * previous_iter_hypothetical_fr_size < track.base_size
             }

--- a/src/compute/grid/types/grid_item.rs
+++ b/src/compute/grid/types/grid_item.rs
@@ -441,7 +441,7 @@ impl GridItem {
                 let only_span_one_track = item_axis_tracks.len() == 1;
                 let spans_a_flexible_track = axis_tracks
                     .iter()
-                    .any(|track| matches!(track.max_track_sizing_function, MaxTrackSizingFunction::Flex(_)));
+                    .any(|track| matches!(track.max_track_sizing_function, MaxTrackSizingFunction::Fraction(_)));
 
                 let use_content_based_minimum =
                     spans_auto_min_track && (only_span_one_track || !spans_a_flexible_track);

--- a/src/compute/grid/types/grid_track.rs
+++ b/src/compute/grid/types/grid_track.rs
@@ -108,7 +108,7 @@ impl GridTrack {
     #[inline(always)]
     /// Returns true if the track is flexible (has a Flex MaxTrackSizingFunction), else false.
     pub fn is_flexible(&self) -> bool {
-        matches!(self.max_track_sizing_function, MaxTrackSizingFunction::Flex(_))
+        matches!(self.max_track_sizing_function, MaxTrackSizingFunction::Fraction(_))
     }
 
     #[inline(always)]
@@ -148,7 +148,7 @@ impl GridTrack {
     /// Returns the track's flex factor if it is a flex track, else 0.
     pub fn flex_factor(&self) -> f32 {
         match self.max_track_sizing_function {
-            MaxTrackSizingFunction::Flex(flex_factor) => flex_factor,
+            MaxTrackSizingFunction::Fraction(flex_factor) => flex_factor,
             _ => 0.0,
         }
     }

--- a/src/compute/grid/util/test_helpers.rs
+++ b/src/compute/grid/util/test_helpers.rs
@@ -11,8 +11,8 @@ impl CreateParentTestNode for (f32, f32, i32, i32) {
         Style {
             display: Display::Grid,
             size: Size { width: Dimension::Points(self.0), height: Dimension::Points(self.1) },
-            grid_template_columns: vec![flex(1f32); self.2 as usize],
-            grid_template_rows: vec![flex(1f32); self.3 as usize],
+            grid_template_columns: vec![fr(1f32); self.2 as usize],
+            grid_template_rows: vec![fr(1f32); self.3 as usize],
             ..Default::default()
         }
     }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -32,7 +32,7 @@ pub use crate::{
         JustifyContent, JustifyItems, JustifySelf, LengthPercentage, LengthPercentageAuto, Position, Style,
     },
     style_helpers::{
-        auto, fit_content, fr, max_content, min_content, minmax, percent, points, zero, FromFlex, FromPercent,
+        auto, fit_content, flex, fr, max_content, min_content, minmax, percent, points, zero, FromFlex, FromPercent,
         FromPoints, TaffyAuto, TaffyFitContent, TaffyMaxContent, TaffyMinContent, TaffyZero,
     },
     tree::LayoutTree,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -32,8 +32,8 @@ pub use crate::{
         JustifyContent, JustifyItems, JustifySelf, LengthPercentage, LengthPercentageAuto, Position, Style,
     },
     style_helpers::{
-        auto, fit_content, flex, fr, max_content, min_content, minmax, percent, points, zero, FromFlex, FromPercent,
-        FromPoints, TaffyAuto, TaffyFitContent, TaffyMaxContent, TaffyMinContent, TaffyZero,
+        auto, evenly_sized_tracks, fit_content, flex, fr, max_content, min_content, minmax, percent, points, zero,
+        FromFlex, FromPercent, FromPoints, TaffyAuto, TaffyFitContent, TaffyMaxContent, TaffyMinContent, TaffyZero,
     },
     tree::LayoutTree,
 };

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -32,7 +32,7 @@ pub use crate::{
         JustifyContent, JustifyItems, JustifySelf, LengthPercentage, LengthPercentageAuto, Position, Style,
     },
     style_helpers::{
-        auto, fit_content, flex, max_content, min_content, minmax, percent, points, zero, FromFlex, FromPercent,
+        auto, fit_content, fr, max_content, min_content, minmax, percent, points, zero, FromFlex, FromPercent,
         FromPoints, TaffyAuto, TaffyFitContent, TaffyMaxContent, TaffyMinContent, TaffyZero,
     },
     tree::LayoutTree,

--- a/src/style/grid.rs
+++ b/src/style/grid.rs
@@ -249,10 +249,10 @@ pub enum MaxTrackSizingFunction {
     FitContent(LengthPercentage),
     /// Track maximum size should be automatically sized
     Auto,
-    /// The dimension as a fraction of the total available grid space.
+    /// The dimension as a fraction of the total available grid space (`fr` units in CSS)
     /// Specified value is the numerator of the fraction. Denominator is the sum of all fraction specified in that grid dimension
     /// Spec: https://www.w3.org/TR/css3-grid-layout/#fr-unit
-    Flex(f32),
+    Fraction(f32),
 }
 impl TaffyAuto for MaxTrackSizingFunction {
     const AUTO: Self = Self::Auto;
@@ -283,7 +283,7 @@ impl FromPercent for MaxTrackSizingFunction {
 }
 impl FromFlex for MaxTrackSizingFunction {
     fn from_flex<Input: Into<f32> + Copy>(flex: Input) -> Self {
-        Self::Flex(flex.into())
+        Self::Fraction(flex.into())
     }
 }
 
@@ -305,7 +305,7 @@ impl MaxTrackSizingFunction {
     /// Returns true if the max track sizing function is `Flex`, else false.
     #[inline(always)]
     pub fn is_flexible(&self) -> bool {
-        matches!(self, Self::Flex(_))
+        matches!(self, Self::Fraction(_))
     }
 
     /// Returns fixed point values directly. Attempts to resolve percentage values against
@@ -317,7 +317,7 @@ impl MaxTrackSizingFunction {
         match self {
             Fixed(LengthPercentage::Points(size)) => Some(size),
             Fixed(LengthPercentage::Percent(fraction)) => parent_size.map(|size| fraction * size),
-            MinContent | MaxContent | FitContent(_) | Auto | Flex(_) => None,
+            MinContent | MaxContent | FitContent(_) | Auto | Fraction(_) => None,
         }
     }
 
@@ -344,7 +344,7 @@ impl MaxTrackSizingFunction {
         use MaxTrackSizingFunction::{Auto, *};
         match self {
             Fixed(LengthPercentage::Percent(fraction)) => Some(fraction * parent_size),
-            Fixed(LengthPercentage::Points(_)) | MinContent | MaxContent | FitContent(_) | Auto | Flex(_) => None,
+            Fixed(LengthPercentage::Points(_)) | MinContent | MaxContent | FitContent(_) | Auto | Fraction(_) => None,
         }
     }
 

--- a/src/style_helpers.rs
+++ b/src/style_helpers.rs
@@ -435,7 +435,7 @@ impl<T: FromPercent> Rect<T> {
 }
 
 /// Returns a value of the inferred type which represents a flex fraction
-pub fn flex<Input: Into<f32> + Copy, T: FromFlex>(flex: Input) -> T {
+pub fn fr<Input: Into<f32> + Copy, T: FromFlex>(flex: Input) -> T {
     T::from_flex(flex)
 }
 

--- a/src/style_helpers.rs
+++ b/src/style_helpers.rs
@@ -45,6 +45,12 @@ mod repeat_fn_tests {
     }
 }
 
+#[cfg(feature = "grid")]
+/// Returns a grid template containing `count` evenly sized tracks
+pub fn evenly_sized_tracks(count: u16) -> Vec<TrackSizingFunction> {
+    vec![repeat(count, vec![flex(1.0)])]
+}
+
 /// Specifies a grid line to place a grid item between in CSS Grid Line coordinates:
 ///  - Positive indicies count upwards from the start (top or left) of the explicit grid
 ///  - Negative indicies count downwards from the end (bottom or right) of the explicit grid

--- a/src/style_helpers.rs
+++ b/src/style_helpers.rs
@@ -77,6 +77,16 @@ where
     MinMax { min, max }.into()
 }
 
+/// Shorthand for minmax(0, Nfr). Probably what you want if you want exactly evenly sized tracks.
+#[cfg(feature = "grid")]
+pub fn flex<Input, Output>(flex_fraction: Input) -> Output
+where
+    Input: Into<f32> + Copy,
+    Output: From<MinMax<MinTrackSizingFunction, MaxTrackSizingFunction>>,
+{
+    MinMax { min: zero(), max: fr(flex_fraction.into()) }.into()
+}
+
 /// Returns the zero value for that type
 pub const fn zero<T: TaffyZero>() -> T {
     T::ZERO
@@ -434,7 +444,7 @@ impl<T: FromPercent> Rect<T> {
     }
 }
 
-/// Returns a value of the inferred type which represents a flex fraction
+/// Create a `Fraction` track sizing function (`fr` in CSS)
 pub fn fr<Input: Into<f32> + Copy, T: FromFlex>(flex: Input) -> T {
     T::from_flex(flex)
 }

--- a/tests/generated/grid_auto_takes_precedence_over_fr.rs
+++ b/tests/generated/grid_auto_takes_precedence_over_fr.rs
@@ -11,7 +11,7 @@ fn grid_auto_takes_precedence_over_fr() {
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
                 grid_template_rows: vec![points(40f32)],
-                grid_template_columns: vec![auto(), flex(1f32)],
+                grid_template_columns: vec![auto(), fr(1f32)],
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(200f32),
                     height: taffy::style::Dimension::Points(200f32),

--- a/tests/generated/grid_fr_fixed_size_no_content_proportions.rs
+++ b/tests/generated/grid_fr_fixed_size_no_content_proportions.rs
@@ -12,7 +12,7 @@ fn grid_fr_fixed_size_no_content_proportions() {
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
                 grid_template_rows: vec![points(40f32)],
-                grid_template_columns: vec![flex(1f32), flex(2f32), flex(3f32)],
+                grid_template_columns: vec![fr(1f32), fr(2f32), fr(3f32)],
                 size: taffy::geometry::Size { width: taffy::style::Dimension::Points(200f32), height: auto() },
                 ..Default::default()
             },

--- a/tests/generated/grid_fr_fixed_size_no_content_proportions_sub_1_sum.rs
+++ b/tests/generated/grid_fr_fixed_size_no_content_proportions_sub_1_sum.rs
@@ -11,7 +11,7 @@ fn grid_fr_fixed_size_no_content_proportions_sub_1_sum() {
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
                 grid_template_rows: vec![points(40f32)],
-                grid_template_columns: vec![flex(0.3f32), flex(0.2f32)],
+                grid_template_columns: vec![fr(0.3f32), fr(0.2f32)],
                 size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), height: auto() },
                 ..Default::default()
             },

--- a/tests/generated/grid_fr_fixed_size_single_item.rs
+++ b/tests/generated/grid_fr_fixed_size_single_item.rs
@@ -22,8 +22,8 @@ fn grid_fr_fixed_size_single_item() {
         .new_with_children(
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
-                grid_template_rows: vec![points(40f32), flex(1f32), flex(1f32)],
-                grid_template_columns: vec![points(40f32), flex(1f32), flex(1f32)],
+                grid_template_rows: vec![points(40f32), fr(1f32), fr(1f32)],
+                grid_template_columns: vec![points(40f32), fr(1f32), fr(1f32)],
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(200f32),
                     height: taffy::style::Dimension::Points(200f32),

--- a/tests/generated/grid_fr_no_sized_items_indefinite.rs
+++ b/tests/generated/grid_fr_no_sized_items_indefinite.rs
@@ -17,8 +17,8 @@ fn grid_fr_no_sized_items_indefinite() {
         .new_with_children(
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
-                grid_template_rows: vec![points(40f32), flex(1f32), flex(1f32)],
-                grid_template_columns: vec![points(40f32), flex(1f32), flex(1f32)],
+                grid_template_rows: vec![points(40f32), fr(1f32), fr(1f32)],
+                grid_template_columns: vec![points(40f32), fr(1f32), fr(1f32)],
                 ..Default::default()
             },
             &[node0, node1, node2, node3, node4, node5, node6, node7, node8],

--- a/tests/generated/grid_fr_single_item_indefinite.rs
+++ b/tests/generated/grid_fr_single_item_indefinite.rs
@@ -22,8 +22,8 @@ fn grid_fr_single_item_indefinite() {
         .new_with_children(
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
-                grid_template_rows: vec![points(40f32), flex(1f32), flex(1f32)],
-                grid_template_columns: vec![points(40f32), flex(1f32), flex(1f32)],
+                grid_template_rows: vec![points(40f32), fr(1f32), fr(1f32)],
+                grid_template_columns: vec![points(40f32), fr(1f32), fr(1f32)],
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Auto,
                     height: taffy::style::Dimension::Auto,

--- a/tests/generated/grid_fr_span_2_proportion.rs
+++ b/tests/generated/grid_fr_span_2_proportion.rs
@@ -21,7 +21,7 @@ fn grid_fr_span_2_proportion() {
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
                 grid_template_rows: vec![points(40f32), points(40f32)],
-                grid_template_columns: vec![flex(1f32), flex(2f32)],
+                grid_template_columns: vec![fr(1f32), fr(2f32)],
                 ..Default::default()
             },
             &[node0, node1, node2],

--- a/tests/generated/grid_fr_span_2_proportion_sub_1_sum.rs
+++ b/tests/generated/grid_fr_span_2_proportion_sub_1_sum.rs
@@ -21,7 +21,7 @@ fn grid_fr_span_2_proportion_sub_1_sum() {
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
                 grid_template_rows: vec![points(40f32), points(40f32)],
-                grid_template_columns: vec![flex(0.2f32), flex(0.3f32)],
+                grid_template_columns: vec![fr(0.2f32), fr(0.3f32)],
                 ..Default::default()
             },
             &[node0, node1, node2],

--- a/tests/generated/grid_fr_span_2_proportion_with_non_spanned_track.rs
+++ b/tests/generated/grid_fr_span_2_proportion_with_non_spanned_track.rs
@@ -23,7 +23,7 @@ fn grid_fr_span_2_proportion_with_non_spanned_track() {
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
                 grid_template_rows: vec![points(40f32), points(40f32)],
-                grid_template_columns: vec![flex(1f32), flex(2f32), flex(3f32)],
+                grid_template_columns: vec![fr(1f32), fr(2f32), fr(3f32)],
                 ..Default::default()
             },
             &[node0, node1, node2, node3, node4],

--- a/tests/generated/grid_fr_span_2_proportion_zero_sum.rs
+++ b/tests/generated/grid_fr_span_2_proportion_zero_sum.rs
@@ -21,7 +21,7 @@ fn grid_fr_span_2_proportion_zero_sum() {
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
                 grid_template_rows: vec![points(40f32), points(40f32)],
-                grid_template_columns: vec![flex(0f32), flex(0f32)],
+                grid_template_columns: vec![fr(0f32), fr(0f32)],
                 ..Default::default()
             },
             &[node0, node1, node2],

--- a/tests/generated/grid_fr_span_2_proportion_zero_sum_with_non_spanned_track.rs
+++ b/tests/generated/grid_fr_span_2_proportion_zero_sum_with_non_spanned_track.rs
@@ -23,7 +23,7 @@ fn grid_fr_span_2_proportion_zero_sum_with_non_spanned_track() {
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
                 grid_template_rows: vec![points(40f32), points(40f32)],
-                grid_template_columns: vec![flex(0f32), flex(0f32), flex(0f32)],
+                grid_template_columns: vec![fr(0f32), fr(0f32), fr(0f32)],
                 ..Default::default()
             },
             &[node0, node1, node2, node3, node4],

--- a/tests/generated/grid_min_content_flex_single_item.rs
+++ b/tests/generated/grid_min_content_flex_single_item.rs
@@ -42,7 +42,7 @@ fn grid_min_content_flex_single_item() {
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
                 grid_template_rows: vec![points(40f32), points(40f32), points(40f32)],
-                grid_template_columns: vec![points(40f32), min_content(), flex(1f32)],
+                grid_template_columns: vec![points(40f32), min_content(), fr(1f32)],
                 ..Default::default()
             },
             &[node0, node1, node2, node3, node4, node5, node6, node7],

--- a/tests/generated/grid_min_content_flex_single_item_margin_auto.rs
+++ b/tests/generated/grid_min_content_flex_single_item_margin_auto.rs
@@ -54,7 +54,7 @@ fn grid_min_content_flex_single_item_margin_auto() {
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
                 grid_template_rows: vec![points(40f32), points(40f32), points(40f32)],
-                grid_template_columns: vec![points(40f32), min_content(), flex(1f32)],
+                grid_template_columns: vec![points(40f32), min_content(), fr(1f32)],
                 ..Default::default()
             },
             &[node0, node1, node2, node3, node4, node5, node6, node7],

--- a/tests/generated/grid_min_content_flex_single_item_margin_fixed.rs
+++ b/tests/generated/grid_min_content_flex_single_item_margin_fixed.rs
@@ -54,7 +54,7 @@ fn grid_min_content_flex_single_item_margin_fixed() {
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
                 grid_template_rows: vec![points(40f32), points(40f32), points(40f32)],
-                grid_template_columns: vec![points(40f32), min_content(), flex(1f32)],
+                grid_template_columns: vec![points(40f32), min_content(), fr(1f32)],
                 ..Default::default()
             },
             &[node0, node1, node2, node3, node4, node5, node6, node7],

--- a/tests/generated/grid_min_content_flex_single_item_margin_percent.rs
+++ b/tests/generated/grid_min_content_flex_single_item_margin_percent.rs
@@ -54,7 +54,7 @@ fn grid_min_content_flex_single_item_margin_percent() {
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
                 grid_template_rows: vec![points(40f32), points(40f32), points(40f32)],
-                grid_template_columns: vec![points(40f32), min_content(), flex(1f32)],
+                grid_template_columns: vec![points(40f32), min_content(), fr(1f32)],
                 ..Default::default()
             },
             &[node0, node1, node2, node3, node4, node5, node6, node7],

--- a/tests/generated/grid_minmax_column_with_fr_fixed.rs
+++ b/tests/generated/grid_minmax_column_with_fr_fixed.rs
@@ -11,7 +11,7 @@ fn grid_minmax_column_with_fr_fixed() {
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
                 grid_template_rows: vec![points(40f32)],
-                grid_template_columns: vec![minmax(points(20f32), points(40f32)), flex(1f32)],
+                grid_template_columns: vec![minmax(points(20f32), points(40f32)), fr(1f32)],
                 size: taffy::geometry::Size { width: taffy::style::Dimension::Points(60f32), height: auto() },
                 ..Default::default()
             },

--- a/tests/generated/grid_minmax_max_content_1fr.rs
+++ b/tests/generated/grid_minmax_max_content_1fr.rs
@@ -24,7 +24,7 @@ fn grid_minmax_max_content_1fr() {
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
                 grid_template_rows: vec![points(40f32)],
-                grid_template_columns: vec![minmax(max_content(), flex(1f32))],
+                grid_template_columns: vec![minmax(max_content(), fr(1f32))],
                 ..Default::default()
             },
             &[node0],

--- a/tests/generated/grid_minmax_min_content_1fr.rs
+++ b/tests/generated/grid_minmax_min_content_1fr.rs
@@ -24,7 +24,7 @@ fn grid_minmax_min_content_1fr() {
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
                 grid_template_rows: vec![points(40f32)],
-                grid_template_columns: vec![minmax(min_content(), flex(1f32))],
+                grid_template_columns: vec![minmax(min_content(), fr(1f32))],
                 ..Default::default()
             },
             &[node0],

--- a/tests/generated/grid_percent_items_nested_with_padding_margin.rs
+++ b/tests/generated/grid_percent_items_nested_with_padding_margin.rs
@@ -71,7 +71,7 @@ fn grid_percent_items_nested_with_padding_margin() {
         .new_with_children(
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
-                grid_template_rows: vec![flex(1f32), flex(4f32)],
+                grid_template_rows: vec![fr(1f32), fr(4f32)],
                 size: taffy::geometry::Size {
                     width: taffy::style::Dimension::Points(200f32),
                     height: taffy::style::Dimension::Points(200f32),

--- a/tests/generated/grid_span_8_all_track_types_indefinite.rs
+++ b/tests/generated/grid_span_8_all_track_types_indefinite.rs
@@ -42,8 +42,8 @@ fn grid_span_8_all_track_types_indefinite() {
                     auto(),
                     points(10f32),
                     percent(0.2f32),
-                    flex(1f32),
-                    flex(2f32),
+                    fr(1f32),
+                    fr(2f32),
                 ],
                 ..Default::default()
             },

--- a/tests/generated/gridflex_column_integration.rs
+++ b/tests/generated/gridflex_column_integration.rs
@@ -68,8 +68,8 @@ fn gridflex_column_integration() {
         .new_with_children(
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
-                grid_template_rows: vec![flex(1f32), flex(1f32)],
-                grid_template_columns: vec![flex(1f32), flex(1f32)],
+                grid_template_rows: vec![fr(1f32), fr(1f32)],
+                grid_template_columns: vec![fr(1f32), fr(1f32)],
                 ..Default::default()
             },
             &[node00, node01, node02, node03],

--- a/tests/generated/gridflex_kitchen_sink.rs
+++ b/tests/generated/gridflex_kitchen_sink.rs
@@ -90,8 +90,8 @@ fn gridflex_kitchen_sink() {
         .new_with_children(
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
-                grid_template_rows: vec![flex(1f32), flex(1f32)],
-                grid_template_columns: vec![flex(1f32), flex(1f32)],
+                grid_template_rows: vec![fr(1f32), fr(1f32)],
+                grid_template_columns: vec![fr(1f32), fr(1f32)],
                 ..Default::default()
             },
             &[node00, node01, node02, node03],

--- a/tests/generated/gridflex_kitchen_sink_minimise.rs
+++ b/tests/generated/gridflex_kitchen_sink_minimise.rs
@@ -16,7 +16,7 @@ fn gridflex_kitchen_sink_minimise() {
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
                 grid_template_rows: vec![points(20f32)],
-                grid_template_columns: vec![flex(1f32), flex(1f32)],
+                grid_template_columns: vec![fr(1f32), fr(1f32)],
                 ..Default::default()
             },
             &[node00, node01],

--- a/tests/generated/gridflex_row_integration.rs
+++ b/tests/generated/gridflex_row_integration.rs
@@ -68,8 +68,8 @@ fn gridflex_row_integration() {
         .new_with_children(
             taffy::style::Style {
                 display: taffy::style::Display::Grid,
-                grid_template_rows: vec![flex(1f32), flex(1f32)],
-                grid_template_columns: vec![flex(1f32), flex(1f32)],
+                grid_template_rows: vec![fr(1f32), fr(1f32)],
+                grid_template_columns: vec![fr(1f32), fr(1f32)],
                 ..Default::default()
             },
             &[node00, node01, node02, node03],


### PR DESCRIPTION
# Objective

This is to more closely align our naming with the spec:
- Renames `MaxTrackSizingFunction::Flex` to `MaxTrackSizingFunction::Fraction`
- Renames `flex()` helper to `fr()`
- Creates a new helper function called `flex()` that resolves to `minmax(0px, Nfr)`

The unit is called `fr` in the spec (although it does also talk about "flexible track sizing functions".

The `flex()` helper is to try to encourage people to use `minmax(0px 1fr)` - this is much faster than plain `1fr` as it doesn't have to do any content sizing. Hopefully the pattern for "4 evenly sized tracks" can be something like:

```rust
grid_template_columns: repeat(4, flex(1.0))
```
although the following would also work and be just as effcient

```rust
grid_template_columns: repeat(4, percent(1/4))
```

## Feedback wanted

Does this naming make sense?

EDIT: Would it perhaps be better to leave the naming as it is and create an `evenly_sized_tracks(count: u16)` helper that directly creates a `repeat(4, flex(1.0))`?
