### PR TITLE
Remove caching from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,8 +144,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo xbench --no-run
         name: Build benchmarks
-      - run: cargo xbench --no-run --features yoga
-        name: Build benchmarks (w/yoga)
 
   benchmarks-with-yoga:
     name: Build Benchmarks (w/ yoga)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,12 +141,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-          components: clippy
+      - uses: dtolnay/rust-toolchain@stable
       - run: cargo xbench --no-run
         name: Build benchmarks
+      - run: cargo xbench --no-run --features yoga
+        name: Build benchmarks (w/yoga)
+
+  benchmarks-with-yoga:
+    name: Build Benchmarks (w/ yoga)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
       - run: cargo xbench --no-run --features yoga
         name: Build benchmarks (w/yoga)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Leafwing-Studios/cargo-cache@v1
       - run: cargo build --no-default-features
       - run: cargo test --no-default-features --features taffy_tree
 
@@ -100,7 +99,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Leafwing-Studios/cargo-cache@v1
       - run: cargo build --no-default-features --features std
       - run: cargo build --no-default-features --features std,taffy_tree
       - run: cargo test --no-default-features --features std,taffy_tree
@@ -114,7 +112,6 @@ jobs:
         with:
           toolchain: stable
           components: rustfmt
-      - uses: Leafwing-Studios/cargo-cache@v1
       - run: cargo fmt --all -- --check
 
   clippy:
@@ -126,7 +123,6 @@ jobs:
         with:
           toolchain: nightly
           components: clippy
-      - uses: Leafwing-Studios/cargo-cache@v1
       - run: cargo +nightly clippy --workspace -- -D warnings
 
   doc:
@@ -138,7 +134,6 @@ jobs:
         with:
           toolchain: stable
           components: clippy
-      - uses: Leafwing-Studios/cargo-cache@v1
       - run: cargo doc
 
   benchmarks:
@@ -150,7 +145,6 @@ jobs:
         with:
           toolchain: stable
           components: clippy
-      - uses: Leafwing-Studios/cargo-cache@v1
       - run: cargo xbench --no-run
         name: Build benchmarks
       - run: cargo xbench --no-run --features yoga

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo xbench --no-run
         name: Build benchmarks
+        env:
+          RUSTFLAGS: "-C opt-level=0" 
 
   benchmarks-with-yoga:
     name: Build Benchmarks (w/ yoga)
@@ -153,6 +155,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo xbench --no-run --features yoga
         name: Build benchmarks (w/yoga)
+        env:
+            RUSTFLAGS: "-C opt-level=0" 
 
   markdownlint:
     name: Markdown Lint


### PR DESCRIPTION
# Objective

Speed up CI:

- Remove caching
- Split up the benchmarks into two jobs so that they can run in parallel
- Set opt-level=0 when compiling benchmarks (as we're not actually running them)

## Context

Somehow CI ended up with some jobs being cached and other not being. And I noticed that the UNcached jobs were running faster. Turns out that Taffy compiles fast enough and GHA's caching is slow enough that it's quicker not to cache!

With caching:

<img width="1112" alt="Screenshot 2023-04-21 at 22 01 20" src="https://user-images.githubusercontent.com/1007307/233735018-4839f8a9-6520-4a79-8fce-fbb996c00899.png">

Without caching:

<img width="1111" alt="Screenshot 2023-04-21 at 22 09 36" src="https://user-images.githubusercontent.com/1007307/233735148-9a59eb46-0548-4779-bc57-a1ced15bf0b2.png">


