### PR TITLE
Fix yoga benchmark compilation

### DIFF
--- a/benches/helpers/mod.rs
+++ b/benches/helpers/mod.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "yoga_benchmark")]
-mod yoga_helpers;
+pub mod yoga_helpers;
 
 /// A helper function to recursively construct a deep tree
 pub fn build_deep_tree<T, N>(


### PR DESCRIPTION
A module that should have been public was private causing the benchmark compilation to fail