### PR TITLE
Don't take `self` by value if we don't have to

### DIFF
--- a/src/compute/grid/types/coordinates.rs
+++ b/src/compute/grid/types/coordinates.rs
@@ -108,7 +108,7 @@ impl OriginZeroLine {
     }
 
     /// The minimum number of positive implicit track there must be if a grid item end at this line.
-    pub(crate) fn implied_positive_implicit_tracks(self, explicit_track_count: u16) -> u16 {
+    pub(crate) fn implied_positive_implicit_tracks(&self, explicit_track_count: u16) -> u16 {
         if self.0 > explicit_track_count as i16 {
             self.0 as u16 - explicit_track_count
         } else {

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -27,10 +27,10 @@ impl AbsoluteAxis {
     }
 }
 
-impl<T> Size<T> {
+impl<T: Copy> Size<T> {
     #[inline(always)]
     /// Get either the width or height depending on the AbsoluteAxis passed in
-    pub fn get_abs(self, axis: AbsoluteAxis) -> T {
+    pub fn get_abs(&self, axis: AbsoluteAxis) -> T {
         match axis {
             AbsoluteAxis::Horizontal => self.width,
             AbsoluteAxis::Vertical => self.height,
@@ -38,10 +38,10 @@ impl<T> Size<T> {
     }
 }
 
-impl<T: Add> Rect<T> {
+impl<T: Add + Copy> Rect<T> {
     #[inline(always)]
     /// Get either the width or height depending on the AbsoluteAxis passed in
-    pub fn grid_axis_sum(self, axis: AbsoluteAxis) -> <T as Add>::Output {
+    pub fn grid_axis_sum(&self, axis: AbsoluteAxis) -> <T as Add>::Output {
         match axis {
             AbsoluteAxis::Horizontal => self.left + self.right,
             AbsoluteAxis::Vertical => self.top + self.bottom,
@@ -127,14 +127,14 @@ impl<U, T: Add<U>> Add<Rect<U>> for Rect<T> {
     }
 }
 
-impl<T> Rect<T> {
+impl<T: Copy> Rect<T> {
     /// Applies the function `f` to all four sides of the rect
     ///
     /// When applied to the left and right sides, the width is used
     /// as the second parameter of `f`.
     /// When applied to the top or bottom sides, the height is used instead.
     #[cfg(feature = "flexbox")]
-    pub(crate) fn zip_size<R, F, U>(self, size: Size<U>, f: F) -> Rect<R>
+    pub(crate) fn zip_size<R, F, U>(&self, size: Size<U>, f: F) -> Rect<R>
     where
         F: Fn(T, U) -> R,
         U: Copy,
@@ -150,7 +150,7 @@ impl<T> Rect<T> {
     /// Applies the function `f` to the left, right, top, and bottom properties
     ///
     /// This is used to transform a `Rect<T>` into a `Rect<R>`.
-    pub fn map<R, F>(self, f: F) -> Rect<R>
+    pub fn map<R, F>(&self, f: F) -> Rect<R>
     where
         F: Fn(T) -> R,
     {
@@ -158,12 +158,12 @@ impl<T> Rect<T> {
     }
 
     /// Returns a `Line<T>` representing the left and right properties of the Rect
-    pub fn horizontal_components(self) -> Line<T> {
+    pub fn horizontal_components(&self) -> Line<T> {
         Line { start: self.left, end: self.right }
     }
 
     /// Returns a `Line<T>` containing the top and bottom properties of the Rect
-    pub fn vertical_components(self) -> Line<T> {
+    pub fn vertical_components(&self) -> Line<T> {
         Line { start: self.top, end: self.bottom }
     }
 }
@@ -297,11 +297,11 @@ pub struct Line<T> {
     pub end: T,
 }
 
-impl<T> Line<T> {
+impl<T: Copy> Line<T> {
     /// Applies the function `f` to both the width and height
     ///
     /// This is used to transform a `Line<T>` into a `Line<R>`.
-    pub fn map<R, F>(self, f: F) -> Line<R>
+    pub fn map<R, F>(&self, f: F) -> Line<R>
     where
         F: Fn(T) -> R,
     {
@@ -351,14 +351,14 @@ impl<U, T: Sub<U>> Sub<Size<U>> for Size<T> {
     }
 }
 
-// Note: we allow dead_code here as we want to provide a complete API of helpers that is symetrical in all axes,
+// Note: we allow dead_code here as we want to provide a complete API of helpers that is symmetrical in all axes,
 // but sometimes we only currently have a use for the helper in a single axis
 #[allow(dead_code)]
-impl<T> Size<T> {
+impl<T: Copy> Size<T> {
     /// Applies the function `f` to both the width and height
     ///
     /// This is used to transform a `Size<T>` into a `Size<R>`.
-    pub fn map<R, F>(self, f: F) -> Size<R>
+    pub fn map<R, F>(&self, f: F) -> Size<R>
     where
         F: Fn(T) -> R,
     {
@@ -366,7 +366,7 @@ impl<T> Size<T> {
     }
 
     /// Applies the function `f` to the width
-    pub fn map_width<F>(self, f: F) -> Size<T>
+    pub fn map_width<F>(&self, f: F) -> Size<T>
     where
         F: Fn(T) -> T,
     {
@@ -374,7 +374,7 @@ impl<T> Size<T> {
     }
 
     /// Applies the function `f` to the height
-    pub fn map_height<F>(self, f: F) -> Size<T>
+    pub fn map_height<F>(&self, f: F) -> Size<T>
     where
         F: Fn(T) -> T,
     {
@@ -383,7 +383,7 @@ impl<T> Size<T> {
 
     /// Applies the function `f` to both the width and height
     /// of this value and another passed value
-    pub fn zip_map<Other, Ret, Func>(self, other: Size<Other>, f: Func) -> Size<Ret>
+    pub fn zip_map<Other, Ret, Func>(&self, other: Size<Other>, f: Func) -> Size<Ret>
     where
         Func: Fn(T, Other) -> Ret,
     {
@@ -474,7 +474,7 @@ impl<T> Size<T> {
     ///
     /// Whether this is the width or height depends on the `direction` provided
     #[cfg(feature = "flexbox")]
-    pub(crate) fn main(self, direction: FlexDirection) -> T {
+    pub(crate) fn main(&self, direction: FlexDirection) -> T {
         if direction.is_row() {
             self.width
         } else {
@@ -486,7 +486,7 @@ impl<T> Size<T> {
     ///
     /// Whether this is the width or height depends on the `direction` provided
     #[cfg(feature = "flexbox")]
-    pub(crate) fn cross(self, direction: FlexDirection) -> T {
+    pub(crate) fn cross(&self, direction: FlexDirection) -> T {
         if direction.is_row() {
             self.height
         } else {
@@ -497,7 +497,7 @@ impl<T> Size<T> {
     /// Gets the extent of the specified layout axis
     /// Whether this is the width or height depends on the `GridAxis` provided
     #[cfg(feature = "grid")]
-    pub(crate) fn get(self, axis: AbstractAxis) -> T {
+    pub(crate) fn get(&self, axis: AbstractAxis) -> T {
         match axis {
             AbstractAxis::Inline => self.width,
             AbstractAxis::Block => self.height,
@@ -520,7 +520,7 @@ impl Size<f32> {
     pub const ZERO: Size<f32> = Self { width: 0.0, height: 0.0 };
 
     /// Applies f32_max to each component separately
-    pub fn f32_max(self, rhs: Size<f32>) -> Size<f32> {
+    pub fn f32_max(&self, rhs: Size<f32>) -> Size<f32> {
         Size { width: f32_max(self.width, rhs.width), height: f32_max(self.height, rhs.height) }
     }
 }
@@ -540,26 +540,26 @@ impl Size<Option<f32>> {
     ///   - If height is `Some` but width is `None`, then width is computed from height and aspect_ratio
     ///
     /// If aspect_ratio is `None` then this function simply returns self.
-    pub fn maybe_apply_aspect_ratio(self, aspect_ratio: Option<f32>) -> Size<Option<f32>> {
+    pub fn maybe_apply_aspect_ratio(&self, aspect_ratio: Option<f32>) -> Size<Option<f32>> {
         match aspect_ratio {
             Some(ratio) => match (self.width, self.height) {
                 (Some(width), None) => Size { width: Some(width), height: Some(width / ratio) },
                 (None, Some(height)) => Size { width: Some(height * ratio), height: Some(height) },
-                _ => self,
+                _ => *self,
             },
-            None => self,
+            None => *self,
         }
     }
 }
 
-impl<T> Size<Option<T>> {
+impl<T: Copy> Size<Option<T>> {
     /// Performs Option::unwrap_or on each component separately
-    pub fn unwrap_or(self, alt: Size<T>) -> Size<T> {
+    pub fn unwrap_or(&self, alt: Size<T>) -> Size<T> {
         Size { width: self.width.unwrap_or(alt.width), height: self.height.unwrap_or(alt.height) }
     }
 
     /// Performs Option::or on each component separately
-    pub fn or(self, alt: Size<Option<T>>) -> Size<Option<T>> {
+    pub fn or(&self, alt: Size<Option<T>>) -> Size<Option<T>> {
         Size { width: self.width.or(alt.width), height: self.height.or(alt.height) }
     }
 
@@ -615,11 +615,11 @@ impl<U, T: Add<U>> Add<Point<U>> for Point<T> {
     }
 }
 
-impl<T> Point<T> {
+impl<T: Copy> Point<T> {
     /// Applies the function `f` to both the x and y
     ///
     /// This is used to transform a `Point<T>` into a `Point<R>`.
-    pub fn map<R, F>(self, f: F) -> Point<R>
+    pub fn map<R, F>(&self, f: F) -> Point<R>
     where
         F: Fn(T) -> R,
     {
@@ -629,7 +629,7 @@ impl<T> Point<T> {
     /// Gets the extent of the specified layout axis
     /// Whether this is the width or height depends on the `GridAxis` provided
     #[cfg(feature = "grid")]
-    pub fn get(self, axis: AbstractAxis) -> T {
+    pub fn get(&self, axis: AbstractAxis) -> T {
         match axis {
             AbstractAxis::Inline => self.x,
             AbstractAxis::Block => self.y,
@@ -637,7 +637,7 @@ impl<T> Point<T> {
     }
 
     /// Swap x and y components
-    pub fn transpose(self) -> Point<T> {
+    pub fn transpose(&self) -> Point<T> {
         Point { x: self.y, y: self.x }
     }
 
@@ -655,7 +655,7 @@ impl<T> Point<T> {
     ///
     /// Whether this is the x or y depends on the `direction` provided
     #[cfg(feature = "flexbox")]
-    pub(crate) fn main(self, direction: FlexDirection) -> T {
+    pub(crate) fn main(&self, direction: FlexDirection) -> T {
         if direction.is_row() {
             self.x
         } else {
@@ -667,7 +667,7 @@ impl<T> Point<T> {
     ///
     /// Whether this is the x or y depends on the `direction` provided
     #[cfg(feature = "flexbox")]
-    pub(crate) fn cross(self, direction: FlexDirection) -> T {
+    pub(crate) fn cross(&self, direction: FlexDirection) -> T {
         if direction.is_row() {
             self.y
         } else {

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -27,13 +27,13 @@ impl AbsoluteAxis {
     }
 }
 
-impl<T: Copy> Size<T> {
+impl<T: Clone> Size<T> {
     #[inline(always)]
     /// Get either the width or height depending on the AbsoluteAxis passed in
     pub fn get_abs(&self, axis: AbsoluteAxis) -> T {
         match axis {
-            AbsoluteAxis::Horizontal => self.width,
-            AbsoluteAxis::Vertical => self.height,
+            AbsoluteAxis::Horizontal => self.width.clone(),
+            AbsoluteAxis::Vertical => self.height.clone(),
         }
     }
 }
@@ -351,6 +351,20 @@ impl<U, T: Sub<U>> Sub<Size<U>> for Size<T> {
     }
 }
 
+impl<T: Clone> Size<T> {
+    /// Gets the extent of the cross layout axis
+    ///
+    /// Whether this is the width or height depends on the `direction` provided
+    #[cfg(feature = "flexbox")]
+    pub(crate) fn cross(&self, direction: FlexDirection) -> T {
+        if direction.is_row() {
+            self.height.clone()
+        } else {
+            self.width.clone()
+        }
+    }
+}
+
 // Note: we allow dead_code here as we want to provide a complete API of helpers that is symmetrical in all axes,
 // but sometimes we only currently have a use for the helper in a single axis
 #[allow(dead_code)]
@@ -479,18 +493,6 @@ impl<T: Copy> Size<T> {
             self.width
         } else {
             self.height
-        }
-    }
-
-    /// Gets the extent of the cross layout axis
-    ///
-    /// Whether this is the width or height depends on the `direction` provided
-    #[cfg(feature = "flexbox")]
-    pub(crate) fn cross(&self, direction: FlexDirection) -> T {
-        if direction.is_row() {
-            self.height
-        } else {
-            self.width
         }
     }
 

--- a/src/style/dimension.rs
+++ b/src/style/dimension.rs
@@ -76,9 +76,9 @@ impl LengthPercentageAuto {
     ///   - Some(resolved) using the provided context for Percent variants
     ///   - None for Auto variants
     #[inline(always)]
-    pub fn resolve_to_option(self, context: f32) -> Option<f32> {
+    pub fn resolve_to_option(&self, context: f32) -> Option<f32> {
         match self {
-            Self::Length(length) => Some(length),
+            Self::Length(length) => Some(*length),
             Self::Percent(percent) => Some(context * percent),
             Self::Auto => None,
         }
@@ -204,8 +204,8 @@ impl FromLength for AvailableSpace {
 
 impl AvailableSpace {
     /// Returns true for definite values, else false
-    pub fn is_definite(self) -> bool {
-        matches!(self, AvailableSpace::Definite(_))
+    pub fn is_definite(&self) -> bool {
+        matches!(*self, AvailableSpace::Definite(_))
     }
 
     /// Convert to Option

--- a/src/style/flex.rs
+++ b/src/style/flex.rs
@@ -63,20 +63,20 @@ impl Default for FlexDirection {
 impl FlexDirection {
     #[inline]
     /// Is the direction [`FlexDirection::Row`] or [`FlexDirection::RowReverse`]?
-    pub(crate) fn is_row(self) -> bool {
-        matches!(self, Self::Row | Self::RowReverse)
+    pub(crate) fn is_row(&self) -> bool {
+        matches!(*self, Self::Row | Self::RowReverse)
     }
 
     #[inline]
     /// Is the direction [`FlexDirection::Column`] or [`FlexDirection::ColumnReverse`]?
-    pub(crate) fn is_column(self) -> bool {
-        matches!(self, Self::Column | Self::ColumnReverse)
+    pub(crate) fn is_column(&self) -> bool {
+        matches!(*self, Self::Column | Self::ColumnReverse)
     }
 
     #[inline]
     /// Is the direction [`FlexDirection::RowReverse`] or [`FlexDirection::ColumnReverse`]?
-    pub(crate) fn is_reverse(self) -> bool {
-        matches!(self, Self::RowReverse | Self::ColumnReverse)
+    pub(crate) fn is_reverse(&self) -> bool {
+        matches!(*self, Self::RowReverse | Self::ColumnReverse)
     }
 }
 

--- a/src/style/grid.rs
+++ b/src/style/grid.rs
@@ -313,10 +313,10 @@ impl MaxTrackSizingFunction {
     /// the passed available_space and returns if this results in a concrete value (which it
     /// will if the available_space is `Some`). Otherwise returns None.
     #[inline(always)]
-    pub fn definite_value(self, parent_size: Option<f32>) -> Option<f32> {
+    pub fn definite_value(&self, parent_size: Option<f32>) -> Option<f32> {
         use MaxTrackSizingFunction::*;
         match self {
-            Fixed(LengthPercentage::Length(size)) => Some(size),
+            Fixed(LengthPercentage::Length(size)) => Some(*size),
             Fixed(LengthPercentage::Percent(fraction)) => parent_size.map(|size| fraction * size),
             MinContent | MaxContent | FitContent(_) | Auto | Fraction(_) => None,
         }
@@ -329,10 +329,10 @@ impl MaxTrackSizingFunction {
     ///     - A fit-content sizing function with percentage argument (with definite available space)
     /// All other kinds of track sizing function return None.
     #[inline(always)]
-    pub fn definite_limit(self, parent_size: Option<f32>) -> Option<f32> {
+    pub fn definite_limit(&self, parent_size: Option<f32>) -> Option<f32> {
         use MaxTrackSizingFunction::FitContent;
         match self {
-            FitContent(LengthPercentage::Length(size)) => Some(size),
+            FitContent(LengthPercentage::Length(size)) => Some(*size),
             FitContent(LengthPercentage::Percent(fraction)) => parent_size.map(|size| fraction * size),
             _ => self.definite_value(parent_size),
         }
@@ -341,7 +341,7 @@ impl MaxTrackSizingFunction {
     /// Resolve percentage values against the passed parent_size, returning Some(value)
     /// Non-percentage values always return None.
     #[inline(always)]
-    pub fn resolved_percentage_size(self, parent_size: f32) -> Option<f32> {
+    pub fn resolved_percentage_size(&self, parent_size: f32) -> Option<f32> {
         use MaxTrackSizingFunction::*;
         match self {
             Fixed(LengthPercentage::Percent(fraction)) => Some(fraction * parent_size),
@@ -351,7 +351,7 @@ impl MaxTrackSizingFunction {
 
     /// Whether the track sizing functions depends on the size of the parent node
     #[inline(always)]
-    pub fn uses_percentage(self) -> bool {
+    pub fn uses_percentage(&self) -> bool {
         use MaxTrackSizingFunction::*;
         matches!(self, Fixed(LengthPercentage::Percent(_)) | FitContent(LengthPercentage::Percent(_)))
     }
@@ -408,10 +408,10 @@ impl MinTrackSizingFunction {
     /// the passed available_space and returns if this results in a concrete value (which it
     /// will if the available_space is `Some`). Otherwise returns `None`.
     #[inline(always)]
-    pub fn definite_value(self, parent_size: Option<f32>) -> Option<f32> {
+    pub fn definite_value(&self, parent_size: Option<f32>) -> Option<f32> {
         use MinTrackSizingFunction::*;
         match self {
-            Fixed(LengthPercentage::Length(size)) => Some(size),
+            Fixed(LengthPercentage::Length(size)) => Some(*size),
             Fixed(LengthPercentage::Percent(fraction)) => parent_size.map(|size| fraction * size),
             MinContent | MaxContent | Auto => None,
         }
@@ -420,7 +420,7 @@ impl MinTrackSizingFunction {
     /// Resolve percentage values against the passed parent_size, returning Some(value)
     /// Non-percentage values always return None.
     #[inline(always)]
-    pub fn resolved_percentage_size(self, parent_size: f32) -> Option<f32> {
+    pub fn resolved_percentage_size(&self, parent_size: f32) -> Option<f32> {
         use MinTrackSizingFunction::*;
         match self {
             Fixed(LengthPercentage::Percent(fraction)) => Some(fraction * parent_size),
@@ -430,9 +430,9 @@ impl MinTrackSizingFunction {
 
     /// Whether the track sizing functions depends on the size of the parent node
     #[inline(always)]
-    pub fn uses_percentage(self) -> bool {
+    pub fn uses_percentage(&self) -> bool {
         use MinTrackSizingFunction::*;
-        matches!(self, Fixed(LengthPercentage::Percent(_)))
+        matches!(*self, Fixed(LengthPercentage::Percent(_)))
     }
 }
 


### PR DESCRIPTION
# Objective

In a lot of functions we currently take `self` by value instead of reference. This is possible because these values are `Copy`, so we can still comfortably use them.

However, this might not always be the case. For example, implementing calculated dimensions will cause them to lose the `Copy` derive, breaking several usages.

## Context

I will probably take another stab at implementing calculated dimensions soon and this PR should make that a bit easier.
There are still 42 errors when removing the `Clone` derive from `Dimension`, but those probably need `.clone()` to be slapped into several places.

See <https://github.com/DioxusLabs/taffy/pull/232> for reference as well.

## Feedback wanted

Do you think this could have a performance impact?
I measured some performance regressions in the benchmarks, but they appear to be quite flaky on my machine.
So I'm not sure if it's noise or an actual regression.
