### PR TITLE
Remove `rstest` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ profile = []
 taffy_tree = ["dep:slotmap"]
 
 [dev-dependencies]
-rstest = "0.17.0"
 serde_json = "1.0.93"
 
 # Enable default features for tests and examples

--- a/src/util/math.rs
+++ b/src/util/math.rs
@@ -251,124 +251,106 @@ impl<In, Out, T: MaybeMath<In, Out>> MaybeMath<Size<In>, Size<Out>> for Size<T> 
 #[cfg(test)]
 mod tests {
     mod lhs_option_f32_rhs_option_f32 {
-
         use crate::util::MaybeMath;
-        use rstest::rstest;
 
-        #[rstest]
-        #[case(Some(3.0), Some(5.0), Some(3.0))]
-        #[case(Some(5.0), Some(3.0), Some(3.0))]
-        #[case(Some(3.0), None, Some(3.0))]
-        #[case(None, Some(3.0), None)]
-        #[case(None, None, None)]
-        fn test_maybe_min(#[case] lhs: Option<f32>, #[case] rhs: Option<f32>, #[case] expected: Option<f32>) {
-            assert_eq!(lhs.maybe_min(rhs), expected);
+        #[test]
+        fn test_maybe_min() {
+            assert_eq!(Some(3.0).maybe_min(Some(5.0)), Some(3.0));
+            assert_eq!(Some(5.0).maybe_min(Some(3.0)), Some(3.0));
+            assert_eq!(Some(3.0).maybe_min(None), Some(3.0));
+            assert_eq!(None.maybe_min(Some(3.0)), None);
+            assert_eq!(None.maybe_min(None), None);
         }
 
-        #[rstest]
-        #[case(Some(3.0), Some(5.0), Some(5.0))]
-        #[case(Some(5.0), Some(3.0), Some(5.0))]
-        #[case(Some(3.0), None, Some(3.0))]
-        #[case(None, Some(3.0), None)]
-        #[case(None, None, None)]
-        fn test_maybe_max(#[case] lhs: Option<f32>, #[case] rhs: Option<f32>, #[case] expected: Option<f32>) {
-            assert_eq!(lhs.maybe_max(rhs), expected);
+        #[test]
+        fn test_maybe_max() {
+            assert_eq!(Some(3.0).maybe_max(Some(5.0)), Some(5.0));
+            assert_eq!(Some(5.0).maybe_max(Some(3.0)), Some(5.0));
+            assert_eq!(Some(3.0).maybe_max(None), Some(3.0));
+            assert_eq!(None.maybe_max(Some(3.0)), None);
+            assert_eq!(None.maybe_max(None), None);
         }
 
-        #[rstest]
-        #[case(Some(3.0), Some(5.0), Some(8.0))]
-        #[case(Some(5.0), Some(3.0), Some(8.0))]
-        #[case(Some(3.0), None, Some(3.0))]
-        #[case(None, Some(3.0), None)]
-        #[case(None, None, None)]
-        fn test_maybe_add(#[case] lhs: Option<f32>, #[case] rhs: Option<f32>, #[case] expected: Option<f32>) {
-            assert_eq!(lhs.maybe_add(rhs), expected);
+        #[test]
+        fn test_maybe_add() {
+            assert_eq!(Some(3.0).maybe_add(Some(5.0)), Some(8.0));
+            assert_eq!(Some(5.0).maybe_add(Some(3.0)), Some(8.0));
+            assert_eq!(Some(3.0).maybe_add(None), Some(3.0));
+            assert_eq!(None.maybe_add(Some(3.0)), None);
+            assert_eq!(None.maybe_add(None), None);
         }
 
-        #[rstest]
-        #[case(Some(3.0), Some(5.0), Some(-2.0))]
-        #[case(Some(5.0), Some(3.0), Some(2.0))]
-        #[case(Some(3.0), None, Some(3.0))]
-        #[case(None, Some(3.0), None)]
-        #[case(None, None, None)]
-        fn test_maybe_sub(#[case] lhs: Option<f32>, #[case] rhs: Option<f32>, #[case] expected: Option<f32>) {
-            assert_eq!(lhs.maybe_sub(rhs), expected);
+        #[test]
+        fn test_maybe_sub() {
+            assert_eq!(Some(3.0).maybe_sub(Some(5.0)), Some(-2.0));
+            assert_eq!(Some(5.0).maybe_sub(Some(3.0)), Some(2.0));
+            assert_eq!(Some(3.0).maybe_sub(None), Some(3.0));
+            assert_eq!(None.maybe_sub(Some(3.0)), None);
+            assert_eq!(None.maybe_sub(None), None);
         }
     }
 
     mod lhs_option_f32_rhs_f32 {
-
         use crate::util::MaybeMath;
-        use rstest::rstest;
 
-        #[rstest]
-        #[case(Some(3.0), 5.0, Some(3.0))]
-        #[case(Some(5.0), 3.0, Some(3.0))]
-        #[case(None, 3.0, None)]
-        fn test_maybe_min(#[case] lhs: Option<f32>, #[case] rhs: f32, #[case] expected: Option<f32>) {
-            assert_eq!(lhs.maybe_min(rhs), expected);
+        #[test]
+        fn test_maybe_min() {
+            assert_eq!(Some(3.0).maybe_min(5.0), Some(3.0));
+            assert_eq!(Some(5.0).maybe_min(3.0), Some(3.0));
+            assert_eq!(None.maybe_min(3.0), None);
         }
 
-        #[rstest]
-        #[case(Some(3.0), 5.0, Some(5.0))]
-        #[case(Some(5.0), 3.0, Some(5.0))]
-        #[case(None, 3.0, None)]
-        fn test_maybe_max(#[case] lhs: Option<f32>, #[case] rhs: f32, #[case] expected: Option<f32>) {
-            assert_eq!(lhs.maybe_max(rhs), expected);
+        #[test]
+        fn test_maybe_max() {
+            assert_eq!(Some(3.0).maybe_max(5.0), Some(5.0));
+            assert_eq!(Some(5.0).maybe_max(3.0), Some(5.0));
+            assert_eq!(None.maybe_max(3.0), None);
         }
 
-        #[rstest]
-        #[case(Some(3.0), 5.0, Some(8.0))]
-        #[case(Some(5.0), 3.0, Some(8.0))]
-        #[case(None, 3.0, None)]
-        fn test_maybe_add(#[case] lhs: Option<f32>, #[case] rhs: f32, #[case] expected: Option<f32>) {
-            assert_eq!(lhs.maybe_add(rhs), expected);
+        #[test]
+        fn test_maybe_add() {
+            assert_eq!(Some(3.0).maybe_add(5.0), Some(8.0));
+            assert_eq!(Some(5.0).maybe_add(3.0), Some(8.0));
+            assert_eq!(None.maybe_add(3.0), None);
         }
 
-        #[rstest]
-        #[case(Some(3.0), 5.0, Some(-2.0))]
-        #[case(Some(5.0), 3.0, Some(2.0))]
-        #[case(None, 3.0, None)]
-        fn test_maybe_sub(#[case] lhs: Option<f32>, #[case] rhs: f32, #[case] expected: Option<f32>) {
-            assert_eq!(lhs.maybe_sub(rhs), expected);
+        #[test]
+        fn test_maybe_sub() {
+            assert_eq!(Some(3.0).maybe_sub(5.0), Some(-2.0));
+            assert_eq!(Some(5.0).maybe_sub(3.0), Some(2.0));
+            assert_eq!(None.maybe_sub(3.0), None);
         }
     }
 
     mod lhs_f32_rhs_option_f32 {
-
         use crate::util::MaybeMath;
-        use rstest::rstest;
 
-        #[rstest]
-        #[case(3.0, Some(5.0), 3.0)]
-        #[case(5.0, Some(3.0), 3.0)]
-        #[case(3.0, None, 3.0)]
-        fn test_maybe_min(#[case] lhs: f32, #[case] rhs: Option<f32>, #[case] expected: f32) {
-            assert_eq!(lhs.maybe_min(rhs), expected);
+        #[test]
+        fn test_maybe_min() {
+            assert_eq!(3.0.maybe_min(Some(5.0)), 3.0);
+            assert_eq!(5.0.maybe_min(Some(3.0)), 3.0);
+            assert_eq!(3.0.maybe_min(None), 3.0);
         }
 
-        #[rstest]
-        #[case(3.0, Some(5.0), 5.0)]
-        #[case(5.0, Some(3.0), 5.0)]
-        #[case(3.0, None, 3.0)]
-        fn test_maybe_max(#[case] lhs: f32, #[case] rhs: Option<f32>, #[case] expected: f32) {
-            assert_eq!(lhs.maybe_max(rhs), expected);
+        #[test]
+        fn test_maybe_max() {
+            assert_eq!(3.0.maybe_max(Some(5.0)), 5.0);
+            assert_eq!(5.0.maybe_max(Some(3.0)), 5.0);
+            assert_eq!(3.0.maybe_max(None), 3.0);
         }
 
-        #[rstest]
-        #[case(3.0, Some(5.0), 8.0)]
-        #[case(5.0, Some(3.0), 8.0)]
-        #[case(3.0, None, 3.0)]
-        fn test_maybe_add(#[case] lhs: f32, #[case] rhs: Option<f32>, #[case] expected: f32) {
-            assert_eq!(lhs.maybe_add(rhs), expected);
+        #[test]
+        fn test_maybe_add() {
+            assert_eq!(3.0.maybe_add(Some(5.0)), 8.0);
+            assert_eq!(5.0.maybe_add(Some(3.0)), 8.0);
+            assert_eq!(3.0.maybe_add(None), 3.0);
         }
 
-        #[rstest]
-        #[case(3.0, Some(5.0), -2.0)]
-        #[case(5.0, Some(3.0), 2.0)]
-        #[case(3.0, None, 3.0)]
-        fn test_maybe_sub(#[case] lhs: f32, #[case] rhs: Option<f32>, #[case] expected: f32) {
-            assert_eq!(lhs.maybe_sub(rhs), expected);
+        #[test]
+        fn test_maybe_sub() {
+            assert_eq!(3.0.maybe_sub(Some(5.0)), -2.0);
+            assert_eq!(5.0.maybe_sub(Some(3.0)), 2.0);
+            assert_eq!(3.0.maybe_sub(None), 3.0);
         }
     }
 }

--- a/src/util/resolve.rs
+++ b/src/util/resolve.rs
@@ -139,7 +139,8 @@ mod tests {
     use crate::style_helpers::TaffyZero;
     use core::fmt::Debug;
 
-    fn maybe_resolve_case<Lhs, Rhs, Out>(input: Lhs, context: Rhs, expected: Out)
+    // MaybeResolve test runner
+    fn mr_case<Lhs, Rhs, Out>(input: Lhs, context: Rhs, expected: Out)
     where
         Lhs: MaybeResolve<Rhs, Out>,
         Out: PartialEq + Debug,
@@ -147,7 +148,8 @@ mod tests {
         assert_eq!(input.maybe_resolve(context), expected);
     }
 
-    fn resolve_or_zero_case<Lhs, Rhs, Out>(input: Lhs, context: Rhs, expected: Out)
+    // ResolveOrZero test runner
+    fn roz_case<Lhs, Rhs, Out>(input: Lhs, context: Rhs, expected: Out)
     where
         Lhs: ResolveOrZero<Rhs, Out>,
         Out: PartialEq + Debug + TaffyZero,
@@ -156,7 +158,7 @@ mod tests {
     }
 
     mod maybe_resolve_dimension {
-        use super::maybe_resolve_case;
+        use super::mr_case;
         use crate::style::Dimension;
 
         /// `Dimension::Auto` should always return `None`
@@ -164,10 +166,10 @@ mod tests {
         /// The parent / context should not affect the outcome.
         #[test]
         fn resolve_auto() {
-            maybe_resolve_case(Dimension::Auto, None, None);
-            maybe_resolve_case(Dimension::Auto, Some(5.0), None);
-            maybe_resolve_case(Dimension::Auto, Some(-5.0), None);
-            maybe_resolve_case(Dimension::Auto, Some(0.), None);
+            mr_case(Dimension::Auto, None, None);
+            mr_case(Dimension::Auto, Some(5.0), None);
+            mr_case(Dimension::Auto, Some(-5.0), None);
+            mr_case(Dimension::Auto, Some(0.), None);
         }
 
         /// `Dimension::Length` should always return `Some(f32)`
@@ -176,10 +178,10 @@ mod tests {
         /// The parent / context should not affect the outcome.
         #[test]
         fn resolve_length() {
-            maybe_resolve_case(Dimension::Length(1.0), None, Some(1.0));
-            maybe_resolve_case(Dimension::Length(1.0), Some(5.0), Some(1.0));
-            maybe_resolve_case(Dimension::Length(1.0), Some(-5.0), Some(1.0));
-            maybe_resolve_case(Dimension::Length(1.0), Some(0.), Some(1.0));
+            mr_case(Dimension::Length(1.0), None, Some(1.0));
+            mr_case(Dimension::Length(1.0), Some(5.0), Some(1.0));
+            mr_case(Dimension::Length(1.0), Some(-5.0), Some(1.0));
+            mr_case(Dimension::Length(1.0), Some(0.), Some(1.0));
         }
 
         /// `Dimension::Percent` should return `None` if context is  `None`.
@@ -189,15 +191,15 @@ mod tests {
         /// The parent / context __should__ affect the outcome.
         #[test]
         fn resolve_percent() {
-            maybe_resolve_case(Dimension::Percent(1.0), None, None);
-            maybe_resolve_case(Dimension::Percent(1.0), Some(5.0), Some(5.0));
-            maybe_resolve_case(Dimension::Percent(1.0), Some(-5.0), Some(-5.0));
-            maybe_resolve_case(Dimension::Percent(1.0), Some(50.0), Some(50.0));
+            mr_case(Dimension::Percent(1.0), None, None);
+            mr_case(Dimension::Percent(1.0), Some(5.0), Some(5.0));
+            mr_case(Dimension::Percent(1.0), Some(-5.0), Some(-5.0));
+            mr_case(Dimension::Percent(1.0), Some(50.0), Some(50.0));
         }
     }
 
     mod maybe_resolve_size_dimension {
-        use super::maybe_resolve_case;
+        use super::mr_case;
         use crate::geometry::Size;
         use crate::style::Dimension;
 
@@ -206,10 +208,10 @@ mod tests {
         /// The parent / context should not affect the outcome.
         #[test]
         fn maybe_resolve_auto() {
-            maybe_resolve_case(Size::<Dimension>::auto(), Size::NONE, Size::NONE);
-            maybe_resolve_case(Size::<Dimension>::auto(), Size::new(5.0, 5.0), Size::NONE);
-            maybe_resolve_case(Size::<Dimension>::auto(), Size::new(-5.0, -5.0), Size::NONE);
-            maybe_resolve_case(Size::<Dimension>::auto(), Size::new(0.0, 0.0), Size::NONE);
+            mr_case(Size::<Dimension>::auto(), Size::NONE, Size::NONE);
+            mr_case(Size::<Dimension>::auto(), Size::new(5.0, 5.0), Size::NONE);
+            mr_case(Size::<Dimension>::auto(), Size::new(-5.0, -5.0), Size::NONE);
+            mr_case(Size::<Dimension>::auto(), Size::new(0.0, 0.0), Size::NONE);
         }
 
         /// Size<Dimension::Length> should always return a Size<Some(f32)>
@@ -218,10 +220,10 @@ mod tests {
         /// The parent / context should not affect the outcome.
         #[test]
         fn maybe_resolve_length() {
-            maybe_resolve_case(Size::from_lengths(5.0, 5.0), Size::NONE, Size::new(5.0, 5.0));
-            maybe_resolve_case(Size::from_lengths(5.0, 5.0), Size::new(5.0, 5.0), Size::new(5.0, 5.0));
-            maybe_resolve_case(Size::from_lengths(5.0, 5.0), Size::new(-5.0, -5.0), Size::new(5.0, 5.0));
-            maybe_resolve_case(Size::from_lengths(5.0, 5.0), Size::new(0.0, 0.0), Size::new(5.0, 5.0));
+            mr_case(Size::from_lengths(5.0, 5.0), Size::NONE, Size::new(5.0, 5.0));
+            mr_case(Size::from_lengths(5.0, 5.0), Size::new(5.0, 5.0), Size::new(5.0, 5.0));
+            mr_case(Size::from_lengths(5.0, 5.0), Size::new(-5.0, -5.0), Size::new(5.0, 5.0));
+            mr_case(Size::from_lengths(5.0, 5.0), Size::new(0.0, 0.0), Size::new(5.0, 5.0));
         }
 
         /// `Size<Dimension::Percent>` should return `Size<None>` if context is `Size<None>`.
@@ -231,121 +233,101 @@ mod tests {
         /// The context __should__ affect the outcome.
         #[test]
         fn maybe_resolve_percent() {
-            maybe_resolve_case(Size::from_percent(5.0, 5.0), Size::NONE, Size::NONE);
-            maybe_resolve_case(Size::from_percent(5.0, 5.0), Size::new(5.0, 5.0), Size::new(25.0, 25.0));
-            maybe_resolve_case(Size::from_percent(5.0, 5.0), Size::new(-5.0, -5.0), Size::new(-25.0, -25.0));
-            maybe_resolve_case(Size::from_percent(5.0, 5.0), Size::new(0.0, 0.0), Size::new(0.0, 0.0));
+            mr_case(Size::from_percent(5.0, 5.0), Size::NONE, Size::NONE);
+            mr_case(Size::from_percent(5.0, 5.0), Size::new(5.0, 5.0), Size::new(25.0, 25.0));
+            mr_case(Size::from_percent(5.0, 5.0), Size::new(-5.0, -5.0), Size::new(-25.0, -25.0));
+            mr_case(Size::from_percent(5.0, 5.0), Size::new(0.0, 0.0), Size::new(0.0, 0.0));
         }
     }
 
     mod resolve_or_zero_dimension_to_option_f32 {
-        use super::resolve_or_zero_case;
+        use super::roz_case;
         use crate::style::Dimension;
 
         #[test]
         fn resolve_or_zero_auto() {
-            resolve_or_zero_case(Dimension::Auto, None, 0.0);
-            resolve_or_zero_case(Dimension::Auto, Some(5.0), 0.0);
-            resolve_or_zero_case(Dimension::Auto, Some(-5.0), 0.0);
-            resolve_or_zero_case(Dimension::Auto, Some(0.0), 0.0);
+            roz_case(Dimension::Auto, None, 0.0);
+            roz_case(Dimension::Auto, Some(5.0), 0.0);
+            roz_case(Dimension::Auto, Some(-5.0), 0.0);
+            roz_case(Dimension::Auto, Some(0.0), 0.0);
         }
         #[test]
         fn resolve_or_zero_length() {
-            resolve_or_zero_case(Dimension::Length(5.0), None, 5.0);
-            resolve_or_zero_case(Dimension::Length(5.0), Some(5.0), 5.0);
-            resolve_or_zero_case(Dimension::Length(5.0), Some(-5.0), 5.0);
-            resolve_or_zero_case(Dimension::Length(5.0), Some(0.0), 5.0);
+            roz_case(Dimension::Length(5.0), None, 5.0);
+            roz_case(Dimension::Length(5.0), Some(5.0), 5.0);
+            roz_case(Dimension::Length(5.0), Some(-5.0), 5.0);
+            roz_case(Dimension::Length(5.0), Some(0.0), 5.0);
         }
         #[test]
         fn resolve_or_zero_percent() {
-            resolve_or_zero_case(Dimension::Percent(5.0), None, 0.0);
-            resolve_or_zero_case(Dimension::Percent(5.0), Some(5.0), 25.0);
-            resolve_or_zero_case(Dimension::Percent(5.0), Some(-5.0), -25.0);
-            resolve_or_zero_case(Dimension::Percent(5.0), Some(0.0), 0.0);
+            roz_case(Dimension::Percent(5.0), None, 0.0);
+            roz_case(Dimension::Percent(5.0), Some(5.0), 25.0);
+            roz_case(Dimension::Percent(5.0), Some(-5.0), -25.0);
+            roz_case(Dimension::Percent(5.0), Some(0.0), 0.0);
         }
     }
 
     mod resolve_or_zero_rect_dimension_to_rect {
-        use super::resolve_or_zero_case;
+        use super::roz_case;
         use crate::geometry::{Rect, Size};
         use crate::style::Dimension;
 
         #[test]
         fn resolve_or_zero_auto() {
-            resolve_or_zero_case(Rect::<Dimension>::auto(), Size::NONE, Rect::zero());
-            resolve_or_zero_case(Rect::<Dimension>::auto(), Size::new(5.0, 5.0), Rect::zero());
-            resolve_or_zero_case(Rect::<Dimension>::auto(), Size::new(-5.0, -5.0), Rect::zero());
-            resolve_or_zero_case(Rect::<Dimension>::auto(), Size::new(0.0, 0.0), Rect::zero());
+            roz_case(Rect::<Dimension>::auto(), Size::NONE, Rect::zero());
+            roz_case(Rect::<Dimension>::auto(), Size::new(5.0, 5.0), Rect::zero());
+            roz_case(Rect::<Dimension>::auto(), Size::new(-5.0, -5.0), Rect::zero());
+            roz_case(Rect::<Dimension>::auto(), Size::new(0.0, 0.0), Rect::zero());
         }
 
         #[test]
         fn resolve_or_zero_length() {
-            resolve_or_zero_case(Rect::from_length(5.0, 5.0, 5.0, 5.0), Size::NONE, Rect::new(5.0, 5.0, 5.0, 5.0));
-            resolve_or_zero_case(
-                Rect::from_length(5.0, 5.0, 5.0, 5.0),
-                Size::new(5.0, 5.0),
-                Rect::new(5.0, 5.0, 5.0, 5.0),
-            );
-            resolve_or_zero_case(
-                Rect::from_length(5.0, 5.0, 5.0, 5.0),
-                Size::new(-5.0, -5.0),
-                Rect::new(5.0, 5.0, 5.0, 5.0),
-            );
-            resolve_or_zero_case(
-                Rect::from_length(5.0, 5.0, 5.0, 5.0),
-                Size::new(0.0, 0.0),
-                Rect::new(5.0, 5.0, 5.0, 5.0),
-            );
+            roz_case(Rect::from_length(5.0, 5.0, 5.0, 5.0), Size::NONE, Rect::new(5.0, 5.0, 5.0, 5.0));
+            roz_case(Rect::from_length(5.0, 5.0, 5.0, 5.0), Size::new(5.0, 5.0), Rect::new(5.0, 5.0, 5.0, 5.0));
+            roz_case(Rect::from_length(5.0, 5.0, 5.0, 5.0), Size::new(-5.0, -5.0), Rect::new(5.0, 5.0, 5.0, 5.0));
+            roz_case(Rect::from_length(5.0, 5.0, 5.0, 5.0), Size::new(0.0, 0.0), Rect::new(5.0, 5.0, 5.0, 5.0));
         }
 
         #[test]
         fn resolve_or_zero_percent() {
-            resolve_or_zero_case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), Size::NONE, Rect::zero());
-            resolve_or_zero_case(
-                Rect::from_percent(5.0, 5.0, 5.0, 5.0),
-                Size::new(5.0, 5.0),
-                Rect::new(25.0, 25.0, 25.0, 25.0),
-            );
-            resolve_or_zero_case(
+            roz_case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), Size::NONE, Rect::zero());
+            roz_case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), Size::new(5.0, 5.0), Rect::new(25.0, 25.0, 25.0, 25.0));
+            roz_case(
                 Rect::from_percent(5.0, 5.0, 5.0, 5.0),
                 Size::new(-5.0, -5.0),
                 Rect::new(-25.0, -25.0, -25.0, -25.0),
             );
-            resolve_or_zero_case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), Size::new(0.0, 0.0), Rect::zero());
+            roz_case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), Size::new(0.0, 0.0), Rect::zero());
         }
     }
 
     mod resolve_or_zero_rect_dimension_to_rect_f32_via_option {
-        use super::resolve_or_zero_case;
+        use super::roz_case;
         use crate::geometry::Rect;
         use crate::style::Dimension;
 
         #[test]
         fn resolve_or_zero_auto() {
-            resolve_or_zero_case(Rect::<Dimension>::auto(), None, Rect::zero());
-            resolve_or_zero_case(Rect::<Dimension>::auto(), Some(5.0), Rect::zero());
-            resolve_or_zero_case(Rect::<Dimension>::auto(), Some(-5.0), Rect::zero());
-            resolve_or_zero_case(Rect::<Dimension>::auto(), Some(0.0), Rect::zero());
+            roz_case(Rect::<Dimension>::auto(), None, Rect::zero());
+            roz_case(Rect::<Dimension>::auto(), Some(5.0), Rect::zero());
+            roz_case(Rect::<Dimension>::auto(), Some(-5.0), Rect::zero());
+            roz_case(Rect::<Dimension>::auto(), Some(0.0), Rect::zero());
         }
 
         #[test]
         fn resolve_or_zero_length() {
-            resolve_or_zero_case(Rect::from_length(5.0, 5.0, 5.0, 5.0), None, Rect::new(5.0, 5.0, 5.0, 5.0));
-            resolve_or_zero_case(Rect::from_length(5.0, 5.0, 5.0, 5.0), Some(5.0), Rect::new(5.0, 5.0, 5.0, 5.0));
-            resolve_or_zero_case(Rect::from_length(5.0, 5.0, 5.0, 5.0), Some(-5.0), Rect::new(5.0, 5.0, 5.0, 5.0));
-            resolve_or_zero_case(Rect::from_length(5.0, 5.0, 5.0, 5.0), Some(0.0), Rect::new(5.0, 5.0, 5.0, 5.0));
+            roz_case(Rect::from_length(5.0, 5.0, 5.0, 5.0), None, Rect::new(5.0, 5.0, 5.0, 5.0));
+            roz_case(Rect::from_length(5.0, 5.0, 5.0, 5.0), Some(5.0), Rect::new(5.0, 5.0, 5.0, 5.0));
+            roz_case(Rect::from_length(5.0, 5.0, 5.0, 5.0), Some(-5.0), Rect::new(5.0, 5.0, 5.0, 5.0));
+            roz_case(Rect::from_length(5.0, 5.0, 5.0, 5.0), Some(0.0), Rect::new(5.0, 5.0, 5.0, 5.0));
         }
 
         #[test]
         fn resolve_or_zero_percent() {
-            resolve_or_zero_case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), None, Rect::zero());
-            resolve_or_zero_case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), Some(5.0), Rect::new(25.0, 25.0, 25.0, 25.0));
-            resolve_or_zero_case(
-                Rect::from_percent(5.0, 5.0, 5.0, 5.0),
-                Some(-5.0),
-                Rect::new(-25.0, -25.0, -25.0, -25.0),
-            );
-            resolve_or_zero_case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), Some(0.0), Rect::zero());
+            roz_case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), None, Rect::zero());
+            roz_case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), Some(5.0), Rect::new(25.0, 25.0, 25.0, 25.0));
+            roz_case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), Some(-5.0), Rect::new(-25.0, -25.0, -25.0, -25.0));
+            roz_case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), Some(0.0), Rect::zero());
         }
     }
 }

--- a/src/util/resolve.rs
+++ b/src/util/resolve.rs
@@ -135,35 +135,51 @@ impl<Out: TaffyZero, T: ResolveOrZero<Option<f32>, Out>> ResolveOrZero<Option<f3
 
 #[cfg(test)]
 mod tests {
-    mod maybe_resolve_dimension {
+    use super::{MaybeResolve, ResolveOrZero};
+    use crate::style_helpers::TaffyZero;
+    use core::fmt::Debug;
 
+    fn maybe_resolve_case<Lhs, Rhs, Out>(input: Lhs, context: Rhs, expected: Out)
+    where
+        Lhs: MaybeResolve<Rhs, Out>,
+        Out: PartialEq + Debug,
+    {
+        assert_eq!(input.maybe_resolve(context), expected);
+    }
+
+    fn resolve_or_zero_case<Lhs, Rhs, Out>(input: Lhs, context: Rhs, expected: Out)
+    where
+        Lhs: ResolveOrZero<Rhs, Out>,
+        Out: PartialEq + Debug + TaffyZero,
+    {
+        assert_eq!(input.resolve_or_zero(context), expected);
+    }
+
+    mod maybe_resolve_dimension {
+        use super::maybe_resolve_case;
         use crate::style::Dimension;
-        use crate::util::MaybeResolve;
-        use rstest::rstest;
 
         /// `Dimension::Auto` should always return `None`
         ///
         /// The parent / context should not affect the outcome.
-        #[rstest]
-        #[case(Dimension::Auto, None, None)]
-        #[case(Dimension::Auto, Some(5.0), None)]
-        #[case(Dimension::Auto, Some(-5.0), None)]
-        #[case(Dimension::Auto, Some(0.), None)]
-        fn resolve_auto(#[case] input: Dimension, #[case] context: Option<f32>, #[case] expected: Option<f32>) {
-            assert_eq!(input.maybe_resolve(context), expected);
+        #[test]
+        fn resolve_auto() {
+            maybe_resolve_case(Dimension::Auto, None, None);
+            maybe_resolve_case(Dimension::Auto, Some(5.0), None);
+            maybe_resolve_case(Dimension::Auto, Some(-5.0), None);
+            maybe_resolve_case(Dimension::Auto, Some(0.), None);
         }
 
         /// `Dimension::Length` should always return `Some(f32)`
         /// where the f32 value is the inner absolute length.
         ///
         /// The parent / context should not affect the outcome.
-        #[rstest]
-        #[case(Dimension::Length(1.0), None, Some(1.0))]
-        #[case(Dimension::Length(1.0), Some(5.0), Some(1.0))]
-        #[case(Dimension::Length(1.0), Some(-5.0), Some(1.0))]
-        #[case(Dimension::Length(1.0), Some(0.), Some(1.0))]
-        fn resolve_length(#[case] input: Dimension, #[case] context: Option<f32>, #[case] expected: Option<f32>) {
-            assert_eq!(input.maybe_resolve(context), expected);
+        #[test]
+        fn resolve_length() {
+            maybe_resolve_case(Dimension::Length(1.0), None, Some(1.0));
+            maybe_resolve_case(Dimension::Length(1.0), Some(5.0), Some(1.0));
+            maybe_resolve_case(Dimension::Length(1.0), Some(-5.0), Some(1.0));
+            maybe_resolve_case(Dimension::Length(1.0), Some(0.), Some(1.0));
         }
 
         /// `Dimension::Percent` should return `None` if context is  `None`.
@@ -171,53 +187,41 @@ mod tests {
         /// where the f32 value is the inner value of the percent * context value.
         ///
         /// The parent / context __should__ affect the outcome.
-        #[rstest]
-        #[case(Dimension::Percent(1.0), None, None)]
-        #[case(Dimension::Percent(1.0), Some(5.0), Some(5.0))]
-        #[case(Dimension::Percent(1.0), Some(-5.0), Some(-5.0))]
-        #[case(Dimension::Percent(1.0), Some(50.0), Some(50.0))]
-        fn resolve_percent(#[case] input: Dimension, #[case] context: Option<f32>, #[case] expected: Option<f32>) {
-            assert_eq!(input.maybe_resolve(context), expected);
+        #[test]
+        fn resolve_percent() {
+            maybe_resolve_case(Dimension::Percent(1.0), None, None);
+            maybe_resolve_case(Dimension::Percent(1.0), Some(5.0), Some(5.0));
+            maybe_resolve_case(Dimension::Percent(1.0), Some(-5.0), Some(-5.0));
+            maybe_resolve_case(Dimension::Percent(1.0), Some(50.0), Some(50.0));
         }
     }
 
     mod maybe_resolve_size_dimension {
-        use super::super::MaybeResolve;
+        use super::maybe_resolve_case;
         use crate::geometry::Size;
         use crate::style::Dimension;
-        use rstest::rstest;
 
         /// Size<Dimension::Auto> should always return Size<None>
         ///
         /// The parent / context should not affect the outcome.
-        #[rstest]
-        #[case(Size::auto(), Size::NONE, Size::NONE)]
-        #[case(Size::auto(), Size::new(5.0, 5.0), Size::NONE)]
-        #[case(Size::auto(), Size::new(-5.0, -5.0), Size::NONE)]
-        #[case(Size::auto(), Size::new(0.0, 0.0), Size::NONE)]
-        fn maybe_resolve_auto(
-            #[case] input: Size<Dimension>,
-            #[case] context: Size<Option<f32>>,
-            #[case] expected: Size<Option<f32>>,
-        ) {
-            assert_eq!(input.maybe_resolve(context), expected);
+        #[test]
+        fn maybe_resolve_auto() {
+            maybe_resolve_case(Size::<Dimension>::auto(), Size::NONE, Size::NONE);
+            maybe_resolve_case(Size::<Dimension>::auto(), Size::new(5.0, 5.0), Size::NONE);
+            maybe_resolve_case(Size::<Dimension>::auto(), Size::new(-5.0, -5.0), Size::NONE);
+            maybe_resolve_case(Size::<Dimension>::auto(), Size::new(0.0, 0.0), Size::NONE);
         }
 
         /// Size<Dimension::Length> should always return a Size<Some(f32)>
         /// where the f32 values are the absolute length.
         ///
         /// The parent / context should not affect the outcome.
-        #[rstest]
-        #[case(Size::from_lengths(5.0, 5.0), Size::NONE, Size::new(5.0, 5.0))]
-        #[case(Size::from_lengths(5.0, 5.0), Size::new(5.0, 5.0), Size::new(5.0, 5.0))]
-        #[case(Size::from_lengths(5.0, 5.0), Size::new(-5.0, -5.0), Size::new(5.0, 5.0))]
-        #[case(Size::from_lengths(5.0, 5.0), Size::new(0.0, 0.0), Size::new(5.0, 5.0))]
-        fn maybe_resolve_length(
-            #[case] input: Size<Dimension>,
-            #[case] context: Size<Option<f32>>,
-            #[case] expected: Size<Option<f32>>,
-        ) {
-            assert_eq!(input.maybe_resolve(context), expected);
+        #[test]
+        fn maybe_resolve_length() {
+            maybe_resolve_case(Size::from_lengths(5.0, 5.0), Size::NONE, Size::new(5.0, 5.0));
+            maybe_resolve_case(Size::from_lengths(5.0, 5.0), Size::new(5.0, 5.0), Size::new(5.0, 5.0));
+            maybe_resolve_case(Size::from_lengths(5.0, 5.0), Size::new(-5.0, -5.0), Size::new(5.0, 5.0));
+            maybe_resolve_case(Size::from_lengths(5.0, 5.0), Size::new(0.0, 0.0), Size::new(5.0, 5.0));
         }
 
         /// `Size<Dimension::Percent>` should return `Size<None>` if context is `Size<None>`.
@@ -225,140 +229,123 @@ mod tests {
         /// where the f32 value is the inner value of the percent * context value.
         ///
         /// The context __should__ affect the outcome.
-        #[rstest]
-        #[case(Size::from_percent(5.0, 5.0), Size::NONE, Size::NONE)]
-        #[case(Size::from_percent(5.0, 5.0), Size::new(5.0, 5.0), Size::new(25.0, 25.0))]
-        #[case(Size::from_percent(5.0, 5.0), Size::new(-5.0, -5.0), Size::new(-25.0, -25.0))]
-        #[case(Size::from_percent(5.0, 5.0), Size::new(0.0, 0.0), Size::new(0.0, 0.0))]
-        fn maybe_resolve_percent(
-            #[case] input: Size<Dimension>,
-            #[case] context: Size<Option<f32>>,
-            #[case] expected: Size<Option<f32>>,
-        ) {
-            assert_eq!(input.maybe_resolve(context), expected);
+        #[test]
+        fn maybe_resolve_percent() {
+            maybe_resolve_case(Size::from_percent(5.0, 5.0), Size::NONE, Size::NONE);
+            maybe_resolve_case(Size::from_percent(5.0, 5.0), Size::new(5.0, 5.0), Size::new(25.0, 25.0));
+            maybe_resolve_case(Size::from_percent(5.0, 5.0), Size::new(-5.0, -5.0), Size::new(-25.0, -25.0));
+            maybe_resolve_case(Size::from_percent(5.0, 5.0), Size::new(0.0, 0.0), Size::new(0.0, 0.0));
         }
     }
 
     mod resolve_or_zero_dimension_to_option_f32 {
+        use super::resolve_or_zero_case;
         use crate::style::Dimension;
-        use crate::util::ResolveOrZero;
-        use rstest::rstest;
 
-        #[rstest]
-        #[case(Dimension::Auto, None, 0.0)]
-        #[case(Dimension::Auto, Some(5.0), 0.0)]
-        #[case(Dimension::Auto, Some(-5.0), 0.0)]
-        #[case(Dimension::Auto, Some(0.0), 0.0)]
-        fn resolve_or_zero_auto(#[case] input: Dimension, #[case] context: Option<f32>, #[case] expected: f32) {
-            assert_eq!(input.resolve_or_zero(context), expected);
+        #[test]
+        fn resolve_or_zero_auto() {
+            resolve_or_zero_case(Dimension::Auto, None, 0.0);
+            resolve_or_zero_case(Dimension::Auto, Some(5.0), 0.0);
+            resolve_or_zero_case(Dimension::Auto, Some(-5.0), 0.0);
+            resolve_or_zero_case(Dimension::Auto, Some(0.0), 0.0);
         }
-        #[rstest]
-        #[case(Dimension::Length(5.0), None, 5.0)]
-        #[case(Dimension::Length(5.0), Some(5.0), 5.0)]
-        #[case(Dimension::Length(5.0), Some(-5.0), 5.0)]
-        #[case(Dimension::Length(5.0), Some(0.0), 5.0)]
-        fn resolve_or_zero_length(#[case] input: Dimension, #[case] context: Option<f32>, #[case] expected: f32) {
-            assert_eq!(input.resolve_or_zero(context), expected);
+        #[test]
+        fn resolve_or_zero_length() {
+            resolve_or_zero_case(Dimension::Length(5.0), None, 5.0);
+            resolve_or_zero_case(Dimension::Length(5.0), Some(5.0), 5.0);
+            resolve_or_zero_case(Dimension::Length(5.0), Some(-5.0), 5.0);
+            resolve_or_zero_case(Dimension::Length(5.0), Some(0.0), 5.0);
         }
-        #[rstest]
-        #[case(Dimension::Percent(5.0), None, 0.0)]
-        #[case(Dimension::Percent(5.0), Some(5.0), 25.0)]
-        #[case(Dimension::Percent(5.0), Some(-5.0), -25.0)]
-        #[case(Dimension::Percent(5.0), Some(0.0), 0.0)]
-        fn resolve_or_zero_percent(#[case] input: Dimension, #[case] context: Option<f32>, #[case] expected: f32) {
-            assert_eq!(input.resolve_or_zero(context), expected);
+        #[test]
+        fn resolve_or_zero_percent() {
+            resolve_or_zero_case(Dimension::Percent(5.0), None, 0.0);
+            resolve_or_zero_case(Dimension::Percent(5.0), Some(5.0), 25.0);
+            resolve_or_zero_case(Dimension::Percent(5.0), Some(-5.0), -25.0);
+            resolve_or_zero_case(Dimension::Percent(5.0), Some(0.0), 0.0);
         }
     }
 
     mod resolve_or_zero_rect_dimension_to_rect {
+        use super::resolve_or_zero_case;
         use crate::geometry::{Rect, Size};
         use crate::style::Dimension;
-        use crate::util::ResolveOrZero;
-        use rstest::rstest;
 
-        #[rstest]
-        #[case(Rect::auto(), Size::NONE, Rect::zero())]
-        #[case(Rect::auto(), Size::new(5.0, 5.0), Rect::zero())]
-        #[case(Rect::auto(), Size::new(-5.0, -5.0), Rect::zero())]
-        #[case(Rect::auto(), Size::new(0.0, 0.0), Rect::zero())]
-        fn resolve_or_zero_auto(
-            #[case] input: Rect<Dimension>,
-            #[case] context: Size<Option<f32>>,
-            #[case] expected: Rect<f32>,
-        ) {
-            assert_eq!(input.resolve_or_zero(context), expected);
+        #[test]
+        fn resolve_or_zero_auto() {
+            resolve_or_zero_case(Rect::<Dimension>::auto(), Size::NONE, Rect::zero());
+            resolve_or_zero_case(Rect::<Dimension>::auto(), Size::new(5.0, 5.0), Rect::zero());
+            resolve_or_zero_case(Rect::<Dimension>::auto(), Size::new(-5.0, -5.0), Rect::zero());
+            resolve_or_zero_case(Rect::<Dimension>::auto(), Size::new(0.0, 0.0), Rect::zero());
         }
 
-        #[rstest]
-        #[case(Rect::from_length(5.0, 5.0, 5.0, 5.0), Size::NONE, Rect::new(5.0, 5.0, 5.0, 5.0))]
-        #[case(Rect::from_length(5.0, 5.0, 5.0, 5.0), Size::new(5.0, 5.0), Rect::new(5.0, 5.0, 5.0, 5.0))]
-        #[case(Rect::from_length(5.0, 5.0, 5.0, 5.0), Size::new(-5.0, -5.0), Rect::new(5.0, 5.0, 5.0, 5.0))]
-        #[case(Rect::from_length(5.0, 5.0, 5.0, 5.0), Size::new(0.0, 0.0), Rect::new(5.0, 5.0, 5.0, 5.0))]
-        fn resolve_or_zero_length(
-            #[case] input: Rect<Dimension>,
-            #[case] context: Size<Option<f32>>,
-            #[case] expected: Rect<f32>,
-        ) {
-            assert_eq!(input.resolve_or_zero(context), expected);
+        #[test]
+        fn resolve_or_zero_length() {
+            resolve_or_zero_case(Rect::from_length(5.0, 5.0, 5.0, 5.0), Size::NONE, Rect::new(5.0, 5.0, 5.0, 5.0));
+            resolve_or_zero_case(
+                Rect::from_length(5.0, 5.0, 5.0, 5.0),
+                Size::new(5.0, 5.0),
+                Rect::new(5.0, 5.0, 5.0, 5.0),
+            );
+            resolve_or_zero_case(
+                Rect::from_length(5.0, 5.0, 5.0, 5.0),
+                Size::new(-5.0, -5.0),
+                Rect::new(5.0, 5.0, 5.0, 5.0),
+            );
+            resolve_or_zero_case(
+                Rect::from_length(5.0, 5.0, 5.0, 5.0),
+                Size::new(0.0, 0.0),
+                Rect::new(5.0, 5.0, 5.0, 5.0),
+            );
         }
 
-        #[rstest]
-        #[case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), Size::NONE, Rect::zero())]
-        #[case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), Size::new(5.0, 5.0), Rect::new(25.0, 25.0, 25.0, 25.0))]
-        #[case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), Size::new(-5.0, -5.0), Rect::new(-25.0, -25.0, -25.0, -25.0))]
-        #[case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), Size::new(0.0, 0.0), Rect::zero())]
-        fn resolve_or_zero_percent(
-            #[case] input: Rect<Dimension>,
-            #[case] context: Size<Option<f32>>,
-            #[case] expected: Rect<f32>,
-        ) {
-            assert_eq!(input.resolve_or_zero(context), expected);
+        #[test]
+        fn resolve_or_zero_percent() {
+            resolve_or_zero_case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), Size::NONE, Rect::zero());
+            resolve_or_zero_case(
+                Rect::from_percent(5.0, 5.0, 5.0, 5.0),
+                Size::new(5.0, 5.0),
+                Rect::new(25.0, 25.0, 25.0, 25.0),
+            );
+            resolve_or_zero_case(
+                Rect::from_percent(5.0, 5.0, 5.0, 5.0),
+                Size::new(-5.0, -5.0),
+                Rect::new(-25.0, -25.0, -25.0, -25.0),
+            );
+            resolve_or_zero_case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), Size::new(0.0, 0.0), Rect::zero());
         }
     }
 
     mod resolve_or_zero_rect_dimension_to_rect_f32_via_option {
+        use super::resolve_or_zero_case;
         use crate::geometry::Rect;
         use crate::style::Dimension;
-        use crate::util::ResolveOrZero;
-        use rstest::rstest;
 
-        #[rstest]
-        #[case(Rect::auto(), None, Rect::zero())]
-        #[case(Rect::auto(), Some(5.0), Rect::zero())]
-        #[case(Rect::auto(), Some(-5.0), Rect::zero())]
-        #[case(Rect::auto(), Some(0.0), Rect::zero())]
-        fn resolve_or_zero_auto(
-            #[case] input: Rect<Dimension>,
-            #[case] context: Option<f32>,
-            #[case] expected: Rect<f32>,
-        ) {
-            assert_eq!(input.resolve_or_zero(context), expected);
+        #[test]
+        fn resolve_or_zero_auto() {
+            resolve_or_zero_case(Rect::<Dimension>::auto(), None, Rect::zero());
+            resolve_or_zero_case(Rect::<Dimension>::auto(), Some(5.0), Rect::zero());
+            resolve_or_zero_case(Rect::<Dimension>::auto(), Some(-5.0), Rect::zero());
+            resolve_or_zero_case(Rect::<Dimension>::auto(), Some(0.0), Rect::zero());
         }
 
-        #[rstest]
-        #[case(Rect::from_length(5.0, 5.0, 5.0, 5.0), None, Rect::new(5.0, 5.0, 5.0, 5.0))]
-        #[case(Rect::from_length(5.0, 5.0, 5.0, 5.0), Some(5.0), Rect::new(5.0, 5.0, 5.0, 5.0))]
-        #[case(Rect::from_length(5.0, 5.0, 5.0, 5.0), Some(-5.0), Rect::new(5.0, 5.0, 5.0, 5.0))]
-        #[case(Rect::from_length(5.0, 5.0, 5.0, 5.0), Some(0.0), Rect::new(5.0, 5.0, 5.0, 5.0))]
-        fn resolve_or_zero_length(
-            #[case] input: Rect<Dimension>,
-            #[case] context: Option<f32>,
-            #[case] expected: Rect<f32>,
-        ) {
-            assert_eq!(input.resolve_or_zero(context), expected);
+        #[test]
+        fn resolve_or_zero_length() {
+            resolve_or_zero_case(Rect::from_length(5.0, 5.0, 5.0, 5.0), None, Rect::new(5.0, 5.0, 5.0, 5.0));
+            resolve_or_zero_case(Rect::from_length(5.0, 5.0, 5.0, 5.0), Some(5.0), Rect::new(5.0, 5.0, 5.0, 5.0));
+            resolve_or_zero_case(Rect::from_length(5.0, 5.0, 5.0, 5.0), Some(-5.0), Rect::new(5.0, 5.0, 5.0, 5.0));
+            resolve_or_zero_case(Rect::from_length(5.0, 5.0, 5.0, 5.0), Some(0.0), Rect::new(5.0, 5.0, 5.0, 5.0));
         }
 
-        #[rstest]
-        #[case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), None, Rect::zero())]
-        #[case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), Some(5.0), Rect::new(25.0, 25.0, 25.0, 25.0))]
-        #[case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), Some(-5.0), Rect::new(-25.0, -25.0, -25.0, -25.0))]
-        #[case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), Some(0.0), Rect::zero())]
-        fn resolve_or_zero_percent(
-            #[case] input: Rect<Dimension>,
-            #[case] context: Option<f32>,
-            #[case] expected: Rect<f32>,
-        ) {
-            assert_eq!(input.resolve_or_zero(context), expected);
+        #[test]
+        fn resolve_or_zero_percent() {
+            resolve_or_zero_case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), None, Rect::zero());
+            resolve_or_zero_case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), Some(5.0), Rect::new(25.0, 25.0, 25.0, 25.0));
+            resolve_or_zero_case(
+                Rect::from_percent(5.0, 5.0, 5.0, 5.0),
+                Some(-5.0),
+                Rect::new(-25.0, -25.0, -25.0, -25.0),
+            );
+            resolve_or_zero_case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), Some(0.0), Rect::zero());
         }
     }
 }


### PR DESCRIPTION
# Objective

Speed up CI

## Context

This is Taffy's dependency tree:

```bash
taffy v0.3.11
├── arrayvec v0.7.2
├── grid v0.9.0
│   └── no-std-compat v0.4.1
├── num-traits v0.2.15
│   [build-dependencies]
│   └── autocfg v1.1.0
└── slotmap v1.0.6
    [build-dependencies]
    └── version_check v0.9.4
```
This is `rstest`s dependency tree:

```bash
├── rstest v0.17.0
│   ├── futures v0.3.28
│   │   ├── futures-channel v0.3.28
│   │   │   ├── futures-core v0.3.28
│   │   │   └── futures-sink v0.3.28
│   │   ├── futures-core v0.3.28
│   │   ├── futures-executor v0.3.28
│   │   │   ├── futures-core v0.3.28
│   │   │   ├── futures-task v0.3.28
│   │   │   └── futures-util v0.3.28
│   │   │       ├── futures-channel v0.3.28 (*)
│   │   │       ├── futures-core v0.3.28
│   │   │       ├── futures-io v0.3.28
│   │   │       ├── futures-macro v0.3.28 (proc-macro)
│   │   │       │   ├── proc-macro2 v1.0.52
│   │   │       │   │   └── unicode-ident v1.0.8
│   │   │       │   ├── quote v1.0.26
│   │   │       │   │   └── proc-macro2 v1.0.52 (*)
│   │   │       │   └── syn v2.0.8
│   │   │       │       ├── proc-macro2 v1.0.52 (*)
│   │   │       │       ├── quote v1.0.26 (*)
│   │   │       │       └── unicode-ident v1.0.8
│   │   │       ├── futures-sink v0.3.28
│   │   │       ├── futures-task v0.3.28
│   │   │       ├── memchr v2.5.0
│   │   │       ├── pin-project-lite v0.2.9
│   │   │       ├── pin-utils v0.1.0
│   │   │       └── slab v0.4.8
│   │   │           [build-dependencies]
│   │   │           └── autocfg v1.1.0
│   │   ├── futures-io v0.3.28
│   │   ├── futures-sink v0.3.28
│   │   ├── futures-task v0.3.28
│   │   └── futures-util v0.3.28 (*)
│   ├── futures-timer v3.0.2
│   └── rstest_macros v0.17.0 (proc-macro)
│       ├── cfg-if v1.0.0
│       ├── proc-macro2 v1.0.52 (*)
│       ├── quote v1.0.26 (*)
│       ├── syn v1.0.109
│       │   ├── proc-macro2 v1.0.52 (*)
│       │   ├── quote v1.0.26 (*)
│       │   └── unicode-ident v1.0.8
│       └── unicode-ident v1.0.8
│       [build-dependencies]
│       └── rustc_version v0.4.0
│           └── semver v1.0.17
│   [build-dependencies]
│   └── rustc_version v0.4.0 (*)
```

We also depend on `serde_json` for tests, but that's not so bad:

```bash
├── serde_json v1.0.94
│   ├── itoa v1.0.6
│   ├── ryu v1.0.13
│   └── serde v1.0.155
```
