### PR TITLE
Add caching to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Leafwing-Studios/cargo-cache@v1
       - run: cargo build --no-default-features
       - run: cargo test --no-default-features
 
@@ -60,6 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Leafwing-Studios/cargo-cache@v1
       - run: cargo build --no-default-features --features std
       - run: cargo test --no-default-features --features std
 
@@ -68,11 +70,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
           components: rustfmt
+      - uses: Leafwing-Studios/cargo-cache@v1
       - run: cargo fmt --all -- --check
 
   clippy:
@@ -84,6 +86,7 @@ jobs:
         with:
           toolchain: nightly
           components: clippy
+      - uses: Leafwing-Studios/cargo-cache@v1
       - run: cargo +nightly clippy --workspace -- -D warnings
 
   doc:
@@ -95,6 +98,7 @@ jobs:
         with:
           toolchain: stable
           components: clippy
+      - uses: Leafwing-Studios/cargo-cache@v1
       - run: cargo doc
         env:
           RUSTDOCFLAGS: "-D warnings"


### PR DESCRIPTION
# Objective

Currently, we download and build taffy's dependencies on every CI run.
With this PR, we use [`cargo-cache`](https://github.com/Leafwing-Studios/cargo-cache) to cache the builds in order to speed up CI times.

## Context

`cargo-cache` is essentially just a wrapper around GitHub Action's `cache` action.
It automatically generates the `Cargo.toml` file for libraries to choose an appropriate cache key and then caches the target folder.

We have been using this with great success for [Emergence](https://github.com/Leafwing-Studios/Emergence).
