### PR TITLE
Prepare for v0.3.6 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taffy"
-version = "0.3.5"
+version = "0.3.6"
 authors = [
     "Alice Cecile <alice.i.cecile@gmail.com>",
     "Johnathan Kelley <jkelleyrtp@gmail.com>",

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.3.6
+
+### Fixes
+
+- Fix: Ignore `align_content` when `flex_wrap` is set to `nowrap` (#383)
+
 ## 0.3.5
 
 ### Fixes


### PR DESCRIPTION
# Objective

Changelog and version bump for v0.3.6
