### PR TITLE
Grid: Fix sizing issues in complex cases

### DIFF
--- a/benches/generated/grid_percent_item_inside_stretch_item.rs
+++ b/benches/generated/grid_percent_item_inside_stretch_item.rs
@@ -1,0 +1,32 @@
+pub fn compute() {
+    #[allow(unused_imports)]
+    use taffy::prelude::*;
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
+        .new_leaf(taffy::style::Style {
+            display: taffy::style::Display::Grid,
+            size: taffy::geometry::Size { width: taffy::style::Dimension::Percent(0.5f32), height: auto() },
+            ..Default::default()
+        })
+        .unwrap();
+    let node0 = taffy
+        .new_with_children(
+            taffy::style::Style { display: taffy::style::Display::Grid, ..Default::default() },
+            &[node00],
+        )
+        .unwrap();
+    let node = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Grid,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
+                },
+                ..Default::default()
+            },
+            &[node0],
+        )
+        .unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
+}

--- a/benches/generated/grid_percent_items_nested_inside_stretch_alignment.rs
+++ b/benches/generated/grid_percent_items_nested_inside_stretch_alignment.rs
@@ -1,0 +1,34 @@
+pub fn compute() {
+    #[allow(unused_imports)]
+    use taffy::prelude::*;
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
+        .new_leaf(taffy::style::Style {
+            display: taffy::style::Display::Grid,
+            padding: taffy::geometry::Rect {
+                left: zero(),
+                right: zero(),
+                top: taffy::style::LengthPercentage::Percent(0.2f32),
+                bottom: zero(),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node0 = taffy
+        .new_with_children(
+            taffy::style::Style { display: taffy::style::Display::Grid, ..Default::default() },
+            &[node00],
+        )
+        .unwrap();
+    let node = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Grid,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(200f32), height: auto() },
+                ..Default::default()
+            },
+            &[node0],
+        )
+        .unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
+}

--- a/benches/generated/grid_percent_items_nested_with_margin.rs
+++ b/benches/generated/grid_percent_items_nested_with_margin.rs
@@ -1,0 +1,38 @@
+pub fn compute() {
+    #[allow(unused_imports)]
+    use taffy::prelude::*;
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
+        .new_leaf(taffy::style::Style {
+            size: taffy::geometry::Size { width: taffy::style::Dimension::Percent(0.45f32), height: auto() },
+            margin: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Percent(0.05f32),
+                right: taffy::style::LengthPercentageAuto::Percent(0.05f32),
+                top: taffy::style::LengthPercentageAuto::Percent(0.05f32),
+                bottom: taffy::style::LengthPercentageAuto::Percent(0.05f32),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node0 = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Grid,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Percent(0.5f32), height: auto() },
+                ..Default::default()
+            },
+            &[node00],
+        )
+        .unwrap();
+    let node = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Grid,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(200f32), height: auto() },
+                ..Default::default()
+            },
+            &[node0],
+        )
+        .unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
+}

--- a/benches/generated/gridflex_column_integration.rs
+++ b/benches/generated/gridflex_column_integration.rs
@@ -1,0 +1,83 @@
+pub fn compute() {
+    #[allow(unused_imports)]
+    use taffy::prelude::*;
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
+        .new_leaf_with_measure(
+            taffy::style::Style { ..Default::default() },
+            taffy::node::MeasureFunc::Raw(|known_dimensions, available_space| {
+                const TEXT: &str = "HH";
+                super::measure_standard_text(
+                    known_dimensions,
+                    available_space,
+                    TEXT,
+                    super::WritingMode::Horizontal,
+                    None,
+                )
+            }),
+        )
+        .unwrap();
+    let node01 = taffy
+        .new_leaf_with_measure(
+            taffy::style::Style { ..Default::default() },
+            taffy::node::MeasureFunc::Raw(|known_dimensions, available_space| {
+                const TEXT: &str = "HH";
+                super::measure_standard_text(
+                    known_dimensions,
+                    available_space,
+                    TEXT,
+                    super::WritingMode::Horizontal,
+                    None,
+                )
+            }),
+        )
+        .unwrap();
+    let node02 = taffy
+        .new_leaf_with_measure(
+            taffy::style::Style { ..Default::default() },
+            taffy::node::MeasureFunc::Raw(|known_dimensions, available_space| {
+                const TEXT: &str = "HH";
+                super::measure_standard_text(
+                    known_dimensions,
+                    available_space,
+                    TEXT,
+                    super::WritingMode::Horizontal,
+                    None,
+                )
+            }),
+        )
+        .unwrap();
+    let node03 = taffy
+        .new_leaf_with_measure(
+            taffy::style::Style { ..Default::default() },
+            taffy::node::MeasureFunc::Raw(|known_dimensions, available_space| {
+                const TEXT: &str = "HH";
+                super::measure_standard_text(
+                    known_dimensions,
+                    available_space,
+                    TEXT,
+                    super::WritingMode::Horizontal,
+                    None,
+                )
+            }),
+        )
+        .unwrap();
+    let node0 = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Grid,
+                grid_template_rows: vec![flex(1f32), flex(1f32)],
+                grid_template_columns: vec![flex(1f32), flex(1f32)],
+                ..Default::default()
+            },
+            &[node00, node01, node02, node03],
+        )
+        .unwrap();
+    let node = taffy
+        .new_with_children(
+            taffy::style::Style { flex_direction: taffy::style::FlexDirection::Column, ..Default::default() },
+            &[node0],
+        )
+        .unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
+}

--- a/benches/generated/gridflex_kitchen_sink.rs
+++ b/benches/generated/gridflex_kitchen_sink.rs
@@ -1,0 +1,100 @@
+pub fn compute() {
+    #[allow(unused_imports)]
+    use taffy::prelude::*;
+    let mut taffy = taffy::Taffy::new();
+    let node000 = taffy
+        .new_leaf(taffy::style::Style {
+            size: taffy::geometry::Size { width: taffy::style::Dimension::Points(20f32), height: auto() },
+            ..Default::default()
+        })
+        .unwrap();
+    let node00100 = taffy
+        .new_leaf(taffy::style::Style {
+            size: taffy::geometry::Size { width: taffy::style::Dimension::Points(20f32), height: auto() },
+            ..Default::default()
+        })
+        .unwrap();
+    let node00101 = taffy.new_leaf(taffy::style::Style { ..Default::default() }).unwrap();
+    let node00102 = taffy.new_leaf(taffy::style::Style { ..Default::default() }).unwrap();
+    let node00103 = taffy.new_leaf(taffy::style::Style { ..Default::default() }).unwrap();
+    let node0010 = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Grid,
+                grid_template_rows: vec![percent(0.3f32), percent(0.1f32)],
+                grid_template_columns: vec![auto(), percent(0.1f32)],
+                ..Default::default()
+            },
+            &[node00100, node00101, node00102, node00103],
+        )
+        .unwrap();
+    let node001 = taffy
+        .new_with_children(
+            taffy::style::Style {
+                flex_grow: 1f32,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(50f32), height: auto() },
+                ..Default::default()
+            },
+            &[node0010],
+        )
+        .unwrap();
+    let node00 = taffy.new_with_children(taffy::style::Style { ..Default::default() }, &[node000, node001]).unwrap();
+    let node01 = taffy
+        .new_leaf_with_measure(
+            taffy::style::Style { ..Default::default() },
+            taffy::node::MeasureFunc::Raw(|known_dimensions, available_space| {
+                const TEXT: &str = "HH";
+                super::measure_standard_text(
+                    known_dimensions,
+                    available_space,
+                    TEXT,
+                    super::WritingMode::Horizontal,
+                    None,
+                )
+            }),
+        )
+        .unwrap();
+    let node02 = taffy
+        .new_leaf_with_measure(
+            taffy::style::Style { ..Default::default() },
+            taffy::node::MeasureFunc::Raw(|known_dimensions, available_space| {
+                const TEXT: &str = "HH";
+                super::measure_standard_text(
+                    known_dimensions,
+                    available_space,
+                    TEXT,
+                    super::WritingMode::Horizontal,
+                    None,
+                )
+            }),
+        )
+        .unwrap();
+    let node03 = taffy
+        .new_leaf_with_measure(
+            taffy::style::Style { ..Default::default() },
+            taffy::node::MeasureFunc::Raw(|known_dimensions, available_space| {
+                const TEXT: &str = "HH";
+                super::measure_standard_text(
+                    known_dimensions,
+                    available_space,
+                    TEXT,
+                    super::WritingMode::Horizontal,
+                    None,
+                )
+            }),
+        )
+        .unwrap();
+    let node0 = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Grid,
+                grid_template_rows: vec![flex(1f32), flex(1f32)],
+                grid_template_columns: vec![flex(1f32), flex(1f32)],
+                ..Default::default()
+            },
+            &[node00, node01, node02, node03],
+        )
+        .unwrap();
+    let node = taffy.new_with_children(taffy::style::Style { ..Default::default() }, &[node0]).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
+}

--- a/benches/generated/gridflex_kitchen_sink_minimise.rs
+++ b/benches/generated/gridflex_kitchen_sink_minimise.rs
@@ -1,0 +1,25 @@
+pub fn compute() {
+    #[allow(unused_imports)]
+    use taffy::prelude::*;
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
+        .new_leaf(taffy::style::Style {
+            size: taffy::geometry::Size { width: taffy::style::Dimension::Points(50f32), height: auto() },
+            ..Default::default()
+        })
+        .unwrap();
+    let node01 = taffy.new_leaf(taffy::style::Style { ..Default::default() }).unwrap();
+    let node0 = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Grid,
+                grid_template_rows: vec![points(20f32)],
+                grid_template_columns: vec![flex(1f32), flex(1f32)],
+                ..Default::default()
+            },
+            &[node00, node01],
+        )
+        .unwrap();
+    let node = taffy.new_with_children(taffy::style::Style { ..Default::default() }, &[node0]).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
+}

--- a/benches/generated/gridflex_kitchen_sink_minimise2.rs
+++ b/benches/generated/gridflex_kitchen_sink_minimise2.rs
@@ -1,0 +1,36 @@
+pub fn compute() {
+    #[allow(unused_imports)]
+    use taffy::prelude::*;
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
+        .new_leaf(taffy::style::Style {
+            size: taffy::geometry::Size {
+                width: taffy::style::Dimension::Points(20f32),
+                height: taffy::style::Dimension::Points(20f32),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node0 = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Grid,
+                grid_template_rows: vec![auto()],
+                grid_template_columns: vec![auto()],
+                ..Default::default()
+            },
+            &[node00],
+        )
+        .unwrap();
+    let node = taffy
+        .new_with_children(
+            taffy::style::Style {
+                flex_grow: 1f32,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(50f32), height: auto() },
+                ..Default::default()
+            },
+            &[node0],
+        )
+        .unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
+}

--- a/benches/generated/gridflex_kitchen_sink_minimise3.rs
+++ b/benches/generated/gridflex_kitchen_sink_minimise3.rs
@@ -1,0 +1,38 @@
+pub fn compute() {
+    #[allow(unused_imports)]
+    use taffy::prelude::*;
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
+        .new_leaf(taffy::style::Style {
+            size: taffy::geometry::Size {
+                width: taffy::style::Dimension::Points(20f32),
+                height: taffy::style::Dimension::Points(20f32),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node01 = taffy.new_leaf(taffy::style::Style { ..Default::default() }).unwrap();
+    let node02 = taffy.new_leaf(taffy::style::Style { ..Default::default() }).unwrap();
+    let node03 = taffy.new_leaf(taffy::style::Style { ..Default::default() }).unwrap();
+    let node0 = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Grid,
+                grid_template_rows: vec![percent(0.3f32), percent(0.1f32)],
+                grid_template_columns: vec![auto(), percent(0.1f32)],
+                ..Default::default()
+            },
+            &[node00, node01, node02, node03],
+        )
+        .unwrap();
+    let node = taffy
+        .new_with_children(
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(50f32), height: auto() },
+                ..Default::default()
+            },
+            &[node0],
+        )
+        .unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
+}

--- a/benches/generated/gridflex_row_integration.rs
+++ b/benches/generated/gridflex_row_integration.rs
@@ -1,0 +1,78 @@
+pub fn compute() {
+    #[allow(unused_imports)]
+    use taffy::prelude::*;
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
+        .new_leaf_with_measure(
+            taffy::style::Style { ..Default::default() },
+            taffy::node::MeasureFunc::Raw(|known_dimensions, available_space| {
+                const TEXT: &str = "HH";
+                super::measure_standard_text(
+                    known_dimensions,
+                    available_space,
+                    TEXT,
+                    super::WritingMode::Horizontal,
+                    None,
+                )
+            }),
+        )
+        .unwrap();
+    let node01 = taffy
+        .new_leaf_with_measure(
+            taffy::style::Style { ..Default::default() },
+            taffy::node::MeasureFunc::Raw(|known_dimensions, available_space| {
+                const TEXT: &str = "HH";
+                super::measure_standard_text(
+                    known_dimensions,
+                    available_space,
+                    TEXT,
+                    super::WritingMode::Horizontal,
+                    None,
+                )
+            }),
+        )
+        .unwrap();
+    let node02 = taffy
+        .new_leaf_with_measure(
+            taffy::style::Style { ..Default::default() },
+            taffy::node::MeasureFunc::Raw(|known_dimensions, available_space| {
+                const TEXT: &str = "HH";
+                super::measure_standard_text(
+                    known_dimensions,
+                    available_space,
+                    TEXT,
+                    super::WritingMode::Horizontal,
+                    None,
+                )
+            }),
+        )
+        .unwrap();
+    let node03 = taffy
+        .new_leaf_with_measure(
+            taffy::style::Style { ..Default::default() },
+            taffy::node::MeasureFunc::Raw(|known_dimensions, available_space| {
+                const TEXT: &str = "HH";
+                super::measure_standard_text(
+                    known_dimensions,
+                    available_space,
+                    TEXT,
+                    super::WritingMode::Horizontal,
+                    None,
+                )
+            }),
+        )
+        .unwrap();
+    let node0 = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Grid,
+                grid_template_rows: vec![flex(1f32), flex(1f32)],
+                grid_template_columns: vec![flex(1f32), flex(1f32)],
+                ..Default::default()
+            },
+            &[node00, node01, node02, node03],
+        )
+        .unwrap();
+    let node = taffy.new_with_children(taffy::style::Style { ..Default::default() }, &[node0]).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
+}

--- a/benches/generated/mod.rs
+++ b/benches/generated/mod.rs
@@ -641,7 +641,13 @@ mod grid_out_of_order_items;
 #[cfg(feature = "grid")]
 mod grid_overflow_rows;
 #[cfg(feature = "grid")]
+mod grid_percent_item_inside_stretch_item;
+#[cfg(feature = "grid")]
+mod grid_percent_items_nested_inside_stretch_alignment;
+#[cfg(feature = "grid")]
 mod grid_percent_items_nested_moderate;
+#[cfg(feature = "grid")]
+mod grid_percent_items_nested_with_margin;
 #[cfg(feature = "grid")]
 mod grid_percent_items_nested_with_padding_margin;
 #[cfg(feature = "grid")]
@@ -698,6 +704,18 @@ mod grid_span_2_min_content_min_content_indefinite;
 mod grid_span_6_all_non_flex_indefinite;
 #[cfg(feature = "grid")]
 mod grid_span_8_all_track_types_indefinite;
+#[cfg(feature = "grid")]
+mod gridflex_column_integration;
+#[cfg(feature = "grid")]
+mod gridflex_kitchen_sink;
+#[cfg(feature = "grid")]
+mod gridflex_kitchen_sink_minimise;
+#[cfg(feature = "grid")]
+mod gridflex_kitchen_sink_minimise2;
+#[cfg(feature = "grid")]
+mod gridflex_kitchen_sink_minimise3;
+#[cfg(feature = "grid")]
+mod gridflex_row_integration;
 mod intrinsic_sizing_cross_size_column;
 mod intrinsic_sizing_main_size_column;
 mod intrinsic_sizing_main_size_column_nested;
@@ -1461,7 +1479,13 @@ fn benchmark(c: &mut Criterion) {
             #[cfg(feature = "grid")]
             grid_overflow_rows::compute();
             #[cfg(feature = "grid")]
+            grid_percent_item_inside_stretch_item::compute();
+            #[cfg(feature = "grid")]
+            grid_percent_items_nested_inside_stretch_alignment::compute();
+            #[cfg(feature = "grid")]
             grid_percent_items_nested_moderate::compute();
+            #[cfg(feature = "grid")]
+            grid_percent_items_nested_with_margin::compute();
             #[cfg(feature = "grid")]
             grid_percent_items_nested_with_padding_margin::compute();
             #[cfg(feature = "grid")]
@@ -1518,6 +1542,18 @@ fn benchmark(c: &mut Criterion) {
             grid_span_6_all_non_flex_indefinite::compute();
             #[cfg(feature = "grid")]
             grid_span_8_all_track_types_indefinite::compute();
+            #[cfg(feature = "grid")]
+            gridflex_column_integration::compute();
+            #[cfg(feature = "grid")]
+            gridflex_kitchen_sink::compute();
+            #[cfg(feature = "grid")]
+            gridflex_kitchen_sink_minimise::compute();
+            #[cfg(feature = "grid")]
+            gridflex_kitchen_sink_minimise2::compute();
+            #[cfg(feature = "grid")]
+            gridflex_kitchen_sink_minimise3::compute();
+            #[cfg(feature = "grid")]
+            gridflex_row_integration::compute();
             intrinsic_sizing_cross_size_column::compute();
             intrinsic_sizing_main_size_column::compute();
             intrinsic_sizing_main_size_column_nested::compute();

--- a/src/compute/grid/alignment.rs
+++ b/src/compute/grid/alignment.rs
@@ -99,14 +99,14 @@ pub(super) fn align_and_position_item(
     // and the then height is calculated from the width according the aspect ratio
     // See: https://www.w3.org/TR/css-grid-1/#grid-item-sizing
     let alignment_styles = InBothAbsAxis {
-        horizontal: container_alignment_styles.horizontal.or(justify_self).unwrap_or_else(|| {
+        horizontal: justify_self.or(container_alignment_styles.horizontal).unwrap_or_else(|| {
             if inherent_size.width.is_some() {
                 AlignSelf::Start
             } else {
                 AlignSelf::Stretch
             }
         }),
-        vertical: container_alignment_styles.vertical.or(align_self).unwrap_or_else(|| {
+        vertical: align_self.or(container_alignment_styles.vertical).unwrap_or_else(|| {
             if inherent_size.height.is_some() || aspect_ratio.is_some() {
                 AlignSelf::Start
             } else {

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -151,7 +151,8 @@ pub fn compute(
         .maybe_clamp(min_size, max_size)
         .map(|size| size.map(AvailableSpace::Definite))
         .unwrap_or(available_space.map(|space| match space {
-            // Available grid space should depend on Definite available space
+            // Available grid space should not depend on Definite available space as a grid is allowed
+            // to expand beyond it's available space
             AvailableSpace::Definite(_) => AvailableSpace::MaxContent,
             _ => space,
         }));

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -108,6 +108,7 @@ pub fn compute(
         in_flow_children_iter,
         style.grid_auto_flow,
         style.align_items.unwrap_or(AlignItems::Stretch),
+        style.justify_items.unwrap_or(AlignItems::Stretch),
     );
 
     // Extract track counts from previous step (auto-placement can expand the number of tracks)
@@ -140,16 +141,20 @@ pub fn compute(
     // https://www.w3.org/TR/css-grid-1/#available-grid-space
     let padding = style.padding.resolve_or_zero(parent_size.width);
     let border = style.border.resolve_or_zero(parent_size.width);
-    let margin = style.margin.resolve_or_zero(parent_size.width);
     let aspect_ratio = style.aspect_ratio;
     let min_size = style.min_size.maybe_resolve(parent_size).maybe_apply_aspect_ratio(aspect_ratio);
     let max_size = style.max_size.maybe_resolve(parent_size).maybe_apply_aspect_ratio(aspect_ratio);
     let size = style.size.maybe_resolve(parent_size).maybe_apply_aspect_ratio(aspect_ratio);
 
-    let constrained_available_space = size
+    let constrained_available_space = known_dimensions
+        .or(size)
         .maybe_clamp(min_size, max_size)
         .map(|size| size.map(AvailableSpace::Definite))
-        .unwrap_or(available_space.maybe_clamp(min_size, max_size));
+        .unwrap_or(available_space.map(|space| match space {
+            // Available grid space should depend on Definite available space
+            AvailableSpace::Definite(_) => AvailableSpace::MaxContent,
+            _ => space,
+        }));
 
     let available_grid_space = Size {
         width: constrained_available_space
@@ -160,7 +165,7 @@ pub fn compute(
             .map_definite_value(|space| space - padding.vertical_axis_sum() - border.vertical_axis_sum()),
     };
 
-    let outer_node_size = size.maybe_clamp(min_size, max_size).or(parent_size.maybe_sub(margin.sum_axes()));
+    let outer_node_size = known_dimensions.or(size.maybe_clamp(min_size, max_size).or(min_size));
     let mut inner_node_size = Size {
         width: outer_node_size.width.map(|space| space - padding.horizontal_axis_sum() - border.horizontal_axis_sum()),
         height: outer_node_size.height.map(|space| space - padding.vertical_axis_sum() - border.vertical_axis_sum()),
@@ -205,7 +210,7 @@ pub fn compute(
     let initial_column_sum = columns.iter().map(|track| track.base_size).sum::<f32>();
     inner_node_size.width = inner_node_size.width.or_else(|| initial_column_sum.into());
 
-    items.iter_mut().for_each(|item| item.known_dimensions_cache = None);
+    items.iter_mut().for_each(|item| item.available_space_cache = None);
 
     // Run track sizing algorithm for Block axis
     track_sizing_algorithm(
@@ -280,18 +285,18 @@ pub fn compute(
             .iter_mut()
             .filter(|item| item.crosses_intrinsic_column)
             .map(|item| {
-                let known_dimensions = item.known_dimensions(
+                let available_space = item.available_space(
                     AbstractAxis::Inline,
                     &rows,
                     inner_node_size.height,
                     |track: &GridTrack, _| Some(track.base_size),
                 );
                 let new_min_content_contribution =
-                    item.min_content_contribution(AbstractAxis::Inline, tree, known_dimensions, inner_node_size);
+                    item.min_content_contribution(AbstractAxis::Inline, tree, available_space, inner_node_size);
 
                 let has_changed = Some(new_min_content_contribution) != item.min_content_contribution_cache.width;
 
-                item.known_dimensions_cache = Some(known_dimensions);
+                item.available_space_cache = Some(available_space);
                 item.min_content_contribution_cache.width = Some(new_min_content_contribution);
                 item.max_content_contribution_cache.width = None;
                 item.minimum_contribution_cache.width = None;
@@ -303,7 +308,7 @@ pub fn compute(
     } else {
         // Clear intrisic width caches
         items.iter_mut().for_each(|item| {
-            item.known_dimensions_cache = None;
+            item.available_space_cache = None;
             item.min_content_contribution_cache.width = None;
             item.max_content_contribution_cache.width = None;
             item.minimum_contribution_cache.width = None;
@@ -342,18 +347,18 @@ pub fn compute(
                 .iter_mut()
                 .filter(|item| item.crosses_intrinsic_column)
                 .map(|item| {
-                    let known_dimensions = item.known_dimensions(
+                    let available_space = item.available_space(
                         AbstractAxis::Block,
                         &columns,
                         inner_node_size.width,
                         |track: &GridTrack, _| Some(track.base_size),
                     );
                     let new_min_content_contribution =
-                        item.min_content_contribution(AbstractAxis::Block, tree, known_dimensions, inner_node_size);
+                        item.min_content_contribution(AbstractAxis::Block, tree, available_space, inner_node_size);
 
                     let has_changed = Some(new_min_content_contribution) != item.min_content_contribution_cache.height;
 
-                    item.known_dimensions_cache = Some(known_dimensions);
+                    item.available_space_cache = Some(available_space);
                     item.min_content_contribution_cache.height = Some(new_min_content_contribution);
                     item.max_content_contribution_cache.height = None;
                     item.minimum_contribution_cache.height = None;
@@ -365,7 +370,7 @@ pub fn compute(
         } else {
             items.iter_mut().for_each(|item| {
                 // Clear intrisic height caches
-                item.known_dimensions_cache = None;
+                item.available_space_cache = None;
                 item.min_content_contribution_cache.height = None;
                 item.max_content_contribution_cache.height = None;
                 item.minimum_contribution_cache.height = None;

--- a/src/compute/grid/placement.rs
+++ b/src/compute/grid/placement.rs
@@ -18,6 +18,7 @@ pub(super) fn place_grid_items<'a, ChildIter>(
     children_iter: impl Fn() -> ChildIter,
     grid_auto_flow: GridAutoFlow,
     align_items: AlignItems,
+    justify_items: AlignItems,
 ) where
     ChildIter: Iterator<Item = (usize, Node, &'a Style)>,
 {
@@ -54,6 +55,7 @@ pub(super) fn place_grid_items<'a, ChildIter>(
                 index,
                 style,
                 align_items,
+                justify_items,
                 primary_axis,
                 row_span,
                 col_span,
@@ -84,6 +86,7 @@ pub(super) fn place_grid_items<'a, ChildIter>(
                 index,
                 style,
                 align_items,
+                justify_items,
                 primary_axis,
                 primary_span,
                 secondary_span,
@@ -139,6 +142,7 @@ pub(super) fn place_grid_items<'a, ChildIter>(
                 index,
                 style,
                 align_items,
+                justify_items,
                 primary_axis,
                 primary_span,
                 secondary_span,
@@ -297,6 +301,7 @@ fn record_grid_placement(
     index: usize,
     style: &Style,
     parent_align_items: AlignItems,
+    parent_justify_items: AlignItems,
     primary_axis: AbsoluteAxis,
     primary_span: Line<OriginZeroLine>,
     secondary_span: Line<OriginZeroLine>,
@@ -321,6 +326,7 @@ fn record_grid_placement(
         row_span,
         style,
         parent_align_items,
+        parent_justify_items,
         index as u16,
     ));
 
@@ -368,7 +374,14 @@ mod tests {
                 CellOccupancyMatrix::with_track_counts(estimated_sizes.0, estimated_sizes.1);
 
             // Run placement algorithm
-            place_grid_items(&mut cell_occupancy_matrix, &mut items, children_iter, flow, AlignSelf::Start);
+            place_grid_items(
+                &mut cell_occupancy_matrix,
+                &mut items,
+                children_iter,
+                flow,
+                AlignSelf::Start,
+                AlignSelf::Start,
+            );
 
             // Assert that each item has been placed in the right location
             let mut sorted_children = children.clone();

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -150,8 +150,6 @@ fn compute_node_layout(
     }
 
     #[cfg(feature = "debug")]
-    NODE_LOGGER.log("COMPUTE");
-    #[cfg(feature = "debug")]
     debug_log_node(known_dimensions, parent_size, available_space, run_mode, sizing_mode);
 
     /// Inlined function generic over the LayoutAlgorithm to reduce code duplication
@@ -248,7 +246,7 @@ fn debug_log_node(
     run_mode: RunMode,
     sizing_mode: SizingMode,
 ) {
-    NODE_LOGGER.labelled_debug_log("run_mode", run_mode);
+    NODE_LOGGER.debug_log(run_mode);
     NODE_LOGGER.labelled_debug_log("sizing_mode", sizing_mode);
     NODE_LOGGER.labelled_debug_log("known_dimensions", known_dimensions);
     NODE_LOGGER.labelled_debug_log("available_space", available_space);

--- a/test_fixtures/grid_percent_item_inside_stretch_item.html
+++ b/test_fixtures/grid_percent_item_inside_stretch_item.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+<head/>
+<body>
+
+<div id="test-root" style="display:grid;width: 100px; height: 100px;">
+  <div style="display: grid;">
+    <div style="display: grid;width: 50%;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid_percent_items_nested_inside_stretch_alignment.html
+++ b/test_fixtures/grid_percent_items_nested_inside_stretch_alignment.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+<head/>
+<body>
+
+<div id="test-root" style="display:grid;width: 200px;">
+  <div style="display: grid;">
+    <div style="display: grid;padding-top: 20%;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid_percent_items_nested_with_margin.html
+++ b/test_fixtures/grid_percent_items_nested_with_margin.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+<head/>
+<body>
+
+<div id="test-root" style="display: grid;width: 200px;">
+  <div style="display: grid;width: 50%;">
+    <div style="width: 45%; margin: 5%;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/gridflex_column_integration.html
+++ b/test_fixtures/gridflex_column_integration.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+<head/>
+<body>
+
+<div id="test-root" style="flex-direction: column;">
+  <div  style="display: grid; grid-template-columns: 1fr 1fr;grid-template-rows: 1fr 1fr;">
+    <div>HH</div>
+    <div>HH</div>
+    <div>HH</div>
+    <div>HH</div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/gridflex_kitchen_sink.html
+++ b/test_fixtures/gridflex_kitchen_sink.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+<head/>
+<body>
+
+<div id="test-root">
+  <div style="display: grid; grid-template-columns: 1fr 1fr;grid-template-rows: 1fr 1fr;">
+    <div>
+      <div style="width: 20px"></div>
+      <div style="width: 50px;flex-grow: 1">
+        <div style="display: grid; grid-template-columns: auto 10%;grid-template-rows: 30% 10%">
+          <div style="width: 20px"></div>
+          <div></div>
+          <div></div>
+          <div></div>
+        </div>
+      </div>
+    </div>
+    <div>HH</div>
+    <div>HH</div>
+    <div>HH</div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/gridflex_kitchen_sink_minimise.html
+++ b/test_fixtures/gridflex_kitchen_sink_minimise.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+<head/>
+<body>
+
+<div id="test-root">
+  <div style="display: grid; grid-template-columns: 1fr 1fr;grid-template-rows: 20px">
+    <div style="width: 50px"></div>
+    <div></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/gridflex_kitchen_sink_minimise2.html
+++ b/test_fixtures/gridflex_kitchen_sink_minimise2.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+<head/>
+<body>
+
+<div id="test-root"style="width: 50px;flex-grow: 1">
+  <div style="display: grid; grid-template-columns: auto;grid-template-rows:auto">
+    <div style="height:20px;width: 20px"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/gridflex_kitchen_sink_minimise3.html
+++ b/test_fixtures/gridflex_kitchen_sink_minimise3.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+<head/>
+<body>
+
+<div id="test-root" style="width: 50px;">
+  <div style="display: grid;grid-template-columns: auto 10%;grid-template-rows: 30% 10%">
+    <div style="height: 20px;width: 20px"></div>
+    <div></div>
+    <div></div>
+    <div></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/gridflex_row_integration.html
+++ b/test_fixtures/gridflex_row_integration.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+<head/>
+<body>
+
+<div id="test-root">
+  <div  style="display: grid; grid-template-columns: 1fr 1fr;grid-template-rows: 1fr 1fr;">
+    <div>HH</div>
+    <div>HH</div>
+    <div>HH</div>
+    <div>HH</div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/generated/grid_percent_item_inside_stretch_item.rs
+++ b/tests/generated/grid_percent_item_inside_stretch_item.rs
@@ -1,0 +1,52 @@
+#[test]
+fn grid_percent_item_inside_stretch_item() {
+    use slotmap::Key;
+    #[allow(unused_imports)]
+    use taffy::{layout::Layout, prelude::*};
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
+        .new_leaf(taffy::style::Style {
+            display: taffy::style::Display::Grid,
+            size: taffy::geometry::Size { width: taffy::style::Dimension::Percent(0.5f32), height: auto() },
+            ..Default::default()
+        })
+        .unwrap();
+    let node0 = taffy
+        .new_with_children(
+            taffy::style::Style { display: taffy::style::Display::Grid, ..Default::default() },
+            &[node00],
+        )
+        .unwrap();
+    let node = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Grid,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
+                },
+                ..Default::default()
+            },
+            &[node0],
+        )
+        .unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
+    println!("\nComputed tree:");
+    taffy::debug::print_tree(&taffy, node);
+    println!();
+    let Layout { size, location, .. } = taffy.layout(node).unwrap();
+    assert_eq!(size.width, 100f32, "width of node {:?}. Expected {}. Actual {}", node.data(), 100f32, size.width);
+    assert_eq!(size.height, 100f32, "height of node {:?}. Expected {}. Actual {}", node.data(), 100f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node0).unwrap();
+    assert_eq!(size.width, 100f32, "width of node {:?}. Expected {}. Actual {}", node0.data(), 100f32, size.width);
+    assert_eq!(size.height, 100f32, "height of node {:?}. Expected {}. Actual {}", node0.data(), 100f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node00).unwrap();
+    assert_eq!(size.width, 50f32, "width of node {:?}. Expected {}. Actual {}", node00.data(), 50f32, size.width);
+    assert_eq!(size.height, 100f32, "height of node {:?}. Expected {}. Actual {}", node00.data(), 100f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node00.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node00.data(), 0f32, location.y);
+}

--- a/tests/generated/grid_percent_items_nested_inside_stretch_alignment.rs
+++ b/tests/generated/grid_percent_items_nested_inside_stretch_alignment.rs
@@ -1,0 +1,54 @@
+#[test]
+fn grid_percent_items_nested_inside_stretch_alignment() {
+    use slotmap::Key;
+    #[allow(unused_imports)]
+    use taffy::{layout::Layout, prelude::*};
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
+        .new_leaf(taffy::style::Style {
+            display: taffy::style::Display::Grid,
+            padding: taffy::geometry::Rect {
+                left: zero(),
+                right: zero(),
+                top: taffy::style::LengthPercentage::Percent(0.2f32),
+                bottom: zero(),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node0 = taffy
+        .new_with_children(
+            taffy::style::Style { display: taffy::style::Display::Grid, ..Default::default() },
+            &[node00],
+        )
+        .unwrap();
+    let node = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Grid,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(200f32), height: auto() },
+                ..Default::default()
+            },
+            &[node0],
+        )
+        .unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
+    println!("\nComputed tree:");
+    taffy::debug::print_tree(&taffy, node);
+    println!();
+    let Layout { size, location, .. } = taffy.layout(node).unwrap();
+    assert_eq!(size.width, 200f32, "width of node {:?}. Expected {}. Actual {}", node.data(), 200f32, size.width);
+    assert_eq!(size.height, 40f32, "height of node {:?}. Expected {}. Actual {}", node.data(), 40f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node0).unwrap();
+    assert_eq!(size.width, 200f32, "width of node {:?}. Expected {}. Actual {}", node0.data(), 200f32, size.width);
+    assert_eq!(size.height, 40f32, "height of node {:?}. Expected {}. Actual {}", node0.data(), 40f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node00).unwrap();
+    assert_eq!(size.width, 200f32, "width of node {:?}. Expected {}. Actual {}", node00.data(), 200f32, size.width);
+    assert_eq!(size.height, 40f32, "height of node {:?}. Expected {}. Actual {}", node00.data(), 40f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node00.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node00.data(), 0f32, location.y);
+}

--- a/tests/generated/grid_percent_items_nested_with_margin.rs
+++ b/tests/generated/grid_percent_items_nested_with_margin.rs
@@ -1,0 +1,58 @@
+#[test]
+fn grid_percent_items_nested_with_margin() {
+    use slotmap::Key;
+    #[allow(unused_imports)]
+    use taffy::{layout::Layout, prelude::*};
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
+        .new_leaf(taffy::style::Style {
+            size: taffy::geometry::Size { width: taffy::style::Dimension::Percent(0.45f32), height: auto() },
+            margin: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Percent(0.05f32),
+                right: taffy::style::LengthPercentageAuto::Percent(0.05f32),
+                top: taffy::style::LengthPercentageAuto::Percent(0.05f32),
+                bottom: taffy::style::LengthPercentageAuto::Percent(0.05f32),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node0 = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Grid,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Percent(0.5f32), height: auto() },
+                ..Default::default()
+            },
+            &[node00],
+        )
+        .unwrap();
+    let node = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Grid,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(200f32), height: auto() },
+                ..Default::default()
+            },
+            &[node0],
+        )
+        .unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
+    println!("\nComputed tree:");
+    taffy::debug::print_tree(&taffy, node);
+    println!();
+    let Layout { size, location, .. } = taffy.layout(node).unwrap();
+    assert_eq!(size.width, 200f32, "width of node {:?}. Expected {}. Actual {}", node.data(), 200f32, size.width);
+    assert_eq!(size.height, 10f32, "height of node {:?}. Expected {}. Actual {}", node.data(), 10f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node0).unwrap();
+    assert_eq!(size.width, 100f32, "width of node {:?}. Expected {}. Actual {}", node0.data(), 100f32, size.width);
+    assert_eq!(size.height, 10f32, "height of node {:?}. Expected {}. Actual {}", node0.data(), 10f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node00).unwrap();
+    assert_eq!(size.width, 45f32, "width of node {:?}. Expected {}. Actual {}", node00.data(), 45f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node00.data(), 0f32, size.height);
+    assert_eq!(location.x, 5f32, "x of node {:?}. Expected {}. Actual {}", node00.data(), 5f32, location.x);
+    assert_eq!(location.y, 5f32, "y of node {:?}. Expected {}. Actual {}", node00.data(), 5f32, location.y);
+}

--- a/tests/generated/gridflex_column_integration.rs
+++ b/tests/generated/gridflex_column_integration.rs
@@ -1,0 +1,118 @@
+#[test]
+fn gridflex_column_integration() {
+    use slotmap::Key;
+    #[allow(unused_imports)]
+    use taffy::{layout::Layout, prelude::*};
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
+        .new_leaf_with_measure(
+            taffy::style::Style { ..Default::default() },
+            taffy::node::MeasureFunc::Raw(|known_dimensions, available_space| {
+                const TEXT: &str = "HH";
+                super::measure_standard_text(
+                    known_dimensions,
+                    available_space,
+                    TEXT,
+                    super::WritingMode::Horizontal,
+                    None,
+                )
+            }),
+        )
+        .unwrap();
+    let node01 = taffy
+        .new_leaf_with_measure(
+            taffy::style::Style { ..Default::default() },
+            taffy::node::MeasureFunc::Raw(|known_dimensions, available_space| {
+                const TEXT: &str = "HH";
+                super::measure_standard_text(
+                    known_dimensions,
+                    available_space,
+                    TEXT,
+                    super::WritingMode::Horizontal,
+                    None,
+                )
+            }),
+        )
+        .unwrap();
+    let node02 = taffy
+        .new_leaf_with_measure(
+            taffy::style::Style { ..Default::default() },
+            taffy::node::MeasureFunc::Raw(|known_dimensions, available_space| {
+                const TEXT: &str = "HH";
+                super::measure_standard_text(
+                    known_dimensions,
+                    available_space,
+                    TEXT,
+                    super::WritingMode::Horizontal,
+                    None,
+                )
+            }),
+        )
+        .unwrap();
+    let node03 = taffy
+        .new_leaf_with_measure(
+            taffy::style::Style { ..Default::default() },
+            taffy::node::MeasureFunc::Raw(|known_dimensions, available_space| {
+                const TEXT: &str = "HH";
+                super::measure_standard_text(
+                    known_dimensions,
+                    available_space,
+                    TEXT,
+                    super::WritingMode::Horizontal,
+                    None,
+                )
+            }),
+        )
+        .unwrap();
+    let node0 = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Grid,
+                grid_template_rows: vec![flex(1f32), flex(1f32)],
+                grid_template_columns: vec![flex(1f32), flex(1f32)],
+                ..Default::default()
+            },
+            &[node00, node01, node02, node03],
+        )
+        .unwrap();
+    let node = taffy
+        .new_with_children(
+            taffy::style::Style { flex_direction: taffy::style::FlexDirection::Column, ..Default::default() },
+            &[node0],
+        )
+        .unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
+    println!("\nComputed tree:");
+    taffy::debug::print_tree(&taffy, node);
+    println!();
+    let Layout { size, location, .. } = taffy.layout(node).unwrap();
+    assert_eq!(size.width, 40f32, "width of node {:?}. Expected {}. Actual {}", node.data(), 40f32, size.width);
+    assert_eq!(size.height, 20f32, "height of node {:?}. Expected {}. Actual {}", node.data(), 20f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node0).unwrap();
+    assert_eq!(size.width, 40f32, "width of node {:?}. Expected {}. Actual {}", node0.data(), 40f32, size.width);
+    assert_eq!(size.height, 20f32, "height of node {:?}. Expected {}. Actual {}", node0.data(), 20f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node00).unwrap();
+    assert_eq!(size.width, 20f32, "width of node {:?}. Expected {}. Actual {}", node00.data(), 20f32, size.width);
+    assert_eq!(size.height, 10f32, "height of node {:?}. Expected {}. Actual {}", node00.data(), 10f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node00.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node00.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node01).unwrap();
+    assert_eq!(size.width, 20f32, "width of node {:?}. Expected {}. Actual {}", node01.data(), 20f32, size.width);
+    assert_eq!(size.height, 10f32, "height of node {:?}. Expected {}. Actual {}", node01.data(), 10f32, size.height);
+    assert_eq!(location.x, 20f32, "x of node {:?}. Expected {}. Actual {}", node01.data(), 20f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node01.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node02).unwrap();
+    assert_eq!(size.width, 20f32, "width of node {:?}. Expected {}. Actual {}", node02.data(), 20f32, size.width);
+    assert_eq!(size.height, 10f32, "height of node {:?}. Expected {}. Actual {}", node02.data(), 10f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node02.data(), 0f32, location.x);
+    assert_eq!(location.y, 10f32, "y of node {:?}. Expected {}. Actual {}", node02.data(), 10f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node03).unwrap();
+    assert_eq!(size.width, 20f32, "width of node {:?}. Expected {}. Actual {}", node03.data(), 20f32, size.width);
+    assert_eq!(size.height, 10f32, "height of node {:?}. Expected {}. Actual {}", node03.data(), 10f32, size.height);
+    assert_eq!(location.x, 20f32, "x of node {:?}. Expected {}. Actual {}", node03.data(), 20f32, location.x);
+    assert_eq!(location.y, 10f32, "y of node {:?}. Expected {}. Actual {}", node03.data(), 10f32, location.y);
+}

--- a/tests/generated/gridflex_kitchen_sink.rs
+++ b/tests/generated/gridflex_kitchen_sink.rs
@@ -1,0 +1,170 @@
+#[test]
+fn gridflex_kitchen_sink() {
+    use slotmap::Key;
+    #[allow(unused_imports)]
+    use taffy::{layout::Layout, prelude::*};
+    let mut taffy = taffy::Taffy::new();
+    let node000 = taffy
+        .new_leaf(taffy::style::Style {
+            size: taffy::geometry::Size { width: taffy::style::Dimension::Points(20f32), height: auto() },
+            ..Default::default()
+        })
+        .unwrap();
+    let node00100 = taffy
+        .new_leaf(taffy::style::Style {
+            size: taffy::geometry::Size { width: taffy::style::Dimension::Points(20f32), height: auto() },
+            ..Default::default()
+        })
+        .unwrap();
+    let node00101 = taffy.new_leaf(taffy::style::Style { ..Default::default() }).unwrap();
+    let node00102 = taffy.new_leaf(taffy::style::Style { ..Default::default() }).unwrap();
+    let node00103 = taffy.new_leaf(taffy::style::Style { ..Default::default() }).unwrap();
+    let node0010 = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Grid,
+                grid_template_rows: vec![percent(0.3f32), percent(0.1f32)],
+                grid_template_columns: vec![auto(), percent(0.1f32)],
+                ..Default::default()
+            },
+            &[node00100, node00101, node00102, node00103],
+        )
+        .unwrap();
+    let node001 = taffy
+        .new_with_children(
+            taffy::style::Style {
+                flex_grow: 1f32,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(50f32), height: auto() },
+                ..Default::default()
+            },
+            &[node0010],
+        )
+        .unwrap();
+    let node00 = taffy.new_with_children(taffy::style::Style { ..Default::default() }, &[node000, node001]).unwrap();
+    let node01 = taffy
+        .new_leaf_with_measure(
+            taffy::style::Style { ..Default::default() },
+            taffy::node::MeasureFunc::Raw(|known_dimensions, available_space| {
+                const TEXT: &str = "HH";
+                super::measure_standard_text(
+                    known_dimensions,
+                    available_space,
+                    TEXT,
+                    super::WritingMode::Horizontal,
+                    None,
+                )
+            }),
+        )
+        .unwrap();
+    let node02 = taffy
+        .new_leaf_with_measure(
+            taffy::style::Style { ..Default::default() },
+            taffy::node::MeasureFunc::Raw(|known_dimensions, available_space| {
+                const TEXT: &str = "HH";
+                super::measure_standard_text(
+                    known_dimensions,
+                    available_space,
+                    TEXT,
+                    super::WritingMode::Horizontal,
+                    None,
+                )
+            }),
+        )
+        .unwrap();
+    let node03 = taffy
+        .new_leaf_with_measure(
+            taffy::style::Style { ..Default::default() },
+            taffy::node::MeasureFunc::Raw(|known_dimensions, available_space| {
+                const TEXT: &str = "HH";
+                super::measure_standard_text(
+                    known_dimensions,
+                    available_space,
+                    TEXT,
+                    super::WritingMode::Horizontal,
+                    None,
+                )
+            }),
+        )
+        .unwrap();
+    let node0 = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Grid,
+                grid_template_rows: vec![flex(1f32), flex(1f32)],
+                grid_template_columns: vec![flex(1f32), flex(1f32)],
+                ..Default::default()
+            },
+            &[node00, node01, node02, node03],
+        )
+        .unwrap();
+    let node = taffy.new_with_children(taffy::style::Style { ..Default::default() }, &[node0]).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
+    println!("\nComputed tree:");
+    taffy::debug::print_tree(&taffy, node);
+    println!();
+    let Layout { size, location, .. } = taffy.layout(node).unwrap();
+    assert_eq!(size.width, 140f32, "width of node {:?}. Expected {}. Actual {}", node.data(), 140f32, size.width);
+    assert_eq!(size.height, 20f32, "height of node {:?}. Expected {}. Actual {}", node.data(), 20f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node0).unwrap();
+    assert_eq!(size.width, 140f32, "width of node {:?}. Expected {}. Actual {}", node0.data(), 140f32, size.width);
+    assert_eq!(size.height, 20f32, "height of node {:?}. Expected {}. Actual {}", node0.data(), 20f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node00).unwrap();
+    assert_eq!(size.width, 70f32, "width of node {:?}. Expected {}. Actual {}", node00.data(), 70f32, size.width);
+    assert_eq!(size.height, 10f32, "height of node {:?}. Expected {}. Actual {}", node00.data(), 10f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node00.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node00.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node000).unwrap();
+    assert_eq!(size.width, 20f32, "width of node {:?}. Expected {}. Actual {}", node000.data(), 20f32, size.width);
+    assert_eq!(size.height, 10f32, "height of node {:?}. Expected {}. Actual {}", node000.data(), 10f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node000.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node000.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node001).unwrap();
+    assert_eq!(size.width, 50f32, "width of node {:?}. Expected {}. Actual {}", node001.data(), 50f32, size.width);
+    assert_eq!(size.height, 10f32, "height of node {:?}. Expected {}. Actual {}", node001.data(), 10f32, size.height);
+    assert_eq!(location.x, 20f32, "x of node {:?}. Expected {}. Actual {}", node001.data(), 20f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node001.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node0010).unwrap();
+    assert_eq!(size.width, 20f32, "width of node {:?}. Expected {}. Actual {}", node0010.data(), 20f32, size.width);
+    assert_eq!(size.height, 10f32, "height of node {:?}. Expected {}. Actual {}", node0010.data(), 10f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node0010.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node0010.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node00100).unwrap();
+    assert_eq!(size.width, 20f32, "width of node {:?}. Expected {}. Actual {}", node00100.data(), 20f32, size.width);
+    assert_eq!(size.height, 3f32, "height of node {:?}. Expected {}. Actual {}", node00100.data(), 3f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node00100.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node00100.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node00101).unwrap();
+    assert_eq!(size.width, 2f32, "width of node {:?}. Expected {}. Actual {}", node00101.data(), 2f32, size.width);
+    assert_eq!(size.height, 3f32, "height of node {:?}. Expected {}. Actual {}", node00101.data(), 3f32, size.height);
+    assert_eq!(location.x, 20f32, "x of node {:?}. Expected {}. Actual {}", node00101.data(), 20f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node00101.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node00102).unwrap();
+    assert_eq!(size.width, 20f32, "width of node {:?}. Expected {}. Actual {}", node00102.data(), 20f32, size.width);
+    assert_eq!(size.height, 1f32, "height of node {:?}. Expected {}. Actual {}", node00102.data(), 1f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node00102.data(), 0f32, location.x);
+    assert_eq!(location.y, 3f32, "y of node {:?}. Expected {}. Actual {}", node00102.data(), 3f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node00103).unwrap();
+    assert_eq!(size.width, 2f32, "width of node {:?}. Expected {}. Actual {}", node00103.data(), 2f32, size.width);
+    assert_eq!(size.height, 1f32, "height of node {:?}. Expected {}. Actual {}", node00103.data(), 1f32, size.height);
+    assert_eq!(location.x, 20f32, "x of node {:?}. Expected {}. Actual {}", node00103.data(), 20f32, location.x);
+    assert_eq!(location.y, 3f32, "y of node {:?}. Expected {}. Actual {}", node00103.data(), 3f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node01).unwrap();
+    assert_eq!(size.width, 70f32, "width of node {:?}. Expected {}. Actual {}", node01.data(), 70f32, size.width);
+    assert_eq!(size.height, 10f32, "height of node {:?}. Expected {}. Actual {}", node01.data(), 10f32, size.height);
+    assert_eq!(location.x, 70f32, "x of node {:?}. Expected {}. Actual {}", node01.data(), 70f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node01.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node02).unwrap();
+    assert_eq!(size.width, 70f32, "width of node {:?}. Expected {}. Actual {}", node02.data(), 70f32, size.width);
+    assert_eq!(size.height, 10f32, "height of node {:?}. Expected {}. Actual {}", node02.data(), 10f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node02.data(), 0f32, location.x);
+    assert_eq!(location.y, 10f32, "y of node {:?}. Expected {}. Actual {}", node02.data(), 10f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node03).unwrap();
+    assert_eq!(size.width, 70f32, "width of node {:?}. Expected {}. Actual {}", node03.data(), 70f32, size.width);
+    assert_eq!(size.height, 10f32, "height of node {:?}. Expected {}. Actual {}", node03.data(), 10f32, size.height);
+    assert_eq!(location.x, 70f32, "x of node {:?}. Expected {}. Actual {}", node03.data(), 70f32, location.x);
+    assert_eq!(location.y, 10f32, "y of node {:?}. Expected {}. Actual {}", node03.data(), 10f32, location.y);
+}

--- a/tests/generated/gridflex_kitchen_sink_minimise.rs
+++ b/tests/generated/gridflex_kitchen_sink_minimise.rs
@@ -1,0 +1,50 @@
+#[test]
+fn gridflex_kitchen_sink_minimise() {
+    use slotmap::Key;
+    #[allow(unused_imports)]
+    use taffy::{layout::Layout, prelude::*};
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
+        .new_leaf(taffy::style::Style {
+            size: taffy::geometry::Size { width: taffy::style::Dimension::Points(50f32), height: auto() },
+            ..Default::default()
+        })
+        .unwrap();
+    let node01 = taffy.new_leaf(taffy::style::Style { ..Default::default() }).unwrap();
+    let node0 = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Grid,
+                grid_template_rows: vec![points(20f32)],
+                grid_template_columns: vec![flex(1f32), flex(1f32)],
+                ..Default::default()
+            },
+            &[node00, node01],
+        )
+        .unwrap();
+    let node = taffy.new_with_children(taffy::style::Style { ..Default::default() }, &[node0]).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
+    println!("\nComputed tree:");
+    taffy::debug::print_tree(&taffy, node);
+    println!();
+    let Layout { size, location, .. } = taffy.layout(node).unwrap();
+    assert_eq!(size.width, 100f32, "width of node {:?}. Expected {}. Actual {}", node.data(), 100f32, size.width);
+    assert_eq!(size.height, 20f32, "height of node {:?}. Expected {}. Actual {}", node.data(), 20f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node0).unwrap();
+    assert_eq!(size.width, 100f32, "width of node {:?}. Expected {}. Actual {}", node0.data(), 100f32, size.width);
+    assert_eq!(size.height, 20f32, "height of node {:?}. Expected {}. Actual {}", node0.data(), 20f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node00).unwrap();
+    assert_eq!(size.width, 50f32, "width of node {:?}. Expected {}. Actual {}", node00.data(), 50f32, size.width);
+    assert_eq!(size.height, 20f32, "height of node {:?}. Expected {}. Actual {}", node00.data(), 20f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node00.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node00.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node01).unwrap();
+    assert_eq!(size.width, 50f32, "width of node {:?}. Expected {}. Actual {}", node01.data(), 50f32, size.width);
+    assert_eq!(size.height, 20f32, "height of node {:?}. Expected {}. Actual {}", node01.data(), 20f32, size.height);
+    assert_eq!(location.x, 50f32, "x of node {:?}. Expected {}. Actual {}", node01.data(), 50f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node01.data(), 0f32, location.y);
+}

--- a/tests/generated/gridflex_kitchen_sink_minimise2.rs
+++ b/tests/generated/gridflex_kitchen_sink_minimise2.rs
@@ -1,0 +1,56 @@
+#[test]
+fn gridflex_kitchen_sink_minimise2() {
+    use slotmap::Key;
+    #[allow(unused_imports)]
+    use taffy::{layout::Layout, prelude::*};
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
+        .new_leaf(taffy::style::Style {
+            size: taffy::geometry::Size {
+                width: taffy::style::Dimension::Points(20f32),
+                height: taffy::style::Dimension::Points(20f32),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node0 = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Grid,
+                grid_template_rows: vec![auto()],
+                grid_template_columns: vec![auto()],
+                ..Default::default()
+            },
+            &[node00],
+        )
+        .unwrap();
+    let node = taffy
+        .new_with_children(
+            taffy::style::Style {
+                flex_grow: 1f32,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(50f32), height: auto() },
+                ..Default::default()
+            },
+            &[node0],
+        )
+        .unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
+    println!("\nComputed tree:");
+    taffy::debug::print_tree(&taffy, node);
+    println!();
+    let Layout { size, location, .. } = taffy.layout(node).unwrap();
+    assert_eq!(size.width, 50f32, "width of node {:?}. Expected {}. Actual {}", node.data(), 50f32, size.width);
+    assert_eq!(size.height, 20f32, "height of node {:?}. Expected {}. Actual {}", node.data(), 20f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node0).unwrap();
+    assert_eq!(size.width, 20f32, "width of node {:?}. Expected {}. Actual {}", node0.data(), 20f32, size.width);
+    assert_eq!(size.height, 20f32, "height of node {:?}. Expected {}. Actual {}", node0.data(), 20f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node00).unwrap();
+    assert_eq!(size.width, 20f32, "width of node {:?}. Expected {}. Actual {}", node00.data(), 20f32, size.width);
+    assert_eq!(size.height, 20f32, "height of node {:?}. Expected {}. Actual {}", node00.data(), 20f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node00.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node00.data(), 0f32, location.y);
+}

--- a/tests/generated/gridflex_kitchen_sink_minimise3.rs
+++ b/tests/generated/gridflex_kitchen_sink_minimise3.rs
@@ -1,0 +1,73 @@
+#[test]
+fn gridflex_kitchen_sink_minimise3() {
+    use slotmap::Key;
+    #[allow(unused_imports)]
+    use taffy::{layout::Layout, prelude::*};
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
+        .new_leaf(taffy::style::Style {
+            size: taffy::geometry::Size {
+                width: taffy::style::Dimension::Points(20f32),
+                height: taffy::style::Dimension::Points(20f32),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node01 = taffy.new_leaf(taffy::style::Style { ..Default::default() }).unwrap();
+    let node02 = taffy.new_leaf(taffy::style::Style { ..Default::default() }).unwrap();
+    let node03 = taffy.new_leaf(taffy::style::Style { ..Default::default() }).unwrap();
+    let node0 = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Grid,
+                grid_template_rows: vec![percent(0.3f32), percent(0.1f32)],
+                grid_template_columns: vec![auto(), percent(0.1f32)],
+                ..Default::default()
+            },
+            &[node00, node01, node02, node03],
+        )
+        .unwrap();
+    let node = taffy
+        .new_with_children(
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(50f32), height: auto() },
+                ..Default::default()
+            },
+            &[node0],
+        )
+        .unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
+    println!("\nComputed tree:");
+    taffy::debug::print_tree(&taffy, node);
+    println!();
+    let Layout { size, location, .. } = taffy.layout(node).unwrap();
+    assert_eq!(size.width, 50f32, "width of node {:?}. Expected {}. Actual {}", node.data(), 50f32, size.width);
+    assert_eq!(size.height, 20f32, "height of node {:?}. Expected {}. Actual {}", node.data(), 20f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node0).unwrap();
+    assert_eq!(size.width, 20f32, "width of node {:?}. Expected {}. Actual {}", node0.data(), 20f32, size.width);
+    assert_eq!(size.height, 20f32, "height of node {:?}. Expected {}. Actual {}", node0.data(), 20f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node00).unwrap();
+    assert_eq!(size.width, 20f32, "width of node {:?}. Expected {}. Actual {}", node00.data(), 20f32, size.width);
+    assert_eq!(size.height, 20f32, "height of node {:?}. Expected {}. Actual {}", node00.data(), 20f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node00.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node00.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node01).unwrap();
+    assert_eq!(size.width, 2f32, "width of node {:?}. Expected {}. Actual {}", node01.data(), 2f32, size.width);
+    assert_eq!(size.height, 6f32, "height of node {:?}. Expected {}. Actual {}", node01.data(), 6f32, size.height);
+    assert_eq!(location.x, 20f32, "x of node {:?}. Expected {}. Actual {}", node01.data(), 20f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node01.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node02).unwrap();
+    assert_eq!(size.width, 20f32, "width of node {:?}. Expected {}. Actual {}", node02.data(), 20f32, size.width);
+    assert_eq!(size.height, 2f32, "height of node {:?}. Expected {}. Actual {}", node02.data(), 2f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node02.data(), 0f32, location.x);
+    assert_eq!(location.y, 6f32, "y of node {:?}. Expected {}. Actual {}", node02.data(), 6f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node03).unwrap();
+    assert_eq!(size.width, 2f32, "width of node {:?}. Expected {}. Actual {}", node03.data(), 2f32, size.width);
+    assert_eq!(size.height, 2f32, "height of node {:?}. Expected {}. Actual {}", node03.data(), 2f32, size.height);
+    assert_eq!(location.x, 20f32, "x of node {:?}. Expected {}. Actual {}", node03.data(), 20f32, location.x);
+    assert_eq!(location.y, 6f32, "y of node {:?}. Expected {}. Actual {}", node03.data(), 6f32, location.y);
+}

--- a/tests/generated/gridflex_row_integration.rs
+++ b/tests/generated/gridflex_row_integration.rs
@@ -1,0 +1,113 @@
+#[test]
+fn gridflex_row_integration() {
+    use slotmap::Key;
+    #[allow(unused_imports)]
+    use taffy::{layout::Layout, prelude::*};
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
+        .new_leaf_with_measure(
+            taffy::style::Style { ..Default::default() },
+            taffy::node::MeasureFunc::Raw(|known_dimensions, available_space| {
+                const TEXT: &str = "HH";
+                super::measure_standard_text(
+                    known_dimensions,
+                    available_space,
+                    TEXT,
+                    super::WritingMode::Horizontal,
+                    None,
+                )
+            }),
+        )
+        .unwrap();
+    let node01 = taffy
+        .new_leaf_with_measure(
+            taffy::style::Style { ..Default::default() },
+            taffy::node::MeasureFunc::Raw(|known_dimensions, available_space| {
+                const TEXT: &str = "HH";
+                super::measure_standard_text(
+                    known_dimensions,
+                    available_space,
+                    TEXT,
+                    super::WritingMode::Horizontal,
+                    None,
+                )
+            }),
+        )
+        .unwrap();
+    let node02 = taffy
+        .new_leaf_with_measure(
+            taffy::style::Style { ..Default::default() },
+            taffy::node::MeasureFunc::Raw(|known_dimensions, available_space| {
+                const TEXT: &str = "HH";
+                super::measure_standard_text(
+                    known_dimensions,
+                    available_space,
+                    TEXT,
+                    super::WritingMode::Horizontal,
+                    None,
+                )
+            }),
+        )
+        .unwrap();
+    let node03 = taffy
+        .new_leaf_with_measure(
+            taffy::style::Style { ..Default::default() },
+            taffy::node::MeasureFunc::Raw(|known_dimensions, available_space| {
+                const TEXT: &str = "HH";
+                super::measure_standard_text(
+                    known_dimensions,
+                    available_space,
+                    TEXT,
+                    super::WritingMode::Horizontal,
+                    None,
+                )
+            }),
+        )
+        .unwrap();
+    let node0 = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Grid,
+                grid_template_rows: vec![flex(1f32), flex(1f32)],
+                grid_template_columns: vec![flex(1f32), flex(1f32)],
+                ..Default::default()
+            },
+            &[node00, node01, node02, node03],
+        )
+        .unwrap();
+    let node = taffy.new_with_children(taffy::style::Style { ..Default::default() }, &[node0]).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
+    println!("\nComputed tree:");
+    taffy::debug::print_tree(&taffy, node);
+    println!();
+    let Layout { size, location, .. } = taffy.layout(node).unwrap();
+    assert_eq!(size.width, 40f32, "width of node {:?}. Expected {}. Actual {}", node.data(), 40f32, size.width);
+    assert_eq!(size.height, 20f32, "height of node {:?}. Expected {}. Actual {}", node.data(), 20f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node0).unwrap();
+    assert_eq!(size.width, 40f32, "width of node {:?}. Expected {}. Actual {}", node0.data(), 40f32, size.width);
+    assert_eq!(size.height, 20f32, "height of node {:?}. Expected {}. Actual {}", node0.data(), 20f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node00).unwrap();
+    assert_eq!(size.width, 20f32, "width of node {:?}. Expected {}. Actual {}", node00.data(), 20f32, size.width);
+    assert_eq!(size.height, 10f32, "height of node {:?}. Expected {}. Actual {}", node00.data(), 10f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node00.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node00.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node01).unwrap();
+    assert_eq!(size.width, 20f32, "width of node {:?}. Expected {}. Actual {}", node01.data(), 20f32, size.width);
+    assert_eq!(size.height, 10f32, "height of node {:?}. Expected {}. Actual {}", node01.data(), 10f32, size.height);
+    assert_eq!(location.x, 20f32, "x of node {:?}. Expected {}. Actual {}", node01.data(), 20f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node01.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node02).unwrap();
+    assert_eq!(size.width, 20f32, "width of node {:?}. Expected {}. Actual {}", node02.data(), 20f32, size.width);
+    assert_eq!(size.height, 10f32, "height of node {:?}. Expected {}. Actual {}", node02.data(), 10f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node02.data(), 0f32, location.x);
+    assert_eq!(location.y, 10f32, "y of node {:?}. Expected {}. Actual {}", node02.data(), 10f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node03).unwrap();
+    assert_eq!(size.width, 20f32, "width of node {:?}. Expected {}. Actual {}", node03.data(), 20f32, size.width);
+    assert_eq!(size.height, 10f32, "height of node {:?}. Expected {}. Actual {}", node03.data(), 10f32, size.height);
+    assert_eq!(location.x, 20f32, "x of node {:?}. Expected {}. Actual {}", node03.data(), 20f32, location.x);
+    assert_eq!(location.y, 10f32, "y of node {:?}. Expected {}. Actual {}", node03.data(), 10f32, location.y);
+}

--- a/tests/generated/mod.rs
+++ b/tests/generated/mod.rs
@@ -640,7 +640,13 @@ mod grid_out_of_order_items;
 #[cfg(feature = "grid")]
 mod grid_overflow_rows;
 #[cfg(feature = "grid")]
+mod grid_percent_item_inside_stretch_item;
+#[cfg(feature = "grid")]
+mod grid_percent_items_nested_inside_stretch_alignment;
+#[cfg(feature = "grid")]
 mod grid_percent_items_nested_moderate;
+#[cfg(feature = "grid")]
+mod grid_percent_items_nested_with_margin;
 #[cfg(feature = "grid")]
 mod grid_percent_items_nested_with_padding_margin;
 #[cfg(feature = "grid")]
@@ -697,6 +703,18 @@ mod grid_span_2_min_content_min_content_indefinite;
 mod grid_span_6_all_non_flex_indefinite;
 #[cfg(feature = "grid")]
 mod grid_span_8_all_track_types_indefinite;
+#[cfg(feature = "grid")]
+mod gridflex_column_integration;
+#[cfg(feature = "grid")]
+mod gridflex_kitchen_sink;
+#[cfg(feature = "grid")]
+mod gridflex_kitchen_sink_minimise;
+#[cfg(feature = "grid")]
+mod gridflex_kitchen_sink_minimise2;
+#[cfg(feature = "grid")]
+mod gridflex_kitchen_sink_minimise3;
+#[cfg(feature = "grid")]
+mod gridflex_row_integration;
 mod intrinsic_sizing_cross_size_column;
 mod intrinsic_sizing_main_size_column;
 mod intrinsic_sizing_main_size_column_nested;


### PR DESCRIPTION
# Objective

Correctness fixes for the CSS Grid algorithm

## Changes made

- Don't constrain grid item's avaiable space based on a grid container's definite available space
- Pass estimates from §11.1. Grid Sizing Algorithm as parent_size/available_space rather than known_dimensions
- Apply stretch sizing to compute estimated known_dimensions for grid items when sizing tracks
- Prioritise align/justify self over parent's align/justify items

**Note: This PR includes the changes from #354 so #354 should be merged before this one.**

