### PR TITLE
Trampoline child measurement/layout through the `LayoutTree` trait

### DIFF
--- a/src/compute/grid/alignment.rs
+++ b/src/compute/grid/alignment.rs
@@ -2,7 +2,6 @@
 use super::types::GridTrack;
 use crate::axis::InBothAbsAxis;
 use crate::compute::common::alignment::compute_alignment_offset;
-use crate::compute::{GenericAlgorithm, LayoutAlgorithm};
 use crate::geometry::{Line, Point, Rect, Size};
 use crate::layout::{Layout, SizingMode};
 use crate::math::MaybeMath;
@@ -189,8 +188,7 @@ pub(super) fn align_and_position_item(
     let Size { width, height } = Size { width, height }.maybe_clamp(min_size, max_size);
 
     // Layout node
-    let measured_size_and_baselines = GenericAlgorithm::perform_layout(
-        tree,
+    let measured_size_and_baselines = tree.perform_child_layout(
         node,
         Size { width, height },
         grid_area_size.map(Option::Some),

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -24,7 +24,7 @@ pub(crate) use types::{GridCoordinate, GridLine, OriginZeroLine};
 #[cfg(feature = "debug")]
 use crate::debug::NODE_LOGGER;
 
-use super::{GenericAlgorithm, LayoutAlgorithm};
+use super::LayoutAlgorithm;
 
 mod alignment;
 mod explicit_grid;
@@ -453,14 +453,7 @@ pub fn compute(
         // Position hidden child
         if child_style.display == Display::None {
             *tree.layout_mut(child) = Layout::with_order(order);
-            GenericAlgorithm::perform_layout(
-                tree,
-                child,
-                Size::NONE,
-                Size::NONE,
-                Size::MAX_CONTENT,
-                SizingMode::InherentSize,
-            );
+            tree.perform_child_layout(child, Size::NONE, Size::NONE, Size::MAX_CONTENT, SizingMode::InherentSize);
             order += 1;
             return;
         }

--- a/src/compute/grid/track_sizing.rs
+++ b/src/compute/grid/track_sizing.rs
@@ -2,7 +2,6 @@
 //! <https://www.w3.org/TR/css-grid-1/#layout-algorithm>
 use super::types::{GridItem, GridTrack, TrackCounts};
 use crate::axis::AbstractAxis;
-use crate::compute::{GenericAlgorithm, LayoutAlgorithm};
 use crate::geometry::Size;
 use crate::layout::SizingMode;
 use crate::math::MaybeMath;
@@ -470,8 +469,7 @@ fn resolve_item_baselines(
 
         // Compute the baselines of all items in the row
         for item in row_items.iter_mut() {
-            let measured_size_and_baselines = GenericAlgorithm::perform_layout(
-                tree,
+            let measured_size_and_baselines = tree.perform_child_layout(
                 item.node,
                 Size::NONE,
                 inner_node_size,

--- a/src/compute/grid/types/grid_item.rs
+++ b/src/compute/grid/types/grid_item.rs
@@ -2,7 +2,6 @@
 use super::GridTrack;
 use crate::axis::AbstractAxis;
 use crate::compute::grid::OriginZeroLine;
-use crate::compute::{GenericAlgorithm, LayoutAlgorithm};
 use crate::geometry::{Line, Rect, Size};
 use crate::layout::SizingMode;
 use crate::math::MaybeMath;
@@ -328,8 +327,7 @@ impl GridItem {
         inner_node_size: Size<Option<f32>>,
     ) -> f32 {
         let known_dimensions = self.known_dimensions(tree, inner_node_size, available_space);
-        GenericAlgorithm::measure_size(
-            tree,
+        tree.measure_child_size(
             self.node,
             known_dimensions,
             available_space,
@@ -367,8 +365,7 @@ impl GridItem {
         inner_node_size: Size<Option<f32>>,
     ) -> f32 {
         let known_dimensions = self.known_dimensions(tree, inner_node_size, available_space);
-        GenericAlgorithm::measure_size(
-            tree,
+        tree.measure_child_size(
             self.node,
             known_dimensions,
             available_space,

--- a/src/node.rs
+++ b/src/node.rs
@@ -6,6 +6,7 @@ use slotmap::{DefaultKey, SlotMap, SparseSecondaryMap};
 /// A node in a layout.
 pub type Node = slotmap::DefaultKey;
 
+use crate::compute::{GenericAlgorithm, LayoutAlgorithm};
 use crate::error::{TaffyError, TaffyResult};
 use crate::geometry::Size;
 use crate::layout::{Cache, Layout};
@@ -115,6 +116,28 @@ impl LayoutTree for Taffy {
 
     fn child(&self, node: Node, id: usize) -> Node {
         self.children[node][id]
+    }
+
+    fn measure_child_size(
+        &mut self,
+        node: Node,
+        known_dimensions: Size<Option<f32>>,
+        parent_size: Size<Option<f32>>,
+        available_space: Size<AvailableSpace>,
+        sizing_mode: crate::layout::SizingMode,
+    ) -> Size<f32> {
+        GenericAlgorithm::measure_size(self, node, known_dimensions, parent_size, available_space, sizing_mode)
+    }
+
+    fn perform_child_layout(
+        &mut self,
+        node: Node,
+        known_dimensions: Size<Option<f32>>,
+        parent_size: Size<Option<f32>>,
+        available_space: Size<AvailableSpace>,
+        sizing_mode: crate::layout::SizingMode,
+    ) -> crate::layout::SizeAndBaselines {
+        GenericAlgorithm::perform_layout(self, node, known_dimensions, parent_size, available_space, sizing_mode)
     }
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -76,18 +76,22 @@ impl Default for Taffy {
 impl LayoutTree for Taffy {
     type ChildIter<'a> = core::slice::Iter<'a, DefaultKey>;
 
+    #[inline(always)]
     fn children(&self, node: Node) -> Self::ChildIter<'_> {
         self.children[node].iter()
     }
 
+    #[inline(always)]
     fn child_count(&self, node: Node) -> usize {
         self.children[node].len()
     }
 
+    #[inline(always)]
     fn style(&self, node: Node) -> &Style {
         &self.nodes[node].style
     }
 
+    #[inline(always)]
     fn layout_mut(&mut self, node: Node) -> &mut Layout {
         &mut self.nodes[node].layout
     }
@@ -114,10 +118,12 @@ impl LayoutTree for Taffy {
         &mut self.nodes[node].size_cache[index]
     }
 
+    #[inline(always)]
     fn child(&self, node: Node, id: usize) -> Node {
         self.children[node][id]
     }
 
+    #[inline(always)]
     fn measure_child_size(
         &mut self,
         node: Node,
@@ -129,6 +135,7 @@ impl LayoutTree for Taffy {
         GenericAlgorithm::measure_size(self, node, known_dimensions, parent_size, available_space, sizing_mode)
     }
 
+    #[inline(always)]
     fn perform_child_layout(
         &mut self,
         node: Node,

--- a/src/node.rs
+++ b/src/node.rs
@@ -9,7 +9,7 @@ pub type Node = slotmap::DefaultKey;
 use crate::compute::{GenericAlgorithm, LayoutAlgorithm};
 use crate::error::{TaffyError, TaffyResult};
 use crate::geometry::Size;
-use crate::layout::{Cache, Layout};
+use crate::layout::{Cache, Layout, SizeAndBaselines, SizingMode};
 use crate::prelude::LayoutTree;
 use crate::style::{AvailableSpace, Style};
 #[cfg(any(feature = "std", feature = "alloc"))]
@@ -130,7 +130,7 @@ impl LayoutTree for Taffy {
         known_dimensions: Size<Option<f32>>,
         parent_size: Size<Option<f32>>,
         available_space: Size<AvailableSpace>,
-        sizing_mode: crate::layout::SizingMode,
+        sizing_mode: SizingMode,
     ) -> Size<f32> {
         GenericAlgorithm::measure_size(self, node, known_dimensions, parent_size, available_space, sizing_mode)
     }
@@ -142,8 +142,8 @@ impl LayoutTree for Taffy {
         known_dimensions: Size<Option<f32>>,
         parent_size: Size<Option<f32>>,
         available_space: Size<AvailableSpace>,
-        sizing_mode: crate::layout::SizingMode,
-    ) -> crate::layout::SizeAndBaselines {
+        sizing_mode: SizingMode,
+    ) -> SizeAndBaselines {
         GenericAlgorithm::perform_layout(self, node, known_dimensions, parent_size, available_space, sizing_mode)
     }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -3,7 +3,7 @@
 use slotmap::DefaultKey;
 
 use crate::{
-    layout::{Cache, Layout},
+    layout::{Cache, Layout, SizeAndBaselines, SizingMode},
     prelude::*,
 };
 
@@ -48,4 +48,24 @@ pub trait LayoutTree {
 
     /// Get a cache entry for this Node by index
     fn cache_mut(&mut self, node: Node, index: usize) -> &mut Option<Cache>;
+
+    /// Compute the size of the node given the specified constraints
+    fn measure_child_size(
+        &mut self,
+        node: Node,
+        known_dimensions: Size<Option<f32>>,
+        parent_size: Size<Option<f32>>,
+        available_space: Size<AvailableSpace>,
+        sizing_mode: SizingMode,
+    ) -> Size<f32>;
+
+    /// Perform a full layout on the node given the specified constraints
+    fn perform_child_layout(
+        &mut self,
+        node: Node,
+        known_dimensions: Size<Option<f32>>,
+        parent_size: Size<Option<f32>>,
+        available_space: Size<AvailableSpace>,
+        sizing_mode: SizingMode,
+    ) -> SizeAndBaselines;
 }


### PR DESCRIPTION
# Objective

The objective here it to make is easy to embed Taffy as part of a larger layout implementation rather than usage of Taffy requiring you to "buy in" to having all your layouting needs handled by Taffy.

This is the core change from #326
Fixes #28

## Context

See https://github.com/DioxusLabs/taffy/issues/28#issuecomment-1374941635

## Notes

Seems to be relatively perf-neutral.
