### PR TITLE
Add flexbox layout benches with all-`auto` node sizes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ ordered-float = "3.4.0"
 serde_json = "1.0.93"
 
 # Enable example and test-specific features
-taffy = { path = ".", features = ["random"] }
+taffy = { path = ".", features = ["random", "yoga_benchmark"] }
 
 [profile.release]
 lto = true

--- a/benches/helpers/mod.rs
+++ b/benches/helpers/mod.rs
@@ -26,3 +26,38 @@ pub fn build_deep_tree<T, N>(
         })
         .collect()
 }
+
+/// A helper function to construct a tree with a fixed number of children per level
+/* The tree would look something like (for per_level_child_count = 3):
+N, N, N
+      |
+      N, N, N
+            |
+            N, N, N
+                   ...
+*/
+#[allow(dead_code)]
+pub fn build_linear_tree_with_n_children_per_level<T, N: Copy>(
+    tree: &mut T,
+    max_nodes: u32,
+    per_level_child_count: u32,
+    create_node: &mut impl FnMut(&mut T) -> N,
+    append_child: &mut impl FnMut(&mut T, N, N),
+) -> N {
+    let mut node_count = max_nodes as i32;
+    let root = create_node(tree);
+    let mut parent = root;
+
+    while node_count > 0 {
+        let mut next_parent = parent;
+        for _ in 0..per_level_child_count {
+            let child = create_node(tree);
+            append_child(tree, parent, child);
+            node_count -= 1;
+            next_parent = child;
+        }
+        parent = next_parent;
+    }
+
+    root
+}

--- a/src/randomizable.rs
+++ b/src/randomizable.rs
@@ -3,7 +3,10 @@
 use rand::Rng;
 
 use crate::geometry::Size;
+use crate::prelude::Rect;
 use crate::style::Dimension;
+use crate::style::LengthPercentage;
+use crate::style::LengthPercentageAuto;
 use crate::style::Style;
 
 /// A trait for generating pseudo-random instances.


### PR DESCRIPTION
# Objective

Auto flex layout right now performs very poorly in Taffy. But the current benches don't measure trees where each node is set to flex auto. This PR adds benchmarks to measure flex auto behavior. This PR is based on the `0.3.1` release so I'll have to bring it up to date. 

## Context

As I was digging into https://github.com/DioxusLabs/taffy/issues/502, I noticed that the current benchmark doesn't have a test that measures the styling of nodes where each node is flex auto

## Feedback wanted

I'm not married to how I've labeled these tests and happy to reorganize and rename. 

- [ ] discuss labels



