### PR TITLE
Prepare for 0.3.5 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taffy"
-version = "0.3.4"
+version = "0.3.5"
 authors = [
     "Alice Cecile <alice.i.cecile@gmail.com>",
     "Johnathan Kelley <jkelleyrtp@gmail.com>",

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Fix `display: none` when it is set on a flexbox child (#380)
+- Fix `display: none` when it is set on a grid child (#381)
 
 ## 0.3.4
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.3.5
+
+### Fixes
+
+- Fix `display: none` when it is set on a flexbox child (#380)
+
 ## 0.3.4
 
 ### Fixes


### PR DESCRIPTION
# Objective

Changelog and version bump for `v0.3.5` release