### PR TITLE
Minor: fixed comment for geometry::Point type

### DIFF
--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -586,7 +586,7 @@ impl Size<Dimension> {
 
 /// A 2-dimensional coordinate.
 ///
-/// When used in association with a [`Rect`], represents the bottom-left corner.
+/// When used in association with a [`Rect`], represents the top-left corner.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Point<T> {


### PR DESCRIPTION
# Objective

> Why did you make this PR?

Due to documentation changes in this PR https://github.com/DioxusLabs/taffy/pull/500, docs for `geometry::Point` must be changed too.