### PR TITLE
Minor: `CellOccupancyMatrix::is_area_in_range()` now immutable

### DIFF
--- a/src/compute/grid/types/cell_occupancy.rs
+++ b/src/compute/grid/types/cell_occupancy.rs
@@ -72,7 +72,7 @@ impl CellOccupancyMatrix {
 
     /// Determines whether the specified area fits within the tracks currently represented by the matrix
     pub fn is_area_in_range(
-        &mut self,
+        &self,
         primary_axis: AbsoluteAxis,
         primary_range: Range<i16>,
         secondary_range: Range<i16>,


### PR DESCRIPTION
# Objective

> Why did you make this PR?

I found, that `CellOccupancyMatrix::is_area_in_range(...)` is immutable, but its not declared. For clarity in this PR removed `mut` near `self`.