### PR TITLE
Upgrade `grid` dependency to `0.10`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,14 @@ arrayvec = { version = "0.7", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 serde = { version = "1.0", optional = true, features = ["serde_derive"] }
 slotmap = { version = "1.0.6", optional = true }
-grid = { version = "0.10.0", optional = true }
+grid = { version = "0.10.0", default-features = false, optional = true }
 
 [features]
 default = ["std", "flexbox", "grid", "taffy_tree"]
 flexbox = []
 grid = ["alloc", "dep:grid"]
 alloc = []
-std = ["num-traits/std"]
+std = ["num-traits/std", "grid?/std"]
 serde = ["dep:serde"]
 debug = []
 profile = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ arrayvec = { version = "0.7", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 serde = { version = "1.0", optional = true, features = ["serde_derive"] }
 slotmap = { version = "1.0.6", optional = true }
-grid = { version = "0.9.0", optional = true }
+grid = { version = "0.10.0", optional = true }
 
 [features]
 default = ["std", "flexbox", "grid", "taffy_tree"]

--- a/src/compute/grid/explicit_grid.rs
+++ b/src/compute/grid/explicit_grid.rs
@@ -9,6 +9,9 @@ use crate::util::MaybeMath;
 use crate::util::ResolveOrZero;
 use core::cmp::{max, min};
 
+#[cfg(not(feature = "std"))]
+use num_traits::float::FloatCore;
+
 /// Compute the number of rows and columns in the explicit grid
 pub(crate) fn compute_explicit_grid_size_in_axis(style: &Style, axis: AbsoluteAxis) -> u16 {
     // Load the grid-template-rows or grid-template-columns definition (depending on the axis)


### PR DESCRIPTION
# Objective

- Upgrade `grid` dependency to `0.10`
- Also fixes a bug that prevented the `grid` feature being used in `alloc` (but no `std`) environments

## Context

This includes a nice change which removes grid's dependency on `no-std-compat`