### PR TITLE
Minor: reordered constructor aguments in Rect<T>::map()

### DIFF
--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -74,7 +74,7 @@ impl<T> Rect<T> {
     where
         F: Fn(T) -> R,
     {
-        Rect { top: f(self.top), bottom: f(self.bottom), left: f(self.left), right: f(self.right) }
+        Rect { left: f(self.left), right: f(self.right), top: f(self.top), bottom: f(self.bottom) }
     }
 
     /// Returns a `Line<T>` representing the left and right properties of the Rect


### PR DESCRIPTION
# Objective

> Why did you make this PR?

Mostly everywhere, for constructing `Rect<T>` used the next arguments order: [left, right, top, bottom]:

```rust
// [left, right, top, bottom] order
pub struct Rect<T> {
    pub left: T,
    pub right: T,
    pub top: T,
    pub bottom: T,
}
```

```rust
// [left, right, top, bottom] order
impl<U, T: Add<U>> Add<Rect<U>> for Rect<T> {
    type Output = Rect<T::Output>;

    fn add(self, rhs: Rect<U>) -> Self::Output {
        Rect {
            left: self.left + rhs.left,
            right: self.right + rhs.right,
            top: self.top + rhs.top,
            bottom: self.bottom + rhs.bottom,
        }
    }
}
```

```rust
impl<T> Rect<T> {
    // [left, right, top, bottom] order
    pub(crate) fn zip_size<R, F, U>(self, size: Size<U>, f: F) -> Rect<R>
    where
        F: Fn(T, U) -> R,
        U: Copy,
    {
        Rect {
            left: f(self.left, size.width),
            right: f(self.right, size.width),
            top: f(self.top, size.height),
            bottom: f(self.bottom, size.height),
        }
    }
    
    // VVVV ATTENTION PLACE VVVV
    pub fn map<R, F>(self, f: F) -> Rect<R>
    where
        F: Fn(T) -> R,
    {
        // [top, bottom, left, right] - is here special order matters? so it's need comment. if not ...
        Rect { top: f(self.top), bottom: f(self.bottom), left: f(self.left), right: f(self.right) }
        // ... [left, right, top, bottom] - common order fixed in this PR :)
        Rect { left: f(self.left), right: f(self.right), top: f(self.top), bottom: f(self.bottom) }
    }
}
```
so it looks strange, why here was [top, bottom, left, right]. It's fixed for **consistency** and to not confuse anyone.

Sorry for such minor PR, but this unanswered line I remember it for a long time and I want to forget it already :D