### PR TITLE
Add fully reduced test case for #387

### DIFF
--- a/test_fixtures/percentage_sizes_should_not_prevent_flex_shrinking.html
+++ b/test_fixtures/percentage_sizes_should_not_prevent_flex_shrinking.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<script src="../scripts/gentest/test_helper.js"></script>
+<link rel="stylesheet" type="text/css" href="../scripts/gentest/test_base_style.css">
+<title>
+    Bevy #8017
+</title>
+</head>
+<body>
+
+<div id="test-root" style="width: 200px;height:200px">
+  <div style="width: 120%;">
+      <div></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/generated/mod.rs
+++ b/tests/generated/mod.rs
@@ -874,6 +874,7 @@ mod percentage_position_bottom_right;
 mod percentage_position_left_top;
 mod percentage_size_based_on_parent_inner_size;
 mod percentage_size_of_flex_basis;
+mod percentage_sizes_should_not_prevent_flex_shrinking;
 mod percentage_width_height;
 mod percentage_width_height_undefined_parent_size;
 mod position_root_with_rtl_should_position_withoutdirection;

--- a/tests/generated/percentage_sizes_should_not_prevent_flex_shrinking.rs
+++ b/tests/generated/percentage_sizes_should_not_prevent_flex_shrinking.rs
@@ -1,0 +1,39 @@
+#[test]
+fn percentage_sizes_should_not_prevent_flex_shrinking() {
+    use slotmap::Key;
+    #[allow(unused_imports)]
+    use taffy::{layout::Layout, prelude::*};
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
+        .new_leaf(taffy::style::Style {
+            size: taffy::geometry::Size { width: taffy::style::Dimension::Percent(1.2f32), height: auto() },
+            ..Default::default()
+        })
+        .unwrap();
+    let node = taffy
+        .new_with_children(
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
+                },
+                ..Default::default()
+            },
+            &[node0],
+        )
+        .unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::MAX_CONTENT).unwrap();
+    println!("\nComputed tree:");
+    taffy::debug::print_tree(&taffy, node);
+    println!();
+    let Layout { size, location, .. } = taffy.layout(node).unwrap();
+    assert_eq!(size.width, 200f32, "width of node {:?}. Expected {}. Actual {}", node.data(), 200f32, size.width);
+    assert_eq!(size.height, 200f32, "height of node {:?}. Expected {}. Actual {}", node.data(), 200f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node.data(), 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node0).unwrap();
+    assert_eq!(size.width, 200f32, "width of node {:?}. Expected {}. Actual {}", node0.data(), 200f32, size.width);
+    assert_eq!(size.height, 200f32, "height of node {:?}. Expected {}. Actual {}", node0.data(), 200f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, location.y);
+}


### PR DESCRIPTION
# Objective

The current test case works fine but is named after the bevy issue rather than the actual cause and contains unecesary styles. This adds an additional unit-style test.