### PR TITLE
Prepare for 0.3.10 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taffy"
-version = "0.3.9"
+version = "0.3.10"
 authors = [
     "Alice Cecile <alice.i.cecile@gmail.com>",
     "Johnathan Kelley <jkelleyrtp@gmail.com>",

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.3.10
+
+### Fixes
+
+- Fix sizing of children when the available_space < min_size (#407)
+
 ## 0.3.9
 
 ### Fixes


### PR DESCRIPTION
# Objective

Release notes and version bump for `v0.3.10` release