### PR TITLE
Remove "parent" references to a node when removing that node

### DIFF
--- a/src/tree/taffy_tree/tree.rs
+++ b/src/tree/taffy_tree/tree.rs
@@ -229,6 +229,12 @@ impl Taffy {
             }
         }
 
+        if let Some(children) = self.children.get(key) {
+            for child in children.iter().copied() {
+                self.parents[child.into()] = None;
+            }
+        }
+
         let _ = self.children.remove(key);
         let _ = self.parents.remove(key);
         let _ = self.nodes.remove(key);


### PR DESCRIPTION
# Objective

Fixes #510 

Seems that the parents list is not updated on the `remove` call, which I have to assume is a mistake.

## Context

See issue.