### PR TITLE
Fix typos in test fixtures

### DIFF
--- a/scripts/import-yoga-tests/FIXTURE_TEMPLATE.html
+++ b/scripts/import-yoga-tests/FIXTURE_TEMPLATE.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 __HTML_GOES_HERE__

--- a/test_fixtures/absolute_aspect_ratio_aspect_ratio_overrides_height_of_full_inset.html
+++ b/test_fixtures/absolute_aspect_ratio_aspect_ratio_overrides_height_of_full_inset.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-</html>
+</head>
 <body>
 
 <div id="test-root" style="display: flex; width: 400px; height: 300px;">

--- a/test_fixtures/absolute_aspect_ratio_aspect_ratio_overrides_height_of_full_inset.html
+++ b/test_fixtures/absolute_aspect_ratio_aspect_ratio_overrides_height_of_full_inset.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</html>
 <body>
 
 <div id="test-root" style="display: flex; width: 400px; height: 300px;">

--- a/test_fixtures/absolute_aspect_ratio_fill_height.html
+++ b/test_fixtures/absolute_aspect_ratio_fill_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex; width: 400px; height: 300px;">

--- a/test_fixtures/absolute_aspect_ratio_fill_height_from_inset.html
+++ b/test_fixtures/absolute_aspect_ratio_fill_height_from_inset.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex; width: 400px; height: 300px;">

--- a/test_fixtures/absolute_aspect_ratio_fill_max_height.html
+++ b/test_fixtures/absolute_aspect_ratio_fill_max_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex; width: 400px; height: 300px;">

--- a/test_fixtures/absolute_aspect_ratio_fill_max_width.html
+++ b/test_fixtures/absolute_aspect_ratio_fill_max_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex; width: 400px; height: 300px;">

--- a/test_fixtures/absolute_aspect_ratio_fill_min_height.html
+++ b/test_fixtures/absolute_aspect_ratio_fill_min_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex; width: 400px; height: 300px;">

--- a/test_fixtures/absolute_aspect_ratio_fill_min_width.html
+++ b/test_fixtures/absolute_aspect_ratio_fill_min_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex; width: 400px; height: 300px;">

--- a/test_fixtures/absolute_aspect_ratio_fill_width.html
+++ b/test_fixtures/absolute_aspect_ratio_fill_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex; width: 400px; height: 300px;">

--- a/test_fixtures/absolute_aspect_ratio_fill_width_from_inset.html
+++ b/test_fixtures/absolute_aspect_ratio_fill_width_from_inset.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex; width: 400px; height: 300px;">

--- a/test_fixtures/absolute_aspect_ratio_height_overrides_inset.html
+++ b/test_fixtures/absolute_aspect_ratio_height_overrides_inset.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex; width: 400px; height: 300px;">

--- a/test_fixtures/absolute_aspect_ratio_width_overrides_inset.html
+++ b/test_fixtures/absolute_aspect_ratio_width_overrides_inset.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex; width: 400px; height: 300px;">

--- a/test_fixtures/absolute_child_with_cross_margin.html
+++ b/test_fixtures/absolute_child_with_cross_margin.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root"

--- a/test_fixtures/absolute_child_with_main_margin.html
+++ b/test_fixtures/absolute_child_with_main_margin.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; width: 20px; height: 37px">

--- a/test_fixtures/absolute_child_with_max_height.html
+++ b/test_fixtures/absolute_child_with_max_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: column;width: 100px; height: 200px">

--- a/test_fixtures/absolute_child_with_max_height_larger_shrinkable_grandchild.html
+++ b/test_fixtures/absolute_child_with_max_height_larger_shrinkable_grandchild.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: column;width: 100px; height: 200px">

--- a/test_fixtures/absolute_layout_align_items_and_justify_content_center.html
+++ b/test_fixtures/absolute_layout_align_items_and_justify_content_center.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 100px; width: 110px; align-items: center; justify-content: center;">

--- a/test_fixtures/absolute_layout_align_items_and_justify_content_center_and_bottom_position.html
+++ b/test_fixtures/absolute_layout_align_items_and_justify_content_center_and_bottom_position.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 100px; width: 110px; align-items: center; justify-content: center;">

--- a/test_fixtures/absolute_layout_align_items_and_justify_content_center_and_left_position.html
+++ b/test_fixtures/absolute_layout_align_items_and_justify_content_center_and_left_position.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 100px; width: 110px; align-items: center; justify-content: center;">

--- a/test_fixtures/absolute_layout_align_items_and_justify_content_center_and_right_position.html
+++ b/test_fixtures/absolute_layout_align_items_and_justify_content_center_and_right_position.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 100px; width: 110px; align-items: center; justify-content: center;">

--- a/test_fixtures/absolute_layout_align_items_and_justify_content_center_and_top_position.html
+++ b/test_fixtures/absolute_layout_align_items_and_justify_content_center_and_top_position.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 100px; width: 110px; align-items: center; justify-content: center;">

--- a/test_fixtures/absolute_layout_align_items_and_justify_content_flex_end.html
+++ b/test_fixtures/absolute_layout_align_items_and_justify_content_flex_end.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 100px; width: 110px; align-items: flex-end; justify-content: flex-end;">

--- a/test_fixtures/absolute_layout_align_items_center.html
+++ b/test_fixtures/absolute_layout_align_items_center.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 100px; width: 110px; align-items: center;">

--- a/test_fixtures/absolute_layout_align_items_center_on_child_only.html
+++ b/test_fixtures/absolute_layout_align_items_center_on_child_only.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 100px; width: 110px;">

--- a/test_fixtures/absolute_layout_child_order.html
+++ b/test_fixtures/absolute_layout_child_order.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 100px; width: 110px; align-items: center; justify-content: center;">

--- a/test_fixtures/absolute_layout_in_wrap_reverse_column_container.html
+++ b/test_fixtures/absolute_layout_in_wrap_reverse_column_container.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: column; width: 100px; height: 100px; flex-wrap: wrap-reverse;">

--- a/test_fixtures/absolute_layout_in_wrap_reverse_column_container_flex_end.html
+++ b/test_fixtures/absolute_layout_in_wrap_reverse_column_container_flex_end.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: column; width: 100px; height: 100px; flex-wrap: wrap-reverse;">

--- a/test_fixtures/absolute_layout_in_wrap_reverse_row_container.html
+++ b/test_fixtures/absolute_layout_in_wrap_reverse_row_container.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; width:100px; height: 100px; flex-wrap: wrap-reverse;">

--- a/test_fixtures/absolute_layout_in_wrap_reverse_row_container_flex_end.html
+++ b/test_fixtures/absolute_layout_in_wrap_reverse_row_container_flex_end.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; width: 100px; height: 100px; flex-wrap: wrap-reverse;">

--- a/test_fixtures/absolute_layout_justify_content_center.html
+++ b/test_fixtures/absolute_layout_justify_content_center.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 100px; width: 110px; justify-content: center;">

--- a/test_fixtures/absolute_layout_no_size.html
+++ b/test_fixtures/absolute_layout_no_size.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 100px; width: 100px;">

--- a/test_fixtures/absolute_layout_percentage_bottom_based_on_parent_height.html
+++ b/test_fixtures/absolute_layout_percentage_bottom_based_on_parent_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 200px;">

--- a/test_fixtures/absolute_layout_percentage_height.html
+++ b/test_fixtures/absolute_layout_percentage_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 100px;">

--- a/test_fixtures/absolute_layout_row_width_height_end_bottom.html
+++ b/test_fixtures/absolute_layout_row_width_height_end_bottom.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: row;">

--- a/test_fixtures/absolute_layout_start_top_end_bottom.html
+++ b/test_fixtures/absolute_layout_start_top_end_bottom.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px;">

--- a/test_fixtures/absolute_layout_width_height_end_bottom.html
+++ b/test_fixtures/absolute_layout_width_height_end_bottom.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px;">

--- a/test_fixtures/absolute_layout_width_height_start_top.html
+++ b/test_fixtures/absolute_layout_width_height_start_top.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px;">

--- a/test_fixtures/absolute_layout_width_height_start_top_end_bottom.html
+++ b/test_fixtures/absolute_layout_width_height_start_top_end_bottom.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px;">

--- a/test_fixtures/absolute_layout_within_border.html
+++ b/test_fixtures/absolute_layout_within_border.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 100px; width: 100px; border-width: 10px; padding: 10px;">

--- a/test_fixtures/absolute_margin_bottom_left.html
+++ b/test_fixtures/absolute_margin_bottom_left.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; justify-content: flex-end; flex-direction: column;">

--- a/test_fixtures/absolute_minmax_bottom_right_max.html
+++ b/test_fixtures/absolute_minmax_bottom_right_max.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px;">

--- a/test_fixtures/absolute_minmax_bottom_right_min_max.html
+++ b/test_fixtures/absolute_minmax_bottom_right_min_max.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px;">

--- a/test_fixtures/absolute_minmax_bottom_right_min_max_preferred.html
+++ b/test_fixtures/absolute_minmax_bottom_right_min_max_preferred.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px;">

--- a/test_fixtures/absolute_minmax_top_left_bottom_right_max.html
+++ b/test_fixtures/absolute_minmax_top_left_bottom_right_max.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px;">

--- a/test_fixtures/absolute_minmax_top_left_bottom_right_min_max.html
+++ b/test_fixtures/absolute_minmax_top_left_bottom_right_min_max.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px;">

--- a/test_fixtures/absolute_padding_border_overrides_max_size.html
+++ b/test_fixtures/absolute_padding_border_overrides_max_size.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root">

--- a/test_fixtures/absolute_padding_border_overrides_size.html
+++ b/test_fixtures/absolute_padding_border_overrides_size.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root">

--- a/test_fixtures/align_baseline.html
+++ b/test_fixtures/align_baseline.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; align-items: baseline;">

--- a/test_fixtures/align_baseline_child.html
+++ b/test_fixtures/align_baseline_child.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: column;width: 100px; height: 100px; flex-direction:row; align-items: baseline;">

--- a/test_fixtures/align_baseline_child_margin.html
+++ b/test_fixtures/align_baseline_child_margin.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction:row; align-items: baseline;">

--- a/test_fixtures/align_baseline_child_margin_percent.html
+++ b/test_fixtures/align_baseline_child_margin_percent.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction:row; align-items: baseline;">

--- a/test_fixtures/align_baseline_child_multiline.html
+++ b/test_fixtures/align_baseline_child_multiline.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; align-items: baseline;">

--- a/test_fixtures/align_baseline_child_multiline_no_override_on_secondline.html
+++ b/test_fixtures/align_baseline_child_multiline_no_override_on_secondline.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction:row; align-items: baseline;">

--- a/test_fixtures/align_baseline_child_multiline_override.html
+++ b/test_fixtures/align_baseline_child_multiline_override.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction:row; align-items: baseline;">

--- a/test_fixtures/align_baseline_child_padding.html
+++ b/test_fixtures/align_baseline_child_padding.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; padding:5px; flex-direction:row; align-items: baseline;">

--- a/test_fixtures/align_baseline_child_top.html
+++ b/test_fixtures/align_baseline_child_top.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction:row; align-items: baseline;">

--- a/test_fixtures/align_baseline_child_top2.html
+++ b/test_fixtures/align_baseline_child_top2.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction:row; align-items: baseline;">

--- a/test_fixtures/align_baseline_column.html
+++ b/test_fixtures/align_baseline_column.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction:column; align-items: baseline;">

--- a/test_fixtures/align_baseline_double_nested_child.html
+++ b/test_fixtures/align_baseline_double_nested_child.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction:row; align-items: baseline;">

--- a/test_fixtures/align_baseline_multiline.html
+++ b/test_fixtures/align_baseline_multiline.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction:row; align-items: baseline;flex-wrap:wrap;">

--- a/test_fixtures/align_baseline_multiline_column.html
+++ b/test_fixtures/align_baseline_multiline_column.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction:column; align-items: baseline;flex-wrap:wrap;">

--- a/test_fixtures/align_baseline_multiline_column2.html
+++ b/test_fixtures/align_baseline_multiline_column2.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction:column; align-items: baseline;flex-wrap:wrap;">

--- a/test_fixtures/align_baseline_multiline_row_and_column.html
+++ b/test_fixtures/align_baseline_multiline_row_and_column.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction:row; align-items: baseline;flex-wrap:wrap;">

--- a/test_fixtures/align_baseline_nested_child.html
+++ b/test_fixtures/align_baseline_nested_child.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; align-items: baseline;">

--- a/test_fixtures/align_baseline_nested_column.html
+++ b/test_fixtures/align_baseline_nested_column.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: row; align-items: baseline;">

--- a/test_fixtures/align_center_should_size_based_on_content.html
+++ b/test_fixtures/align_center_should_size_based_on_content.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; align-items: center;">

--- a/test_fixtures/align_content_flex_end.html
+++ b/test_fixtures/align_content_flex_end.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-wrap: wrap; flex-direction: column; align-content: flex-end;">

--- a/test_fixtures/align_content_flex_start.html
+++ b/test_fixtures/align_content_flex_start.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 130px; height: 100px; flex-wrap: wrap; flex-direction: row; align-content: flex-start;">

--- a/test_fixtures/align_content_flex_start_with_flex.html
+++ b/test_fixtures/align_content_flex_start_with_flex.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 120px; flex-wrap: wrap; flex-direction: column; align-content: flex-start;">

--- a/test_fixtures/align_content_flex_start_without_height_on_children.html
+++ b/test_fixtures/align_content_flex_start_without_height_on_children.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-wrap: wrap; flex-direction: column; align-content: flex-start;">

--- a/test_fixtures/align_content_not_stretch_with_align_items_stretch.html
+++ b/test_fixtures/align_content_not_stretch_with_align_items_stretch.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root"

--- a/test_fixtures/align_content_space_around_single_line.html
+++ b/test_fixtures/align_content_space_around_single_line.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: row; align-content: space-around;">

--- a/test_fixtures/align_content_space_around_wrapped.html
+++ b/test_fixtures/align_content_space_around_wrapped.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: row; flex-wrap: wrap; align-content: space-around;">

--- a/test_fixtures/align_content_space_between_single_line.html
+++ b/test_fixtures/align_content_space_between_single_line.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: row; align-content: space-between;">

--- a/test_fixtures/align_content_space_between_wrapped.html
+++ b/test_fixtures/align_content_space_between_wrapped.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: row; flex-wrap: wrap; align-content: space-between;">

--- a/test_fixtures/align_content_space_evenly_single_line.html
+++ b/test_fixtures/align_content_space_evenly_single_line.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: row; align-content: space-evenly;">

--- a/test_fixtures/align_content_space_evenly_wrapped.html
+++ b/test_fixtures/align_content_space_evenly_wrapped.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: row; flex-wrap: wrap; align-content: space-evenly;">

--- a/test_fixtures/align_content_spacearound.html
+++ b/test_fixtures/align_content_spacearound.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 140px; height: 120px; flex-wrap: wrap; flex-direction: row; align-content: space-around;">

--- a/test_fixtures/align_content_spacebetween.html
+++ b/test_fixtures/align_content_spacebetween.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 130px; height: 100px; flex-wrap: wrap; flex-direction: row; align-content: space-between;">

--- a/test_fixtures/align_content_stretch.html
+++ b/test_fixtures/align_content_stretch.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 150px; height: 100px; flex-wrap: wrap; flex-direction: column; align-content: stretch;">

--- a/test_fixtures/align_content_stretch_column.html
+++ b/test_fixtures/align_content_stretch_column.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 150px; flex-wrap: wrap; flex-direction: column; align-content: stretch;">

--- a/test_fixtures/align_content_stretch_is_not_overriding_align_items.html
+++ b/test_fixtures/align_content_stretch_is_not_overriding_align_items.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="align-content:stretch;">

--- a/test_fixtures/align_content_stretch_row.html
+++ b/test_fixtures/align_content_stretch_row.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 150px; height: 100px; flex-wrap: wrap; flex-direction: row; align-content: stretch;">

--- a/test_fixtures/align_content_stretch_row_with_children.html
+++ b/test_fixtures/align_content_stretch_row_with_children.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 150px; height: 100px; flex-wrap: wrap; flex-direction: row; align-content: stretch;">

--- a/test_fixtures/align_content_stretch_row_with_fixed_height.html
+++ b/test_fixtures/align_content_stretch_row_with_fixed_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 150px; height: 100px; flex-wrap: wrap; flex-direction: row; align-content: stretch;">

--- a/test_fixtures/align_content_stretch_row_with_flex.html
+++ b/test_fixtures/align_content_stretch_row_with_flex.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 150px; height: 100px; flex-wrap: wrap; flex-direction: row; align-content: stretch;">

--- a/test_fixtures/align_content_stretch_row_with_flex_no_shrink.html
+++ b/test_fixtures/align_content_stretch_row_with_flex_no_shrink.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 150px; height: 100px; flex-wrap: wrap; flex-direction: row; align-content: stretch;">

--- a/test_fixtures/align_content_stretch_row_with_margin.html
+++ b/test_fixtures/align_content_stretch_row_with_margin.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 150px; height: 100px; flex-wrap: wrap; flex-direction: row; align-content: stretch;">

--- a/test_fixtures/align_content_stretch_row_with_max_height.html
+++ b/test_fixtures/align_content_stretch_row_with_max_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 150px; height: 100px; flex-wrap: wrap; flex-direction: row; align-content: stretch;">

--- a/test_fixtures/align_content_stretch_row_with_min_height.html
+++ b/test_fixtures/align_content_stretch_row_with_min_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 150px; height: 100px; flex-wrap: wrap; flex-direction: row; align-content: stretch;">

--- a/test_fixtures/align_content_stretch_row_with_padding.html
+++ b/test_fixtures/align_content_stretch_row_with_padding.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 150px; height: 100px; flex-wrap: wrap; flex-direction: row; align-content: stretch;">

--- a/test_fixtures/align_content_stretch_row_with_single_row.html
+++ b/test_fixtures/align_content_stretch_row_with_single_row.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 150px; height: 100px; flex-wrap: wrap; flex-direction: row; align-content: stretch;">

--- a/test_fixtures/align_flex_start_with_shrinking_children.html
+++ b/test_fixtures/align_flex_start_with_shrinking_children.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 500px; width: 500px;">

--- a/test_fixtures/align_flex_start_with_shrinking_children_with_stretch.html
+++ b/test_fixtures/align_flex_start_with_shrinking_children_with_stretch.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 500px; width: 500px">

--- a/test_fixtures/align_flex_start_with_stretching_children.html
+++ b/test_fixtures/align_flex_start_with_stretching_children.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 500px; width: 500px">

--- a/test_fixtures/align_items_center.html
+++ b/test_fixtures/align_items_center.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; align-items: center;">

--- a/test_fixtures/align_items_center_child_with_margin_bigger_than_parent.html
+++ b/test_fixtures/align_items_center_child_with_margin_bigger_than_parent.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 50px; width: 50px; align-items: center; justify-content: center;">

--- a/test_fixtures/align_items_center_child_without_margin_bigger_than_parent.html
+++ b/test_fixtures/align_items_center_child_without_margin_bigger_than_parent.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 50px; width: 50px; align-items: center; justify-content: center;">

--- a/test_fixtures/align_items_center_justify_content_center.html
+++ b/test_fixtures/align_items_center_justify_content_center.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: column;height: 500px; width: 500px">

--- a/test_fixtures/align_items_center_min_max_with_padding.html
+++ b/test_fixtures/align_items_center_min_max_with_padding.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; max-width: 320px; min-width: 320px; min-height: 72px; max-height: 504px; align-items: center; padding-top: 8px; padding-bottom: 8px;">

--- a/test_fixtures/align_items_center_with_child_margin.html
+++ b/test_fixtures/align_items_center_with_child_margin.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; align-items: center;">

--- a/test_fixtures/align_items_center_with_child_top.html
+++ b/test_fixtures/align_items_center_with_child_top.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; align-items: center;">

--- a/test_fixtures/align_items_flex_end.html
+++ b/test_fixtures/align_items_flex_end.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; align-items: flex-end;">

--- a/test_fixtures/align_items_flex_end_child_with_margin_bigger_than_parent.html
+++ b/test_fixtures/align_items_flex_end_child_with_margin_bigger_than_parent.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 50px; width: 50px; align-items: center; justify-content: center;">

--- a/test_fixtures/align_items_flex_end_child_without_margin_bigger_than_parent.html
+++ b/test_fixtures/align_items_flex_end_child_without_margin_bigger_than_parent.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 50px; width: 50px; align-items: center; justify-content: center;">

--- a/test_fixtures/align_items_flex_start.html
+++ b/test_fixtures/align_items_flex_start.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; align-items: flex-start;">

--- a/test_fixtures/align_items_min_max.html
+++ b/test_fixtures/align_items_min_max.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="max-width: 200px; min-width: 100px; height: 100px; align-items: center; flex-direction: column;">

--- a/test_fixtures/align_items_stretch.html
+++ b/test_fixtures/align_items_stretch.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px;">

--- a/test_fixtures/align_items_stretch_min_cross.html
+++ b/test_fixtures/align_items_stretch_min_cross.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: column; min-width: 400px; min-height: 50px;">

--- a/test_fixtures/align_self_baseline.html
+++ b/test_fixtures/align_self_baseline.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px;">

--- a/test_fixtures/align_self_center.html
+++ b/test_fixtures/align_self_center.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width:100px; height: 100px;">

--- a/test_fixtures/align_self_center_undefined_max_height.html
+++ b/test_fixtures/align_self_center_undefined_max_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: column;width: 280px; min-height: 52px; flex-direction: row;">

--- a/test_fixtures/align_self_flex_end.html
+++ b/test_fixtures/align_self_flex_end.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width:100px; height: 100px;">

--- a/test_fixtures/align_self_flex_end_override_flex_start.html
+++ b/test_fixtures/align_self_flex_end_override_flex_start.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width:100px; height: 100px; align-items: flex-start;">

--- a/test_fixtures/align_self_flex_start.html
+++ b/test_fixtures/align_self_flex_start.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width:100px; height: 100px;">

--- a/test_fixtures/align_stretch_should_size_based_on_parent.html
+++ b/test_fixtures/align_stretch_should_size_based_on_parent.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px;">

--- a/test_fixtures/android_news_feed.html
+++ b/test_fixtures/android_news_feed.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
   <div id="test-root" layout="width: 1080; height: 444; top: 0; left: 0;" style="flex-direction: column;align-content: stretch; flex-shrink: 0; width: 1080px; " >

--- a/test_fixtures/aspect_ratio_flex_column_fill_height.html
+++ b/test_fixtures/aspect_ratio_flex_column_fill_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex;flex-direction: column;align-items: start;height: 100px; width: 100px;">

--- a/test_fixtures/aspect_ratio_flex_column_fill_max_height.html
+++ b/test_fixtures/aspect_ratio_flex_column_fill_max_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex;flex-direction: column;align-items: start;height: 100px; width: 100px;">

--- a/test_fixtures/aspect_ratio_flex_column_fill_max_width.html
+++ b/test_fixtures/aspect_ratio_flex_column_fill_max_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex;flex-direction: column;align-items: start;height: 100px; width: 100px;">

--- a/test_fixtures/aspect_ratio_flex_column_fill_min_height.html
+++ b/test_fixtures/aspect_ratio_flex_column_fill_min_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex;flex-direction: column;align-items: start;height: 100px; width: 100px;">

--- a/test_fixtures/aspect_ratio_flex_column_fill_min_width.html
+++ b/test_fixtures/aspect_ratio_flex_column_fill_min_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex;flex-direction: column;align-items: start;height: 100px; width: 100px;">

--- a/test_fixtures/aspect_ratio_flex_column_fill_width.html
+++ b/test_fixtures/aspect_ratio_flex_column_fill_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex;flex-direction: column;align-items: start;height: 100px; width: 100px;">

--- a/test_fixtures/aspect_ratio_flex_column_fill_width_flex.html
+++ b/test_fixtures/aspect_ratio_flex_column_fill_width_flex.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid;flex-direction: column;height: 100px; width: 100px;">

--- a/test_fixtures/aspect_ratio_flex_column_stretch_fill_height.html
+++ b/test_fixtures/aspect_ratio_flex_column_stretch_fill_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex;flex-direction: column;height: 100px; width: 100px;">

--- a/test_fixtures/aspect_ratio_flex_column_stretch_fill_max_height.html
+++ b/test_fixtures/aspect_ratio_flex_column_stretch_fill_max_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex;flex-direction: column;height: 100px; width: 100px;">

--- a/test_fixtures/aspect_ratio_flex_column_stretch_fill_max_width.html
+++ b/test_fixtures/aspect_ratio_flex_column_stretch_fill_max_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex;flex-direction: column;height: 100px; width: 100px;">

--- a/test_fixtures/aspect_ratio_flex_column_stretch_fill_width.html
+++ b/test_fixtures/aspect_ratio_flex_column_stretch_fill_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex;flex-direction: column;height: 100px; width: 100px;">

--- a/test_fixtures/aspect_ratio_flex_row_fill_height.html
+++ b/test_fixtures/aspect_ratio_flex_row_fill_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex;align-items: start;height: 100px; width: 100px;">

--- a/test_fixtures/aspect_ratio_flex_row_fill_max_height.html
+++ b/test_fixtures/aspect_ratio_flex_row_fill_max_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex;align-items: start;height: 100px; width: 100px;">

--- a/test_fixtures/aspect_ratio_flex_row_fill_max_width.html
+++ b/test_fixtures/aspect_ratio_flex_row_fill_max_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex;align-items: start;height: 100px; width: 100px;">

--- a/test_fixtures/aspect_ratio_flex_row_fill_min_height.html
+++ b/test_fixtures/aspect_ratio_flex_row_fill_min_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex;align-items: start;height: 100px; width: 100px;">

--- a/test_fixtures/aspect_ratio_flex_row_fill_min_width.html
+++ b/test_fixtures/aspect_ratio_flex_row_fill_min_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex;align-items: start;height: 100px; width: 100px;">

--- a/test_fixtures/aspect_ratio_flex_row_fill_width.html
+++ b/test_fixtures/aspect_ratio_flex_row_fill_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex;align-items: start;height: 100px; width: 100px;">

--- a/test_fixtures/aspect_ratio_flex_row_fill_width_flex.html
+++ b/test_fixtures/aspect_ratio_flex_row_fill_width_flex.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid;align-items: start;height: 100px; width: 100px;">

--- a/test_fixtures/aspect_ratio_flex_row_stretch_fill_height.html
+++ b/test_fixtures/aspect_ratio_flex_row_stretch_fill_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex;height: 100px; width: 100px;">

--- a/test_fixtures/aspect_ratio_flex_row_stretch_fill_max_height.html
+++ b/test_fixtures/aspect_ratio_flex_row_stretch_fill_max_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex;height: 100px; width: 100px;">

--- a/test_fixtures/aspect_ratio_flex_row_stretch_fill_max_width.html
+++ b/test_fixtures/aspect_ratio_flex_row_stretch_fill_max_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex;height: 100px; width: 100px;">

--- a/test_fixtures/aspect_ratio_flex_row_stretch_fill_width.html
+++ b/test_fixtures/aspect_ratio_flex_row_stretch_fill_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex;height: 100px; width: 100px;">

--- a/test_fixtures/bevy_issue_7976_3_level.html
+++ b/test_fixtures/bevy_issue_7976_3_level.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 200px; align-content: start">

--- a/test_fixtures/bevy_issue_7976_4_level.html
+++ b/test_fixtures/bevy_issue_7976_4_level.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 200px; align-content: start">

--- a/test_fixtures/bevy_issue_7976_reduced.html
+++ b/test_fixtures/bevy_issue_7976_reduced.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height:200px;align-content: start">

--- a/test_fixtures/bevy_issue_8082.html
+++ b/test_fixtures/bevy_issue_8082.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 400px; align-content: center;justify-content: flex-start;align-items:stretch;flex-direction: column;">

--- a/test_fixtures/bevy_issue_8082_percent.html
+++ b/test_fixtures/bevy_issue_8082_percent.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 400px; align-content: center;justify-content: flex-start;align-items:stretch;flex-direction: column;">

--- a/test_fixtures/border_center_child.html
+++ b/test_fixtures/border_center_child.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; border-start-width: 10px; border-top-width: 10px; border-end-width: 20px; border-bottom-width: 20px; align-items: center; justify-content: center;">

--- a/test_fixtures/border_container_match_child.html
+++ b/test_fixtures/border_container_match_child.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: column;border-width: 10px;">

--- a/test_fixtures/border_flex_child.html
+++ b/test_fixtures/border_flex_child.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; border-width: 10px;">

--- a/test_fixtures/border_no_child.html
+++ b/test_fixtures/border_no_child.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="border-width: 10px;"></div>

--- a/test_fixtures/border_no_size.html
+++ b/test_fixtures/border_no_size.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: column;border-width: 10px;"></div>

--- a/test_fixtures/border_stretch_child.html
+++ b/test_fixtures/border_stretch_child.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; border-width: 10px;">

--- a/test_fixtures/child_min_max_width_flexing.html
+++ b/test_fixtures/child_min_max_width_flexing.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 120px; height: 50px; flex-direction: row; align-items:stretch">

--- a/test_fixtures/child_with_padding_align_end.html
+++ b/test_fixtures/child_with_padding_align_end.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: column;width: 200px; height: 200px; justify-content: flex-end; align-items: flex-end;">

--- a/test_fixtures/container_with_unsized_child.html
+++ b/test_fixtures/container_with_unsized_child.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px;">

--- a/test_fixtures/display_none.html
+++ b/test_fixtures/display_none.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: row;">

--- a/test_fixtures/display_none_absolute_child.html
+++ b/test_fixtures/display_none_absolute_child.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: row;">

--- a/test_fixtures/display_none_fixed_size.html
+++ b/test_fixtures/display_none_fixed_size.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: row;">

--- a/test_fixtures/display_none_only_node.html
+++ b/test_fixtures/display_none_only_node.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; display: none"></div>

--- a/test_fixtures/display_none_with_child.html
+++ b/test_fixtures/display_none_with_child.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: row;">

--- a/test_fixtures/display_none_with_margin.html
+++ b/test_fixtures/display_none_with_margin.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: row;">

--- a/test_fixtures/display_none_with_position.html
+++ b/test_fixtures/display_none_with_position.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: row;">

--- a/test_fixtures/display_none_with_position_absolute.html
+++ b/test_fixtures/display_none_with_position_absolute.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px;">

--- a/test_fixtures/flex_basis_and_main_dimen_set_when_flexing.html
+++ b/test_fixtures/flex_basis_and_main_dimen_set_when_flexing.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; width: 100px;">

--- a/test_fixtures/flex_basis_flex_grow_column.html
+++ b/test_fixtures/flex_basis_flex_grow_column.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: column;">

--- a/test_fixtures/flex_basis_flex_grow_row.html
+++ b/test_fixtures/flex_basis_flex_grow_row.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: row;">

--- a/test_fixtures/flex_basis_flex_shrink_column.html
+++ b/test_fixtures/flex_basis_flex_shrink_column.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: column;">

--- a/test_fixtures/flex_basis_flex_shrink_row.html
+++ b/test_fixtures/flex_basis_flex_shrink_row.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: row;">

--- a/test_fixtures/flex_basis_larger_than_content_column.html
+++ b/test_fixtures/flex_basis_larger_than_content_column.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 100px; flex-direction: column;">

--- a/test_fixtures/flex_basis_larger_than_content_row.html
+++ b/test_fixtures/flex_basis_larger_than_content_row.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; width: 100px;">

--- a/test_fixtures/flex_basis_overrides_main_size.html
+++ b/test_fixtures/flex_basis_overrides_main_size.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 100px; width: 100px;">

--- a/test_fixtures/flex_basis_slightly_smaller_then_content_with_flex_grow_large_size.html
+++ b/test_fixtures/flex_basis_slightly_smaller_then_content_with_flex_grow_large_size.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; width: 100px;">

--- a/test_fixtures/flex_basis_smaller_than_content_column.html
+++ b/test_fixtures/flex_basis_smaller_than_content_column.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 100px; flex-direction: column;">

--- a/test_fixtures/flex_basis_smaller_than_content_row.html
+++ b/test_fixtures/flex_basis_smaller_than_content_row.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; width: 100px;">

--- a/test_fixtures/flex_basis_smaller_than_main_dimen_column.html
+++ b/test_fixtures/flex_basis_smaller_than_main_dimen_column.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 100px; flex-direction: column;">

--- a/test_fixtures/flex_basis_smaller_than_main_dimen_row.html
+++ b/test_fixtures/flex_basis_smaller_than_main_dimen_row.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; width: 100px;">

--- a/test_fixtures/flex_basis_smaller_then_content_with_flex_grow_large_size.html
+++ b/test_fixtures/flex_basis_smaller_then_content_with_flex_grow_large_size.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; width: 100px;">

--- a/test_fixtures/flex_basis_smaller_then_content_with_flex_grow_small_size.html
+++ b/test_fixtures/flex_basis_smaller_then_content_with_flex_grow_small_size.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; width: 10px;">

--- a/test_fixtures/flex_basis_smaller_then_content_with_flex_grow_unconstraint_size.html
+++ b/test_fixtures/flex_basis_smaller_then_content_with_flex_grow_unconstraint_size.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row;">

--- a/test_fixtures/flex_basis_smaller_then_content_with_flex_grow_very_large_size.html
+++ b/test_fixtures/flex_basis_smaller_then_content_with_flex_grow_very_large_size.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; width: 200px;">

--- a/test_fixtures/flex_basis_unconstraint_column.html
+++ b/test_fixtures/flex_basis_unconstraint_column.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: column;">

--- a/test_fixtures/flex_basis_unconstraint_row.html
+++ b/test_fixtures/flex_basis_unconstraint_row.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row;">

--- a/test_fixtures/flex_basis_zero_undefined_main_size.html
+++ b/test_fixtures/flex_basis_zero_undefined_main_size.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row;">

--- a/test_fixtures/flex_column_relative_all_sides.html
+++ b/test_fixtures/flex_column_relative_all_sides.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 100px; width: 100px;flex-direction: column;">

--- a/test_fixtures/flex_direction_column.html
+++ b/test_fixtures/flex_direction_column.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 100px; width: 100px; flex-direction: column;">

--- a/test_fixtures/flex_direction_column_no_height.html
+++ b/test_fixtures/flex_direction_column_no_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; flex-direction: column;">

--- a/test_fixtures/flex_direction_column_reverse.html
+++ b/test_fixtures/flex_direction_column_reverse.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 100px; width: 100px; flex-direction: column-reverse;">

--- a/test_fixtures/flex_direction_column_reverse_no_height.html
+++ b/test_fixtures/flex_direction_column_reverse_no_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; flex-direction: column-reverse;">

--- a/test_fixtures/flex_direction_row.html
+++ b/test_fixtures/flex_direction_row.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 100px; width: 100px;">

--- a/test_fixtures/flex_direction_row_no_width.html
+++ b/test_fixtures/flex_direction_row_no_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 100px;">

--- a/test_fixtures/flex_direction_row_reverse.html
+++ b/test_fixtures/flex_direction_row_reverse.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 100px; width: 100px; flex-direction: row-reverse;">

--- a/test_fixtures/flex_grow_child.html
+++ b/test_fixtures/flex_grow_child.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row;">

--- a/test_fixtures/flex_grow_flex_basis_percent_min_max.html
+++ b/test_fixtures/flex_grow_flex_basis_percent_min_max.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 120px; flex-direction: row;">

--- a/test_fixtures/flex_grow_height_maximized.html
+++ b/test_fixtures/flex_grow_height_maximized.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height:500px; flex-direction: column;">

--- a/test_fixtures/flex_grow_in_at_most_container.html
+++ b/test_fixtures/flex_grow_in_at_most_container.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; background-color: white; flex-direction: row; align-items: flex-start;">

--- a/test_fixtures/flex_grow_less_than_factor_one.html
+++ b/test_fixtures/flex_grow_less_than_factor_one.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 500px; height: 200px;">

--- a/test_fixtures/flex_grow_root_minimized.html
+++ b/test_fixtures/flex_grow_root_minimized.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; min-height: 100px; max-height: 500px; flex-direction: column;">

--- a/test_fixtures/flex_grow_shrink_at_most.html
+++ b/test_fixtures/flex_grow_shrink_at_most.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 100px; width: 100px;">

--- a/test_fixtures/flex_grow_to_min.html
+++ b/test_fixtures/flex_grow_to_min.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="min-height: 100px; max-height: 500px; width: 100px; flex-direction: column;">

--- a/test_fixtures/flex_grow_within_constrained_max_column.html
+++ b/test_fixtures/flex_grow_within_constrained_max_column.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="max-height: 100px; width: 100px; flex-direction: column;">

--- a/test_fixtures/flex_grow_within_constrained_max_row.html
+++ b/test_fixtures/flex_grow_within_constrained_max_row.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; flex-direction: column;">

--- a/test_fixtures/flex_grow_within_constrained_max_width.html
+++ b/test_fixtures/flex_grow_within_constrained_max_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 100px; flex-direction: column;">

--- a/test_fixtures/flex_grow_within_constrained_min_column.html
+++ b/test_fixtures/flex_grow_within_constrained_min_column.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="min-height: 100px; flex-direction: column;">

--- a/test_fixtures/flex_grow_within_constrained_min_max_column.html
+++ b/test_fixtures/flex_grow_within_constrained_min_max_column.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="min-height: 100px; max-height: 200px; flex-direction: column;">

--- a/test_fixtures/flex_grow_within_constrained_min_row.html
+++ b/test_fixtures/flex_grow_within_constrained_min_row.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="min-width: 100px; height:100px; flex-direction: row;">

--- a/test_fixtures/flex_grow_within_max_width.html
+++ b/test_fixtures/flex_grow_within_max_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 100px; flex-direction: column;">

--- a/test_fixtures/flex_root_ignored.html
+++ b/test_fixtures/flex_root_ignored.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; min-height: 100px; max-height: 500px; flex-direction: column;">

--- a/test_fixtures/flex_row_relative_all_sides.html
+++ b/test_fixtures/flex_row_relative_all_sides.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 100px; width: 100px;">

--- a/test_fixtures/flex_shrink_by_outer_margin_with_max_size.html
+++ b/test_fixtures/flex_shrink_by_outer_margin_with_max_size.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 100px; max-height: 80px; flex-direction: column;">

--- a/test_fixtures/flex_shrink_flex_grow_child_flex_shrink_other_child.html
+++ b/test_fixtures/flex_shrink_flex_grow_child_flex_shrink_other_child.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 500px; height: 500px; flex-direction: row;">

--- a/test_fixtures/flex_shrink_flex_grow_row.html
+++ b/test_fixtures/flex_shrink_flex_grow_row.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 500px; height: 500px; flex-direction: row;">

--- a/test_fixtures/flex_shrink_to_zero.html
+++ b/test_fixtures/flex_shrink_to_zero.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 75px;">

--- a/test_fixtures/flex_wrap_align_stretch_fits_one_row.html
+++ b/test_fixtures/flex_wrap_align_stretch_fits_one_row.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 150px; height: 100px; flex-wrap: wrap; flex-direction: row;">

--- a/test_fixtures/flex_wrap_children_with_min_main_overriding_flex_basis.html
+++ b/test_fixtures/flex_wrap_children_with_min_main_overriding_flex_basis.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; flex-wrap: wrap; flex-direction: row;">

--- a/test_fixtures/flex_wrap_wrap_to_child_height.html
+++ b/test_fixtures/flex_wrap_wrap_to_child_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: column;">

--- a/test_fixtures/gap_column_gap_child_margins.html
+++ b/test_fixtures/gap_column_gap_child_margins.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; width: 80px; height: 100px; column-gap: 10px;">

--- a/test_fixtures/gap_column_gap_determines_parent_width.html
+++ b/test_fixtures/gap_column_gap_determines_parent_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; height: 100px; align-items: stretch; column-gap: 10px;">

--- a/test_fixtures/gap_column_gap_flexible.html
+++ b/test_fixtures/gap_column_gap_flexible.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; width: 80px; height: 100px; column-gap: 10px; row-gap: 20px;">

--- a/test_fixtures/gap_column_gap_flexible_undefined_parent.html
+++ b/test_fixtures/gap_column_gap_flexible_undefined_parent.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; height: 100px; column-gap: 10px; row-gap: 20px;">

--- a/test_fixtures/gap_column_gap_inflexible.html
+++ b/test_fixtures/gap_column_gap_inflexible.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; width: 80px; height: 100px; column-gap: 10px;">

--- a/test_fixtures/gap_column_gap_inflexible_undefined_parent.html
+++ b/test_fixtures/gap_column_gap_inflexible_undefined_parent.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; height: 100px; column-gap: 10px;">

--- a/test_fixtures/gap_column_gap_justify_center.html
+++ b/test_fixtures/gap_column_gap_justify_center.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; justify-content: center; width: 100px; height: 100px; column-gap: 10px;">

--- a/test_fixtures/gap_column_gap_justify_flex_end.html
+++ b/test_fixtures/gap_column_gap_justify_flex_end.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; justify-content: flex-end; width: 100px; height: 100px; column-gap: 10px;">

--- a/test_fixtures/gap_column_gap_justify_flex_start.html
+++ b/test_fixtures/gap_column_gap_justify_flex_start.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; justify-content: flex-start; width: 100px; height: 100px; column-gap: 10px;">

--- a/test_fixtures/gap_column_gap_justify_space_around.html
+++ b/test_fixtures/gap_column_gap_justify_space_around.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; justify-content: space-around; width: 100px; height: 100px; column-gap: 10px;">

--- a/test_fixtures/gap_column_gap_justify_space_between.html
+++ b/test_fixtures/gap_column_gap_justify_space_between.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; justify-content: space-between; width: 100px; height: 100px; column-gap: 10px;">

--- a/test_fixtures/gap_column_gap_justify_space_evenly.html
+++ b/test_fixtures/gap_column_gap_justify_space_evenly.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; justify-content: space-evenly; width: 100px; height: 100px; column-gap: 10px;">

--- a/test_fixtures/gap_column_gap_mixed_flexible.html
+++ b/test_fixtures/gap_column_gap_mixed_flexible.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; width: 80px; height: 100px; column-gap: 10px;">

--- a/test_fixtures/gap_column_gap_percentage_cyclic_partially_shrinkable.html
+++ b/test_fixtures/gap_column_gap_percentage_cyclic_partially_shrinkable.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; column-gap: 50%;">

--- a/test_fixtures/gap_column_gap_percentage_cyclic_shrinkable.html
+++ b/test_fixtures/gap_column_gap_percentage_cyclic_shrinkable.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; column-gap: 20%;">

--- a/test_fixtures/gap_column_gap_percentage_cyclic_unshrinkable.html
+++ b/test_fixtures/gap_column_gap_percentage_cyclic_unshrinkable.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; column-gap: 20%;">

--- a/test_fixtures/gap_column_gap_percentage_flexible.html
+++ b/test_fixtures/gap_column_gap_percentage_flexible.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; width: 100px; height: 100px; column-gap: 10%; row-gap: 20px;">

--- a/test_fixtures/gap_column_gap_percentage_flexible_with_padding.html
+++ b/test_fixtures/gap_column_gap_percentage_flexible_with_padding.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; width: 100px; height: 100px; column-gap: 10%; row-gap: 20px;padding: 10px">

--- a/test_fixtures/gap_column_gap_percentage_inflexible.html
+++ b/test_fixtures/gap_column_gap_percentage_inflexible.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; width: 100px; height: 100px; column-gap: 20%;">

--- a/test_fixtures/gap_column_gap_row_gap_wrapping.html
+++ b/test_fixtures/gap_column_gap_row_gap_wrapping.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; flex-wrap: wrap; width: 80px; column-gap: 10px; row-gap: 20px;">

--- a/test_fixtures/gap_column_gap_wrap_align_center.html
+++ b/test_fixtures/gap_column_gap_wrap_align_center.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; flex-wrap: wrap; align-content: center; width: 100px; height: 100px; column-gap: 10px; row-gap: 20px;">

--- a/test_fixtures/gap_column_gap_wrap_align_flex_end.html
+++ b/test_fixtures/gap_column_gap_wrap_align_flex_end.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; flex-wrap: wrap; align-content: flex-end; width: 100px; height: 100px; column-gap: 10px; row-gap: 20px;">

--- a/test_fixtures/gap_column_gap_wrap_align_flex_start.html
+++ b/test_fixtures/gap_column_gap_wrap_align_flex_start.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; flex-wrap: wrap; align-content: flex-start; width: 100px; height: 100px; column-gap: 10px; row-gap: 20px;">

--- a/test_fixtures/gap_column_gap_wrap_align_space_around.html
+++ b/test_fixtures/gap_column_gap_wrap_align_space_around.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; flex-wrap: wrap; align-content: space-around; width: 100px; height: 100px; column-gap: 10px; row-gap: 20px;">

--- a/test_fixtures/gap_column_gap_wrap_align_space_between.html
+++ b/test_fixtures/gap_column_gap_wrap_align_space_between.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; flex-wrap: wrap; align-content: space-between; width: 100px; height: 100px; column-gap: 10px; row-gap: 20px;">

--- a/test_fixtures/gap_column_gap_wrap_align_stretch.html
+++ b/test_fixtures/gap_column_gap_wrap_align_stretch.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; flex-wrap: wrap; width: 300px; height: 300px; column-gap: 5px; align-content: stretch;">

--- a/test_fixtures/gap_column_row_gap_wrapping.html
+++ b/test_fixtures/gap_column_row_gap_wrapping.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; flex-wrap: wrap; width: 80px; column-gap: 10px; row-gap: 20px;">

--- a/test_fixtures/gap_percentage_row_gap_wrapping.html
+++ b/test_fixtures/gap_percentage_row_gap_wrapping.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; flex-wrap: wrap; width: 80px; column-gap: 10px; row-gap: 10%;">

--- a/test_fixtures/gap_row_gap_align_items_end.html
+++ b/test_fixtures/gap_row_gap_align_items_end.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; flex-wrap: wrap; width: 100px; height: 200px; column-gap: 10px; row-gap: 20px; align-items:flex-end;">

--- a/test_fixtures/gap_row_gap_align_items_stretch.html
+++ b/test_fixtures/gap_row_gap_align_items_stretch.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; flex-wrap: wrap; width: 100px; height: 200px; column-gap: 10px; row-gap: 20px; align-items:stretch; align-content: stretch">

--- a/test_fixtures/gap_row_gap_column_child_margins.html
+++ b/test_fixtures/gap_row_gap_column_child_margins.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: column; width: 100px; height: 200px; row-gap: 10px;">

--- a/test_fixtures/gap_row_gap_determines_parent_height.html
+++ b/test_fixtures/gap_row_gap_determines_parent_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: column; width: 100px; align-items: stretch; row-gap: 10px;">

--- a/test_fixtures/gap_row_gap_row_wrap_child_margins.html
+++ b/test_fixtures/gap_row_gap_row_wrap_child_margins.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; flex-wrap: wrap; width: 100px; height: 200px; row-gap: 10px;">

--- a/test_fixtures/grid_absolute_align_self_sized_all.html
+++ b/test_fixtures/grid_absolute_align_self_sized_all.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 120px; width: 120px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;">

--- a/test_fixtures/grid_absolute_column_end.html
+++ b/test_fixtures/grid_absolute_column_end.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;padding: 10px 20px 30px 40px">

--- a/test_fixtures/grid_absolute_column_start.html
+++ b/test_fixtures/grid_absolute_column_start.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;padding: 10px 20px 30px 40px">

--- a/test_fixtures/grid_absolute_container_bottom_left.html
+++ b/test_fixtures/grid_absolute_container_bottom_left.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;padding: 10px 20px 30px 40px">

--- a/test_fixtures/grid_absolute_container_bottom_left_margin.html
+++ b/test_fixtures/grid_absolute_container_bottom_left_margin.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;padding: 10px 20px 30px 40px">

--- a/test_fixtures/grid_absolute_container_left_overrides_right.html
+++ b/test_fixtures/grid_absolute_container_left_overrides_right.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;padding: 10px 20px 30px 40px">

--- a/test_fixtures/grid_absolute_container_left_right.html
+++ b/test_fixtures/grid_absolute_container_left_right.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;padding: 10px 20px 30px 40px">

--- a/test_fixtures/grid_absolute_container_left_right_margin.html
+++ b/test_fixtures/grid_absolute_container_left_right_margin.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;padding: 10px 20px 30px 40px">

--- a/test_fixtures/grid_absolute_container_left_right_margin.html
+++ b/test_fixtures/grid_absolute_container_left_right_margin.html
@@ -16,7 +16,7 @@
     background-color: red;
     right: 2px;
     left: 5px;
-    margin: 1px 2p 3px 4px;
+    margin: 1px 2px 3px 4px;
   "></div>
   <div></div>
   <div></div>

--- a/test_fixtures/grid_absolute_container_negative_position.html
+++ b/test_fixtures/grid_absolute_container_negative_position.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;padding: 10px 20px 30px 40px">

--- a/test_fixtures/grid_absolute_container_negative_position_margin.html
+++ b/test_fixtures/grid_absolute_container_negative_position_margin.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;padding: 10px 20px 30px 40px">

--- a/test_fixtures/grid_absolute_container_negative_position_margin.html
+++ b/test_fixtures/grid_absolute_container_negative_position_margin.html
@@ -16,7 +16,7 @@
     background-color: red;
     right: -15px;
     top: -5px;
-    margin: 1px 2p 3px 4px;
+    margin: 1px 2px 3px 4px;
   "></div>
   <div style="
     position: absolute;
@@ -24,7 +24,7 @@
     background-color: red;
     bottom: -25px;
     left: -35px;
-    margin: 1px 2p 3px 4px;
+    margin: 1px 2px 3px 4px;
   "></div>
   <div></div>
   <div></div>

--- a/test_fixtures/grid_absolute_container_top_bottom.html
+++ b/test_fixtures/grid_absolute_container_top_bottom.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;padding: 10px 20px 30px 40px">

--- a/test_fixtures/grid_absolute_container_top_bottom_margin.html
+++ b/test_fixtures/grid_absolute_container_top_bottom_margin.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;padding: 10px 20px 30px 40px">

--- a/test_fixtures/grid_absolute_container_top_bottom_margin.html
+++ b/test_fixtures/grid_absolute_container_top_bottom_margin.html
@@ -16,7 +16,7 @@
     background-color: red;
     top: 2px;
     bottom: 5px;
-    margin: 1px 2p 3px 4px;
+    margin: 1px 2px 3px 4px;
   "></div>
   <div></div>
   <div></div>

--- a/test_fixtures/grid_absolute_container_top_right.html
+++ b/test_fixtures/grid_absolute_container_top_right.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;padding: 10px 20px 30px 40px">

--- a/test_fixtures/grid_absolute_container_top_right_margin.html
+++ b/test_fixtures/grid_absolute_container_top_right_margin.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;padding: 10px 20px 30px 40px">

--- a/test_fixtures/grid_absolute_container_top_right_margin.html
+++ b/test_fixtures/grid_absolute_container_top_right_margin.html
@@ -16,7 +16,7 @@
     background-color: red;
     right: 0;
     top: 0;
-    margin: 1px 2p 3px 4px;
+    margin: 1px 2px 3px 4px;
   "></div>
   <div></div>
   <div></div>

--- a/test_fixtures/grid_absolute_justify_self_sized_all.html
+++ b/test_fixtures/grid_absolute_justify_self_sized_all.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 120px; width: 120px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;">

--- a/test_fixtures/grid_absolute_layout_within_border.html
+++ b/test_fixtures/grid_absolute_layout_within_border.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid;height: 100px; width: 100px; border-width: 10px; padding: 10px;">

--- a/test_fixtures/grid_absolute_layout_within_border_static.html
+++ b/test_fixtures/grid_absolute_layout_within_border_static.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid;height: 100px; width: 100px; border-width: 10px; padding: 10px;">

--- a/test_fixtures/grid_absolute_row_end.html
+++ b/test_fixtures/grid_absolute_row_end.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;padding: 10px 20px 30px 40px">

--- a/test_fixtures/grid_absolute_row_start.html
+++ b/test_fixtures/grid_absolute_row_start.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;padding: 10px 20px 30px 40px">

--- a/test_fixtures/grid_absolute_top_overrides_bottom.html
+++ b/test_fixtures/grid_absolute_top_overrides_bottom.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;padding: 10px 20px 30px 40px">

--- a/test_fixtures/grid_absolute_with_padding.html
+++ b/test_fixtures/grid_absolute_with_padding.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;padding: 10px 20px 30px 40px">

--- a/test_fixtures/grid_absolute_with_padding_and_margin.html
+++ b/test_fixtures/grid_absolute_with_padding_and_margin.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;padding: 10px 20px 30px 40px">

--- a/test_fixtures/grid_absolute_with_padding_and_margin.html
+++ b/test_fixtures/grid_absolute_with_padding_and_margin.html
@@ -16,7 +16,7 @@
     background-color: red;
     right: 0;
     top: 0;
-    margin: 1px 2p 3px 4px;
+    margin: 1px 2px 3px 4px;
   "></div>
   <div style="
     position: absolute;
@@ -24,7 +24,7 @@
     background-color: red;
     bottom: 10px;
     left: 10px;
-    margin: 1px 2p 3px 4px;
+    margin: 1px 2px 3px 4px;
   "></div>
   <div></div>
   <div></div>

--- a/test_fixtures/grid_align_content_center.html
+++ b/test_fixtures/grid_align_content_center.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 200px; width: 200px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;align-content: center">

--- a/test_fixtures/grid_align_content_end.html
+++ b/test_fixtures/grid_align_content_end.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 200px; width: 200px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;align-content: end">

--- a/test_fixtures/grid_align_content_end_with_padding_border.html
+++ b/test_fixtures/grid_align_content_end_with_padding_border.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 200px; width: 200px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;align-content: end;padding: 10px 20px 30px 40px;border-width: 2px 4px 6px 8px;">

--- a/test_fixtures/grid_align_content_space_around.html
+++ b/test_fixtures/grid_align_content_space_around.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 200px; width: 200px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;align-content: space-around;">

--- a/test_fixtures/grid_align_content_space_around_with_padding_border.html
+++ b/test_fixtures/grid_align_content_space_around_with_padding_border.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 200px; width: 200px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;align-content: space-around;padding: 10px 20px 30px 40px;border-width: 2px 4px 6px 8px;">

--- a/test_fixtures/grid_align_content_space_between.html
+++ b/test_fixtures/grid_align_content_space_between.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 200px; width: 200px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;align-content: space-between;">

--- a/test_fixtures/grid_align_content_space_between_with_padding_border.html
+++ b/test_fixtures/grid_align_content_space_between_with_padding_border.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 200px; width: 200px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;align-content: space-between;padding: 10px 20px 30px 40px;border-width: 2px 4px 6px 8px;">

--- a/test_fixtures/grid_align_content_space_evenly.html
+++ b/test_fixtures/grid_align_content_space_evenly.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 200px; width: 200px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;align-content: space-evenly;">

--- a/test_fixtures/grid_align_content_space_evenly_with_padding_border.html
+++ b/test_fixtures/grid_align_content_space_evenly_with_padding_border.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 200px; width: 200px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;align-content: space-evenly;padding: 10px 20px 30px 40px;border-width: 2px 4px 6px 8px;">

--- a/test_fixtures/grid_align_content_start.html
+++ b/test_fixtures/grid_align_content_start.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 200px; width: 200px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;align-content: start">

--- a/test_fixtures/grid_align_content_start_with_padding_border.html
+++ b/test_fixtures/grid_align_content_start_with_padding_border.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 200px; width: 200px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;align-content: start;padding: 10px 20px 30px 40px;border-width: 2px 4px 6px 8px;">

--- a/test_fixtures/grid_align_items_baseline.html
+++ b/test_fixtures/grid_align_items_baseline.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display:grid;width: 100px; height: 100px; align-items: baseline;">

--- a/test_fixtures/grid_align_items_baseline_child.html
+++ b/test_fixtures/grid_align_items_baseline_child.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display:grid;width: 100px; height: 100px;align-items: baseline;">

--- a/test_fixtures/grid_align_items_baseline_child_margin.html
+++ b/test_fixtures/grid_align_items_baseline_child_margin.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display:grid;width: 100px; height: 100px; align-items: baseline;">

--- a/test_fixtures/grid_align_items_baseline_child_margin_percent.html
+++ b/test_fixtures/grid_align_items_baseline_child_margin_percent.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display:grid;width: 100px; height: 100px;align-items: baseline;">

--- a/test_fixtures/grid_align_items_baseline_child_multiline.html
+++ b/test_fixtures/grid_align_items_baseline_child_multiline.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display:grid;width: 100px; align-items: baseline;">

--- a/test_fixtures/grid_align_items_baseline_child_multiline_no_override_on_secondline.html
+++ b/test_fixtures/grid_align_items_baseline_child_multiline_no_override_on_secondline.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display:grid;width: 100px; height: 100px;align-items: baseline;">

--- a/test_fixtures/grid_align_items_baseline_child_multiline_override.html
+++ b/test_fixtures/grid_align_items_baseline_child_multiline_override.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display:grid;width: 100px; height: 100px;align-items: baseline;">

--- a/test_fixtures/grid_align_items_baseline_child_padding.html
+++ b/test_fixtures/grid_align_items_baseline_child_padding.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid;width: 100px; height: 100px; padding:5px; align-items: baseline;">

--- a/test_fixtures/grid_align_items_baseline_child_top.html
+++ b/test_fixtures/grid_align_items_baseline_child_top.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid;width: 100px; height: 100px;align-items: baseline;">

--- a/test_fixtures/grid_align_items_baseline_child_top2.html
+++ b/test_fixtures/grid_align_items_baseline_child_top2.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid;width: 100px; height: 100px;align-items: baseline;">

--- a/test_fixtures/grid_align_items_baseline_complex.html
+++ b/test_fixtures/grid_align_items_baseline_complex.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 120px; width: 120px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;align-items: baseline;">

--- a/test_fixtures/grid_align_items_baseline_double_nested_child.html
+++ b/test_fixtures/grid_align_items_baseline_double_nested_child.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid;width: 100px; height: 100px;align-items: baseline;">

--- a/test_fixtures/grid_align_items_baseline_multiline.html
+++ b/test_fixtures/grid_align_items_baseline_multiline.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid;grid-template-columns: auto auto;width: 100px; height: 100px; align-items: baseline;">

--- a/test_fixtures/grid_align_items_baseline_multiline_column.html
+++ b/test_fixtures/grid_align_items_baseline_multiline_column.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid;grid-template-columns: auto auto;width: 100px; height: 100px;align-items: baseline;">

--- a/test_fixtures/grid_align_items_baseline_multiline_row_and_column.html
+++ b/test_fixtures/grid_align_items_baseline_multiline_row_and_column.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid;grid-template-columns: auto auto;width: 100px; height: 100px;align-items: baseline;">

--- a/test_fixtures/grid_align_items_baseline_nested_column.html
+++ b/test_fixtures/grid_align_items_baseline_nested_column.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid;width: 100px; height: 100px; align-items: baseline;">

--- a/test_fixtures/grid_align_items_sized_center.html
+++ b/test_fixtures/grid_align_items_sized_center.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 120px; width: 120px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;align-items: center;">

--- a/test_fixtures/grid_align_items_sized_end.html
+++ b/test_fixtures/grid_align_items_sized_end.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 120px; width: 120px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;align-items: end;">

--- a/test_fixtures/grid_align_items_sized_start.html
+++ b/test_fixtures/grid_align_items_sized_start.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 120px; width: 120px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;align-items: start;">

--- a/test_fixtures/grid_align_items_sized_stretch.html
+++ b/test_fixtures/grid_align_items_sized_stretch.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 120px; width: 120px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;align-items: stretch;">

--- a/test_fixtures/grid_align_self_sized_all.html
+++ b/test_fixtures/grid_align_self_sized_all.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 120px; width: 120px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;">

--- a/test_fixtures/grid_aspect_ratio_absolute_aspect_ratio_overrides_height_of_full_inset.html
+++ b/test_fixtures/grid_aspect_ratio_absolute_aspect_ratio_overrides_height_of_full_inset.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; width: 400px; height: 300px;">

--- a/test_fixtures/grid_aspect_ratio_absolute_fill_height_from_inset.html
+++ b/test_fixtures/grid_aspect_ratio_absolute_fill_height_from_inset.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; width: 400px; height: 300px;">

--- a/test_fixtures/grid_aspect_ratio_absolute_fill_width_from_inset.html
+++ b/test_fixtures/grid_aspect_ratio_absolute_fill_width_from_inset.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex; width: 400px; height: 300px;">

--- a/test_fixtures/grid_aspect_ratio_absolute_height_overrides_inset.html
+++ b/test_fixtures/grid_aspect_ratio_absolute_height_overrides_inset.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex; width: 400px; height: 300px;">

--- a/test_fixtures/grid_aspect_ratio_absolute_width_overrides_inset.html
+++ b/test_fixtures/grid_aspect_ratio_absolute_width_overrides_inset.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; width: 400px; height: 300px;">

--- a/test_fixtures/grid_aspect_ratio_child_fill_content_height.html
+++ b/test_fixtures/grid_aspect_ratio_child_fill_content_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid">

--- a/test_fixtures/grid_aspect_ratio_child_fill_content_width.html
+++ b/test_fixtures/grid_aspect_ratio_child_fill_content_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid">

--- a/test_fixtures/grid_aspect_ratio_fill_child_height.html
+++ b/test_fixtures/grid_aspect_ratio_fill_child_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid;height: 100px; width: 100px;">

--- a/test_fixtures/grid_aspect_ratio_fill_child_max_height.html
+++ b/test_fixtures/grid_aspect_ratio_fill_child_max_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid;height: 100px; width: 100px;">

--- a/test_fixtures/grid_aspect_ratio_fill_child_max_width.html
+++ b/test_fixtures/grid_aspect_ratio_fill_child_max_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid;height: 100px; width: 100px;">

--- a/test_fixtures/grid_aspect_ratio_fill_child_min_height.html
+++ b/test_fixtures/grid_aspect_ratio_fill_child_min_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid;height: 100px; width: 100px;">

--- a/test_fixtures/grid_aspect_ratio_fill_child_min_width.html
+++ b/test_fixtures/grid_aspect_ratio_fill_child_min_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid;height: 100px; width: 100px;">

--- a/test_fixtures/grid_aspect_ratio_fill_child_width.html
+++ b/test_fixtures/grid_aspect_ratio_fill_child_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid;height: 100px; width: 100px;">

--- a/test_fixtures/grid_aspect_ratio_overriden_by_explicit_sizes.html
+++ b/test_fixtures/grid_aspect_ratio_overriden_by_explicit_sizes.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid;height: 100px; width: 100px;">

--- a/test_fixtures/grid_aspect_ratio_overriden_by_explicit_sizes_flex.html
+++ b/test_fixtures/grid_aspect_ratio_overriden_by_explicit_sizes_flex.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid;height: 100px; width: 100px;">

--- a/test_fixtures/grid_auto_columns_fixed_width.html
+++ b/test_fixtures/grid_auto_columns_fixed_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px;height:200px;display: grid; grid-template-columns: 40px auto 40px auto;grid-template-rows: 40px auto 40px auto;">

--- a/test_fixtures/grid_auto_fill_fixed_size.html
+++ b/test_fixtures/grid_auto_fill_fixed_size.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 120px; width: 120px; display: grid; grid-template-columns: 40px repeat(auto-fill, 40px);grid-template-rows: 40px 40px 40px;">

--- a/test_fixtures/grid_auto_fill_with_empty_auto_track.html
+++ b/test_fixtures/grid_auto_fill_with_empty_auto_track.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 120px; width: 120px; display: grid; grid-template-columns: repeat(auto-fill, 40px);grid-template-rows: 40px 40px 40px;justify-content: space-evenly;">

--- a/test_fixtures/grid_auto_fit_with_empty_auto_track.html
+++ b/test_fixtures/grid_auto_fit_with_empty_auto_track.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 120px; width: 120px; display: grid; grid-template-columns: repeat(auto-fit, 40px);grid-template-rows: 40px 40px 40px;justify-content: space-evenly;">

--- a/test_fixtures/grid_auto_single_item.html
+++ b/test_fixtures/grid_auto_single_item.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px auto 40px;grid-template-rows: 40px 40px 40px">

--- a/test_fixtures/grid_auto_single_item_fixed_width.html
+++ b/test_fixtures/grid_auto_single_item_fixed_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px;display: grid; grid-template-columns: 40px auto auto;grid-template-rows: 40px 40px 40px">

--- a/test_fixtures/grid_auto_single_item_fixed_width_with_definite_width.html
+++ b/test_fixtures/grid_auto_single_item_fixed_width_with_definite_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px;display: grid; grid-template-columns: 40px auto auto;grid-template-rows: 40px 40px 40px">

--- a/test_fixtures/grid_auto_takes_precedence_over_fr.html
+++ b/test_fixtures/grid_auto_takes_precedence_over_fr.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px;height: 200px;display: grid; grid-template-columns: auto 1fr;grid-template-rows: 40px">

--- a/test_fixtures/grid_basic.html
+++ b/test_fixtures/grid_basic.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 120px; width: 120px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;">

--- a/test_fixtures/grid_basic_implicit_tracks.html
+++ b/test_fixtures/grid_basic_implicit_tracks.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px;grid-template-rows: 40px;">

--- a/test_fixtures/grid_basic_with_overflow.html
+++ b/test_fixtures/grid_basic_with_overflow.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 120px; width: 120px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;">

--- a/test_fixtures/grid_basic_with_padding.html
+++ b/test_fixtures/grid_basic_with_padding.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;padding: 10px 20px 30px 40px">

--- a/test_fixtures/grid_display_none_fixed_size.html
+++ b/test_fixtures/grid_display_none_fixed_size.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; display: grid;">

--- a/test_fixtures/grid_fit_content_percent_definite_argument.html
+++ b/test_fixtures/grid_fit_content_percent_definite_argument.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; width: 60px; grid-template-columns: fit-content(50%);grid-template-rows: 40px">

--- a/test_fixtures/grid_fit_content_percent_definite_max_content.html
+++ b/test_fixtures/grid_fit_content_percent_definite_max_content.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; width: 60px; grid-template-columns: fit-content(50%);grid-template-rows: 40px">

--- a/test_fixtures/grid_fit_content_percent_definite_min_content.html
+++ b/test_fixtures/grid_fit_content_percent_definite_min_content.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; width: 60px; grid-template-columns: fit-content(50%);grid-template-rows: 40px">

--- a/test_fixtures/grid_fit_content_percent_indefinite_argument.html
+++ b/test_fixtures/grid_fit_content_percent_indefinite_argument.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: fit-content(50%);grid-template-rows: 40px">

--- a/test_fixtures/grid_fit_content_percent_indefinite_max_content.html
+++ b/test_fixtures/grid_fit_content_percent_indefinite_max_content.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: fit-content(50%);grid-template-rows: 40px">

--- a/test_fixtures/grid_fit_content_percent_indefinite_min_content.html
+++ b/test_fixtures/grid_fit_content_percent_indefinite_min_content.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: fit-content(50%);grid-template-rows: 40px">

--- a/test_fixtures/grid_fit_content_points_argument.html
+++ b/test_fixtures/grid_fit_content_points_argument.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: fit-content(30px);grid-template-rows: 40px">

--- a/test_fixtures/grid_fit_content_points_max_content.html
+++ b/test_fixtures/grid_fit_content_points_max_content.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: fit-content(30px);grid-template-rows: 40px">

--- a/test_fixtures/grid_fit_content_points_min_content.html
+++ b/test_fixtures/grid_fit_content_points_min_content.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: fit-content(30px);grid-template-rows: 40px">

--- a/test_fixtures/grid_fr_fixed_size_no_content_proportions.html
+++ b/test_fixtures/grid_fr_fixed_size_no_content_proportions.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px;display: grid; grid-template-columns: 1fr 2fr 3fr;grid-template-rows: 40px">

--- a/test_fixtures/grid_fr_fixed_size_no_content_proportions_sub_1_sum.html
+++ b/test_fixtures/grid_fr_fixed_size_no_content_proportions_sub_1_sum.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px;display: grid; grid-template-columns: 0.3fr 0.2fr;grid-template-rows: 40px">

--- a/test_fixtures/grid_fr_fixed_size_single_item.html
+++ b/test_fixtures/grid_fr_fixed_size_single_item.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px;height: 200px;display: grid; grid-template-columns: 40px 1fr 1fr;grid-template-rows: 40px 1fr 1fr">

--- a/test_fixtures/grid_fr_no_sized_items_indefinite.html
+++ b/test_fixtures/grid_fr_no_sized_items_indefinite.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px 1fr 1fr;grid-template-rows: 40px 1fr 1fr">

--- a/test_fixtures/grid_fr_single_item_indefinite.html
+++ b/test_fixtures/grid_fr_single_item_indefinite.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: auto;height: auto;display: grid; grid-template-columns: 40px 1fr 1fr;grid-template-rows: 40px 1fr 1fr">

--- a/test_fixtures/grid_fr_span_2_proportion.html
+++ b/test_fixtures/grid_fr_span_2_proportion.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 1fr 2fr;grid-template-rows: 40px 40px">

--- a/test_fixtures/grid_fr_span_2_proportion_sub_1_sum.html
+++ b/test_fixtures/grid_fr_span_2_proportion_sub_1_sum.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 0.2fr 0.3fr;grid-template-rows: 40px 40px">

--- a/test_fixtures/grid_fr_span_2_proportion_with_non_spanned_track.html
+++ b/test_fixtures/grid_fr_span_2_proportion_with_non_spanned_track.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 1fr 2fr 3fr;grid-template-rows: 40px 40px">

--- a/test_fixtures/grid_fr_span_2_proportion_zero_sum.html
+++ b/test_fixtures/grid_fr_span_2_proportion_zero_sum.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 0fr 0fr;grid-template-rows: 40px 40px">

--- a/test_fixtures/grid_fr_span_2_proportion_zero_sum_with_non_spanned_track.html
+++ b/test_fixtures/grid_fr_span_2_proportion_zero_sum_with_non_spanned_track.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 0fr 0fr 0fr;grid-template-rows: 40px 40px">

--- a/test_fixtures/grid_gap.html
+++ b/test_fixtures/grid_gap.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 200px; width: 200px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;gap: 40px 40px">

--- a/test_fixtures/grid_hidden.html
+++ b/test_fixtures/grid_hidden.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 120px; width: 120px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;">

--- a/test_fixtures/grid_justify_content_center.html
+++ b/test_fixtures/grid_justify_content_center.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 200px; width: 200px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;justify-content: center">

--- a/test_fixtures/grid_justify_content_center_with_padding_border.html
+++ b/test_fixtures/grid_justify_content_center_with_padding_border.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 200px; width: 200px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;justify-content: center;padding: 10px 20px 30px 40px;border-width: 2px 4px 6px 8px;">

--- a/test_fixtures/grid_justify_content_end.html
+++ b/test_fixtures/grid_justify_content_end.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 200px; width: 200px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;justify-content: end">

--- a/test_fixtures/grid_justify_content_end_with_padding_border.html
+++ b/test_fixtures/grid_justify_content_end_with_padding_border.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 200px; width: 200px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;justify-content: end;padding: 10px 20px 30px 40px;border-width: 2px 4px 6px 8px;">

--- a/test_fixtures/grid_justify_content_space_around.html
+++ b/test_fixtures/grid_justify_content_space_around.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 200px; width: 200px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;justify-content: space-around;">

--- a/test_fixtures/grid_justify_content_space_around_with_padding_border.html
+++ b/test_fixtures/grid_justify_content_space_around_with_padding_border.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 200px; width: 200px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;justify-content: space-around;padding: 10px 20px 30px 40px;border-width: 2px 4px 6px 8px;">

--- a/test_fixtures/grid_justify_content_space_between.html
+++ b/test_fixtures/grid_justify_content_space_between.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 200px; width: 200px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;justify-content: space-between;">

--- a/test_fixtures/grid_justify_content_space_between_with_padding_border.html
+++ b/test_fixtures/grid_justify_content_space_between_with_padding_border.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 200px; width: 200px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;justify-content: space-between;padding: 10px 20px 30px 40px;border-width: 2px 4px 6px 8px;">

--- a/test_fixtures/grid_justify_content_space_evenly.html
+++ b/test_fixtures/grid_justify_content_space_evenly.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 200px; width: 200px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;justify-content: space-evenly;">

--- a/test_fixtures/grid_justify_content_space_evenly_with_padding_border.html
+++ b/test_fixtures/grid_justify_content_space_evenly_with_padding_border.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 200px; width: 200px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;justify-content: space-evenly;padding: 10px 20px 30px 40px;border-width: 2px 4px 6px 8px;">

--- a/test_fixtures/grid_justify_content_start.html
+++ b/test_fixtures/grid_justify_content_start.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 200px; width: 200px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;justify-content: start">

--- a/test_fixtures/grid_justify_content_start_with_padding_border.html
+++ b/test_fixtures/grid_justify_content_start_with_padding_border.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 200px; width: 200px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;justify-content: start;padding: 10px 20px 30px 40px;border-width: 2px 4px 6px 8px;">

--- a/test_fixtures/grid_justify_items_sized_center.html
+++ b/test_fixtures/grid_justify_items_sized_center.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 120px; width: 120px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;justify-items: center;">

--- a/test_fixtures/grid_justify_items_sized_end.html
+++ b/test_fixtures/grid_justify_items_sized_end.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 120px; width: 120px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;justify-items: end;">

--- a/test_fixtures/grid_justify_items_sized_start.html
+++ b/test_fixtures/grid_justify_items_sized_start.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 120px; width: 120px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;justify-items: start;">

--- a/test_fixtures/grid_justify_items_sized_stretch.html
+++ b/test_fixtures/grid_justify_items_sized_stretch.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 120px; width: 120px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;justify-items: stretch;">

--- a/test_fixtures/grid_justify_self_sized_all.html
+++ b/test_fixtures/grid_justify_self_sized_all.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 120px; width: 120px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;">

--- a/test_fixtures/grid_margins_auto_margins.html
+++ b/test_fixtures/grid_margins_auto_margins.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;padding: 10px 20px 30px 40px">

--- a/test_fixtures/grid_margins_auto_margins_override_stretch.html
+++ b/test_fixtures/grid_margins_auto_margins_override_stretch.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;padding: 10px 20px 30px 40px">

--- a/test_fixtures/grid_margins_fixed_center.html
+++ b/test_fixtures/grid_margins_fixed_center.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;padding: 10px 20px 30px 40px">

--- a/test_fixtures/grid_margins_fixed_end.html
+++ b/test_fixtures/grid_margins_fixed_end.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;padding: 10px 20px 30px 40px">

--- a/test_fixtures/grid_margins_fixed_start.html
+++ b/test_fixtures/grid_margins_fixed_start.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;padding: 10px 20px 30px 40px">

--- a/test_fixtures/grid_margins_fixed_stretch.html
+++ b/test_fixtures/grid_margins_fixed_stretch.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;padding: 10px 20px 30px 40px">

--- a/test_fixtures/grid_margins_percent_center.html
+++ b/test_fixtures/grid_margins_percent_center.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 20px 20px 20px;grid-template-rows: 40px 40px 40px;">

--- a/test_fixtures/grid_margins_percent_end.html
+++ b/test_fixtures/grid_margins_percent_end.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 20px 20px 20px;grid-template-rows: 40px 40px 40px;">

--- a/test_fixtures/grid_margins_percent_start.html
+++ b/test_fixtures/grid_margins_percent_start.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 20px 20px 20px;grid-template-rows: 40px 40px 40px;">

--- a/test_fixtures/grid_margins_percent_stretch.html
+++ b/test_fixtures/grid_margins_percent_stretch.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 20px 20px 20px;grid-template-rows: 40px 40px 40px;">

--- a/test_fixtures/grid_max_content_maximum_single_item.html
+++ b/test_fixtures/grid_max_content_maximum_single_item.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px minmax(0px, max-content) 40px;grid-template-rows: 40px 40px 40px">

--- a/test_fixtures/grid_max_content_single_item.html
+++ b/test_fixtures/grid_max_content_single_item.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px max-content 40px;grid-template-rows: 40px 40px 40px">

--- a/test_fixtures/grid_max_content_single_item_margin_auto.html
+++ b/test_fixtures/grid_max_content_single_item_margin_auto.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px max-content 40px;grid-template-rows: 40px 40px 40px">

--- a/test_fixtures/grid_max_content_single_item_margin_fixed.html
+++ b/test_fixtures/grid_max_content_single_item_margin_fixed.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px max-content 40px;grid-template-rows: 40px 40px 40px">

--- a/test_fixtures/grid_max_content_single_item_margin_percent.html
+++ b/test_fixtures/grid_max_content_single_item_margin_percent.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px max-content 40px;grid-template-rows: 40px 40px 40px">

--- a/test_fixtures/grid_max_content_single_item_span_2.html
+++ b/test_fixtures/grid_max_content_single_item_span_2.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px max-content max-content;grid-template-rows: 40px 40px 40px">

--- a/test_fixtures/grid_max_content_single_item_span_2_gap_fixed.html
+++ b/test_fixtures/grid_max_content_single_item_span_2_gap_fixed.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px max-content max-content;grid-template-rows: 40px 40px 40px; column-gap: 20px">

--- a/test_fixtures/grid_max_content_single_item_span_2_gap_percent_definite.html
+++ b/test_fixtures/grid_max_content_single_item_span_2_gap_percent_definite.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px max-content max-content;grid-template-rows: 40px 40px 40px; column-gap: 20%;width:100px">

--- a/test_fixtures/grid_max_content_single_item_span_2_gap_percent_indefinite.html
+++ b/test_fixtures/grid_max_content_single_item_span_2_gap_percent_indefinite.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px max-content max-content;grid-template-rows: 40px 40px 40px; column-gap: 20%">

--- a/test_fixtures/grid_min_content_flex_column.html
+++ b/test_fixtures/grid_min_content_flex_column.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: min-content;grid-template-rows: 40px">

--- a/test_fixtures/grid_min_content_flex_row.html
+++ b/test_fixtures/grid_min_content_flex_row.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: min-content;grid-template-rows: 40px">

--- a/test_fixtures/grid_min_content_flex_single_item.html
+++ b/test_fixtures/grid_min_content_flex_single_item.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px min-content 1fr;grid-template-rows: 40px 40px 40px">

--- a/test_fixtures/grid_min_content_flex_single_item_margin_auto.html
+++ b/test_fixtures/grid_min_content_flex_single_item_margin_auto.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px min-content 1fr;grid-template-rows: 40px 40px 40px">

--- a/test_fixtures/grid_min_content_flex_single_item_margin_fixed.html
+++ b/test_fixtures/grid_min_content_flex_single_item_margin_fixed.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px min-content 1fr;grid-template-rows: 40px 40px 40px">

--- a/test_fixtures/grid_min_content_flex_single_item_margin_percent.html
+++ b/test_fixtures/grid_min_content_flex_single_item_margin_percent.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px min-content 1fr;grid-template-rows: 40px 40px 40px">

--- a/test_fixtures/grid_min_content_maximum_single_item.html
+++ b/test_fixtures/grid_min_content_maximum_single_item.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px minmax(0px, min-content) 40px;grid-template-rows: 40px 40px 40px">

--- a/test_fixtures/grid_min_content_single_item.html
+++ b/test_fixtures/grid_min_content_single_item.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px min-content 40px;grid-template-rows: 40px 40px 40px">

--- a/test_fixtures/grid_minmax_auto_fixed_10px.html
+++ b/test_fixtures/grid_minmax_auto_fixed_10px.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: minmax(auto, 10px);grid-template-rows: 40px">

--- a/test_fixtures/grid_minmax_auto_max_content.html
+++ b/test_fixtures/grid_minmax_auto_max_content.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: minmax(auto, max-content);grid-template-rows: 40px">

--- a/test_fixtures/grid_minmax_auto_min_content.html
+++ b/test_fixtures/grid_minmax_auto_min_content.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: minmax(auto, min-content);grid-template-rows: 40px">

--- a/test_fixtures/grid_minmax_auto_percent_definite.html
+++ b/test_fixtures/grid_minmax_auto_percent_definite.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid;width:100px;grid-template-columns: minmax(auto, 20%);grid-template-rows: 40px">

--- a/test_fixtures/grid_minmax_auto_percent_indefinite.html
+++ b/test_fixtures/grid_minmax_auto_percent_indefinite.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: minmax(auto, 20%);grid-template-rows: 40px">

--- a/test_fixtures/grid_minmax_column_fixed_width_above_range.html
+++ b/test_fixtures/grid_minmax_column_fixed_width_above_range.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 140px; display: grid; grid-template-columns: 40px minmax(20px, 40px) 40px;grid-template-rows: 40px 40px 40px;">

--- a/test_fixtures/grid_minmax_column_fixed_width_below_range.html
+++ b/test_fixtures/grid_minmax_column_fixed_width_below_range.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 90px; display: grid; grid-template-columns: 40px minmax(20px, 40px) 40px;grid-template-rows: 40px 40px 40px;">

--- a/test_fixtures/grid_minmax_column_fixed_width_within_range.html
+++ b/test_fixtures/grid_minmax_column_fixed_width_within_range.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 110px; display: grid; grid-template-columns: 40px minmax(20px, 40px) 40px;grid-template-rows: 40px 40px 40px;">

--- a/test_fixtures/grid_minmax_column_indefinite.html
+++ b/test_fixtures/grid_minmax_column_indefinite.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40px minmax(20px, 40px) 40px;grid-template-rows: 40px 40px 40px;">

--- a/test_fixtures/grid_minmax_column_with_auto_fixed.html
+++ b/test_fixtures/grid_minmax_column_with_auto_fixed.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 60px;display: grid; grid-template-columns: minmax(20px, 40px) auto;grid-template-rows: 40px">

--- a/test_fixtures/grid_minmax_column_with_fr_fixed.html
+++ b/test_fixtures/grid_minmax_column_with_fr_fixed.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 60px;display: grid; grid-template-columns: minmax(20px, 40px) 1fr;grid-template-rows: 40px">

--- a/test_fixtures/grid_minmax_max_content_1fr.html
+++ b/test_fixtures/grid_minmax_max_content_1fr.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: minmax(max-content, 1fr);grid-template-rows: 40px">

--- a/test_fixtures/grid_minmax_max_content_auto.html
+++ b/test_fixtures/grid_minmax_max_content_auto.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: minmax(max-content, auto);grid-template-rows: 40px">

--- a/test_fixtures/grid_minmax_max_content_fixed_10px.html
+++ b/test_fixtures/grid_minmax_max_content_fixed_10px.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: minmax(max-content, 10px);grid-template-rows: 40px">

--- a/test_fixtures/grid_minmax_max_content_min_content.html
+++ b/test_fixtures/grid_minmax_max_content_min_content.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: minmax(max-content, min-content);grid-template-rows: 40px">

--- a/test_fixtures/grid_minmax_max_content_percent_definite.html
+++ b/test_fixtures/grid_minmax_max_content_percent_definite.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid;width:100px;grid-template-columns: minmax(max-content, 20%);grid-template-rows: 40px">

--- a/test_fixtures/grid_minmax_max_content_percent_indefinite.html
+++ b/test_fixtures/grid_minmax_max_content_percent_indefinite.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: minmax(max-content, 20%);grid-template-rows: 40px">

--- a/test_fixtures/grid_minmax_min_content_1fr.html
+++ b/test_fixtures/grid_minmax_min_content_1fr.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: minmax(min-content, 1fr);grid-template-rows: 40px">

--- a/test_fixtures/grid_minmax_min_content_auto.html
+++ b/test_fixtures/grid_minmax_min_content_auto.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: minmax(min-content, auto);grid-template-rows: 40px">

--- a/test_fixtures/grid_minmax_min_content_fixed_10px.html
+++ b/test_fixtures/grid_minmax_min_content_fixed_10px.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: minmax(min-content, 10px);grid-template-rows: 40px">

--- a/test_fixtures/grid_minmax_min_content_max_content.html
+++ b/test_fixtures/grid_minmax_min_content_max_content.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: minmax(min-content, max-content);grid-template-rows: 40px">

--- a/test_fixtures/grid_minmax_min_content_percent_definite.html
+++ b/test_fixtures/grid_minmax_min_content_percent_definite.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid;width:100px;grid-template-columns: minmax(min-content, 20%);grid-template-rows: 40px">

--- a/test_fixtures/grid_minmax_min_content_percent_indefinite.html
+++ b/test_fixtures/grid_minmax_min_content_percent_indefinite.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: minmax(min-content, 20%);grid-template-rows: 40px">

--- a/test_fixtures/grid_out_of_order_items.html
+++ b/test_fixtures/grid_out_of_order_items.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 120px; width: 120px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;grid-auto-flow: row dense;">

--- a/test_fixtures/grid_overflow_rows.html
+++ b/test_fixtures/grid_overflow_rows.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="

--- a/test_fixtures/grid_padding_border_overrides_container_max_size.html
+++ b/test_fixtures/grid_padding_border_overrides_container_max_size.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid;max-width: 12px; max-height: 12px;padding:2px 4px 6px 8px;border-width: 1px 3px 5px 7px;border-style:solid;border-color:red">

--- a/test_fixtures/grid_padding_border_overrides_container_size.html
+++ b/test_fixtures/grid_padding_border_overrides_container_size.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid;width: 12px; height: 12px;padding:2px 4px 6px 8px;border-width: 1px 3px 5px 7px;border-style:solid;border-color:red solid red">

--- a/test_fixtures/grid_padding_border_overrides_container_size.html
+++ b/test_fixtures/grid_padding_border_overrides_container_size.html
@@ -9,7 +9,7 @@
 </head>
 <body>
 
-<div id="test-root" style="display: grid;width: 12px; height: 12px;padding:2px 4px 6px 8px;border-width: 1px 3px 5px 7px;border-style:solid;border-color:red solid red">
+<div id="test-root" style="display: grid;width: 12px; height: 12px;padding:2px 4px 6px 8px;border-width: 1px 3px 5px 7px;border-style:solid;border-color:red">
   <div></div>
 </div>
 

--- a/test_fixtures/grid_padding_border_overrides_max_size.html
+++ b/test_fixtures/grid_padding_border_overrides_max_size.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display:grid">

--- a/test_fixtures/grid_padding_border_overrides_min_size.html
+++ b/test_fixtures/grid_padding_border_overrides_min_size.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid">

--- a/test_fixtures/grid_padding_border_overrides_size.html
+++ b/test_fixtures/grid_padding_border_overrides_size.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid">

--- a/test_fixtures/grid_percent_item_inside_stretch_item.html
+++ b/test_fixtures/grid_percent_item_inside_stretch_item.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display:grid;width: 100px; height: 100px;">

--- a/test_fixtures/grid_percent_items_nested_inside_stretch_alignment.html
+++ b/test_fixtures/grid_percent_items_nested_inside_stretch_alignment.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display:grid;width: 200px;">

--- a/test_fixtures/grid_percent_items_nested_moderate.html
+++ b/test_fixtures/grid_percent_items_nested_moderate.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" data-test-rounding="false" style="display: grid;width: 200px;padding: 3px;">

--- a/test_fixtures/grid_percent_items_nested_with_margin.html
+++ b/test_fixtures/grid_percent_items_nested_with_margin.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid;width: 200px;">

--- a/test_fixtures/grid_percent_items_nested_with_padding_margin.html
+++ b/test_fixtures/grid_percent_items_nested_with_padding_margin.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display:grid;width: 200px; height: 200px;grid-template-rows: 1fr 4fr;">

--- a/test_fixtures/grid_percent_items_width_and_margin.html
+++ b/test_fixtures/grid_percent_items_width_and_margin.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid;width: 200px;padding: 3px;">

--- a/test_fixtures/grid_percent_items_width_and_padding.html
+++ b/test_fixtures/grid_percent_items_width_and_padding.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid;width: 200px;">

--- a/test_fixtures/grid_percent_tracks_definite_overflow.html
+++ b/test_fixtures/grid_percent_tracks_definite_overflow.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 60px; width: 120px; display: grid; grid-template-columns: 40% 40% 40%;grid-template-rows: 50% 80%;">

--- a/test_fixtures/grid_percent_tracks_definite_underflow.html
+++ b/test_fixtures/grid_percent_tracks_definite_underflow.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 60px; width: 120px; display: grid; grid-template-columns: 10% 20% 30%;grid-template-rows: 30% 60%;">

--- a/test_fixtures/grid_percent_tracks_indefinite_only.html
+++ b/test_fixtures/grid_percent_tracks_indefinite_only.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 10% 20% 30%;grid-template-rows: 30% 60%;">

--- a/test_fixtures/grid_percent_tracks_indefinite_with_content_overflow.html
+++ b/test_fixtures/grid_percent_tracks_indefinite_with_content_overflow.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 40% 40% 40%;grid-template-rows: 50% 80%;">

--- a/test_fixtures/grid_percent_tracks_indefinite_with_content_underflow.html
+++ b/test_fixtures/grid_percent_tracks_indefinite_with_content_underflow.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 10% 20% 30%;grid-template-rows: 30% 60%;">

--- a/test_fixtures/grid_placement_auto_negative.html
+++ b/test_fixtures/grid_placement_auto_negative.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 120px; width: 120px; display: grid; grid-template-columns: 40px 40px;grid-template-rows: 40px 40px;">

--- a/test_fixtures/grid_placement_definite_in_secondary_axis_with_fully_definite_negative.html
+++ b/test_fixtures/grid_placement_definite_in_secondary_axis_with_fully_definite_negative.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 120px; width: 120px; display: grid; grid-template-columns: 40px 40px;grid-template-rows: 40px 40px;">

--- a/test_fixtures/grid_relative_all_sides.html
+++ b/test_fixtures/grid_relative_all_sides.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid;height: 100px; width: 100px;">

--- a/test_fixtures/grid_relayout_vertical_text.html
+++ b/test_fixtures/grid_relayout_vertical_text.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
   <div id="test-root" style="display: grid;grid-template-columns: min-content;grid-template-rows: 40px;">

--- a/test_fixtures/grid_repeat_integer.html
+++ b/test_fixtures/grid_repeat_integer.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 120px; width: 120px; display: grid; grid-template-columns: repeat(3, 40px);grid-template-rows: repeat(3, 40px)">

--- a/test_fixtures/grid_repeat_mixed.html
+++ b/test_fixtures/grid_repeat_mixed.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 120px; width: 120px; display: grid; grid-template-columns: 40px repeat(1, 40px) repeat(auto-fill, 40px);grid-template-rows: 40px repeat(1, 40px) repeat(auto-fill, 40px)">

--- a/test_fixtures/grid_size_child_fixed_tracks.html
+++ b/test_fixtures/grid_size_child_fixed_tracks.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 120px; width: 120px; display: grid; grid-template-columns: 40px 40px 40px;grid-template-rows: 40px 40px 40px;">

--- a/test_fixtures/grid_span_13_most_non_flex_with_minmax_indefinite.html
+++ b/test_fixtures/grid_span_13_most_non_flex_with_minmax_indefinite.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="

--- a/test_fixtures/grid_span_2_max_content_auto_indefinite.html
+++ b/test_fixtures/grid_span_2_max_content_auto_indefinite.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns:max-content auto;grid-template-rows: 40px">

--- a/test_fixtures/grid_span_2_max_content_fit_content_10px_indefinite.html
+++ b/test_fixtures/grid_span_2_max_content_fit_content_10px_indefinite.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns:max-content fit-content(10px);grid-template-rows: 40px">

--- a/test_fixtures/grid_span_2_max_content_fit_content_80px_indefinite.html
+++ b/test_fixtures/grid_span_2_max_content_fit_content_80px_indefinite.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns:max-content fit-content(80px);grid-template-rows: 40px">

--- a/test_fixtures/grid_span_2_max_content_max_content_indefinite.html
+++ b/test_fixtures/grid_span_2_max_content_max_content_indefinite.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns:max-content max-content;grid-template-rows: 40px">

--- a/test_fixtures/grid_span_2_min_content_auto_indefinite.html
+++ b/test_fixtures/grid_span_2_min_content_auto_indefinite.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns:min-content auto;grid-template-rows: 40px">

--- a/test_fixtures/grid_span_2_min_content_fit_content_10px_indefinite.html
+++ b/test_fixtures/grid_span_2_min_content_fit_content_10px_indefinite.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns:min-content fit-content(10px);grid-template-rows: 40px">

--- a/test_fixtures/grid_span_2_min_content_fit_content_30px_indefinite.html
+++ b/test_fixtures/grid_span_2_min_content_fit_content_30px_indefinite.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns:min-content fit-content(30px);grid-template-rows: 40px">

--- a/test_fixtures/grid_span_2_min_content_fit_content_80px_indefinite.html
+++ b/test_fixtures/grid_span_2_min_content_fit_content_80px_indefinite.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns:min-content fit-content(80px);grid-template-rows: 40px">

--- a/test_fixtures/grid_span_2_min_content_max_content_indefinite.html
+++ b/test_fixtures/grid_span_2_min_content_max_content_indefinite.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns:min-content max-content;grid-template-rows: 40px">

--- a/test_fixtures/grid_span_2_min_content_min_content_indefinite.html
+++ b/test_fixtures/grid_span_2_min_content_min_content_indefinite.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns:min-content min-content;grid-template-rows: 40px">

--- a/test_fixtures/grid_span_6_all_non_flex_indefinite.html
+++ b/test_fixtures/grid_span_6_all_non_flex_indefinite.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns:min-content max-content fit-content(20px) auto 10px 20%;grid-template-rows: 40px 40px">

--- a/test_fixtures/grid_span_8_all_track_types_indefinite.html
+++ b/test_fixtures/grid_span_8_all_track_types_indefinite.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns:min-content max-content fit-content(20px) auto 10px 20% 1fr 2fr;grid-template-rows: 40px 40px">

--- a/test_fixtures/gridflex_column_integration.html
+++ b/test_fixtures/gridflex_column_integration.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: column;">

--- a/test_fixtures/gridflex_kitchen_sink.html
+++ b/test_fixtures/gridflex_kitchen_sink.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root">

--- a/test_fixtures/gridflex_kitchen_sink_minimise.html
+++ b/test_fixtures/gridflex_kitchen_sink_minimise.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root">

--- a/test_fixtures/gridflex_kitchen_sink_minimise2.html
+++ b/test_fixtures/gridflex_kitchen_sink_minimise2.html
@@ -9,7 +9,7 @@
 </head>
 <body>
 
-<div id="test-root"style="width: 50px;flex-grow: 1">
+<div id="test-root" style="width: 50px;flex-grow: 1">
   <div style="display: grid; grid-template-columns: auto;grid-template-rows:auto">
     <div style="height:20px;width: 20px"></div>
   </div>

--- a/test_fixtures/gridflex_kitchen_sink_minimise2.html
+++ b/test_fixtures/gridflex_kitchen_sink_minimise2.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root"style="width: 50px;flex-grow: 1">

--- a/test_fixtures/gridflex_kitchen_sink_minimise3.html
+++ b/test_fixtures/gridflex_kitchen_sink_minimise3.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 50px;">

--- a/test_fixtures/gridflex_row_integration.html
+++ b/test_fixtures/gridflex_row_integration.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root">

--- a/test_fixtures/intrinsic_sizing_cross_size_column.html
+++ b/test_fixtures/intrinsic_sizing_cross_size_column.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: column;">HH&ZeroWidthSpace;HH</div>

--- a/test_fixtures/intrinsic_sizing_main_size_column.html
+++ b/test_fixtures/intrinsic_sizing_main_size_column.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: column;writing-mode: vertical-lr;">HH&ZeroWidthSpace;HH</div>

--- a/test_fixtures/intrinsic_sizing_main_size_column_nested.html
+++ b/test_fixtures/intrinsic_sizing_main_size_column_nested.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: column;">

--- a/test_fixtures/intrinsic_sizing_main_size_column_wrap.html
+++ b/test_fixtures/intrinsic_sizing_main_size_column_wrap.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-wrap:wrap;flex-direction: column;">

--- a/test_fixtures/intrinsic_sizing_main_size_row.html
+++ b/test_fixtures/intrinsic_sizing_main_size_row.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root">HH&ZeroWidthSpace;HH</div>

--- a/test_fixtures/intrinsic_sizing_main_size_row_nested.html
+++ b/test_fixtures/intrinsic_sizing_main_size_row_nested.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root">

--- a/test_fixtures/intrinsic_sizing_main_size_row_wrap.html
+++ b/test_fixtures/intrinsic_sizing_main_size_row_wrap.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-wrap:wrap">

--- a/test_fixtures/justify_content_column_center.html
+++ b/test_fixtures/justify_content_column_center.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; justify-content: center; flex-direction: column;">

--- a/test_fixtures/justify_content_column_flex_end.html
+++ b/test_fixtures/justify_content_column_flex_end.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; justify-content: flex-end; flex-direction: column;">

--- a/test_fixtures/justify_content_column_flex_start.html
+++ b/test_fixtures/justify_content_column_flex_start.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; justify-content: flex-start; flex-direction: column;">

--- a/test_fixtures/justify_content_column_max_height_and_margin.html
+++ b/test_fixtures/justify_content_column_max_height_and_margin.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <!-- this test has an extra node compared to the yoga version because yoga's gentest script wraps places the test

--- a/test_fixtures/justify_content_column_min_height_and_margin.html
+++ b/test_fixtures/justify_content_column_min_height_and_margin.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <!-- this test has an extra node compared to the yoga version because yoga's gentest script wraps places the test

--- a/test_fixtures/justify_content_column_min_height_and_margin_bottom.html
+++ b/test_fixtures/justify_content_column_min_height_and_margin_bottom.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="min-height: 50px; justify-content: center; flex-direction: column;">

--- a/test_fixtures/justify_content_column_min_height_and_margin_top.html
+++ b/test_fixtures/justify_content_column_min_height_and_margin_top.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="min-height: 50px; justify-content: center; flex-direction: column;">

--- a/test_fixtures/justify_content_column_space_around.html
+++ b/test_fixtures/justify_content_column_space_around.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; justify-content: space-around; flex-direction: column;">

--- a/test_fixtures/justify_content_column_space_between.html
+++ b/test_fixtures/justify_content_column_space_between.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; justify-content: space-between; flex-direction: column;">

--- a/test_fixtures/justify_content_column_space_evenly.html
+++ b/test_fixtures/justify_content_column_space_evenly.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; justify-content: space-evenly; flex-direction: column;">

--- a/test_fixtures/justify_content_min_max.html
+++ b/test_fixtures/justify_content_min_max.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="max-height: 200px; min-height: 100px; width: 100px; justify-content: center; flex-direction: column;">

--- a/test_fixtures/justify_content_min_width_with_padding_child_width_greater_than_parent.html
+++ b/test_fixtures/justify_content_min_width_with_padding_child_width_greater_than_parent.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 1000px; height: 1584px; align-content: stretch; flex-direction: column;">

--- a/test_fixtures/justify_content_min_width_with_padding_child_width_lower_than_parent.html
+++ b/test_fixtures/justify_content_min_width_with_padding_child_width_lower_than_parent.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 1080px; height: 1584px; align-content: stretch; flex-direction: column;">

--- a/test_fixtures/justify_content_overflow_min_max.html
+++ b/test_fixtures/justify_content_overflow_min_max.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="min-height: 100px; max-height: 110px; justify-content: center; flex-direction: column;">

--- a/test_fixtures/justify_content_row_center.html
+++ b/test_fixtures/justify_content_row_center.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: row; justify-content: center;">

--- a/test_fixtures/justify_content_row_flex_end.html
+++ b/test_fixtures/justify_content_row_flex_end.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: row; justify-content: flex-end;">

--- a/test_fixtures/justify_content_row_flex_start.html
+++ b/test_fixtures/justify_content_row_flex_start.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: row; justify-content: flex-start;">

--- a/test_fixtures/justify_content_row_max_width_and_margin.html
+++ b/test_fixtures/justify_content_row_max_width_and_margin.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; max-width: 80px; justify-content: center; flex-direction: row;">

--- a/test_fixtures/justify_content_row_min_width_and_margin.html
+++ b/test_fixtures/justify_content_row_min_width_and_margin.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="min-width: 50px; justify-content: center; flex-direction: row;">

--- a/test_fixtures/justify_content_row_space_around.html
+++ b/test_fixtures/justify_content_row_space_around.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: row; justify-content: space-around;">

--- a/test_fixtures/justify_content_row_space_between.html
+++ b/test_fixtures/justify_content_row_space_between.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: row; justify-content: space-between;">

--- a/test_fixtures/justify_content_row_space_evenly.html
+++ b/test_fixtures/justify_content_row_space_evenly.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; justify-content: space-evenly; flex-direction: row; ">

--- a/test_fixtures/leaf_padding_border_overrides_max_size.html
+++ b/test_fixtures/leaf_padding_border_overrides_max_size.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="max-width: 12px; max-height: 12px;padding:2px 4px 6px 8px;border-width: 1px 3px 5px 7px;border-style:solid;border-color:red"></div>

--- a/test_fixtures/leaf_padding_border_overrides_min_size.html
+++ b/test_fixtures/leaf_padding_border_overrides_min_size.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="min-width: 0px; min-height: 0px;padding:2px 4px 6px 8px;border-width: 1px 3px 5px 7px;border-style:solid;border-color:red"></div>

--- a/test_fixtures/leaf_padding_border_overrides_size.html
+++ b/test_fixtures/leaf_padding_border_overrides_size.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 12px; height: 12px;padding:2px 4px 6px 8px;border-width: 1px 3px 5px 7px;border-style:solid;border-color:red"></div>

--- a/test_fixtures/margin_and_flex_column.html
+++ b/test_fixtures/margin_and_flex_column.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: column;">

--- a/test_fixtures/margin_and_flex_row.html
+++ b/test_fixtures/margin_and_flex_row.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: row;">

--- a/test_fixtures/margin_and_stretch_column.html
+++ b/test_fixtures/margin_and_stretch_column.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: column;">

--- a/test_fixtures/margin_and_stretch_row.html
+++ b/test_fixtures/margin_and_stretch_row.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: row;">

--- a/test_fixtures/margin_auto_bottom.html
+++ b/test_fixtures/margin_auto_bottom.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 200px; align-items: center;">

--- a/test_fixtures/margin_auto_bottom_and_top.html
+++ b/test_fixtures/margin_auto_bottom_and_top.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 200px; align-items: center;">

--- a/test_fixtures/margin_auto_bottom_and_top_justify_center.html
+++ b/test_fixtures/margin_auto_bottom_and_top_justify_center.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 200px; justify-content: center;">

--- a/test_fixtures/margin_auto_left.html
+++ b/test_fixtures/margin_auto_left.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 200px; align-items: center;">

--- a/test_fixtures/margin_auto_left_and_right.html
+++ b/test_fixtures/margin_auto_left_and_right.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 200px; ">

--- a/test_fixtures/margin_auto_left_and_right_column.html
+++ b/test_fixtures/margin_auto_left_and_right_column.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 200px; align-items: center; flex-direction: row;">

--- a/test_fixtures/margin_auto_left_and_right_column_and_center.html
+++ b/test_fixtures/margin_auto_left_and_right_column_and_center.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 200px; align-items: center;">

--- a/test_fixtures/margin_auto_left_and_right_stretch.html
+++ b/test_fixtures/margin_auto_left_and_right_stretch.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 200px; flex-direction:row; align-items: stretch;">

--- a/test_fixtures/margin_auto_left_child_bigger_than_parent.html
+++ b/test_fixtures/margin_auto_left_child_bigger_than_parent.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 52px; width: 52px; justify-content: center;">

--- a/test_fixtures/margin_auto_left_fix_right_child_bigger_than_parent.html
+++ b/test_fixtures/margin_auto_left_fix_right_child_bigger_than_parent.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 52px; width: 52px; justify-content: center;">

--- a/test_fixtures/margin_auto_left_right_child_bigger_than_parent.html
+++ b/test_fixtures/margin_auto_left_right_child_bigger_than_parent.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 52px; width: 52px; justify-content: center;">

--- a/test_fixtures/margin_auto_left_stretching_child.html
+++ b/test_fixtures/margin_auto_left_stretching_child.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 200px; align-items: center;">

--- a/test_fixtures/margin_auto_mutiple_children_column.html
+++ b/test_fixtures/margin_auto_mutiple_children_column.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 200px; flex-direction: column; align-items: center;">

--- a/test_fixtures/margin_auto_mutiple_children_row.html
+++ b/test_fixtures/margin_auto_mutiple_children_row.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 200px; flex-direction:row; align-items: center;">

--- a/test_fixtures/margin_auto_right.html
+++ b/test_fixtures/margin_auto_right.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 200px; align-items: center;">

--- a/test_fixtures/margin_auto_top.html
+++ b/test_fixtures/margin_auto_top.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 200px; align-items: center;">

--- a/test_fixtures/margin_auto_top_and_bottom_stretch.html
+++ b/test_fixtures/margin_auto_top_and_bottom_stretch.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 200px; flex-direction: column; align-items: stretch;">

--- a/test_fixtures/margin_auto_top_stretching_child.html
+++ b/test_fixtures/margin_auto_top_stretching_child.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 200px; align-items: center;">

--- a/test_fixtures/margin_bottom.html
+++ b/test_fixtures/margin_bottom.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; justify-content: flex-end; flex-direction: column;">

--- a/test_fixtures/margin_fix_left_auto_right_child_bigger_than_parent.html
+++ b/test_fixtures/margin_fix_left_auto_right_child_bigger_than_parent.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 52px; width: 52px; justify-content: center;">

--- a/test_fixtures/margin_left.html
+++ b/test_fixtures/margin_left.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: row;">

--- a/test_fixtures/margin_right.html
+++ b/test_fixtures/margin_right.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: row; justify-content: flex-end;">

--- a/test_fixtures/margin_should_not_be_part_of_max_height.html
+++ b/test_fixtures/margin_should_not_be_part_of_max_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 250px; height: 250px;">

--- a/test_fixtures/margin_should_not_be_part_of_max_width.html
+++ b/test_fixtures/margin_should_not_be_part_of_max_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 250px; height: 250px;">

--- a/test_fixtures/margin_top.html
+++ b/test_fixtures/margin_top.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: column;">

--- a/test_fixtures/margin_with_sibling_column.html
+++ b/test_fixtures/margin_with_sibling_column.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: column;">

--- a/test_fixtures/margin_with_sibling_row.html
+++ b/test_fixtures/margin_with_sibling_row.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: row;">

--- a/test_fixtures/max_height.html
+++ b/test_fixtures/max_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: row;">

--- a/test_fixtures/max_height_overrides_height.html
+++ b/test_fixtures/max_height_overrides_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root">

--- a/test_fixtures/max_height_overrides_height_on_root.html
+++ b/test_fixtures/max_height_overrides_height_on_root.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="max-height: 100px; height: 200px;"></div>

--- a/test_fixtures/max_width.html
+++ b/test_fixtures/max_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: column;">

--- a/test_fixtures/max_width_overrides_width.html
+++ b/test_fixtures/max_width_overrides_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root">

--- a/test_fixtures/max_width_overrides_width_on_root.html
+++ b/test_fixtures/max_width_overrides_width_on_root.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="max-width: 100px; width: 200px;">

--- a/test_fixtures/measure_child.html
+++ b/test_fixtures/measure_child.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root">

--- a/test_fixtures/measure_child_absolute.html
+++ b/test_fixtures/measure_child_absolute.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px;height: 100px">

--- a/test_fixtures/measure_child_constraint.html
+++ b/test_fixtures/measure_child_constraint.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width:50px; height: auto;">

--- a/test_fixtures/measure_child_constraint_padding_parent.html
+++ b/test_fixtures/measure_child_constraint_padding_parent.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width:50px; height: auto;padding: 10px">

--- a/test_fixtures/measure_child_with_flex_grow.html
+++ b/test_fixtures/measure_child_with_flex_grow.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width:100px; height: auto">

--- a/test_fixtures/measure_child_with_flex_shrink.html
+++ b/test_fixtures/measure_child_with_flex_shrink.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width:100px; height: auto">

--- a/test_fixtures/measure_child_with_min_size_greater_than_available_space.html
+++ b/test_fixtures/measure_child_with_min_size_greater_than_available_space.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex; flex-direction: column; width: 100px;">

--- a/test_fixtures/measure_flex_basis_overrides_measure.html
+++ b/test_fixtures/measure_flex_basis_overrides_measure.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 50px;height: 50px;">

--- a/test_fixtures/measure_height_overrides_measure.html
+++ b/test_fixtures/measure_height_overrides_measure.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root">

--- a/test_fixtures/measure_remeasure_child_after_growing.html
+++ b/test_fixtures/measure_remeasure_child_after_growing.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width:100px; height: auto;align-items: start;">

--- a/test_fixtures/measure_remeasure_child_after_shrinking.html
+++ b/test_fixtures/measure_remeasure_child_after_shrinking.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width:100px; height: auto;align-items: start;">

--- a/test_fixtures/measure_remeasure_child_after_stretching.html
+++ b/test_fixtures/measure_remeasure_child_after_stretching.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width:100px; height: 100px;">

--- a/test_fixtures/measure_root.html
+++ b/test_fixtures/measure_root.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root">HHHHHH</div>

--- a/test_fixtures/measure_stretch_overrides_measure.html
+++ b/test_fixtures/measure_stretch_overrides_measure.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 20px;height: 10px;">

--- a/test_fixtures/measure_width_overrides_measure.html
+++ b/test_fixtures/measure_width_overrides_measure.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root">

--- a/test_fixtures/min_height.html
+++ b/test_fixtures/min_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: column;">

--- a/test_fixtures/min_height_larger_than_height.html
+++ b/test_fixtures/min_height_larger_than_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: row;">

--- a/test_fixtures/min_height_overrides_height.html
+++ b/test_fixtures/min_height_overrides_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root">

--- a/test_fixtures/min_height_overrides_height_on_root.html
+++ b/test_fixtures/min_height_overrides_height_on_root.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="min-height: 100px; height: 50px;">

--- a/test_fixtures/min_height_overrides_max_height.html
+++ b/test_fixtures/min_height_overrides_max_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root">

--- a/test_fixtures/min_height_with_nested_fixed_height.html
+++ b/test_fixtures/min_height_with_nested_fixed_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 320px; min-height: 44px; flex-direction: row; padding-left: 16px; padding-right: 16px;">

--- a/test_fixtures/min_max_percent_different_width_height.html
+++ b/test_fixtures/min_max_percent_different_width_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: column;width: 100px; height: 200px; align-items: flex-start;">

--- a/test_fixtures/min_max_percent_no_width_height.html
+++ b/test_fixtures/min_max_percent_no_width_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; align-items: flex-start; flex-direction: column;">

--- a/test_fixtures/min_width.html
+++ b/test_fixtures/min_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: row">

--- a/test_fixtures/min_width_larger_than_width.html
+++ b/test_fixtures/min_width_larger_than_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: column;width: 100px; height: 100px;">

--- a/test_fixtures/min_width_overrides_max_width.html
+++ b/test_fixtures/min_width_overrides_max_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root">

--- a/test_fixtures/min_width_overrides_width.html
+++ b/test_fixtures/min_width_overrides_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root">

--- a/test_fixtures/min_width_overrides_width_on_root.html
+++ b/test_fixtures/min_width_overrides_width_on_root.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="min-width: 100px; width: 50px;">

--- a/test_fixtures/nested_overflowing_child.html
+++ b/test_fixtures/nested_overflowing_child.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 100px; width: 100px;">

--- a/test_fixtures/nested_overflowing_child_in_constraint_parent.html
+++ b/test_fixtures/nested_overflowing_child_in_constraint_parent.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 100px; width: 100px;">

--- a/test_fixtures/only_shrinkable_item_with_flex_basis_zero.html
+++ b/test_fixtures/only_shrinkable_item_with_flex_basis_zero.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: column; width: 480px; max-height: 764px;">

--- a/test_fixtures/overflow_cross_axis.html
+++ b/test_fixtures/overflow_cross_axis.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width:100px; height: 100px;">

--- a/test_fixtures/overflow_main_axis.html
+++ b/test_fixtures/overflow_main_axis.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width:100px; height: 100px;">

--- a/test_fixtures/padding_align_end_child.html
+++ b/test_fixtures/padding_align_end_child.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 200px; justify-content: flex-end; align-items: flex-end;">

--- a/test_fixtures/padding_border_overrides_max_size.html
+++ b/test_fixtures/padding_border_overrides_max_size.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root">

--- a/test_fixtures/padding_border_overrides_min_size.html
+++ b/test_fixtures/padding_border_overrides_min_size.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root">

--- a/test_fixtures/padding_border_overrides_size.html
+++ b/test_fixtures/padding_border_overrides_size.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root">

--- a/test_fixtures/padding_border_overrides_size_flex_basis_0.html
+++ b/test_fixtures/padding_border_overrides_size_flex_basis_0.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root">

--- a/test_fixtures/padding_border_overrides_size_flex_basis_0_growable.html
+++ b/test_fixtures/padding_border_overrides_size_flex_basis_0_growable.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root">

--- a/test_fixtures/padding_center_child.html
+++ b/test_fixtures/padding_center_child.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; padding-left: 10px; padding-top: 10px; padding-right: 20px; padding-bottom: 20px; align-items: center; justify-content: center;">

--- a/test_fixtures/padding_container_match_child.html
+++ b/test_fixtures/padding_container_match_child.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: column;padding: 10px;">

--- a/test_fixtures/padding_flex_child.html
+++ b/test_fixtures/padding_flex_child.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; padding: 10px;">

--- a/test_fixtures/padding_no_child.html
+++ b/test_fixtures/padding_no_child.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="padding: 10px;">

--- a/test_fixtures/padding_no_size.html
+++ b/test_fixtures/padding_no_size.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="padding: 10px;"></div>

--- a/test_fixtures/padding_stretch_child.html
+++ b/test_fixtures/padding_stretch_child.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; padding: 10px;">

--- a/test_fixtures/parent_wrap_child_size_overflowing_parent.html
+++ b/test_fixtures/parent_wrap_child_size_overflowing_parent.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px;">

--- a/test_fixtures/percent_absolute_position.html
+++ b/test_fixtures/percent_absolute_position.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 60px; height: 50px; flex-direction: column;">

--- a/test_fixtures/percent_within_flex_grow.html
+++ b/test_fixtures/percent_within_flex_grow.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction:row; width: 350px; height: 100px;">

--- a/test_fixtures/percentage_absolute_position.html
+++ b/test_fixtures/percentage_absolute_position.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 100px; flex-direction: column;">

--- a/test_fixtures/percentage_container_in_wrapping_container.html
+++ b/test_fixtures/percentage_container_in_wrapping_container.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="align-items: center; width: 200px; height: 200px; justify-content: center; flex-direction: column;">

--- a/test_fixtures/percentage_different_width_height.html
+++ b/test_fixtures/percentage_different_width_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 300px; flex-direction: row;">

--- a/test_fixtures/percentage_different_width_height_column.html
+++ b/test_fixtures/percentage_different_width_height_column.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 300px; flex-direction: column;">

--- a/test_fixtures/percentage_flex_basis.html
+++ b/test_fixtures/percentage_flex_basis.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 200px; flex-direction: row;">

--- a/test_fixtures/percentage_flex_basis_cross.html
+++ b/test_fixtures/percentage_flex_basis_cross.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 400px; flex-direction: column;">

--- a/test_fixtures/percentage_flex_basis_cross_max_height.html
+++ b/test_fixtures/percentage_flex_basis_cross_max_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 400px; flex-direction: column;">

--- a/test_fixtures/percentage_flex_basis_cross_max_width.html
+++ b/test_fixtures/percentage_flex_basis_cross_max_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 400px; flex-direction: column;">

--- a/test_fixtures/percentage_flex_basis_cross_min_height.html
+++ b/test_fixtures/percentage_flex_basis_cross_min_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 400px; flex-direction: column;">

--- a/test_fixtures/percentage_flex_basis_cross_min_width.html
+++ b/test_fixtures/percentage_flex_basis_cross_min_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 400px; flex-direction: column;">

--- a/test_fixtures/percentage_flex_basis_main_max_height.html
+++ b/test_fixtures/percentage_flex_basis_main_max_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 400px; flex-direction: row;">

--- a/test_fixtures/percentage_flex_basis_main_max_width.html
+++ b/test_fixtures/percentage_flex_basis_main_max_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 400px; flex-direction: row;">

--- a/test_fixtures/percentage_flex_basis_main_min_width.html
+++ b/test_fixtures/percentage_flex_basis_main_min_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 400px; flex-direction: row;">

--- a/test_fixtures/percentage_main_max_height.html
+++ b/test_fixtures/percentage_main_max_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: column;width: 71px;">

--- a/test_fixtures/percentage_margin_should_calculate_based_only_on_width.html
+++ b/test_fixtures/percentage_margin_should_calculate_based_only_on_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 100px; flex-direction: column;">

--- a/test_fixtures/percentage_moderate_complexity.html
+++ b/test_fixtures/percentage_moderate_complexity.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" data-test-rounding="false" style="display: flex;flex-direction:column;width: 200px;padding: 3px;">

--- a/test_fixtures/percentage_moderate_complexity2.html
+++ b/test_fixtures/percentage_moderate_complexity2.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 200px; flex-direction: column;">

--- a/test_fixtures/percentage_multiple_nested_with_padding_margin_and_percentage_values.html
+++ b/test_fixtures/percentage_multiple_nested_with_padding_margin_and_percentage_values.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 200px; flex-direction: column;">

--- a/test_fixtures/percentage_padding_should_calculate_based_only_on_width.html
+++ b/test_fixtures/percentage_padding_should_calculate_based_only_on_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 100px; flex-direction: column;">

--- a/test_fixtures/percentage_position_bottom_right.html
+++ b/test_fixtures/percentage_position_bottom_right.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 500px; height: 500px; flex-direction: row;">

--- a/test_fixtures/percentage_position_left_top.html
+++ b/test_fixtures/percentage_position_left_top.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 400px; height: 400px; flex-direction: row;">

--- a/test_fixtures/percentage_size_based_on_parent_inner_size.html
+++ b/test_fixtures/percentage_size_based_on_parent_inner_size.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 400px; padding: 20px; flex-direction: column;">

--- a/test_fixtures/percentage_size_of_flex_basis.html
+++ b/test_fixtures/percentage_size_of_flex_basis.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; width: 100px;">

--- a/test_fixtures/percentage_width_height.html
+++ b/test_fixtures/percentage_width_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 400px; flex-direction: row;">

--- a/test_fixtures/percentage_width_height_undefined_parent_size.html
+++ b/test_fixtures/percentage_width_height_undefined_parent_size.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: column;">

--- a/test_fixtures/position_root_with_rtl_should_position_withoutdirection.html
+++ b/test_fixtures/position_root_with_rtl_should_position_withoutdirection.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <!-- this test has an extra node compared to the yoga version because yoga's gentest script wraps places the test

--- a/test_fixtures/relative_position_should_not_nudge_siblings.html
+++ b/test_fixtures/relative_position_should_not_nudge_siblings.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 100px; width: 100px; flex-direction: column;">

--- a/test_fixtures/rounding_flex_basis_flex_grow_row_prime_number_width.html
+++ b/test_fixtures/rounding_flex_basis_flex_grow_row_prime_number_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 113px; height: 100px; flex-direction: row;">

--- a/test_fixtures/rounding_flex_basis_flex_grow_row_width_of_100.html
+++ b/test_fixtures/rounding_flex_basis_flex_grow_row_width_of_100.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: row;">

--- a/test_fixtures/rounding_flex_basis_flex_shrink_row.html
+++ b/test_fixtures/rounding_flex_basis_flex_shrink_row.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 101px; height: 100px; flex-direction: row;">

--- a/test_fixtures/rounding_flex_basis_overrides_main_size.html
+++ b/test_fixtures/rounding_flex_basis_overrides_main_size.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 113px; width: 100px; flex-direction: column;">

--- a/test_fixtures/rounding_fractial_input_1.html
+++ b/test_fixtures/rounding_fractial_input_1.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 113.4px; width: 100px; flex-direction: column;">

--- a/test_fixtures/rounding_fractial_input_2.html
+++ b/test_fixtures/rounding_fractial_input_2.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 113.6px; width: 100px; flex-direction: column;">

--- a/test_fixtures/rounding_fractial_input_3.html
+++ b/test_fixtures/rounding_fractial_input_3.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 113.4px; width: 100px; flex-direction: column;">

--- a/test_fixtures/rounding_fractial_input_4.html
+++ b/test_fixtures/rounding_fractial_input_4.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 113.4px; width: 100px; flex-direction: column;">

--- a/test_fixtures/rounding_fractial_input_5.html
+++ b/test_fixtures/rounding_fractial_input_5.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 100px;width:963.3333px;justify-content: center;">

--- a/test_fixtures/rounding_fractial_input_6.html
+++ b/test_fixtures/rounding_fractial_input_6.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width:7px;">

--- a/test_fixtures/rounding_fractial_input_7.html
+++ b/test_fixtures/rounding_fractial_input_7.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width:7px;">

--- a/test_fixtures/rounding_inner_node_controversy_combined.html
+++ b/test_fixtures/rounding_inner_node_controversy_combined.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 640px; height: 320px; flex-direction: row;">

--- a/test_fixtures/rounding_inner_node_controversy_horizontal.html
+++ b/test_fixtures/rounding_inner_node_controversy_horizontal.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 320px; flex-direction: row;">

--- a/test_fixtures/rounding_inner_node_controversy_vertical.html
+++ b/test_fixtures/rounding_inner_node_controversy_vertical.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: column;height: 320px;">

--- a/test_fixtures/rounding_total_fractial.html
+++ b/test_fixtures/rounding_total_fractial.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 113.4px; width: 87.4px; flex-direction: column;">

--- a/test_fixtures/rounding_total_fractial_nested.html
+++ b/test_fixtures/rounding_total_fractial_nested.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 113.4px; width: 87.4px; flex-direction: column;">

--- a/test_fixtures/simple_child.html
+++ b/test_fixtures/simple_child.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width:100px;height:100px">

--- a/test_fixtures/single_flex_child_after_absolute_child.html
+++ b/test_fixtures/single_flex_child_after_absolute_child.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: column;width: 428px; height: 845px">

--- a/test_fixtures/size_defined_by_child.html
+++ b/test_fixtures/size_defined_by_child.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root">

--- a/test_fixtures/size_defined_by_child_with_border.html
+++ b/test_fixtures/size_defined_by_child_with_border.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="border-width: 10px;">

--- a/test_fixtures/size_defined_by_child_with_padding.html
+++ b/test_fixtures/size_defined_by_child_with_padding.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="padding: 10px;">

--- a/test_fixtures/size_defined_by_grand_child.html
+++ b/test_fixtures/size_defined_by_grand_child.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root">

--- a/test_fixtures/undefined_height_with_min_max.html
+++ b/test_fixtures/undefined_height_with_min_max.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: column;width: 320px; min-height: 0px;">

--- a/test_fixtures/undefined_width_with_min_max.html
+++ b/test_fixtures/undefined_width_with_min_max.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: column;height: 50px;">

--- a/test_fixtures/undefined_width_with_min_max_row.html
+++ b/test_fixtures/undefined_width_with_min_max_row.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 50px; flex-direction: row;">

--- a/test_fixtures/width_smaller_then_content_with_flex_grow_large_size.html
+++ b/test_fixtures/width_smaller_then_content_with_flex_grow_large_size.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; width: 100px;">

--- a/test_fixtures/width_smaller_then_content_with_flex_grow_small_size.html
+++ b/test_fixtures/width_smaller_then_content_with_flex_grow_small_size.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; width: 10px;">

--- a/test_fixtures/width_smaller_then_content_with_flex_grow_unconstraint_size.html
+++ b/test_fixtures/width_smaller_then_content_with_flex_grow_unconstraint_size.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row;">

--- a/test_fixtures/width_smaller_then_content_with_flex_grow_very_large_size.html
+++ b/test_fixtures/width_smaller_then_content_with_flex_grow_very_large_size.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: row; width: 200px;">

--- a/test_fixtures/wrap_child.html
+++ b/test_fixtures/wrap_child.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: column;">

--- a/test_fixtures/wrap_column.html
+++ b/test_fixtures/wrap_column.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-wrap: wrap; flex-direction: column;">

--- a/test_fixtures/wrap_grandchild.html
+++ b/test_fixtures/wrap_grandchild.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root">

--- a/test_fixtures/wrap_nodes_with_content_sizing_margin_cross.html
+++ b/test_fixtures/wrap_nodes_with_content_sizing_margin_cross.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 500px; height: 500px; flex-direction: column;">

--- a/test_fixtures/wrap_nodes_with_content_sizing_overflowing_margin.html
+++ b/test_fixtures/wrap_nodes_with_content_sizing_overflowing_margin.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 500px; height: 500px; flex-direction: column;">

--- a/test_fixtures/wrap_reverse_column.html
+++ b/test_fixtures/wrap_reverse_column.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-wrap: wrap-reverse; flex-direction: column;">

--- a/test_fixtures/wrap_reverse_column_fixed_size.html
+++ b/test_fixtures/wrap_reverse_column_fixed_size.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 100px; flex-direction: column; flex-wrap: wrap-reverse; align-items: center;">

--- a/test_fixtures/wrap_reverse_row.html
+++ b/test_fixtures/wrap_reverse_row.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; flex-direction: row; flex-wrap: wrap-reverse">

--- a/test_fixtures/wrap_reverse_row_align_content_center.html
+++ b/test_fixtures/wrap_reverse_row_align_content_center.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; flex-direction: row; flex-wrap: wrap-reverse; align-content: center;">

--- a/test_fixtures/wrap_reverse_row_align_content_flex_start.html
+++ b/test_fixtures/wrap_reverse_row_align_content_flex_start.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; flex-direction: row; flex-wrap: wrap-reverse; align-content: flex-start;">

--- a/test_fixtures/wrap_reverse_row_align_content_space_around.html
+++ b/test_fixtures/wrap_reverse_row_align_content_space_around.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; flex-direction: row; flex-wrap: wrap-reverse; align-content: space-around;">

--- a/test_fixtures/wrap_reverse_row_align_content_stretch.html
+++ b/test_fixtures/wrap_reverse_row_align_content_stretch.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; flex-direction: row; flex-wrap: wrap-reverse; align-content: stretch;">

--- a/test_fixtures/wrap_reverse_row_single_line_different_size.html
+++ b/test_fixtures/wrap_reverse_row_single_line_different_size.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 300px; flex-direction: row; flex-wrap: wrap-reverse; align-content: flex-start;">

--- a/test_fixtures/wrap_row.html
+++ b/test_fixtures/wrap_row.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; flex-direction: row; flex-wrap: wrap">

--- a/test_fixtures/wrap_row_align_items_center.html
+++ b/test_fixtures/wrap_row_align_items_center.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; flex-direction: row; flex-wrap: wrap; align-items: center;">

--- a/test_fixtures/wrap_row_align_items_flex_end.html
+++ b/test_fixtures/wrap_row_align_items_flex_end.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; flex-direction: row; flex-wrap: wrap; align-items: flex-end;">

--- a/test_fixtures/wrapped_column_max_height.html
+++ b/test_fixtures/wrapped_column_max_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 500px; width: 700px; flex-direction: column;align-items: center; justify-content: center; align-content: center; flex-wrap:wrap;">

--- a/test_fixtures/wrapped_column_max_height_flex.html
+++ b/test_fixtures/wrapped_column_max_height_flex.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 500px; width: 700px; flex-direction: column;align-items: center; justify-content: center; align-content: center; flex-wrap:wrap;">

--- a/test_fixtures/wrapped_row_within_align_items_center.html
+++ b/test_fixtures/wrapped_row_within_align_items_center.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 200px; align-items: center; flex-direction: column;">

--- a/test_fixtures/wrapped_row_within_align_items_flex_end.html
+++ b/test_fixtures/wrapped_row_within_align_items_flex_end.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 200px; align-items: flex-end; flex-direction: column;">

--- a/test_fixtures/wrapped_row_within_align_items_flex_start.html
+++ b/test_fixtures/wrapped_row_within_align_items_flex_start.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 200px; align-items: flex-start; flex-direction: column;">

--- a/test_fixtures/xaspect_ratio_flex_column_stretch_fill_min_height.html
+++ b/test_fixtures/xaspect_ratio_flex_column_stretch_fill_min_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex;flex-direction: column;height: 100px; width: 100px;">

--- a/test_fixtures/xaspect_ratio_flex_column_stretch_fill_min_width.html
+++ b/test_fixtures/xaspect_ratio_flex_column_stretch_fill_min_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex;flex-direction: column;height: 100px; width: 100px;">

--- a/test_fixtures/xaspect_ratio_flex_row_stretch_fill_min_height.html
+++ b/test_fixtures/xaspect_ratio_flex_row_stretch_fill_min_height.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex;height: 100px; width: 100px;">

--- a/test_fixtures/xaspect_ratio_flex_row_stretch_fill_min_width.html
+++ b/test_fixtures/xaspect_ratio_flex_row_stretch_fill_min_width.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: flex;height: 100px; width: 100px;">

--- a/test_fixtures/xdo_not_clamp_height_of_absolute_node_to_height_of_its_overflow_hidden_parent.html
+++ b/test_fixtures/xdo_not_clamp_height_of_absolute_node_to_height_of_its_overflow_hidden_parent.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="height: 50px; width: 50px; overflow: hidden; flex-direction: row;">

--- a/test_fixtures/xgrid_fr_span_2_proportion_sub_1_sum_with_non_spanned_track.html
+++ b/test_fixtures/xgrid_fr_span_2_proportion_sub_1_sum_with_non_spanned_track.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns: 0.2fr 0.3fr 0.5fr;grid-template-rows: 40px 40px">

--- a/test_fixtures/xgrid_span_2_max_content_minmax_max_content_min_content_indefinite.html
+++ b/test_fixtures/xgrid_span_2_max_content_minmax_max_content_min_content_indefinite.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="display: grid; grid-template-columns:max-content minmax(max-content, min-content);grid-template-rows: 40px 40px">

--- a/test_fixtures/xmargin_auto_start_and_end.html
+++ b/test_fixtures/xmargin_auto_start_and_end.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="flex-direction: column;width: 200px; height: 200px; ">

--- a/test_fixtures/xmargin_auto_start_and_end_column.html
+++ b/test_fixtures/xmargin_auto_start_and_end_column.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 200px; height: 200px; align-items: center; flex-direction: row;">

--- a/test_fixtures/xmargin_end.html
+++ b/test_fixtures/xmargin_end.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: row; justify-content: flex-end;">

--- a/test_fixtures/xmargin_start.html
+++ b/test_fixtures/xmargin_start.html
@@ -6,7 +6,7 @@
   <title>
     Test description
   </title>
-<head/>
+</head>
 <body>
 
 <div id="test-root" style="width: 100px; height: 100px; flex-direction: row;">

--- a/tests/generated/grid_absolute_container_left_right_margin.rs
+++ b/tests/generated/grid_absolute_container_left_right_margin.rs
@@ -7,6 +7,12 @@ fn grid_absolute_container_left_right_margin() {
     let node0 = taffy
         .new_leaf(taffy::style::Style {
             position: taffy::style::Position::Absolute,
+            margin: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Points(4f32),
+                right: taffy::style::LengthPercentageAuto::Points(2f32),
+                top: taffy::style::LengthPercentageAuto::Points(1f32),
+                bottom: taffy::style::LengthPercentageAuto::Points(3f32),
+            },
             inset: taffy::geometry::Rect {
                 left: taffy::style::LengthPercentageAuto::Points(5f32),
                 right: taffy::style::LengthPercentageAuto::Points(2f32),
@@ -51,10 +57,10 @@ fn grid_absolute_container_left_right_margin() {
     assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node.data(), 0f32, location.x);
     assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node.data(), 0f32, location.y);
     let Layout { size, location, .. } = taffy.layout(node0).unwrap();
-    assert_eq!(size.width, 173f32, "width of node {:?}. Expected {}. Actual {}", node0.data(), 173f32, size.width);
+    assert_eq!(size.width, 167f32, "width of node {:?}. Expected {}. Actual {}", node0.data(), 167f32, size.width);
     assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, size.height);
-    assert_eq!(location.x, 5f32, "x of node {:?}. Expected {}. Actual {}", node0.data(), 5f32, location.x);
-    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, location.y);
+    assert_eq!(location.x, 9f32, "x of node {:?}. Expected {}. Actual {}", node0.data(), 9f32, location.x);
+    assert_eq!(location.y, 1f32, "y of node {:?}. Expected {}. Actual {}", node0.data(), 1f32, location.y);
     let Layout { size, location, .. } = taffy.layout(node1).unwrap();
     assert_eq!(size.width, 40f32, "width of node {:?}. Expected {}. Actual {}", node1.data(), 40f32, size.width);
     assert_eq!(size.height, 40f32, "height of node {:?}. Expected {}. Actual {}", node1.data(), 40f32, size.height);

--- a/tests/generated/grid_absolute_container_negative_position_margin.rs
+++ b/tests/generated/grid_absolute_container_negative_position_margin.rs
@@ -7,6 +7,12 @@ fn grid_absolute_container_negative_position_margin() {
     let node0 = taffy
         .new_leaf(taffy::style::Style {
             position: taffy::style::Position::Absolute,
+            margin: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Points(4f32),
+                right: taffy::style::LengthPercentageAuto::Points(2f32),
+                top: taffy::style::LengthPercentageAuto::Points(1f32),
+                bottom: taffy::style::LengthPercentageAuto::Points(3f32),
+            },
             inset: taffy::geometry::Rect {
                 left: auto(),
                 right: taffy::style::LengthPercentageAuto::Points(-15f32),
@@ -19,6 +25,12 @@ fn grid_absolute_container_negative_position_margin() {
     let node1 = taffy
         .new_leaf(taffy::style::Style {
             position: taffy::style::Position::Absolute,
+            margin: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Points(4f32),
+                right: taffy::style::LengthPercentageAuto::Points(2f32),
+                top: taffy::style::LengthPercentageAuto::Points(1f32),
+                bottom: taffy::style::LengthPercentageAuto::Points(3f32),
+            },
             inset: taffy::geometry::Rect {
                 left: taffy::style::LengthPercentageAuto::Points(-35f32),
                 right: auto(),
@@ -64,13 +76,13 @@ fn grid_absolute_container_negative_position_margin() {
     let Layout { size, location, .. } = taffy.layout(node0).unwrap();
     assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, size.width);
     assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, size.height);
-    assert_eq!(location.x, 195f32, "x of node {:?}. Expected {}. Actual {}", node0.data(), 195f32, location.x);
-    assert_eq!(location.y, -5f32, "y of node {:?}. Expected {}. Actual {}", node0.data(), -5f32, location.y);
+    assert_eq!(location.x, 193f32, "x of node {:?}. Expected {}. Actual {}", node0.data(), 193f32, location.x);
+    assert_eq!(location.y, -4f32, "y of node {:?}. Expected {}. Actual {}", node0.data(), -4f32, location.y);
     let Layout { size, location, .. } = taffy.layout(node1).unwrap();
     assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node1.data(), 0f32, size.width);
     assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node1.data(), 0f32, size.height);
-    assert_eq!(location.x, -35f32, "x of node {:?}. Expected {}. Actual {}", node1.data(), -35f32, location.x);
-    assert_eq!(location.y, 185f32, "y of node {:?}. Expected {}. Actual {}", node1.data(), 185f32, location.y);
+    assert_eq!(location.x, -31f32, "x of node {:?}. Expected {}. Actual {}", node1.data(), -31f32, location.x);
+    assert_eq!(location.y, 182f32, "y of node {:?}. Expected {}. Actual {}", node1.data(), 182f32, location.y);
     let Layout { size, location, .. } = taffy.layout(node2).unwrap();
     assert_eq!(size.width, 40f32, "width of node {:?}. Expected {}. Actual {}", node2.data(), 40f32, size.width);
     assert_eq!(size.height, 40f32, "height of node {:?}. Expected {}. Actual {}", node2.data(), 40f32, size.height);

--- a/tests/generated/grid_absolute_container_top_bottom_margin.rs
+++ b/tests/generated/grid_absolute_container_top_bottom_margin.rs
@@ -7,6 +7,12 @@ fn grid_absolute_container_top_bottom_margin() {
     let node0 = taffy
         .new_leaf(taffy::style::Style {
             position: taffy::style::Position::Absolute,
+            margin: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Points(4f32),
+                right: taffy::style::LengthPercentageAuto::Points(2f32),
+                top: taffy::style::LengthPercentageAuto::Points(1f32),
+                bottom: taffy::style::LengthPercentageAuto::Points(3f32),
+            },
             inset: taffy::geometry::Rect {
                 left: auto(),
                 right: auto(),
@@ -52,9 +58,9 @@ fn grid_absolute_container_top_bottom_margin() {
     assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node.data(), 0f32, location.y);
     let Layout { size, location, .. } = taffy.layout(node0).unwrap();
     assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, size.width);
-    assert_eq!(size.height, 153f32, "height of node {:?}. Expected {}. Actual {}", node0.data(), 153f32, size.height);
-    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, location.x);
-    assert_eq!(location.y, 2f32, "y of node {:?}. Expected {}. Actual {}", node0.data(), 2f32, location.y);
+    assert_eq!(size.height, 149f32, "height of node {:?}. Expected {}. Actual {}", node0.data(), 149f32, size.height);
+    assert_eq!(location.x, 4f32, "x of node {:?}. Expected {}. Actual {}", node0.data(), 4f32, location.x);
+    assert_eq!(location.y, 3f32, "y of node {:?}. Expected {}. Actual {}", node0.data(), 3f32, location.y);
     let Layout { size, location, .. } = taffy.layout(node1).unwrap();
     assert_eq!(size.width, 40f32, "width of node {:?}. Expected {}. Actual {}", node1.data(), 40f32, size.width);
     assert_eq!(size.height, 40f32, "height of node {:?}. Expected {}. Actual {}", node1.data(), 40f32, size.height);

--- a/tests/generated/grid_absolute_container_top_right_margin.rs
+++ b/tests/generated/grid_absolute_container_top_right_margin.rs
@@ -7,6 +7,12 @@ fn grid_absolute_container_top_right_margin() {
     let node0 = taffy
         .new_leaf(taffy::style::Style {
             position: taffy::style::Position::Absolute,
+            margin: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Points(4f32),
+                right: taffy::style::LengthPercentageAuto::Points(2f32),
+                top: taffy::style::LengthPercentageAuto::Points(1f32),
+                bottom: taffy::style::LengthPercentageAuto::Points(3f32),
+            },
             inset: taffy::geometry::Rect {
                 left: auto(),
                 right: taffy::style::LengthPercentageAuto::Points(0f32),
@@ -53,8 +59,8 @@ fn grid_absolute_container_top_right_margin() {
     let Layout { size, location, .. } = taffy.layout(node0).unwrap();
     assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, size.width);
     assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, size.height);
-    assert_eq!(location.x, 180f32, "x of node {:?}. Expected {}. Actual {}", node0.data(), 180f32, location.x);
-    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, location.y);
+    assert_eq!(location.x, 178f32, "x of node {:?}. Expected {}. Actual {}", node0.data(), 178f32, location.x);
+    assert_eq!(location.y, 1f32, "y of node {:?}. Expected {}. Actual {}", node0.data(), 1f32, location.y);
     let Layout { size, location, .. } = taffy.layout(node1).unwrap();
     assert_eq!(size.width, 40f32, "width of node {:?}. Expected {}. Actual {}", node1.data(), 40f32, size.width);
     assert_eq!(size.height, 40f32, "height of node {:?}. Expected {}. Actual {}", node1.data(), 40f32, size.height);

--- a/tests/generated/grid_absolute_with_padding_and_margin.rs
+++ b/tests/generated/grid_absolute_with_padding_and_margin.rs
@@ -7,6 +7,12 @@ fn grid_absolute_with_padding_and_margin() {
     let node0 = taffy
         .new_leaf(taffy::style::Style {
             position: taffy::style::Position::Absolute,
+            margin: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Points(4f32),
+                right: taffy::style::LengthPercentageAuto::Points(2f32),
+                top: taffy::style::LengthPercentageAuto::Points(1f32),
+                bottom: taffy::style::LengthPercentageAuto::Points(3f32),
+            },
             inset: taffy::geometry::Rect {
                 left: auto(),
                 right: taffy::style::LengthPercentageAuto::Points(0f32),
@@ -19,6 +25,12 @@ fn grid_absolute_with_padding_and_margin() {
     let node1 = taffy
         .new_leaf(taffy::style::Style {
             position: taffy::style::Position::Absolute,
+            margin: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Points(4f32),
+                right: taffy::style::LengthPercentageAuto::Points(2f32),
+                top: taffy::style::LengthPercentageAuto::Points(1f32),
+                bottom: taffy::style::LengthPercentageAuto::Points(3f32),
+            },
             inset: taffy::geometry::Rect {
                 left: taffy::style::LengthPercentageAuto::Points(10f32),
                 right: auto(),
@@ -64,13 +76,13 @@ fn grid_absolute_with_padding_and_margin() {
     let Layout { size, location, .. } = taffy.layout(node0).unwrap();
     assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, size.width);
     assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, size.height);
-    assert_eq!(location.x, 180f32, "x of node {:?}. Expected {}. Actual {}", node0.data(), 180f32, location.x);
-    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node0.data(), 0f32, location.y);
+    assert_eq!(location.x, 178f32, "x of node {:?}. Expected {}. Actual {}", node0.data(), 178f32, location.x);
+    assert_eq!(location.y, 1f32, "y of node {:?}. Expected {}. Actual {}", node0.data(), 1f32, location.y);
     let Layout { size, location, .. } = taffy.layout(node1).unwrap();
     assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node1.data(), 0f32, size.width);
     assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node1.data(), 0f32, size.height);
-    assert_eq!(location.x, 10f32, "x of node {:?}. Expected {}. Actual {}", node1.data(), 10f32, location.x);
-    assert_eq!(location.y, 150f32, "y of node {:?}. Expected {}. Actual {}", node1.data(), 150f32, location.y);
+    assert_eq!(location.x, 14f32, "x of node {:?}. Expected {}. Actual {}", node1.data(), 14f32, location.x);
+    assert_eq!(location.y, 147f32, "y of node {:?}. Expected {}. Actual {}", node1.data(), 147f32, location.y);
     let Layout { size, location, .. } = taffy.layout(node2).unwrap();
     assert_eq!(size.width, 40f32, "width of node {:?}. Expected {}. Actual {}", node2.data(), 40f32, size.width);
     assert_eq!(size.height, 40f32, "height of node {:?}. Expected {}. Actual {}", node2.data(), 40f32, size.height);

--- a/tests/generated/grid_percent_items_nested_moderate.rs
+++ b/tests/generated/grid_percent_items_nested_moderate.rs
@@ -89,10 +89,10 @@ fn grid_percent_items_nested_moderate() {
     assert!(location.y - 8f32 < 0.1, "y of node {:?}. Expected {}. Actual {}", node0.data(), 8f32, location.y);
     let Layout { size, location, .. } = taffy.layout(node00).unwrap();
     assert!(
-        size.width - 38.414063f32 < 0.1,
+        size.width - 38.40625f32 < 0.1,
         "width of node {:?}. Expected {}. Actual {}",
         node00.data(),
-        38.414063f32,
+        38.40625f32,
         size.width
     );
     assert!(size.height - 6f32 < 0.1, "height of node {:?}. Expected {}. Actual {}", node00.data(), 6f32, size.height);

--- a/tests/generated/percentage_moderate_complexity.rs
+++ b/tests/generated/percentage_moderate_complexity.rs
@@ -91,10 +91,10 @@ fn percentage_moderate_complexity() {
     assert!(location.y - 8f32 < 0.1, "y of node {:?}. Expected {}. Actual {}", node0.data(), 8f32, location.y);
     let Layout { size, location, .. } = taffy.layout(node00).unwrap();
     assert!(
-        size.width - 38.414063f32 < 0.1,
+        size.width - 38.40625f32 < 0.1,
         "width of node {:?}. Expected {}. Actual {}",
         node00.data(),
-        38.414063f32,
+        38.40625f32,
         size.width
     );
     assert!(size.height - 6f32 < 0.1, "height of node {:?}. Expected {}. Actual {}", node00.data(), 6f32, size.height);


### PR DESCRIPTION
# Objective

Work in #422 uncovered various typos in the html of the test fixtures. This fixes that.