### PR TITLE
Remove duplicate types definitions (`Layout`, `RunMode`, `SizingMode`, `SizeAndBaselines`)

### DIFF
--- a/src/tree/layout.rs
+++ b/src/tree/layout.rs
@@ -4,7 +4,6 @@ use crate::geometry::{Point, Size};
 
 /// Whether we are performing a full layout, or we merely need to size the node
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[cfg(all(feature = "grid", not(feature = "flexbox")))]
 pub enum RunMode {
     /// A full layout for this node and all children should be computed
     PeformLayout,
@@ -15,7 +14,6 @@ pub enum RunMode {
 
 /// Whether styles should be taken into account when computing size
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[cfg(all(feature = "grid", not(feature = "flexbox")))]
 pub enum SizingMode {
     /// Only content contributions should be taken into account
     ContentSize,
@@ -57,7 +55,6 @@ pub struct Layout {
     pub location: Point<f32>,
 }
 
-#[cfg(all(feature = "grid", not(feature = "flexbox")))]
 impl Layout {
     /// Creates a new zero-[`Layout`].
     ///

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1,6 +1,6 @@
 //! Contains both [a high-level interface to Taffy](crate::Taffy) using a ready-made node tree, and [a trait for defining a custom node trees](crate::tree::LayoutTree) / utility types to help with that.
 
-use crate::geometry::{Point, Size};
+use crate::geometry::Size;
 use crate::style::{AvailableSpace, Style};
 
 // Submodules
@@ -17,6 +17,8 @@ mod taffy_tree;
 #[cfg(feature = "taffy_tree")]
 pub use taffy_tree::{Taffy, TaffyChildIter, TaffyError, TaffyResult};
 mod layout;
+pub use layout::{Layout, SizeAndBaselines};
+pub use layout::{RunMode, SizingMode};
 
 /// Any item that implements the LayoutTree can be layed out using Taffy's algorithms.
 ///
@@ -65,78 +67,4 @@ pub trait LayoutTree {
         available_space: Size<AvailableSpace>,
         sizing_mode: SizingMode,
     ) -> SizeAndBaselines;
-}
-
-/// Whether we are performing a full layout, or we merely need to size the node
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum RunMode {
-    /// A full layout for this node and all children should be computed
-    PeformLayout,
-    /// The layout algorithm should be executed such that an accurate container size for the node can be determined.
-    /// Layout steps that aren't necessary for determining the container size of the current node can be skipped.
-    ComputeSize,
-}
-
-/// Whether styles should be taken into account when computing size
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum SizingMode {
-    /// Only content contributions should be taken into account
-    ContentSize,
-    /// Inherent size styles should be taken into account in addition to content contributions
-    InherentSize,
-}
-
-/// A struct containing both the size of a node and it's first baseline in each dimension (if it has any)
-///
-/// A baseline is the line on which text sits. Your node likely has a baseline if it is a text node, or contains
-/// children that may be text nodes. See <https://www.w3.org/TR/css-writing-modes-3/#intro-baselines> for details.
-/// If your node does not have a baseline (or you are unsure how to compute it), then simply return `Point::NONE`
-/// for the first_baselines field
-#[derive(Debug, Copy, Clone)]
-pub struct SizeAndBaselines {
-    /// The size of the node
-    pub size: Size<f32>,
-    /// The first baseline of the node in each dimension, if any
-    pub first_baselines: Point<Option<f32>>,
-}
-
-impl From<Size<f32>> for SizeAndBaselines {
-    fn from(size: Size<f32>) -> Self {
-        Self { size, first_baselines: Point::NONE }
-    }
-}
-
-/// The final result of a layout algorithm for a single node.
-#[derive(Debug, Copy, Clone)]
-pub struct Layout {
-    /// The relative ordering of the node
-    ///
-    /// Nodes with a higher order should be rendered on top of those with a lower order.
-    /// This is effectively a topological sort of each tree.
-    pub order: u32,
-    /// The width and height of the node
-    pub size: Size<f32>,
-    /// The bottom-left corner of the node
-    pub location: Point<f32>,
-}
-
-impl Layout {
-    /// Creates a new zero-[`Layout`].
-    ///
-    /// The Zero-layout has size and location set to ZERO.
-    /// The `order` value of this layout is set to the minimum value of 0.
-    /// This means it should be rendered below all other [`Layout`]s.
-    #[must_use]
-    pub const fn new() -> Self {
-        Self { order: 0, size: Size::zero(), location: Point::ZERO }
-    }
-
-    /// Creates a new zero-[`Layout`] with the supplied `order` value.
-    ///
-    /// Nodes with a higher order should be rendered on top of those with a lower order.
-    /// The Zero-layout has size and location set to ZERO.
-    #[must_use]
-    pub const fn with_order(order: u32) -> Self {
-        Self { order, size: Size::zero(), location: Point::ZERO }
-    }
 }

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -17,8 +17,7 @@ mod taffy_tree;
 #[cfg(feature = "taffy_tree")]
 pub use taffy_tree::{Taffy, TaffyChildIter, TaffyError, TaffyResult};
 mod layout;
-pub use layout::{Layout, SizeAndBaselines};
-pub use layout::{RunMode, SizingMode};
+pub use layout::{Layout, RunMode, SizeAndBaselines, SizingMode};
 
 /// Any item that implements the LayoutTree can be layed out using Taffy's algorithms.
 ///


### PR DESCRIPTION
# Objective

Remove duplicate code. 

## Context

This is an accidental remnant of #448
