### PR TITLE
Remove `cache_mut`, `needs_measure` and `measure_node` methods from `LayoutTree` trait

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -5,7 +5,7 @@
 ### Removed
 
 - `layout_flexbox()` has been removed from the prelude. Use `FlexboxAlgorithm::perform_layout()` instead.
-- The following methods have been removed from the `LayoutTree` trait: `parent`, `is_childless`, `layout`, and `mark_dirty`. These no longer need to be implemented in custom implementation of `LayoutTree`.
+- The following methods have been removed from the `LayoutTree` trait: `parent`, `is_childless`, `layout`, `measure_node`, `needs_measure`, `cache_mut` and `mark_dirty`. These no longer need to be implemented in custom implementation of `LayoutTree`.
 
 ### Changes
 

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -23,7 +23,6 @@ use self::flexbox::FlexboxAlgorithm;
 
 #[cfg(feature = "grid")]
 use self::grid::CssGridAlgorithm;
-use self::leaf::LeafAlgorithm;
 
 #[cfg(any(feature = "debug", feature = "profile"))]
 use crate::debug::NODE_LOGGER;
@@ -35,7 +34,7 @@ pub fn compute_layout(
     available_space: Size<AvailableSpace>,
 ) -> Result<(), TaffyError> {
     // Recursively compute node layout
-    let size_and_baselines = GenericAlgorithm::perform_layout(
+    let size_and_baselines = perform_node_layout(
         taffy,
         root,
         Size::NONE,
@@ -81,55 +80,34 @@ pub(crate) trait LayoutAlgorithm {
     ) -> SizeAndBaselines;
 }
 
-/// The public interface to a generic algorithm that abstracts over all of Taffy's algorithms
-/// and applies the correct one based on the `Display` style
-pub struct GenericAlgorithm;
-impl LayoutAlgorithm for GenericAlgorithm {
-    const NAME: &'static str = "GENERIC";
+/// Perform full layout on a node. Chooses which algorithm to use based on the `display` property.
+pub(crate) fn perform_node_layout(
+    tree: &mut Taffy,
+    node: NodeId,
+    known_dimensions: Size<Option<f32>>,
+    parent_size: Size<Option<f32>>,
+    available_space: Size<AvailableSpace>,
+    sizing_mode: SizingMode,
+) -> SizeAndBaselines {
+    compute_node_layout(tree, node, known_dimensions, parent_size, available_space, RunMode::PeformLayout, sizing_mode)
+}
 
-    fn perform_layout(
-        tree: &mut impl LayoutTree,
-        node: NodeId,
-        known_dimensions: Size<Option<f32>>,
-        parent_size: Size<Option<f32>>,
-        available_space: Size<AvailableSpace>,
-        sizing_mode: SizingMode,
-    ) -> SizeAndBaselines {
-        compute_node_layout(
-            tree,
-            node,
-            known_dimensions,
-            parent_size,
-            available_space,
-            RunMode::PeformLayout,
-            sizing_mode,
-        )
-    }
-
-    fn measure_size(
-        tree: &mut impl LayoutTree,
-        node: NodeId,
-        known_dimensions: Size<Option<f32>>,
-        parent_size: Size<Option<f32>>,
-        available_space: Size<AvailableSpace>,
-        sizing_mode: SizingMode,
-    ) -> Size<f32> {
-        compute_node_layout(
-            tree,
-            node,
-            known_dimensions,
-            parent_size,
-            available_space,
-            RunMode::ComputeSize,
-            sizing_mode,
-        )
+/// Measure a node's size. Chooses which algorithm to use based on the `display` property.
+pub(crate) fn measure_node_size(
+    tree: &mut Taffy,
+    node: NodeId,
+    known_dimensions: Size<Option<f32>>,
+    parent_size: Size<Option<f32>>,
+    available_space: Size<AvailableSpace>,
+    sizing_mode: SizingMode,
+) -> Size<f32> {
+    compute_node_layout(tree, node, known_dimensions, parent_size, available_space, RunMode::ComputeSize, sizing_mode)
         .size
-    }
 }
 
 /// Updates the stored layout of the provided `node` and its children
 fn compute_node_layout(
-    tree: &mut impl LayoutTree,
+    tree: &mut Taffy,
     node: NodeId,
     known_dimensions: Size<Option<f32>>,
     parent_size: Size<Option<f32>>,
@@ -142,8 +120,11 @@ fn compute_node_layout(
     #[cfg(feature = "debug")]
     println!();
 
+    let node_key = node.into();
+    let has_children = !tree.children[node_key].is_empty();
+
     // First we check if we have a cached result for the given input
-    let cache_run_mode = if tree.child_count(node) == 0 { RunMode::PeformLayout } else { run_mode };
+    let cache_run_mode = if !has_children { RunMode::PeformLayout } else { run_mode };
     if let Some(cached_size_and_baselines) =
         compute_from_cache(tree, node, known_dimensions, available_space, cache_run_mode)
     {
@@ -178,15 +159,12 @@ fn compute_node_layout(
                 Algorithm::perform_layout(tree, node, known_dimensions, parent_size, available_space, sizing_mode)
             }
             RunMode::ComputeSize => {
-                let size =
-                    Algorithm::measure_size(tree, node, known_dimensions, parent_size, available_space, sizing_mode);
-                SizeAndBaselines { size, first_baselines: Point::NONE }
+                Algorithm::measure_size(tree, node, known_dimensions, parent_size, available_space, sizing_mode).into()
             }
         }
     }
 
-    let display_mode = tree.style(node).display;
-    let has_children = tree.child_count(node) != 0;
+    let display_mode = tree.nodes[node_key].style.display;
     let computed_size_and_baselines = match (display_mode, has_children) {
         (Display::None, _) => perform_computations::<HiddenAlgorithm>(
             tree,
@@ -217,15 +195,14 @@ fn compute_node_layout(
             run_mode,
             sizing_mode,
         ),
-        (_, false) => perform_computations::<LeafAlgorithm>(
-            tree,
-            node,
-            known_dimensions,
-            parent_size,
-            available_space,
-            run_mode,
-            sizing_mode,
-        ),
+        (_, false) => match run_mode {
+            RunMode::PeformLayout => {
+                leaf::perform_layout(tree, node, known_dimensions, parent_size, available_space, sizing_mode)
+            }
+            RunMode::ComputeSize => {
+                leaf::measure_size(tree, node, known_dimensions, parent_size, available_space, sizing_mode).into()
+            }
+        },
     };
 
     // Cache result

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -207,7 +207,7 @@ fn compute_node_layout(
 
     // Cache result
     let cache_slot = compute_cache_slot(known_dimensions, available_space);
-    *tree.cache_mut(node, cache_slot) = Some(Cache {
+    tree.nodes[node_key].size_cache[cache_slot] = Some(Cache {
         known_dimensions,
         available_space,
         run_mode: cache_run_mode,
@@ -289,14 +289,15 @@ fn compute_cache_slot(known_dimensions: Size<Option<f32>>, available_space: Size
 /// Try to get the computation result from the cache.
 #[inline]
 fn compute_from_cache(
-    tree: &mut impl LayoutTree,
+    tree: &mut Taffy,
     node: NodeId,
     known_dimensions: Size<Option<f32>>,
     available_space: Size<AvailableSpace>,
     run_mode: RunMode,
 ) -> Option<SizeAndBaselines> {
+    let node_key = node.into();
     for idx in 0..CACHE_SIZE {
-        let entry = tree.cache_mut(node, idx);
+        let entry = tree.nodes[node_key].size_cache[idx];
         if let Some(entry) = entry {
             // Cached ComputeSize results are not valid if we are running in PerformLayout mode
             if entry.run_mode == RunMode::ComputeSize && run_mode == RunMode::PeformLayout {

--- a/src/node.rs
+++ b/src/node.rs
@@ -7,7 +7,7 @@ use crate::compute::{measure_node_size, perform_node_layout};
 use crate::data::NodeData;
 use crate::error::{TaffyError, TaffyResult};
 use crate::geometry::Size;
-use crate::layout::{Cache, Layout, SizeAndBaselines, SizingMode};
+use crate::layout::{Layout, SizeAndBaselines, SizingMode};
 use crate::prelude::LayoutTree;
 use crate::style::{AvailableSpace, Style};
 #[cfg(any(feature = "std", feature = "alloc"))]
@@ -114,10 +114,6 @@ impl LayoutTree for Taffy {
     #[inline(always)]
     fn layout_mut(&mut self, node: NodeId) -> &mut Layout {
         &mut self.nodes[node.into()].layout
-    }
-
-    fn cache_mut(&mut self, node: NodeId, index: usize) -> &mut Option<Cache> {
-        &mut self.nodes[node.into()].size_cache[index]
     }
 
     #[inline(always)]

--- a/src/node.rs
+++ b/src/node.rs
@@ -3,7 +3,7 @@
 //! Layouts are composed of multiple nodes, which live in a tree-like data structure.
 use slotmap::{DefaultKey, SlotMap, SparseSecondaryMap};
 
-use crate::compute::{GenericAlgorithm, LayoutAlgorithm};
+use crate::compute::{measure_node_size, perform_node_layout};
 use crate::data::NodeData;
 use crate::error::{TaffyError, TaffyResult};
 use crate::geometry::Size;
@@ -29,6 +29,18 @@ pub enum MeasureFunc {
     /// Stores a boxed function
     #[cfg(any(feature = "std", feature = "alloc"))]
     Boxed(Box<dyn Measurable>),
+}
+
+impl MeasureFunc {
+    /// Call the measure function to measure to the node
+    #[inline(always)]
+    pub fn measure(&self, known_dimensions: Size<Option<f32>>, available_space: Size<AvailableSpace>) -> Size<f32> {
+        match self {
+            MeasureFunc::Raw(measure) => measure(known_dimensions, available_space),
+            #[cfg(any(feature = "std", feature = "alloc"))]
+            MeasureFunc::Boxed(measure) => (measure as &dyn Fn(_, _) -> _)(known_dimensions, available_space),
+        }
+    }
 }
 
 /// Global configuration values for a Taffy instance
@@ -104,25 +116,6 @@ impl LayoutTree for Taffy {
         &mut self.nodes[node.into()].layout
     }
 
-    fn measure_node(
-        &self,
-        node: NodeId,
-        known_dimensions: Size<Option<f32>>,
-        available_space: Size<AvailableSpace>,
-    ) -> Size<f32> {
-        match &self.measure_funcs[node.into()] {
-            MeasureFunc::Raw(measure) => measure(known_dimensions, available_space),
-
-            #[cfg(any(feature = "std", feature = "alloc"))]
-            MeasureFunc::Boxed(measure) => (measure as &dyn Fn(_, _) -> _)(known_dimensions, available_space),
-        }
-    }
-
-    fn needs_measure(&self, node: NodeId) -> bool {
-        let node = node.into();
-        self.nodes[node].needs_measure && self.measure_funcs.get(node).is_some()
-    }
-
     fn cache_mut(&mut self, node: NodeId, index: usize) -> &mut Option<Cache> {
         &mut self.nodes[node.into()].size_cache[index]
     }
@@ -141,7 +134,7 @@ impl LayoutTree for Taffy {
         available_space: Size<AvailableSpace>,
         sizing_mode: SizingMode,
     ) -> Size<f32> {
-        GenericAlgorithm::measure_size(self, node, known_dimensions, parent_size, available_space, sizing_mode)
+        measure_node_size(self, node, known_dimensions, parent_size, available_space, sizing_mode)
     }
 
     #[inline(always)]
@@ -153,7 +146,7 @@ impl LayoutTree for Taffy {
         available_space: Size<AvailableSpace>,
         sizing_mode: SizingMode,
     ) -> SizeAndBaselines {
-        GenericAlgorithm::perform_layout(self, node, known_dimensions, parent_size, available_space, sizing_mode)
+        perform_node_layout(self, node, known_dimensions, parent_size, available_space, sizing_mode)
     }
 }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,6 +1,6 @@
 //! The baseline requirements of any UI Tree so Taffy can efficiently calculate the layout
 use crate::{
-    layout::{Cache, Layout, SizeAndBaselines, SizingMode},
+    layout::{Layout, SizeAndBaselines, SizingMode},
     prelude::*,
 };
 use slotmap::{DefaultKey, Key, KeyData};
@@ -76,9 +76,6 @@ pub trait LayoutTree {
 
     /// Modify the node's output layout
     fn layout_mut(&mut self, node: NodeId) -> &mut Layout;
-
-    /// Get a cache entry for this Node by index
-    fn cache_mut(&mut self, node: NodeId, index: usize) -> &mut Option<Cache>;
 
     /// Compute the size of the node given the specified constraints
     fn measure_child_size(

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -77,17 +77,6 @@ pub trait LayoutTree {
     /// Modify the node's output layout
     fn layout_mut(&mut self, node: NodeId) -> &mut Layout;
 
-    /// Measure a node. Taffy uses this to force reflows of things like text and overflowing content.
-    fn measure_node(
-        &self,
-        node: NodeId,
-        known_dimensions: Size<Option<f32>>,
-        available_space: Size<AvailableSpace>,
-    ) -> Size<f32>;
-
-    /// Node needs to be measured
-    fn needs_measure(&self, node: NodeId) -> bool;
-
     /// Get a cache entry for this Node by index
     fn cache_mut(&mut self, node: NodeId, index: usize) -> &mut Option<Cache>;
 


### PR DESCRIPTION
# Objective

The aim is again to simplify the `LayoutTree` trait by removing unncessary methods. In this case, it is achieved by making the generic `compute/mod` and `leaf` compute functions take `&mut Taffy` instead of `&mut impl LayoutTree`. This works because these methods are private, and are only used when using the built in `Taffy` tree anyway.

## Context

Split out from #326 

## Feedback wanted

General PR review.
