### PR TITLE
Prepare for 0.3.8 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taffy"
-version = "0.3.7"
+version = "0.3.8"
 authors = [
     "Alice Cecile <alice.i.cecile@gmail.com>",
     "Johnathan Kelley <jkelleyrtp@gmail.com>",

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.3.8
+
+### Fixes
+
+- Fix incorrect min-content size for `flex-wrap: wrap` nodes (bevyengine/bevy#8082)
+
 ## 0.3.7
 
 ### Fixes


### PR DESCRIPTION
# Objective

Update changelog and version number for `v0.3.8` release.