### PR TITLE
Remove `layout_flexbox` function from prelude

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## Unreleased
+
+### Removed
+
+- `layout_flexbox()` has been removed from the prelude. Use `FlexboxAlgorithm::perform_layout()` instead.
+
 ## 0.3.11
 
 ### Fixes

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,28 +1,5 @@
 //! Commonly used types
 
-use crate::compute::LayoutAlgorithm;
-use crate::layout::{SizeAndBaselines, SizingMode};
-
-/// Apply the flexbox algorithm and recursively layout the specified node
-#[inline(always)]
-pub fn layout_flexbox(
-    tree: &mut impl LayoutTree,
-    node: Node,
-    known_dimensions: Size<Option<f32>>,
-    parent_size: Size<Option<f32>>,
-    available_space: Size<AvailableSpace>,
-    sizing_mode: SizingMode,
-) -> SizeAndBaselines {
-    crate::compute::flexbox::FlexboxAlgorithm::perform_layout(
-        tree,
-        node,
-        known_dimensions,
-        parent_size,
-        available_space,
-        sizing_mode,
-    )
-}
-
 pub use crate::{
     geometry::{Line, Rect, Size},
     layout::Layout,


### PR DESCRIPTION
# Objective

The prelude contained a single method that has been kept around for backwards compatibility. It is simply a wrapper around `FlexboxAlgorithm::perform_layout()`. The idiomatic way to use taffy now and going forward is to use the `perform_layout()` on the trait so I don't think we need to keep this around for much longer. 

The migration path is also very simple, but it is a breaking change.

## Feedback wanted

Are there any reasons why we would not want this? Or want to delay this? I know #326 might change how end users interact with taffy, and so we might want to bundle these changes together?