### PR TITLE
Prepare for 0.3.4 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taffy"
-version = "0.3.3"
+version = "0.3.4"
 authors = [
     "Alice Cecile <alice.i.cecile@gmail.com>",
     "Johnathan Kelley <jkelleyrtp@gmail.com>",

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.3.4
+
+### Fixes
+
+- Fix `display: none` when it is set for the only node in the hierarchy (#377)
+
 ## 0.3.3
 
 ### Added


### PR DESCRIPTION
# Objective

Release `0.3.4` version. Includes fix in #377 