### PR TITLE
Fix clippy lints

### DIFF
--- a/src/style/grid.rs
+++ b/src/style/grid.rs
@@ -314,7 +314,7 @@ impl MaxTrackSizingFunction {
     /// will if the available_space is `Some`). Otherwise returns None.
     #[inline(always)]
     pub fn definite_value(self, parent_size: Option<f32>) -> Option<f32> {
-        use MaxTrackSizingFunction::{Auto, *};
+        use MaxTrackSizingFunction::*;
         match self {
             Fixed(LengthPercentage::Points(size)) => Some(size),
             Fixed(LengthPercentage::Percent(fraction)) => parent_size.map(|size| fraction * size),
@@ -342,7 +342,7 @@ impl MaxTrackSizingFunction {
     /// Non-percentage values always return None.
     #[inline(always)]
     pub fn resolved_percentage_size(self, parent_size: f32) -> Option<f32> {
-        use MaxTrackSizingFunction::{Auto, *};
+        use MaxTrackSizingFunction::*;
         match self {
             Fixed(LengthPercentage::Percent(fraction)) => Some(fraction * parent_size),
             Fixed(LengthPercentage::Points(_)) | MinContent | MaxContent | FitContent(_) | Auto | Fraction(_) => None,
@@ -409,7 +409,7 @@ impl MinTrackSizingFunction {
     /// will if the available_space is `Some`). Otherwise returns `None`.
     #[inline(always)]
     pub fn definite_value(self, parent_size: Option<f32>) -> Option<f32> {
-        use MinTrackSizingFunction::{Auto, *};
+        use MinTrackSizingFunction::*;
         match self {
             Fixed(LengthPercentage::Points(size)) => Some(size),
             Fixed(LengthPercentage::Percent(fraction)) => parent_size.map(|size| fraction * size),
@@ -421,7 +421,7 @@ impl MinTrackSizingFunction {
     /// Non-percentage values always return None.
     #[inline(always)]
     pub fn resolved_percentage_size(self, parent_size: f32) -> Option<f32> {
-        use MinTrackSizingFunction::{Auto, *};
+        use MinTrackSizingFunction::*;
         match self {
             Fixed(LengthPercentage::Percent(fraction)) => Some(fraction * parent_size),
             Fixed(LengthPercentage::Points(_)) | MinContent | MaxContent | Auto => None,


### PR DESCRIPTION
(cherry picked from commit 55225737802b3e2a0e0ce6194c9fce2603a18a30)
Cherry picked from #414 but realized this was an unrelated change.

# Objective

Clippy complains about duplicate imports, so cleaning that up.