### PR TITLE
Minor: In a few tests simplified default Style construction

### DIFF
--- a/tests/caching.rs
+++ b/tests/caching.rs
@@ -12,7 +12,7 @@ mod caching {
 
         let leaf = taffy
             .new_leaf_with_measure(
-                Style { ..Default::default() },
+                Style::default(),
                 MeasureFunc::Raw(|known_dimensions, _available_space| {
                     NUM_MEASURES.fetch_add(1, Ordering::SeqCst);
                     Size {

--- a/tests/measure.rs
+++ b/tests/measure.rs
@@ -8,7 +8,7 @@ mod measure {
         let mut taffy = Taffy::new();
         let node = taffy
             .new_leaf_with_measure(
-                Style { ..Default::default() },
+                Style::default(),
                 MeasureFunc::Raw(|known_dimensions, _available_space| Size {
                     width: known_dimensions.width.unwrap_or(100.0),
                     height: known_dimensions.height.unwrap_or(100.0),
@@ -28,7 +28,7 @@ mod measure {
 
         let child = taffy
             .new_leaf_with_measure(
-                Style { ..Default::default() },
+                Style::default(),
                 MeasureFunc::Raw(|known_dimensions, _available_space| Size {
                     width: known_dimensions.width.unwrap_or(100.0),
                     height: known_dimensions.height.unwrap_or(100.0),
@@ -36,7 +36,7 @@ mod measure {
             )
             .unwrap();
 
-        let node = taffy.new_with_children(Style { ..Default::default() }, &[child]).unwrap();
+        let node = taffy.new_with_children(Style::default(), &[child]).unwrap();
         taffy.compute_layout(node, Size::MAX_CONTENT).unwrap();
 
         assert_eq!(taffy.layout(node).unwrap().size.width, 100.0);
@@ -51,7 +51,7 @@ mod measure {
         let mut taffy = Taffy::new();
         let child = taffy
             .new_leaf_with_measure(
-                Style { ..Default::default() },
+                Style::default(),
                 MeasureFunc::Raw(|known_dimensions, _available_space| Size {
                     width: known_dimensions.width.unwrap_or(100.0),
                     height: known_dimensions.height.unwrap_or(100.0),
@@ -81,7 +81,7 @@ mod measure {
         let mut taffy = Taffy::new();
         let child = taffy
             .new_leaf_with_measure(
-                Style { ..Default::default() },
+                Style::default(),
                 MeasureFunc::Raw(|known_dimensions, _available_space| Size {
                     width: known_dimensions.width.unwrap_or(100.0),
                     height: known_dimensions.height.unwrap_or(100.0),
@@ -163,7 +163,7 @@ mod measure {
 
         let child1 = taffy
             .new_leaf_with_measure(
-                Style { ..Default::default() },
+                Style::default(),
                 MeasureFunc::Raw(|known_dimensions, _available_space| Size {
                     width: known_dimensions.width.unwrap_or(100.0),
                     height: known_dimensions.height.unwrap_or(50.0),
@@ -236,7 +236,7 @@ mod measure {
 
         let child1 = taffy
             .new_leaf_with_measure(
-                Style { ..Default::default() },
+                Style::default(),
                 MeasureFunc::Raw(|known_dimensions, _available_space| {
                     let width = known_dimensions.width.unwrap_or(100.0);
                     let height = known_dimensions.height.unwrap_or(width * 2.0);
@@ -268,7 +268,7 @@ mod measure {
 
         let child = taffy
             .new_leaf_with_measure(
-                Style { ..Default::default() },
+                Style::default(),
                 MeasureFunc::Raw(|known_dimensions, _available_space| {
                     let height = known_dimensions.height.unwrap_or(50.0);
                     let width = known_dimensions.width.unwrap_or(height);
@@ -306,7 +306,7 @@ mod measure {
             )
             .unwrap();
 
-        let node = taffy.new_with_children(Style { ..Default::default() }, &[child]).unwrap();
+        let node = taffy.new_with_children(Style::default(), &[child]).unwrap();
         taffy.compute_layout(node, Size::MAX_CONTENT).unwrap();
 
         assert_eq!(taffy.layout(child).unwrap().size.width, 50.0);
@@ -326,7 +326,7 @@ mod measure {
             )
             .unwrap();
 
-        let node = taffy.new_with_children(Style { ..Default::default() }, &[child]).unwrap();
+        let node = taffy.new_with_children(Style::default(), &[child]).unwrap();
         taffy.compute_layout(node, Size::MAX_CONTENT).unwrap();
 
         assert_eq!(taffy.layout(child).unwrap().size.width, 100.0);
@@ -373,7 +373,7 @@ mod measure {
         let mut taffy = Taffy::new();
         let child = taffy
             .new_leaf_with_measure(
-                Style { ..Default::default() },
+                Style::default(),
                 MeasureFunc::Raw(|known_dimensions, _available_space| Size {
                     width: known_dimensions.width.unwrap_or(50.0),
                     height: known_dimensions.height.unwrap_or(50.0),

--- a/tests/root_constraints.rs
+++ b/tests/root_constraints.rs
@@ -33,7 +33,7 @@ mod root_constraints {
     #[test]
     fn root_with_no_size() {
         let mut taffy = taffy::Taffy::new();
-        let node = taffy.new_leaf(taffy::style::Style { ..Default::default() }).unwrap();
+        let node = taffy.new_leaf(taffy::style::Style::default()).unwrap();
 
         taffy
             .compute_layout(


### PR DESCRIPTION
# Objective

> Why did you make this PR?

I found in a few manually-written tests (not generated) the next pattern for creating default `Style` - `Style::{ ..Default::default() }` (instead of `Style::default()`), that looks "unusual" (why here is 'create Style with all fields in default state', instead of simple 'create default Style' ?). This small minor PR fixes such places, to reduce mental load during reading :D