### PR TITLE
Enable `taffy_tree` feature when running tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Leafwing-Studios/cargo-cache@v1
       - run: cargo build --no-default-features
-      - run: cargo test --no-default-features
+      - run: cargo test --no-default-features --features taffy_tree
 
   # Default
   test-features-default:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build --no-default-features --features std
       - run: cargo build --no-default-features --features std,taffy_tree
       - run: cargo test --no-default-features --features std,taffy_tree
 
@@ -55,6 +56,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build --no-default-features --features flexbox,std
       - run: cargo build --no-default-features --features flexbox,std,taffy_tree
       - run: cargo test --no-default-features --features flexbox,std,taffy_tree
 
@@ -65,6 +67,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build --no-default-features --features grid,std
       - run: cargo build --no-default-features --features grid,std,taffy_tree
       - run: cargo test --no-default-features --features grid,std,taffy_tree
 
@@ -74,6 +77,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build --no-default-features --features alloc,grid
       - run: cargo build --no-default-features --features alloc,grid,taffy_tree
       - run: cargo test --no-default-features --features alloc,grid,taffy_tree
 
@@ -83,6 +87,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build --no-default-features --features alloc
       - run: cargo build --no-default-features --features alloc,taffy_tree
       - run: cargo test  --no-default-features --features alloc,taffy_tree
 
@@ -93,6 +98,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - uses: Leafwing-Studios/cargo-cache@v1
+      - run: cargo build --no-default-features --features std
       - run: cargo build --no-default-features --features std,taffy_tree
       - run: cargo test --no-default-features --features std,taffy_tree
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo build --no-default-features --features std
-      - run: cargo test --no-default-features --features std
+      - run: cargo build --no-default-features --features std,taffy_tree
+      - run: cargo test --no-default-features --features std,taffy_tree
 
   # Flexbox
   test-features-flexbox:
@@ -55,8 +55,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo build --no-default-features --features flexbox,std
-      - run: cargo test --no-default-features --features flexbox,std
+      - run: cargo build --no-default-features --features flexbox,std,taffy_tree
+      - run: cargo test --no-default-features --features flexbox,std,taffy_tree
 
   # Grid
   test-features-grid:
@@ -65,8 +65,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo build --no-default-features --features grid,std
-      - run: cargo test --no-default-features --features grid,std
+      - run: cargo build --no-default-features --features grid,std,taffy_tree
+      - run: cargo test --no-default-features --features grid,std,taffy_tree
 
   test-features-grid-with-alloc:
     name: "Test Suite [Features: grid + alloc]"
@@ -74,8 +74,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo build --no-default-features --features alloc,grid
-      - run: cargo test --no-default-features --features alloc,grid
+      - run: cargo build --no-default-features --features alloc,grid,taffy_tree
+      - run: cargo test --no-default-features --features alloc,grid,taffy_tree
 
   test-features-alloc:
     name: "Test Suite [Features: alloc]"
@@ -83,8 +83,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo build --no-default-features --features alloc
-      - run: cargo test  --no-default-features --features alloc
+      - run: cargo build --no-default-features --features alloc,taffy_tree
+      - run: cargo test  --no-default-features --features alloc,taffy_tree
 
   test-features-default-no-grid:
     name: "Test Suite [Features: std (no grid)]"
@@ -93,8 +93,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - uses: Leafwing-Studios/cargo-cache@v1
-      - run: cargo build --no-default-features --features std
-      - run: cargo test --no-default-features --features std
+      - run: cargo build --no-default-features --features std,taffy_tree
+      - run: cargo test --no-default-features --features std,taffy_tree
 
   fmt:
     name: Rustfmt

--- a/src/compute/taffy_tree.rs
+++ b/src/compute/taffy_tree.rs
@@ -1,16 +1,16 @@
 //! Computation specific for the default `Taffy` tree implementation
 
-use crate::compute::{leaf, HiddenAlgorithm};
+use crate::compute::{leaf, HiddenAlgorithm, LayoutAlgorithm};
 use crate::geometry::{Point, Size};
 use crate::style::{AvailableSpace, Display};
 use crate::tree::{Layout, LayoutTree, NodeId, RunMode, SizeAndBaselines, SizingMode, Taffy, TaffyError};
 use crate::util::sys::round;
 
 #[cfg(feature = "flexbox")]
-use super::FlexboxAlgorithm;
+use crate::compute::FlexboxAlgorithm;
 
 #[cfg(feature = "grid")]
-use super::CssGridAlgorithm;
+use crate::compute::CssGridAlgorithm;
 
 /// Updates the stored layout of the provided `node` and its children
 pub(crate) fn compute_layout(

--- a/src/compute/taffy_tree.rs
+++ b/src/compute/taffy_tree.rs
@@ -1,17 +1,16 @@
 //! Computation specific for the default `Taffy` tree implementation
 
-use crate::{
-    compute::{
-        leaf::{measure_size, perform_layout},
-        HiddenAlgorithm,
-    },
-    geometry::Point,
-    prelude::{Layout, NodeId, Size},
-    style::{AvailableSpace, Display},
-    tree::{RunMode, SizeAndBaselines, SizingMode},
-    util::sys::round,
-    CssGridAlgorithm, FlexboxAlgorithm, LayoutAlgorithm, LayoutTree, Taffy, TaffyError,
-};
+use crate::compute::{leaf, HiddenAlgorithm};
+use crate::geometry::{Point, Size};
+use crate::style::{AvailableSpace, Display};
+use crate::tree::{Layout, LayoutTree, NodeId, RunMode, SizeAndBaselines, SizingMode, Taffy, TaffyError};
+use crate::util::sys::round;
+
+#[cfg(feature = "flexbox")]
+use super::FlexboxAlgorithm;
+
+#[cfg(feature = "grid")]
+use super::CssGridAlgorithm;
 
 /// Updates the stored layout of the provided `node` and its children
 pub(crate) fn compute_layout(
@@ -156,7 +155,7 @@ fn compute_node_layout(
             sizing_mode,
         ),
         (_, false) => match run_mode {
-            RunMode::PeformLayout => perform_layout(
+            RunMode::PeformLayout => leaf::perform_layout(
                 &tree.nodes[node_key].style,
                 tree.nodes[node_key].needs_measure.then(|| &tree.measure_funcs[node_key]),
                 known_dimensions,
@@ -164,7 +163,7 @@ fn compute_node_layout(
                 available_space,
                 sizing_mode,
             ),
-            RunMode::ComputeSize => measure_size(
+            RunMode::ComputeSize => leaf::measure_size(
                 &tree.nodes[node_key].style,
                 tree.nodes[node_key].needs_measure.then(|| &tree.measure_funcs[node_key]),
                 known_dimensions,


### PR DESCRIPTION
# Objective

Currently CI fails due to missing feature flag

## Feedback wanted

Does any have any idea how CI managed to pass in the PR itself?