### PR TITLE
Fixed clippy lint errors (needless_pass_by_ref_mut)

### DIFF
--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -504,7 +504,7 @@ fn perform_final_layout_on_in_flow_children(
 #[inline]
 fn perform_absolute_layout_on_absolute_children(
     tree: &mut impl LayoutTree,
-    items: &mut [BlockItem],
+    items: &[BlockItem],
     area_size: Size<f32>,
     area_offset: Point<f32>,
 ) {

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -260,7 +260,7 @@ fn compute_inner(
     let absolute_position_inset = resolved_border + scrollbar_gutter;
     let absolute_position_area = final_outer_size - absolute_position_inset.sum_axes();
     let absolute_position_offset = Point { x: absolute_position_inset.left, y: absolute_position_inset.top };
-    perform_absolute_layout_on_absolute_children(tree, &mut items, absolute_position_area, absolute_position_offset);
+    perform_absolute_layout_on_absolute_children(tree, &items, absolute_position_area, absolute_position_offset);
 
     // 5. Perform hidden layout on hidden children
     let len = tree.child_count(node_id);

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -358,7 +358,7 @@ fn compute_preliminary(
     // 15. Determine the flex container’s used cross size.
     #[cfg(feature = "debug")]
     NODE_LOGGER.log("determine_container_cross_size");
-    let total_line_cross_size = determine_container_cross_size(&mut flex_lines, known_dimensions, &mut constants);
+    let total_line_cross_size = determine_container_cross_size(&flex_lines, known_dimensions, &mut constants);
 
     // We have the container size.
     // If our caller does not care about performing layout we are done now.

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -1475,7 +1475,7 @@ fn handle_align_content_stretch(flex_lines: &mut [FlexLine], node_size: Size<Opt
 ///
 ///     **Note that this step does not affect the main size of the flex item, even if it has an intrinsic aspect ratio**.
 #[inline]
-fn determine_used_cross_size(tree: &mut impl LayoutTree, flex_lines: &mut [FlexLine], constants: &AlgoConstants) {
+fn determine_used_cross_size(tree: &impl LayoutTree, flex_lines: &mut [FlexLine], constants: &AlgoConstants) {
     for line in flex_lines {
         let line_cross_size = line.cross_size;
 
@@ -1634,7 +1634,7 @@ fn resolve_cross_axis_auto_margins(flex_lines: &mut [FlexLine], constants: &Algo
 ///     if neither of the item's cross-axis margins are `auto`.
 #[inline]
 fn align_flex_items_along_cross_axis(
-    child: &mut FlexItem,
+    child: &FlexItem,
     free_space: f32,
     max_baseline: f32,
     constants: &AlgoConstants,
@@ -1692,7 +1692,7 @@ fn align_flex_items_along_cross_axis(
 #[inline]
 #[must_use]
 fn determine_container_cross_size(
-    flex_lines: &mut [FlexLine],
+    flex_lines: &[FlexLine],
     node_size: Size<Option<f32>>,
     constants: &mut AlgoConstants,
 ) -> f32 {

--- a/src/compute/grid/track_sizing.rs
+++ b/src/compute/grid/track_sizing.rs
@@ -107,7 +107,7 @@ where
     /// Compute the item's resolved margins for size contributions. Horizontal percentage margins always resolve
     /// to zero if the container size is indefinite as otherwise this would introduce a cyclic dependency.
     #[inline(always)]
-    fn margins_axis_sums_with_baseline_shims(&self, item: &mut GridItem) -> Size<f32> {
+    fn margins_axis_sums_with_baseline_shims(&self, item: &GridItem) -> Size<f32> {
         item.margins_axis_sums_with_baseline_shims(self.inner_node_size.width)
     }
 
@@ -501,7 +501,7 @@ fn resolve_intrinsic_track_sizes(
     tree: &mut impl LayoutTree,
     axis: AbstractAxis,
     axis_tracks: &mut [GridTrack],
-    other_axis_tracks: &mut [GridTrack],
+    other_axis_tracks: &[GridTrack],
     items: &mut [GridItem],
     axis_available_grid_space: AvailableSpace,
     inner_node_size: Size<Option<f32>>,


### PR DESCRIPTION
# Objective

> Why did you make this PR?

I found, that `Clippy` pass in `GitHub CI` produces a few errors (about **mutable** reference usage without mutability) - this PR fixes them.