### PR TITLE
Implement `Display::Contents` (tree-side implementation)

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -87,6 +87,7 @@ Example usage change:
 ### Added
 
 - Support for [CSS Block layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flow_Layout/Block_and_Inline_Layout_in_Normal_Flow#elements_participating_in_a_block_formatting_context) has been added. This can be used via the new `Display::Block` variant of the `Display` enum. Note that inline, inline-block and float have *not* been implemented. The use case supported is block container nodes which contain block-level children.
+- Support for [`Display::Contents`](https://css-tricks.com/get-ready-for-display-contents/)
 - Support for running each layout algorithm individually on a single node via the following top-level functions:
   - `compute_flexbox_layout`
   - `compute_grid_layout`

--- a/benches/src/taffy_03_helpers.rs
+++ b/benches/src/taffy_03_helpers.rs
@@ -147,6 +147,7 @@ fn convert_display(input: taffy::style::Display) -> taffy_03::style::Display {
         taffy::style::Display::None => taffy_03::style::Display::None,
         taffy::style::Display::Flex => taffy_03::style::Display::Flex,
         taffy::style::Display::Grid => taffy_03::style::Display::Grid,
+        taffy::style::Display::Contents => panic!("Contents layout not implemented in taffy 0.3"),
         taffy::style::Display::Block => panic!("Block layout not implemented in taffy 0.3"),
     }
 }

--- a/benches/src/yoga_helpers.rs
+++ b/benches/src/yoga_helpers.rs
@@ -187,6 +187,7 @@ fn apply_taffy_style(node: &mut yg::Node, style: &tf::Style) {
     node.set_display(match style.display {
         tf::Display::None => yg::Display::None,
         tf::Display::Flex => yg::Display::Flex,
+        tf::Display::Contents => panic!("Yoga does not support display: contents"),
         tf::Display::Grid => panic!("Yoga does not support CSS Grid layout"),
         tf::Display::Block => panic!("Yoga does not support CSS Block layout"),
     });

--- a/scripts/gentest/src/main.rs
+++ b/scripts/gentest/src/main.rs
@@ -352,6 +352,7 @@ fn generate_node(ident: &str, node: &Value) -> TokenStream {
     let display = match style["display"] {
         Value::String(ref value) => match value.as_ref() {
             "none" => quote!(display: taffy::style::Display::None,),
+            "contents" => quote!(display: taffy::style::Display::Contents,),
             "block" => quote!(display: taffy::style::Display::Block,),
             "grid" => quote!(display: taffy::style::Display::Grid,),
             _ => quote!(display: taffy::style::Display::Flex,),

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -44,6 +44,9 @@ pub enum Display {
     /// The children will follow the CSS Grid layout algorithm
     #[cfg(feature = "grid")]
     Grid,
+    /// The node will behave as if it does not exist, and it's children will be laid
+    /// out as if they were direct children of the node's parent.
+    Contents,
     /// The children will not be laid out, and will follow absolute positioning
     None,
 }
@@ -70,6 +73,7 @@ impl core::fmt::Display for Display {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Display::None => write!(f, "NONE"),
+            Display::Contents => write!(f, "CONTENTS"),
             #[cfg(feature = "block_layout")]
             Display::Block => write!(f, "BLOCK"),
             #[cfg(feature = "flexbox")]

--- a/src/util/debug.rs
+++ b/src/util/debug.rs
@@ -23,6 +23,7 @@ fn print_node(tree: &impl LayoutTree, node: NodeId, has_sibling: bool, lines_str
 
     let display = match (num_children, style.display) {
         (_, style::Display::None) => "NONE",
+        (_, style::Display::Contents) => "CONTENTS",
         (0, _) => "LEAF",
         #[cfg(feature = "block_layout")]
         (_, style::Display::Block) => "BLOCK",
@@ -48,7 +49,8 @@ fn print_node(tree: &impl LayoutTree, node: NodeId, has_sibling: bool, lines_str
     let new_string = lines_string + bar;
 
     // Recurse into children
-    for (index, child) in tree.child_ids(node).enumerate() {
+    let child_ids: Vec<NodeId> = tree.child_ids(node).collect();
+    for (index, child) in child_ids.into_iter().enumerate() {
         let has_sibling = index < num_children - 1;
         print_node(tree, child, has_sibling, new_string.clone());
     }

--- a/test_fixtures/contents/contents_flex_basic.html
+++ b/test_fixtures/contents/contents_flex_basic.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; width: 400px; height: 300px; justify-content: space-between;">
+  <div style="width: 30px;"></div>
+  <div style="width: 30px;"></div>
+  <div style="width: 30px;"></div>
+  <div style="display: contents;">
+    <div style="width: 30px;"></div>
+    <div style="width: 30px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contents/contents_flex_nested.html
+++ b/test_fixtures/contents/contents_flex_nested.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; width: 400px; height: 300px; justify-content: space-between;">
+  <div style="width: 30px;"></div>
+  <div style="width: 30px;"></div>
+  <div style="width: 30px;"></div>
+  <div style="display: contents;">
+    <div style="display: contents;">
+      <div style="width: 30px;"></div>
+      <div style="width: 30px;"></div>
+    </div>
+    <div style="width: 30px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contents/contents_flex_nested2.html
+++ b/test_fixtures/contents/contents_flex_nested2.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; width: 400px; height: 300px; justify-content: space-between;">
+  <div style="width: 30px;"></div>
+  <div style="width: 30px;"></div>
+  <div style="display: contents;">
+    <div style="width: 30px;"></div>
+    <div style="display: contents;">
+      <div style="display: contents;">
+        <div style="width: 30px;"></div>
+        <div style="width: 30px;"></div>
+      </div>
+      <div style="width: 30px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/generated/contents/contents_flex_basic.rs
+++ b/tests/generated/contents/contents_flex_basic.rs
@@ -1,0 +1,95 @@
+#[test]
+fn contents_flex_basic() {
+    #[allow(unused_imports)]
+    use taffy::{prelude::*, tree::Layout, Taffy};
+    let mut taffy: Taffy<crate::TextMeasure> = Taffy::new();
+    let node0 = taffy
+        .new_leaf(taffy::style::Style {
+            size: taffy::geometry::Size { width: taffy::style::Dimension::Length(30f32), height: auto() },
+            ..Default::default()
+        })
+        .unwrap();
+    let node1 = taffy
+        .new_leaf(taffy::style::Style {
+            size: taffy::geometry::Size { width: taffy::style::Dimension::Length(30f32), height: auto() },
+            ..Default::default()
+        })
+        .unwrap();
+    let node2 = taffy
+        .new_leaf(taffy::style::Style {
+            size: taffy::geometry::Size { width: taffy::style::Dimension::Length(30f32), height: auto() },
+            ..Default::default()
+        })
+        .unwrap();
+    let node30 = taffy
+        .new_leaf(taffy::style::Style {
+            size: taffy::geometry::Size { width: taffy::style::Dimension::Length(30f32), height: auto() },
+            ..Default::default()
+        })
+        .unwrap();
+    let node31 = taffy
+        .new_leaf(taffy::style::Style {
+            size: taffy::geometry::Size { width: taffy::style::Dimension::Length(30f32), height: auto() },
+            ..Default::default()
+        })
+        .unwrap();
+    let node3 = taffy
+        .new_with_children(
+            taffy::style::Style { display: taffy::style::Display::Contents, ..Default::default() },
+            &[node30, node31],
+        )
+        .unwrap();
+    let node = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Flex,
+                justify_content: Some(taffy::style::JustifyContent::SpaceBetween),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Length(400f32),
+                    height: taffy::style::Dimension::Length(300f32),
+                },
+                ..Default::default()
+            },
+            &[node0, node1, node2, node3],
+        )
+        .unwrap();
+    taffy.compute_layout_with_measure(node, taffy::geometry::Size::MAX_CONTENT, crate::test_measure_function).unwrap();
+    println!("\nComputed tree:");
+    taffy.print_tree(node);
+    println!();
+    let Layout { size, location, .. } = taffy.layout(node).unwrap();
+    assert_eq!(size.width, 400f32, "width of node {:?}. Expected {}. Actual {}", node, 400f32, size.width);
+    assert_eq!(size.height, 300f32, "height of node {:?}. Expected {}. Actual {}", node, 300f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node, 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node, 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node0).unwrap();
+    assert_eq!(size.width, 30f32, "width of node {:?}. Expected {}. Actual {}", node0, 30f32, size.width);
+    assert_eq!(size.height, 300f32, "height of node {:?}. Expected {}. Actual {}", node0, 300f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node0, 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node0, 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node1).unwrap();
+    assert_eq!(size.width, 30f32, "width of node {:?}. Expected {}. Actual {}", node1, 30f32, size.width);
+    assert_eq!(size.height, 300f32, "height of node {:?}. Expected {}. Actual {}", node1, 300f32, size.height);
+    assert_eq!(location.x, 93f32, "x of node {:?}. Expected {}. Actual {}", node1, 93f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node1, 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node2).unwrap();
+    assert_eq!(size.width, 30f32, "width of node {:?}. Expected {}. Actual {}", node2, 30f32, size.width);
+    assert_eq!(size.height, 300f32, "height of node {:?}. Expected {}. Actual {}", node2, 300f32, size.height);
+    assert_eq!(location.x, 185f32, "x of node {:?}. Expected {}. Actual {}", node2, 185f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node2, 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node3).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node3, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node3, 0f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node3, 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node3, 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node30).unwrap();
+    assert_eq!(size.width, 30f32, "width of node {:?}. Expected {}. Actual {}", node30, 30f32, size.width);
+    assert_eq!(size.height, 300f32, "height of node {:?}. Expected {}. Actual {}", node30, 300f32, size.height);
+    assert_eq!(location.x, 278f32, "x of node {:?}. Expected {}. Actual {}", node30, 278f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node30, 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node31).unwrap();
+    assert_eq!(size.width, 30f32, "width of node {:?}. Expected {}. Actual {}", node31, 30f32, size.width);
+    assert_eq!(size.height, 300f32, "height of node {:?}. Expected {}. Actual {}", node31, 300f32, size.height);
+    assert_eq!(location.x, 370f32, "x of node {:?}. Expected {}. Actual {}", node31, 370f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node31, 0f32, location.y);
+}

--- a/tests/generated/contents/contents_flex_nested.rs
+++ b/tests/generated/contents/contents_flex_nested.rs
@@ -1,0 +1,117 @@
+#[test]
+fn contents_flex_nested() {
+    #[allow(unused_imports)]
+    use taffy::{prelude::*, tree::Layout, Taffy};
+    let mut taffy: Taffy<crate::TextMeasure> = Taffy::new();
+    let node0 = taffy
+        .new_leaf(taffy::style::Style {
+            size: taffy::geometry::Size { width: taffy::style::Dimension::Length(30f32), height: auto() },
+            ..Default::default()
+        })
+        .unwrap();
+    let node1 = taffy
+        .new_leaf(taffy::style::Style {
+            size: taffy::geometry::Size { width: taffy::style::Dimension::Length(30f32), height: auto() },
+            ..Default::default()
+        })
+        .unwrap();
+    let node2 = taffy
+        .new_leaf(taffy::style::Style {
+            size: taffy::geometry::Size { width: taffy::style::Dimension::Length(30f32), height: auto() },
+            ..Default::default()
+        })
+        .unwrap();
+    let node300 = taffy
+        .new_leaf(taffy::style::Style {
+            size: taffy::geometry::Size { width: taffy::style::Dimension::Length(30f32), height: auto() },
+            ..Default::default()
+        })
+        .unwrap();
+    let node301 = taffy
+        .new_leaf(taffy::style::Style {
+            size: taffy::geometry::Size { width: taffy::style::Dimension::Length(30f32), height: auto() },
+            ..Default::default()
+        })
+        .unwrap();
+    let node30 = taffy
+        .new_with_children(
+            taffy::style::Style { display: taffy::style::Display::Contents, ..Default::default() },
+            &[node300, node301],
+        )
+        .unwrap();
+    let node31 = taffy
+        .new_leaf(taffy::style::Style {
+            size: taffy::geometry::Size { width: taffy::style::Dimension::Length(30f32), height: auto() },
+            ..Default::default()
+        })
+        .unwrap();
+    let node3 = taffy
+        .new_with_children(
+            taffy::style::Style { display: taffy::style::Display::Contents, ..Default::default() },
+            &[node30, node31],
+        )
+        .unwrap();
+    let node = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Flex,
+                justify_content: Some(taffy::style::JustifyContent::SpaceBetween),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Length(400f32),
+                    height: taffy::style::Dimension::Length(300f32),
+                },
+                ..Default::default()
+            },
+            &[node0, node1, node2, node3],
+        )
+        .unwrap();
+    taffy.compute_layout_with_measure(node, taffy::geometry::Size::MAX_CONTENT, crate::test_measure_function).unwrap();
+    println!("\nComputed tree:");
+    taffy.print_tree(node);
+    println!();
+    let Layout { size, location, .. } = taffy.layout(node).unwrap();
+    assert_eq!(size.width, 400f32, "width of node {:?}. Expected {}. Actual {}", node, 400f32, size.width);
+    assert_eq!(size.height, 300f32, "height of node {:?}. Expected {}. Actual {}", node, 300f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node, 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node, 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node0).unwrap();
+    assert_eq!(size.width, 30f32, "width of node {:?}. Expected {}. Actual {}", node0, 30f32, size.width);
+    assert_eq!(size.height, 300f32, "height of node {:?}. Expected {}. Actual {}", node0, 300f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node0, 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node0, 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node1).unwrap();
+    assert_eq!(size.width, 30f32, "width of node {:?}. Expected {}. Actual {}", node1, 30f32, size.width);
+    assert_eq!(size.height, 300f32, "height of node {:?}. Expected {}. Actual {}", node1, 300f32, size.height);
+    assert_eq!(location.x, 74f32, "x of node {:?}. Expected {}. Actual {}", node1, 74f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node1, 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node2).unwrap();
+    assert_eq!(size.width, 30f32, "width of node {:?}. Expected {}. Actual {}", node2, 30f32, size.width);
+    assert_eq!(size.height, 300f32, "height of node {:?}. Expected {}. Actual {}", node2, 300f32, size.height);
+    assert_eq!(location.x, 148f32, "x of node {:?}. Expected {}. Actual {}", node2, 148f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node2, 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node3).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node3, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node3, 0f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node3, 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node3, 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node30).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node30, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node30, 0f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node30, 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node30, 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node300).unwrap();
+    assert_eq!(size.width, 30f32, "width of node {:?}. Expected {}. Actual {}", node300, 30f32, size.width);
+    assert_eq!(size.height, 300f32, "height of node {:?}. Expected {}. Actual {}", node300, 300f32, size.height);
+    assert_eq!(location.x, 222f32, "x of node {:?}. Expected {}. Actual {}", node300, 222f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node300, 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node301).unwrap();
+    assert_eq!(size.width, 30f32, "width of node {:?}. Expected {}. Actual {}", node301, 30f32, size.width);
+    assert_eq!(size.height, 300f32, "height of node {:?}. Expected {}. Actual {}", node301, 300f32, size.height);
+    assert_eq!(location.x, 296f32, "x of node {:?}. Expected {}. Actual {}", node301, 296f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node301, 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node31).unwrap();
+    assert_eq!(size.width, 30f32, "width of node {:?}. Expected {}. Actual {}", node31, 30f32, size.width);
+    assert_eq!(size.height, 300f32, "height of node {:?}. Expected {}. Actual {}", node31, 300f32, size.height);
+    assert_eq!(location.x, 370f32, "x of node {:?}. Expected {}. Actual {}", node31, 370f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node31, 0f32, location.y);
+}

--- a/tests/generated/contents/contents_flex_nested2.rs
+++ b/tests/generated/contents/contents_flex_nested2.rs
@@ -1,0 +1,128 @@
+#[test]
+fn contents_flex_nested2() {
+    #[allow(unused_imports)]
+    use taffy::{prelude::*, tree::Layout, Taffy};
+    let mut taffy: Taffy<crate::TextMeasure> = Taffy::new();
+    let node0 = taffy
+        .new_leaf(taffy::style::Style {
+            size: taffy::geometry::Size { width: taffy::style::Dimension::Length(30f32), height: auto() },
+            ..Default::default()
+        })
+        .unwrap();
+    let node1 = taffy
+        .new_leaf(taffy::style::Style {
+            size: taffy::geometry::Size { width: taffy::style::Dimension::Length(30f32), height: auto() },
+            ..Default::default()
+        })
+        .unwrap();
+    let node20 = taffy
+        .new_leaf(taffy::style::Style {
+            size: taffy::geometry::Size { width: taffy::style::Dimension::Length(30f32), height: auto() },
+            ..Default::default()
+        })
+        .unwrap();
+    let node2100 = taffy
+        .new_leaf(taffy::style::Style {
+            size: taffy::geometry::Size { width: taffy::style::Dimension::Length(30f32), height: auto() },
+            ..Default::default()
+        })
+        .unwrap();
+    let node2101 = taffy
+        .new_leaf(taffy::style::Style {
+            size: taffy::geometry::Size { width: taffy::style::Dimension::Length(30f32), height: auto() },
+            ..Default::default()
+        })
+        .unwrap();
+    let node210 = taffy
+        .new_with_children(
+            taffy::style::Style { display: taffy::style::Display::Contents, ..Default::default() },
+            &[node2100, node2101],
+        )
+        .unwrap();
+    let node211 = taffy
+        .new_leaf(taffy::style::Style {
+            size: taffy::geometry::Size { width: taffy::style::Dimension::Length(30f32), height: auto() },
+            ..Default::default()
+        })
+        .unwrap();
+    let node21 = taffy
+        .new_with_children(
+            taffy::style::Style { display: taffy::style::Display::Contents, ..Default::default() },
+            &[node210, node211],
+        )
+        .unwrap();
+    let node2 = taffy
+        .new_with_children(
+            taffy::style::Style { display: taffy::style::Display::Contents, ..Default::default() },
+            &[node20, node21],
+        )
+        .unwrap();
+    let node = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Flex,
+                justify_content: Some(taffy::style::JustifyContent::SpaceBetween),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Length(400f32),
+                    height: taffy::style::Dimension::Length(300f32),
+                },
+                ..Default::default()
+            },
+            &[node0, node1, node2],
+        )
+        .unwrap();
+    taffy.compute_layout_with_measure(node, taffy::geometry::Size::MAX_CONTENT, crate::test_measure_function).unwrap();
+    println!("\nComputed tree:");
+    taffy.print_tree(node);
+    println!();
+    let Layout { size, location, .. } = taffy.layout(node).unwrap();
+    assert_eq!(size.width, 400f32, "width of node {:?}. Expected {}. Actual {}", node, 400f32, size.width);
+    assert_eq!(size.height, 300f32, "height of node {:?}. Expected {}. Actual {}", node, 300f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node, 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node, 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node0).unwrap();
+    assert_eq!(size.width, 30f32, "width of node {:?}. Expected {}. Actual {}", node0, 30f32, size.width);
+    assert_eq!(size.height, 300f32, "height of node {:?}. Expected {}. Actual {}", node0, 300f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node0, 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node0, 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node1).unwrap();
+    assert_eq!(size.width, 30f32, "width of node {:?}. Expected {}. Actual {}", node1, 30f32, size.width);
+    assert_eq!(size.height, 300f32, "height of node {:?}. Expected {}. Actual {}", node1, 300f32, size.height);
+    assert_eq!(location.x, 74f32, "x of node {:?}. Expected {}. Actual {}", node1, 74f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node1, 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node2).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node2, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node2, 0f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node2, 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node2, 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node20).unwrap();
+    assert_eq!(size.width, 30f32, "width of node {:?}. Expected {}. Actual {}", node20, 30f32, size.width);
+    assert_eq!(size.height, 300f32, "height of node {:?}. Expected {}. Actual {}", node20, 300f32, size.height);
+    assert_eq!(location.x, 148f32, "x of node {:?}. Expected {}. Actual {}", node20, 148f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node20, 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node21).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node21, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node21, 0f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node21, 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node21, 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node210).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node210, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node210, 0f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node210, 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node210, 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node2100).unwrap();
+    assert_eq!(size.width, 30f32, "width of node {:?}. Expected {}. Actual {}", node2100, 30f32, size.width);
+    assert_eq!(size.height, 300f32, "height of node {:?}. Expected {}. Actual {}", node2100, 300f32, size.height);
+    assert_eq!(location.x, 222f32, "x of node {:?}. Expected {}. Actual {}", node2100, 222f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node2100, 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node2101).unwrap();
+    assert_eq!(size.width, 30f32, "width of node {:?}. Expected {}. Actual {}", node2101, 30f32, size.width);
+    assert_eq!(size.height, 300f32, "height of node {:?}. Expected {}. Actual {}", node2101, 300f32, size.height);
+    assert_eq!(location.x, 296f32, "x of node {:?}. Expected {}. Actual {}", node2101, 296f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node2101, 0f32, location.y);
+    let Layout { size, location, .. } = taffy.layout(node211).unwrap();
+    assert_eq!(size.width, 30f32, "width of node {:?}. Expected {}. Actual {}", node211, 30f32, size.width);
+    assert_eq!(size.height, 300f32, "height of node {:?}. Expected {}. Actual {}", node211, 300f32, size.height);
+    assert_eq!(location.x, 370f32, "x of node {:?}. Expected {}. Actual {}", node211, 370f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node211, 0f32, location.y);
+}

--- a/tests/generated/contents/mod.rs
+++ b/tests/generated/contents/mod.rs
@@ -1,0 +1,3 @@
+mod contents_flex_basic;
+mod contents_flex_nested;
+mod contents_flex_nested2;

--- a/tests/generated/mod.rs
+++ b/tests/generated/mod.rs
@@ -1,6 +1,7 @@
 mod block;
 mod blockflex;
 mod blockgrid;
+mod contents;
 mod flex;
 mod grid;
 mod gridflex;


### PR DESCRIPTION
# Objective

Closes #533
Can be used to build https://github.com/bevyengine/bevy/issues/9731

## Todo

- [ ] Could probably do with more tests before merging. Although due to the nature of the implementation, this features coupling with specific layout modes is low, and it's unlikely that some would work while others don't. So we probably don't need loads of tests (we should probably have at least some for each layout mode though).
- [ ] Update release notes

## Feedback wanted

- This code includes a `Vec` that is allocated every time a node's children are iterated over, and which will almost always of length 1 (any non-`display: contents` will result in a `Vec` that only ever has length 1). How would people feel about depending on the `smallvec` crate to optimise this case?
