### PR TITLE
Fix rounding accumulation bug

### DIFF
--- a/src/tree/cache.rs
+++ b/src/tree/cache.rs
@@ -114,13 +114,6 @@ impl Cache {
         None
     }
 
-    /// Try to retrieve a cached result from the cache
-    #[inline]
-    pub(crate) fn get_raw(&self, index: usize) -> Option<SizeBaselinesAndMargins> {
-        let Some(entry) = self.entries.get(index) else { return None };
-        entry.map(|entry| entry.cached_size_and_baselines)
-    }
-
     /// Store a computed size in the cache
     pub fn store(
         &mut self,

--- a/src/tree/cache.rs
+++ b/src/tree/cache.rs
@@ -114,6 +114,13 @@ impl Cache {
         None
     }
 
+    /// Try to retrieve a cached result from the cache
+    #[inline]
+    pub(crate) fn get_raw(&self, index: usize) -> Option<SizeBaselinesAndMargins> {
+        let Some(entry) = self.entries.get(index) else { return None };
+        entry.map(|entry| entry.cached_size_and_baselines)
+    }
+
     /// Store a computed size in the cache
     pub fn store(
         &mut self,

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -70,7 +70,7 @@ pub(crate) struct NodeData {
     pub(crate) style: Style,
 
     /// The always unrounded results of the layout computation. We must store this separately from the rounded
-    /// layout to avoid errors from rounding already-rounded values
+    /// layout to avoid errors from rounding already-rounded values. See <https://github.com/DioxusLabs/taffy/issues/501>.
     pub(crate) unrounded_layout: Layout,
 
     /// The final (possibly rounded) results of the layout computation

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -68,8 +68,13 @@ impl From<NodeId> for DefaultKey {
 pub(crate) struct NodeData {
     /// The layout strategy used by this node
     pub(crate) style: Style,
-    /// The results of the layout computation
-    pub(crate) layout: Layout,
+
+    /// The always unrounded results of the layout computation. We must store this separately from the rounded
+    /// layout to avoid errors from rounding already-rounded values
+    pub(crate) unrounded_layout: Layout,
+
+    /// The final (possibly rounded) results of the layout computation
+    pub(crate) final_layout: Layout,
 
     /// Should we try and measure this node?
     pub(crate) needs_measure: bool,
@@ -82,7 +87,13 @@ impl NodeData {
     /// Create the data for a new node
     #[must_use]
     pub const fn new(style: Style) -> Self {
-        Self { style, cache: Cache::new(), layout: Layout::new(), needs_measure: false }
+        Self {
+            style,
+            cache: Cache::new(),
+            unrounded_layout: Layout::new(),
+            final_layout: Layout::new(),
+            needs_measure: false,
+        }
     }
 
     /// Marks a node and all of its parents (recursively) as dirty

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -73,7 +73,8 @@ pub(crate) struct NodeData {
     /// layout to avoid errors from rounding already-rounded values. See <https://github.com/DioxusLabs/taffy/issues/501>.
     pub(crate) unrounded_layout: Layout,
 
-    /// The final (possibly rounded) results of the layout computation
+    /// The final results of the layout computation.
+    /// These may be rounded or unrounded depending on what the `use_rounding` config setting is set to.
     pub(crate) final_layout: Layout,
 
     /// Should we try and measure this node?

--- a/src/tree/taffy_tree/tree.rs
+++ b/src/tree/taffy_tree/tree.rs
@@ -47,7 +47,7 @@ pub struct Taffy {
 
     /// Hack to allow the `LayoutTree::layout_mut` function to expose the `NodeData.unrounded_layout` of a node to
     /// the layout algorithms during layout, while exposing the `NodeData.final_layout` when called by external users.
-    /// This allows us to fix https://github.com/DioxusLabs/taffy/issues/501 without breaking backwards compatibility
+    /// This allows us to fix <https://github.com/DioxusLabs/taffy/issues/501> without breaking backwards compatibility
     pub(crate) is_layouting: bool,
 }
 

--- a/tests/relayout.rs
+++ b/tests/relayout.rs
@@ -333,30 +333,34 @@ fn relayout_is_stable_with_rounding() {
     //     </div>
     // </div>
 
-    let inner = taffy.new_leaf(Style { min_size: Size { width: length(300.), height: auto() }, ..Default::default() }).unwrap();
-    let wrapper = taffy.new_with_children( 
-        Style {
-            size: Size { width: length(150.), height: auto() },
-            justify_content: Some(JustifyContent::End),
-            ..Default::default()
-        }, 
-        &[inner]
-    ).unwrap();
-    let outer = taffy.new_with_children( 
-        Style {
-            size: Size { width: percent(1.), height: auto() },            
-            inset: Rect { left: length(1.5), right: auto(), top: auto(), bottom: auto() },
-            ..Default::default()
-        },
-        &[wrapper]
-    ).unwrap();
-    let root =  taffy.new_with_children(
-        Style { 
-            size: Size { width: length(1920.),height: length(1080.) },
-            ..Default::default()
-        },
-        &[outer]
-    ).unwrap();
+    let inner =
+        taffy.new_leaf(Style { min_size: Size { width: length(300.), height: auto() }, ..Default::default() }).unwrap();
+    let wrapper = taffy
+        .new_with_children(
+            Style {
+                size: Size { width: length(150.), height: auto() },
+                justify_content: Some(JustifyContent::End),
+                ..Default::default()
+            },
+            &[inner],
+        )
+        .unwrap();
+    let outer = taffy
+        .new_with_children(
+            Style {
+                size: Size { width: percent(1.), height: auto() },
+                inset: Rect { left: length(1.5), right: auto(), top: auto(), bottom: auto() },
+                ..Default::default()
+            },
+            &[wrapper],
+        )
+        .unwrap();
+    let root = taffy
+        .new_with_children(
+            Style { size: Size { width: length(1920.), height: length(1080.) }, ..Default::default() },
+            &[outer],
+        )
+        .unwrap();
     for _ in 0..5 {
         taffy.mark_dirty(root).ok();
         taffy.compute_layout(root, Size::MAX_CONTENT).ok();

--- a/tests/relayout.rs
+++ b/tests/relayout.rs
@@ -323,6 +323,7 @@ fn toggle_grid_container_display_none() {
 #[test]
 fn relayout_is_stable_with_rounding() {
     let mut taffy = Taffy::new();
+    taffy.enable_rounding();
 
     // <div style="width: 1920px; height: 1080px">
     //     <div style="width: 100%; left: 1.5px">
@@ -349,7 +350,7 @@ fn relayout_is_stable_with_rounding() {
         },
         &[wrapper]
     ).unwrap();
-    let viewport =  taffy.new_with_children(
+    let root =  taffy.new_with_children(
         Style { 
             size: Size { width: length(1920.),height: length(1080.) },
             ..Default::default()
@@ -357,9 +358,32 @@ fn relayout_is_stable_with_rounding() {
         &[outer]
     ).unwrap();
     for _ in 0..5 {
-        taffy.mark_dirty(viewport).ok();
-        taffy.compute_layout(viewport, Size::MAX_CONTENT).ok();
-        taffy::util::print_tree(&taffy, viewport);
-        println!();
+        taffy.mark_dirty(root).ok();
+        taffy.compute_layout(root, Size::MAX_CONTENT).ok();
+        taffy::util::print_tree(&taffy, root);
+
+        let root_layout = taffy.layout(root).unwrap();
+        assert_eq!(root_layout.location.x, 0.0);
+        assert_eq!(root_layout.location.y, 0.0);
+        assert_eq!(root_layout.size.width, 1920.0);
+        assert_eq!(root_layout.size.height, 1080.0);
+
+        let outer_layout = taffy.layout(outer).unwrap();
+        assert_eq!(outer_layout.location.x, 2.0);
+        assert_eq!(outer_layout.location.y, 0.0);
+        assert_eq!(outer_layout.size.width, 1920.0);
+        assert_eq!(outer_layout.size.height, 1080.0);
+
+        let wrapper_layout = taffy.layout(wrapper).unwrap();
+        assert_eq!(wrapper_layout.location.x, 0.0);
+        assert_eq!(wrapper_layout.location.y, 0.0);
+        assert_eq!(wrapper_layout.size.width, 150.0);
+        assert_eq!(wrapper_layout.size.height, 1080.0);
+
+        let inner_layout = taffy.layout(inner).unwrap();
+        assert_eq!(inner_layout.location.x, -150.0);
+        assert_eq!(inner_layout.location.y, 0.0);
+        assert_eq!(inner_layout.size.width, 301.0);
+        assert_eq!(inner_layout.size.height, 1080.0);
     }
 }


### PR DESCRIPTION
# Objective

- Fixes https://github.com/DioxusLabs/taffy/issues/501

## Notes

- This fix is a bit hacky. I think ideally we'd want to differentiate between rounded and unrounded values in the public API. But the advantage of this implementation is that it's backwards compatible and can be released as a patch to the 0.3.x series. We can of course always improve upon this in the 0.4 release.
- It requires us to store both rounded and unrounded values, adding (I believe) 20 bytes per node. This is not ideal, but it seems like the simplest way to fix the issue. Perhaps in future we could improve upon this on future too.

## Feedback wanted

General code review
