### PR TITLE
Make low-level layout algorithm functions public

### DIFF
--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -21,7 +21,7 @@ use crate::tree::{LayoutTree, NodeId};
 use crate::debug::NODE_LOGGER;
 
 /// The public interface to Taffy's Flexbox algorithm implementation
-pub(crate) struct FlexboxAlgorithm;
+pub struct FlexboxAlgorithm;
 impl LayoutAlgorithm for FlexboxAlgorithm {
     const NAME: &'static str = "FLEXBOX";
 

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -34,7 +34,7 @@ mod types;
 mod util;
 
 /// The public interface to Taffy's CSS Grid algorithm implementation
-pub(crate) struct CssGridAlgorithm;
+pub struct CssGridAlgorithm;
 impl LayoutAlgorithm for CssGridAlgorithm {
     const NAME: &'static str = "CSS GRID";
 

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -54,7 +54,7 @@ pub fn compute_layout(
 }
 
 /// A common interface that all Taffy layout algorithms conform to
-pub(crate) trait LayoutAlgorithm {
+pub trait LayoutAlgorithm {
     /// The name of the algorithm (mainly used for debug purposes)
     const NAME: &'static str;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,9 @@ mod resolve;
 mod sys;
 
 pub use crate::compute::compute_layout;
+#[cfg(feature = "flexbox")]
 pub use crate::compute::flexbox::FlexboxAlgorithm;
+#[cfg(feature = "grid")]
 pub use crate::compute::grid::CssGridAlgorithm;
 pub use crate::compute::LayoutAlgorithm;
 pub use crate::node::Taffy;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,4 +42,7 @@ mod resolve;
 mod sys;
 
 pub use crate::compute::compute_layout;
+pub use crate::compute::flexbox::FlexboxAlgorithm;
+pub use crate::compute::grid::CssGridAlgorithm;
+pub use crate::compute::LayoutAlgorithm;
 pub use crate::node::Taffy;

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -11,6 +11,12 @@ use slotmap::{DefaultKey, Key, KeyData};
 /// and u64 if needed.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct NodeId(u64);
+impl NodeId {
+    /// Create a new NodeId from a u64 value
+    pub const fn new(val: u64) -> Self {
+        Self(val)
+    }
+}
 
 impl From<u64> for NodeId {
     #[inline]


### PR DESCRIPTION
# Objective

We have a low-level API that we intend consumers of Taffy to use, but it's currently private!

## Context

Split out from https://github.com/DioxusLabs/taffy/pull/326
We may want to change the interface before releasing, but for now just making the existing interface public seems like a good start.
