### PR TITLE
Add rust-version to Cargo.toml (+ track in CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,18 @@ jobs:
       - run: cargo build --no-default-features
       - run: cargo test --no-default-features --features taffy_tree
 
+  # MSRV check.
+  # Taffy only guarantees "latest stable". However we have this check here to ensure that we advertise
+  # our MSRV. We also make an effort not to increase MSRV in patch versions of Taffy.
+  test-features-msrv:
+    name: "Test Suite [Features: Default] (Rust 1.65)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.65
+      - run: cargo build
+      - run: cargo test
+
   # Default
   test-features-default:
     name: "Test Suite [Features: Default]"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = [
     "Johnathan Kelley <jkelleyrtp@gmail.com>",
 ]
 edition = "2021"
+rust-version = "1.65"
 include = ["src/**/*", "Cargo.toml", "README.md"]
 description = "A flexible UI layout library "
 repository = "https://github.com/DioxusLabs/taffy"


### PR DESCRIPTION
# Objective

Make it easy for users to work out what version of Rust they need to compile Taffy.

## Context

Taffy will soon have C bindings, and that may well bring users who are less familiar with the Rust ecosystem and who may not be using the latest Rust version.

## Policy proposed

At most "latest stable" on a per-minor version basis, with the MSRV frozen for the life of that minor version at the minimum version that the `x.y.0` version actually compiles on (so no bumping in patch versions).

We currently support back to `1.65`.

## Feedback wanted

Does this policy make sense?