### PR TITLE
Fix layout of direct flex children with `display:none` set

### DIFF
--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -403,8 +403,8 @@ fn compute_preliminary(
     for order in 0..len {
         let child = tree.child(node, order);
         if tree.style(child).display == Display::None {
-            *tree.layout_mut(node) = Layout::with_order(order as u32);
-            GenericAlgorithm::measure_size(
+            *tree.layout_mut(child) = Layout::with_order(order as u32);
+            GenericAlgorithm::perform_layout(
                 tree,
                 child,
                 Size::NONE,

--- a/tests/relayout.rs
+++ b/tests/relayout.rs
@@ -146,3 +146,49 @@ fn toggle_flex_child_display_none() {
     assert_eq!(layout.size.width, 0.0);
     assert_eq!(layout.size.height, 0.0);
 }
+
+#[test]
+fn toggle_flex_container_display_none() {
+    let hidden_style = Style {
+        display: Display::None,
+        size: Size { width: points(100.0), height: points(100.0) },
+        ..Default::default()
+    };
+
+    let flex_style = Style {
+        display: Display::Flex,
+        size: Size { width: points(100.0), height: points(100.0) },
+        ..Default::default()
+    };
+
+    // Setup
+    let mut taffy = taffy::Taffy::new();
+    let node = taffy.new_leaf(hidden_style.clone()).unwrap();
+    let root = taffy.new_with_children(hidden_style.clone(), &[node]).unwrap();
+
+    // Layout 1 (None)
+    taffy.compute_layout(root, Size::MAX_CONTENT).unwrap();
+    let layout = taffy.layout(root).unwrap();
+    assert_eq!(layout.location.x, 0.0);
+    assert_eq!(layout.location.y, 0.0);
+    assert_eq!(layout.size.width, 0.0);
+    assert_eq!(layout.size.height, 0.0);
+
+    // Layout 2 (Flex)
+    taffy.set_style(root, flex_style).unwrap();
+    taffy.compute_layout(root, Size::MAX_CONTENT).unwrap();
+    let layout = taffy.layout(root).unwrap();
+    assert_eq!(layout.location.x, 0.0);
+    assert_eq!(layout.location.y, 0.0);
+    assert_eq!(layout.size.width, 100.0);
+    assert_eq!(layout.size.height, 100.0);
+
+    // Layout 3 (None)
+    taffy.set_style(root, hidden_style).unwrap();
+    taffy.compute_layout(root, Size::MAX_CONTENT).unwrap();
+    let layout = taffy.layout(root).unwrap();
+    assert_eq!(layout.location.x, 0.0);
+    assert_eq!(layout.location.y, 0.0);
+    assert_eq!(layout.size.width, 0.0);
+    assert_eq!(layout.size.height, 0.0);
+}

--- a/tests/relayout.rs
+++ b/tests/relayout.rs
@@ -1,11 +1,11 @@
-use taffy::style::{AvailableSpace, Dimension};
+use taffy::prelude::*;
 
 #[test]
 fn relayout() {
     let mut taffy = taffy::Taffy::new();
     let node1 = taffy
         .new_leaf(taffy::style::Style {
-            size: taffy::geometry::Size { width: Dimension::Points(8f32), height: Dimension::Points(80f32) },
+            size: taffy::geometry::Size { width: points(8.0), height: points(80.0) },
             ..Default::default()
         })
         .unwrap();
@@ -54,4 +54,49 @@ fn relayout() {
         assert_eq!(taffy.layout(node0).unwrap().location, initial0);
         assert_eq!(taffy.layout(node1).unwrap().location, initial1);
     }
+}
+
+#[test]
+fn toggle_display_none() {
+    let hidden_style = Style {
+        display: Display::None,
+        size: Size { width: points(100.0), height: points(100.0) },
+        ..Default::default()
+    };
+
+    let flex_style = Style {
+        display: Display::Flex,
+        size: Size { width: points(100.0), height: points(100.0) },
+        ..Default::default()
+    };
+
+    // Setup
+    let mut taffy = taffy::Taffy::new();
+    let node = taffy.new_leaf(hidden_style.clone()).unwrap();
+
+    // Layout 1 (None)
+    taffy.compute_layout(node, Size::MAX_CONTENT).unwrap();
+    let layout = taffy.layout(node).unwrap();
+    assert_eq!(layout.location.x, 0.0);
+    assert_eq!(layout.location.y, 0.0);
+    assert_eq!(layout.size.width, 0.0);
+    assert_eq!(layout.size.height, 0.0);
+
+    // Layout 2 (Flex)
+    taffy.set_style(node, flex_style).unwrap();
+    taffy.compute_layout(node, Size::MAX_CONTENT).unwrap();
+    let layout = taffy.layout(node).unwrap();
+    assert_eq!(layout.location.x, 0.0);
+    assert_eq!(layout.location.y, 0.0);
+    assert_eq!(layout.size.width, 100.0);
+    assert_eq!(layout.size.height, 100.0);
+
+    // Layout 3 (None)
+    taffy.set_style(node, hidden_style).unwrap();
+    taffy.compute_layout(node, Size::MAX_CONTENT).unwrap();
+    let layout = taffy.layout(node).unwrap();
+    assert_eq!(layout.location.x, 0.0);
+    assert_eq!(layout.location.y, 0.0);
+    assert_eq!(layout.size.width, 0.0);
+    assert_eq!(layout.size.height, 0.0);
 }

--- a/tests/relayout.rs
+++ b/tests/relayout.rs
@@ -57,7 +57,7 @@ fn relayout() {
 }
 
 #[test]
-fn toggle_display_none() {
+fn toggle_root_display_none() {
     let hidden_style = Style {
         display: Display::None,
         size: Size { width: points(100.0), height: points(100.0) },
@@ -94,6 +94,52 @@ fn toggle_display_none() {
     // Layout 3 (None)
     taffy.set_style(node, hidden_style).unwrap();
     taffy.compute_layout(node, Size::MAX_CONTENT).unwrap();
+    let layout = taffy.layout(node).unwrap();
+    assert_eq!(layout.location.x, 0.0);
+    assert_eq!(layout.location.y, 0.0);
+    assert_eq!(layout.size.width, 0.0);
+    assert_eq!(layout.size.height, 0.0);
+}
+
+#[test]
+fn toggle_flex_child_display_none() {
+    let hidden_style = Style {
+        display: Display::None,
+        size: Size { width: points(100.0), height: points(100.0) },
+        ..Default::default()
+    };
+
+    let flex_style = Style {
+        display: Display::Flex,
+        size: Size { width: points(100.0), height: points(100.0) },
+        ..Default::default()
+    };
+
+    // Setup
+    let mut taffy = taffy::Taffy::new();
+    let node = taffy.new_leaf(hidden_style.clone()).unwrap();
+    let root = taffy.new_with_children(flex_style.clone(), &[node]).unwrap();
+
+    // Layout 1 (None)
+    taffy.compute_layout(root, Size::MAX_CONTENT).unwrap();
+    let layout = taffy.layout(node).unwrap();
+    assert_eq!(layout.location.x, 0.0);
+    assert_eq!(layout.location.y, 0.0);
+    assert_eq!(layout.size.width, 0.0);
+    assert_eq!(layout.size.height, 0.0);
+
+    // Layout 2 (Flex)
+    taffy.set_style(node, flex_style).unwrap();
+    taffy.compute_layout(root, Size::MAX_CONTENT).unwrap();
+    let layout = taffy.layout(node).unwrap();
+    assert_eq!(layout.location.x, 0.0);
+    assert_eq!(layout.location.y, 0.0);
+    assert_eq!(layout.size.width, 100.0);
+    assert_eq!(layout.size.height, 100.0);
+
+    // Layout 3 (None)
+    taffy.set_style(node, hidden_style).unwrap();
+    taffy.compute_layout(root, Size::MAX_CONTENT).unwrap();
     let layout = taffy.layout(node).unwrap();
     assert_eq!(layout.location.x, 0.0);
     assert_eq!(layout.location.y, 0.0);


### PR DESCRIPTION
# Objective

Fix https://github.com/bevyengine/bevy/issues/7952 (Take 2)