### PR TITLE
Minor misspelling fix (RunMode::PeformLayout -> RunMode::PerformLayout)

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -47,6 +47,7 @@ Example usage change:
   - The `axis` module has been merged into the `geometry` module
   - The debug module is no longer public. The `print_tree` function is now accesible under `util`.
   - All types from the `node`, `data`, `layout`, `error` and `cache` modules have been moved to the  the `tree` module.
+- Fixed misspelling: `RunMode::PeformLayout` renamed into `RunMode::PerformLayout` (added missing `r`).
 
 ### Fixes
 

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -33,7 +33,7 @@ impl LayoutAlgorithm for BlockAlgorithm {
             known_dimensions,
             parent_size,
             available_space,
-            RunMode::PeformLayout,
+            RunMode::PerformLayout,
             vertical_margins_are_collapsible,
         )
     }

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -34,7 +34,7 @@ impl LayoutAlgorithm for FlexboxAlgorithm {
         _sizing_mode: SizingMode,
         _vertical_margins_are_collapsible: Line<bool>,
     ) -> SizeBaselinesAndMargins {
-        compute(tree, node, known_dimensions, parent_size, available_space, RunMode::PeformLayout)
+        compute(tree, node, known_dimensions, parent_size, available_space, RunMode::PerformLayout)
     }
 
     fn measure_size(

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -47,7 +47,7 @@ impl LayoutAlgorithm for CssGridAlgorithm {
         _sizing_mode: SizingMode,
         _vertical_margins_are_collapsible: Line<bool>,
     ) -> SizeBaselinesAndMargins {
-        compute(tree, node, known_dimensions, parent_size, available_space, RunMode::PeformLayout)
+        compute(tree, node, known_dimensions, parent_size, available_space, RunMode::PerformLayout)
     }
 
     fn measure_size(

--- a/src/compute/taffy_tree.rs
+++ b/src/compute/taffy_tree.rs
@@ -77,7 +77,7 @@ pub(crate) fn perform_node_layout(
         known_dimensions,
         parent_size,
         available_space,
-        RunMode::PeformLayout,
+        RunMode::PerformLayout,
         sizing_mode,
         vertical_margins_are_collapsible,
     )
@@ -127,7 +127,7 @@ fn compute_node_layout(
     let has_children = !tree.children[node_key].is_empty();
 
     // First we check if we have a cached result for the given input
-    let cache_run_mode = if !has_children { RunMode::PeformLayout } else { run_mode };
+    let cache_run_mode = if !has_children { RunMode::PerformLayout } else { run_mode };
     if let Some(cached_size_and_baselines) =
         tree.nodes[node_key].cache.get(known_dimensions, available_space, cache_run_mode)
     {
@@ -159,7 +159,7 @@ fn compute_node_layout(
         NODE_LOGGER.log(Algorithm::NAME);
 
         match run_mode {
-            RunMode::PeformLayout => Algorithm::perform_layout(
+            RunMode::PerformLayout => Algorithm::perform_layout(
                 tree,
                 node,
                 known_dimensions,
@@ -221,7 +221,7 @@ fn compute_node_layout(
             vertical_margins_are_collapsible,
         ),
         (_, false) => match run_mode {
-            RunMode::PeformLayout => leaf::perform_layout(
+            RunMode::PerformLayout => leaf::perform_layout(
                 &tree.nodes[node_key].style,
                 tree.nodes[node_key].needs_measure.then(|| &tree.measure_funcs[node_key]),
                 known_dimensions,

--- a/src/tree/cache.rs
+++ b/src/tree/cache.rs
@@ -92,7 +92,7 @@ impl Cache {
     ) -> Option<SizeBaselinesAndMargins> {
         for entry in self.entries.iter().flatten() {
             // Cached ComputeSize results are not valid if we are running in PerformLayout mode
-            if entry.run_mode == RunMode::ComputeSize && run_mode == RunMode::PeformLayout {
+            if entry.run_mode == RunMode::ComputeSize && run_mode == RunMode::PerformLayout {
                 return None;
             }
 

--- a/src/tree/layout.rs
+++ b/src/tree/layout.rs
@@ -9,7 +9,7 @@ use crate::{
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum RunMode {
     /// A full layout for this node and all children should be computed
-    PeformLayout,
+    PerformLayout,
     /// The layout algorithm should be executed such that an accurate container size for the node can be determined.
     /// Layout steps that aren't necessary for determining the container size of the current node can be skipped.
     ComputeSize,


### PR DESCRIPTION
# Objective

> Why did you make this PR?

I found minor misspelling. `RunMode::PeformLayout` changed into `RunMode::PerformLayout` (added missing `r`)