### PR TITLE
Fix caching of `display:none` nodes (backport of #454 to 0.3.x)

### DIFF
--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -371,6 +371,9 @@ fn perform_hidden_layout(tree: &mut impl LayoutTree, node: Node) {
     /// Recursive function to apply hidden layout to all descendents
     fn perform_hidden_layout_inner(tree: &mut impl LayoutTree, node: Node, order: u32) {
         *tree.layout_mut(node) = Layout::with_order(order);
+        for i in 0..7 {
+            *tree.cache_mut(node, i) = None;
+        }
         for order in 0..tree.child_count(node) {
             perform_hidden_layout_inner(tree, tree.child(node, order), order as _);
         }

--- a/tests/relayout.rs
+++ b/tests/relayout.rs
@@ -102,6 +102,41 @@ fn toggle_root_display_none() {
 }
 
 #[test]
+fn toggle_root_display_none_with_children() {
+    use taffy::prelude::*;
+
+    let mut taffy = taffy::Taffy::new();
+
+    let child = taffy
+        .new_leaf(Style { size: Size { width: points(800.0), height: points(100.0) }, ..Default::default() })
+        .unwrap();
+
+    let parent = taffy
+        .new_with_children(
+            Style { size: Size { width: points(800.0), height: points(100.0) }, ..Default::default() },
+            &[child],
+        )
+        .unwrap();
+
+    let root = taffy.new_with_children(Style::default(), &[parent]).unwrap();
+    taffy.compute_layout(root, Size::MAX_CONTENT).unwrap();
+    assert_eq!(taffy.layout(child).unwrap().size.width, 800.0);
+    assert_eq!(taffy.layout(child).unwrap().size.height, 100.0);
+
+    taffy.set_style(root, Style { display: Display::None, ..Default::default() }).unwrap();
+    taffy.compute_layout(root, Size::MAX_CONTENT).unwrap();
+    assert_eq!(taffy.layout(child).unwrap().size.width, 0.0);
+    assert_eq!(taffy.layout(child).unwrap().size.height, 0.0);
+
+    taffy.set_style(root, Style::default()).unwrap();
+    taffy.compute_layout(root, Size::MAX_CONTENT).unwrap();
+    assert_eq!(taffy.layout(parent).unwrap().size.width, 800.0);
+    assert_eq!(taffy.layout(parent).unwrap().size.height, 100.0);
+    assert_eq!(taffy.layout(child).unwrap().size.width, 800.0);
+    assert_eq!(taffy.layout(child).unwrap().size.height, 100.0);
+}
+
+#[test]
 fn toggle_flex_child_display_none() {
     let hidden_style = Style {
         display: Display::None,


### PR DESCRIPTION
# Objective

Backport #454 to 0.3.x branch