### PR TITLE
Upgrade to better Github Actions for faster and better maintained CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
         with:
           toolchain: stable
           components: clippy
-      - run: cargo doc --workspace -- -D warnings
+      - run: cargo doc
         env:
           RUSTDOCFLAGS: "-D warnings"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,162 +13,90 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --no-default-features
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-default-features
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build --no-default-features
+      - run: cargo test --no-default-features
 
   test-features-default:
     name: "Test Suite [Features: Default]"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build
+      - run: cargo test
 
   test-features-default-with-serde:
     name: "Test Suite [Features: Default + serde]"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --features serde
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features serde
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build --features serde
+      - run: cargo test --features serde
 
   test-features-alloc:
     name: "Test Suite [Features: alloc]"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --no-default-features --features alloc,grid
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-default-features --features alloc,grid
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build --no-default-features --features alloc,grid
+      - run: cargo test --no-default-features --features alloc,grid
 
   test-features-alloc-no-grid:
     name: "Test Suite [Features: alloc (no grid)]"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --no-default-features --features alloc
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-default-features --features alloc
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build --no-default-features --features alloc
+      - run: cargo test  --no-default-features --features alloc
 
   test-features-default-no-grid:
     name: "Test Suite [Features: std (no grid)]"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --no-default-features --features std
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-default-features --features std
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build --no-default-features --features std
+      - run: cargo test --no-default-features --features std
 
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
-          override: true
-      - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+          components: rustfmt
+      - run: cargo fmt --all -- --check
 
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: nightly
-          override: true
-      - run: rustup component add clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --workspace -- -D warnings
+          components: clippy
+      - run: cargo +nightly clippy --workspace -- -D warnings
 
   doc:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
-          override: true
-      - run: rustup component add clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: doc
+          components: clippy
+      - run: cargo doc --workspace -- -D warnings
         env:
           RUSTDOCFLAGS: "-D warnings"
-
 
   markdownlint:
     name: Markdown Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - 0.2.x
+      - 0.3.x
 
 name: Continuous integration
 

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -22,12 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Install cargo-deny
-        run: cargo install cargo-deny
+      - uses: taiki-e/install-action@cargo-deny
       - name: Check for security advisories and unmaintained crates
         run: cargo deny check advisories
 
@@ -35,12 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Install cargo-deny
-        run: cargo install cargo-deny
+      - uses: taiki-e/install-action@cargo-deny
       - name: Check for banned and duplicated dependencies
         run: cargo deny check bans
 
@@ -48,12 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Install cargo-deny
-        run: cargo install cargo-deny
+      - uses: taiki-e/install-action@cargo-deny
       - name: Check for unauthorized licenses
         run: cargo deny check licenses
 
@@ -61,11 +46,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Install cargo-deny
-        run: cargo install cargo-deny
+      - uses: taiki-e/install-action@cargo-deny
       - name: Checked for unauthorized crate sources
         run: cargo deny check sources

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 edition = "2021"
 include = ["src/**/*", "Cargo.toml", "README.md"]
-description = "A flexible UI layout library"
+description = "A flexible UI layout library "
 repository = "https://github.com/DioxusLabs/taffy"
 keywords = ["cross-platform", "layout", "flexbox", "css-grid", "grid"]
 categories = ["gui"]


### PR DESCRIPTION
# Objective

- Speed up CI by using binary version of `cargo-deny` rather than compiling from source
- Move off unmaintained actions-rs actions