### PR TITLE
Flexbox: fix performance of nodes with very large numbers of children

### DIFF
--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -55,6 +55,9 @@ struct FlexItem {
     /// The identifier for the associated node
     node: NodeId,
 
+    /// The order of the node relative to it's siblings
+    order: u32,
+
     /// The base size of this item
     size: Size<Option<f32>>,
     /// The minimum allowable size of this item
@@ -381,7 +384,7 @@ fn compute_preliminary(
     // Do a final layout pass and gather the resulting layouts
     #[cfg(feature = "debug")]
     NODE_LOGGER.log("final_layout_pass");
-    final_layout_pass(tree, node, &mut flex_lines, &constants);
+    final_layout_pass(tree, &mut flex_lines, &constants);
 
     // Before returning we perform absolute layout on all absolutely positioned children
     #[cfg(feature = "debug")]
@@ -499,13 +502,15 @@ fn compute_constants(
 #[inline]
 fn generate_anonymous_flex_items(tree: &impl LayoutTree, node: NodeId, constants: &AlgoConstants) -> Vec<FlexItem> {
     tree.children(node)
-        .map(|child| (child, tree.style(child)))
-        .filter(|(_, style)| style.position != Position::Absolute)
-        .filter(|(_, style)| style.display != Display::None)
-        .map(|(child, child_style)| {
+        .enumerate()
+        .map(|(index, child)| (index, child, tree.style(child)))
+        .filter(|(_, _, style)| style.position != Position::Absolute)
+        .filter(|(_, _, style)| style.display != Display::None)
+        .map(|(index, child, child_style)| {
             let aspect_ratio = child_style.aspect_ratio;
             FlexItem {
                 node: child,
+                order: index as u32,
                 size: child_style.size.maybe_resolve(constants.node_inner_size).maybe_apply_aspect_ratio(aspect_ratio),
                 min_size: child_style
                     .min_size
@@ -1767,7 +1772,6 @@ fn align_flex_lines_per_align_content(flex_lines: &mut [FlexLine], constants: &A
 #[allow(clippy::too_many_arguments)]
 fn calculate_flex_item(
     tree: &mut impl LayoutTree,
-    node: NodeId,
     item: &mut FlexItem,
     total_offset_main: &mut f32,
     total_offset_cross: f32,
@@ -1807,10 +1811,8 @@ fn calculate_flex_item(
         item.baseline = baseline_offset_main + inner_baseline;
     }
 
-    let order = tree.children(node).position(|n| n == item.node).unwrap() as u32;
-
     *tree.layout_mut(item.node) = Layout {
-        order,
+        order: item.order,
         size: preliminary_size_and_baselines.size,
         location: Point {
             x: if direction.is_row() { offset_main } else { offset_cross },
@@ -1825,7 +1827,6 @@ fn calculate_flex_item(
 #[allow(clippy::too_many_arguments)]
 fn calculate_layout_line(
     tree: &mut impl LayoutTree,
-    node: NodeId,
     line: &mut FlexLine,
     total_offset_cross: &mut f32,
     container_size: Size<f32>,
@@ -1840,7 +1841,6 @@ fn calculate_layout_line(
         for item in line.items.iter_mut().rev() {
             calculate_flex_item(
                 tree,
-                node,
                 item,
                 &mut total_offset_main,
                 *total_offset_cross,
@@ -1854,7 +1854,6 @@ fn calculate_layout_line(
         for item in line.items.iter_mut() {
             calculate_flex_item(
                 tree,
-                node,
                 item,
                 &mut total_offset_main,
                 *total_offset_cross,
@@ -1871,14 +1870,13 @@ fn calculate_layout_line(
 
 /// Do a final layout pass and collect the resulting layouts.
 #[inline]
-fn final_layout_pass(tree: &mut impl LayoutTree, node: NodeId, flex_lines: &mut [FlexLine], constants: &AlgoConstants) {
+fn final_layout_pass(tree: &mut impl LayoutTree, flex_lines: &mut [FlexLine], constants: &AlgoConstants) {
     let mut total_offset_cross = constants.content_box_inset.cross_start(constants.dir);
 
     if constants.is_wrap_reverse {
         for line in flex_lines.iter_mut().rev() {
             calculate_layout_line(
                 tree,
-                node,
                 line,
                 &mut total_offset_cross,
                 constants.container_size,
@@ -1891,7 +1889,6 @@ fn final_layout_pass(tree: &mut impl LayoutTree, node: NodeId, flex_lines: &mut 
         for line in flex_lines.iter_mut() {
             calculate_layout_line(
                 tree,
-                node,
                 line,
                 &mut total_offset_cross,
                 constants.container_size,


### PR DESCRIPTION
# Objective

This is huge performance win on our 100k node "wide" benchmark, bringing the numbers roughly in line with our "deep" benchmarks for the same node count. Somewhat embarrassingly this one line was dominating performance for very wide trees:

```rust
let order = tree.children(node).position(|n| n == item.node).unwrap() as u32;
```

## Benchmark Results

| Benchmark          | Node Count | Depth | Yoga ([ba27f9d]) | Taffy 0.3     | Taffy (main)  | Taffy (this PR) |
| ---                | ---        | ---   | ---              | ---           | ---           | ---             |
| yoga 'huge nested' | 1,000      | 3     | 408.72 µs        | 329.04 µs     | 177.16 µs     | 295.64 µs       |
| yoga 'huge nested' | 10,000     | 4     | 3.9276 ms        | 4.3486 ms     | 2.8241 ms     | 2.7671 ms       |
| yoga 'huge nested' | 100,000    | 5     | 46.782 ms        | 38.559 ms     | 29.523 ms     | 24.912 ms       |
| big trees (wide)   | 1,000      | 1     | 741.25 µs        | 505.99 µs     | 464.12 µs     | 486.94 µs       |
| big trees (wide)   | 10,000     | 1     | **7.1613 ms**    | **8.3395 ms** | **6.5570 ms** | **5.1362 ms**   |
| big trees (wide)   | 100,000    | 1     | **132.09 ms**    | **247.42 ms** | **196.79 ms** | **64.096 ms**   |
| big trees (deep)   | 4,000      | 12    | 2.2308 ms        | 1.7400 ms     | 1.7071 ms     | 1.8021 ms       |
| big trees (deep)   | 10,000     | 14    | **5.8912 ms**    | **4.4445 ms** | **4.3659 ms** | **4.4437 ms**   |
| big trees (deep)   | 100,000    | 17    | **76.437 ms**    | **63.778 ms** | **60.390 ms** | **62.042 ms**   |
| super deep         | 1,000      | 1,000 | 561.34 µs        | 472.85 µs     | 412.16 µs     | 415.73 µs       |


## Context

Discovered while trying to optimise `display: contents` which makes calling `tree.children(node)` more expensive.
