### PR TITLE
Minor: changed docs for Layout::location (bottom-left -> top-left) & added test

### DIFF
--- a/src/tree/layout.rs
+++ b/src/tree/layout.rs
@@ -137,7 +137,7 @@ pub struct Layout {
     pub order: u32,
     /// The width and height of the node
     pub size: Size<f32>,
-    /// The bottom-left corner of the node
+    /// The top-left corner of the node
     pub location: Point<f32>,
 }
 

--- a/src/tree/taffy_tree/tree.rs
+++ b/src/tree/taffy_tree/tree.rs
@@ -788,4 +788,42 @@ mod tests {
         );
         assert!(layout_result.is_ok());
     }
+
+    #[test]
+    fn make_sure_layout_location_is_top_left() {
+        use crate::prelude::Rect;
+
+        let mut taffy = Taffy::new();
+
+        let node = taffy.new_leaf(Style {
+            size: Size { width: Dimension::Length(10f32), height: Dimension::Length(10f32) },
+            ..Default::default()
+        }).unwrap();
+
+        let root = taffy.new_with_children(Style {
+            size: Size { width: Dimension::Length(100f32), height: Dimension::Length(100f32) },
+            padding: Rect {
+                left:   length(10f32),
+                right:  length(20f32),
+                top:    length(30f32),
+                bottom: length(40f32),
+            },
+            ..Default::default()
+        }, &[node]
+        ).unwrap();
+
+        taffy.compute_layout(root, Size::MAX_CONTENT).unwrap();
+
+        // If Layout::location represents top-left coord, 'node' location
+        // must be (due applied 'root' padding): {x: 10, y: 30}.
+        //
+        // It's important, since result will be different for each other
+        // coordinate space:
+        // - bottom-left:  {x: 10, y: 40}
+        // - top-right:    {x: 20, y: 30}
+        // - bottom-right: {x: 20, y: 40}
+        let layout = taffy.layout(node).unwrap();
+        assert_eq!(layout.location.x, 10f32);
+        assert_eq!(layout.location.y, 30f32);
+    }
 }

--- a/src/tree/taffy_tree/tree.rs
+++ b/src/tree/taffy_tree/tree.rs
@@ -795,22 +795,28 @@ mod tests {
 
         let mut taffy = Taffy::new();
 
-        let node = taffy.new_leaf(Style {
-            size: Size { width: Dimension::Percent(1f32), height: Dimension::Percent(1f32) },
-            ..Default::default()
-        }).unwrap();
+        let node = taffy
+            .new_leaf(Style {
+                size: Size { width: Dimension::Percent(1f32), height: Dimension::Percent(1f32) },
+                ..Default::default()
+            })
+            .unwrap();
 
-        let root = taffy.new_with_children(Style {
-            size: Size { width: Dimension::Length(100f32), height: Dimension::Length(100f32) },
-            padding: Rect {
-                left:   length(10f32),
-                right:  length(20f32),
-                top:    length(30f32),
-                bottom: length(40f32),
-            },
-            ..Default::default()
-        }, &[node]
-        ).unwrap();
+        let root = taffy
+            .new_with_children(
+                Style {
+                    size: Size { width: Dimension::Length(100f32), height: Dimension::Length(100f32) },
+                    padding: Rect {
+                        left: length(10f32),
+                        right: length(20f32),
+                        top: length(30f32),
+                        bottom: length(40f32),
+                    },
+                    ..Default::default()
+                },
+                &[node],
+            )
+            .unwrap();
 
         taffy.compute_layout(root, Size::MAX_CONTENT).unwrap();
 

--- a/src/tree/taffy_tree/tree.rs
+++ b/src/tree/taffy_tree/tree.rs
@@ -796,7 +796,7 @@ mod tests {
         let mut taffy = Taffy::new();
 
         let node = taffy.new_leaf(Style {
-            size: Size { width: Dimension::Length(10f32), height: Dimension::Length(10f32) },
+            size: Size { width: Dimension::Percent(1f32), height: Dimension::Percent(1f32) },
             ..Default::default()
         }).unwrap();
 


### PR DESCRIPTION
# Objective

> Why did you make this PR?

I found a discrepancy between documentation and code behavior. As I can see (after playing with `Style::padding`), `Layout`::`location` represents `top-left` point of the node rect, not `bottom-left`.

Also I added test for it. I don't know where to add it, so I added it into `src/tree/taffy_tree/tree.rs`