### PR TITLE
Minor: replaced `Result<(), TaffyError>` by `TaffyResult<()>` for consistency

### DIFF
--- a/src/tree/taffy_tree/tree.rs
+++ b/src/tree/taffy_tree/tree.rs
@@ -427,7 +427,7 @@ impl Taffy {
     }
 
     /// Updates the stored layout of the provided `node` and its children
-    pub fn compute_layout(&mut self, node: NodeId, available_space: Size<AvailableSpace>) -> Result<(), TaffyError> {
+    pub fn compute_layout(&mut self, node: NodeId, available_space: Size<AvailableSpace>) -> TaffyResult<()> {
         compute_layout(self, node, available_space)
     }
 }


### PR DESCRIPTION
# Objective

> Why did you make this PR?

I found, that in `src/tree/taffy_tree/tree.rs` **everywhere** used `TaffyResult<T>`, except only one place - `Taffy::compute_layout(...) -> Result<(), TaffyError>`. This small minor PR fixes it :)