### PR TITLE
Prevent percentages contributing to min-content sizes

### DIFF
--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -706,11 +706,14 @@ fn determine_flex_base_size(
         child.hypothetical_inner_size.set_main(constants.dir, hypothetical_inner_size);
         child.hypothetical_outer_size.set_main(constants.dir, hypothetical_outer_size);
 
+        // Note that it is important that the `parent_size` parameter is not set for this function call
+        // as it used to resolve percentages against, and percentage size should not contribute to a
+        // min-content contribution. See https://drafts.csswg.org/css-sizing-3/#min-percentage-contribution
         let min_content_size = GenericAlgorithm::measure_size(
             tree,
             child.node,
             Size::NONE,
-            constants.node_inner_size,
+            Size::NONE,
             Size::MIN_CONTENT,
             SizingMode::ContentSize,
         );

--- a/test_fixtures/bevy_issue_8017.html
+++ b/test_fixtures/bevy_issue_8017.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<script src="../scripts/gentest/test_helper.js"></script>
+<link rel="stylesheet" type="text/css" href="../scripts/gentest/test_base_style.css">
+<title>
+    Bevy #8017
+</title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; flex-direction: column; gap: 8px;width: 400px;height:400px;padding: 8px;">
+  <div style="display: flex; gap: 8px; width: 100%; height: 50%;">
+      <div style="width: 100%; height: 100%;"></div>
+      <div style="width: 100%; height: 100%;"></div>
+  </div>
+  <div style="display: flex; gap: 8px; width: 100%; height: 50%;">
+      <div style="width: 100%; height: 100%;"></div>
+      <div style="width: 100%; height: 100%;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/bevy_issue_8017_reduced.html
+++ b/test_fixtures/bevy_issue_8017_reduced.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<script src="../scripts/gentest/test_helper.js"></script>
+<link rel="stylesheet" type="text/css" href="../scripts/gentest/test_base_style.css">
+<title>
+    Bevy #8017
+</title>
+</head>
+<body>
+
+<div id="test-root" style="flex-direction: column;width: 200px;height:400px;gap: 8px;">
+  <div style="height: 50%;">
+      <div></div>
+  </div>
+  <div style="height: 50%;">
+      <div></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/generated/bevy_issue_8017.rs
+++ b/tests/generated/bevy_issue_8017.rs
@@ -1,0 +1,140 @@
+#[test]
+fn bevy_issue_8017() {
+    use slotmap::Key;
+    #[allow(unused_imports)]
+    use taffy::{layout::Layout, prelude::*};
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
+        .new_leaf(taffy::style::Style {
+            size: taffy::geometry::Size {
+                width: taffy::style::Dimension::Percent(1f32),
+                height: taffy::style::Dimension::Percent(1f32),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node01 = taffy
+        .new_leaf(taffy::style::Style {
+            size: taffy::geometry::Size {
+                width: taffy::style::Dimension::Percent(1f32),
+                height: taffy::style::Dimension::Percent(1f32),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node0 = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Flex,
+                gap: taffy::geometry::Size {
+                    width: taffy::style::LengthPercentage::Points(8f32),
+                    height: taffy::style::LengthPercentage::Points(8f32),
+                },
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(1f32),
+                    height: taffy::style::Dimension::Percent(0.5f32),
+                },
+                ..Default::default()
+            },
+            &[node00, node01],
+        )
+        .unwrap();
+    let node10 = taffy
+        .new_leaf(taffy::style::Style {
+            size: taffy::geometry::Size {
+                width: taffy::style::Dimension::Percent(1f32),
+                height: taffy::style::Dimension::Percent(1f32),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node11 = taffy
+        .new_leaf(taffy::style::Style {
+            size: taffy::geometry::Size {
+                width: taffy::style::Dimension::Percent(1f32),
+                height: taffy::style::Dimension::Percent(1f32),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node1 = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Flex,
+                gap: taffy::geometry::Size {
+                    width: taffy::style::LengthPercentage::Points(8f32),
+                    height: taffy::style::LengthPercentage::Points(8f32),
+                },
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(1f32),
+                    height: taffy::style::Dimension::Percent(0.5f32),
+                },
+                ..Default::default()
+            },
+            &[node10, node11],
+        )
+        .unwrap();
+    let node = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Flex,
+                flex_direction: taffy::style::FlexDirection::Column,
+                gap: taffy::geometry::Size {
+                    width: taffy::style::LengthPercentage::Points(8f32),
+                    height: taffy::style::LengthPercentage::Points(8f32),
+                },
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(400f32),
+                    height: taffy::style::Dimension::Points(400f32),
+                },
+                padding: taffy::geometry::Rect {
+                    left: taffy::style::LengthPercentage::Points(8f32),
+                    right: taffy::style::LengthPercentage::Points(8f32),
+                    top: taffy::style::LengthPercentage::Points(8f32),
+                    bottom: taffy::style::LengthPercentage::Points(8f32),
+                },
+                ..Default::default()
+            },
+            &[node0, node1],
+        )
+        .unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
+    println!("\nComputed tree:");
+    taffy::debug::print_tree(&taffy, node);
+    println!();
+    let Layout { size, location, .. } = taffy.layout(node).unwrap();
+    assert_eq!(size.width, 400f32, "width of node {:?}. Expected {}. Actual {}", node.data(), 400f32, size.width);
+    assert_eq!(size.height, 400f32, "height of node {:?}. Expected {}. Actual {}", node.data(), 400f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node0).unwrap();
+    assert_eq!(size.width, 384f32, "width of node {:?}. Expected {}. Actual {}", node0.data(), 384f32, size.width);
+    assert_eq!(size.height, 188f32, "height of node {:?}. Expected {}. Actual {}", node0.data(), 188f32, size.height);
+    assert_eq!(location.x, 8f32, "x of node {:?}. Expected {}. Actual {}", node0.data(), 8f32, location.x);
+    assert_eq!(location.y, 8f32, "y of node {:?}. Expected {}. Actual {}", node0.data(), 8f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node00).unwrap();
+    assert_eq!(size.width, 188f32, "width of node {:?}. Expected {}. Actual {}", node00.data(), 188f32, size.width);
+    assert_eq!(size.height, 188f32, "height of node {:?}. Expected {}. Actual {}", node00.data(), 188f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node00.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node00.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node01).unwrap();
+    assert_eq!(size.width, 188f32, "width of node {:?}. Expected {}. Actual {}", node01.data(), 188f32, size.width);
+    assert_eq!(size.height, 188f32, "height of node {:?}. Expected {}. Actual {}", node01.data(), 188f32, size.height);
+    assert_eq!(location.x, 196f32, "x of node {:?}. Expected {}. Actual {}", node01.data(), 196f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node01.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node1).unwrap();
+    assert_eq!(size.width, 384f32, "width of node {:?}. Expected {}. Actual {}", node1.data(), 384f32, size.width);
+    assert_eq!(size.height, 188f32, "height of node {:?}. Expected {}. Actual {}", node1.data(), 188f32, size.height);
+    assert_eq!(location.x, 8f32, "x of node {:?}. Expected {}. Actual {}", node1.data(), 8f32, location.x);
+    assert_eq!(location.y, 204f32, "y of node {:?}. Expected {}. Actual {}", node1.data(), 204f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node10).unwrap();
+    assert_eq!(size.width, 188f32, "width of node {:?}. Expected {}. Actual {}", node10.data(), 188f32, size.width);
+    assert_eq!(size.height, 188f32, "height of node {:?}. Expected {}. Actual {}", node10.data(), 188f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node10.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node10.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node11).unwrap();
+    assert_eq!(size.width, 188f32, "width of node {:?}. Expected {}. Actual {}", node11.data(), 188f32, size.width);
+    assert_eq!(size.height, 188f32, "height of node {:?}. Expected {}. Actual {}", node11.data(), 188f32, size.height);
+    assert_eq!(location.x, 196f32, "x of node {:?}. Expected {}. Actual {}", node11.data(), 196f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node11.data(), 0f32, location.y);
+}

--- a/tests/generated/bevy_issue_8017_reduced.rs
+++ b/tests/generated/bevy_issue_8017_reduced.rs
@@ -1,0 +1,73 @@
+#[test]
+fn bevy_issue_8017_reduced() {
+    use slotmap::Key;
+    #[allow(unused_imports)]
+    use taffy::{layout::Layout, prelude::*};
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy.new_leaf(taffy::style::Style { ..Default::default() }).unwrap();
+    let node0 = taffy
+        .new_with_children(
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: auto(), height: taffy::style::Dimension::Percent(0.5f32) },
+                ..Default::default()
+            },
+            &[node00],
+        )
+        .unwrap();
+    let node10 = taffy.new_leaf(taffy::style::Style { ..Default::default() }).unwrap();
+    let node1 = taffy
+        .new_with_children(
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: auto(), height: taffy::style::Dimension::Percent(0.5f32) },
+                ..Default::default()
+            },
+            &[node10],
+        )
+        .unwrap();
+    let node = taffy
+        .new_with_children(
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                gap: taffy::geometry::Size {
+                    width: taffy::style::LengthPercentage::Points(8f32),
+                    height: taffy::style::LengthPercentage::Points(8f32),
+                },
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(400f32),
+                },
+                ..Default::default()
+            },
+            &[node0, node1],
+        )
+        .unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
+    println!("\nComputed tree:");
+    taffy::debug::print_tree(&taffy, node);
+    println!();
+    let Layout { size, location, .. } = taffy.layout(node).unwrap();
+    assert_eq!(size.width, 200f32, "width of node {:?}. Expected {}. Actual {}", node.data(), 200f32, size.width);
+    assert_eq!(size.height, 400f32, "height of node {:?}. Expected {}. Actual {}", node.data(), 400f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node0).unwrap();
+    assert_eq!(size.width, 200f32, "width of node {:?}. Expected {}. Actual {}", node0.data(), 200f32, size.width);
+    assert_eq!(size.height, 196f32, "height of node {:?}. Expected {}. Actual {}", node0.data(), 196f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node00).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node00.data(), 0f32, size.width);
+    assert_eq!(size.height, 196f32, "height of node {:?}. Expected {}. Actual {}", node00.data(), 196f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node00.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node00.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node1).unwrap();
+    assert_eq!(size.width, 200f32, "width of node {:?}. Expected {}. Actual {}", node1.data(), 200f32, size.width);
+    assert_eq!(size.height, 196f32, "height of node {:?}. Expected {}. Actual {}", node1.data(), 196f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node1.data(), 0f32, location.x);
+    assert_eq!(location.y, 204f32, "y of node {:?}. Expected {}. Actual {}", node1.data(), 204f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node10).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node10.data(), 0f32, size.width);
+    assert_eq!(size.height, 196f32, "height of node {:?}. Expected {}. Actual {}", node10.data(), 196f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node10.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node10.data(), 0f32, location.y);
+}

--- a/tests/generated/mod.rs
+++ b/tests/generated/mod.rs
@@ -201,6 +201,8 @@ mod aspect_ratio_flex_row_stretch_fill_width;
 mod bevy_issue_7976_3_level;
 mod bevy_issue_7976_4_level;
 mod bevy_issue_7976_reduced;
+mod bevy_issue_8017;
+mod bevy_issue_8017_reduced;
 mod border_center_child;
 mod border_container_match_child;
 mod border_flex_child;


### PR DESCRIPTION
# Objective

Fixes https://github.com/DioxusLabs/taffy/issues/387
Fixes https://github.com/bevyengine/bevy/issues/8017

## Context

- https://drafts.csswg.org/css-sizing-3/#min-percentage-contribution

Above states that percentage sizes should not contribute to min-content sizes