### PR TITLE
Pass cross-axis known_dimension when computing flex item min size (0.3.x)

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.3.14
+
+### Fixes
+
+- Flex: Fix issue where constraints were not being propagated, causing nodes with inherent aspect-ratio (typically images) to not apply that aspect-ratio (#545) (Fixes bevyengine/bevy#9841)
+
 ## 0.3.13
 
 ### Fixes

--- a/tests/caching.rs
+++ b/tests/caching.rs
@@ -30,7 +30,7 @@ mod caching {
 
         taffy.compute_layout(node, Size::MAX_CONTENT).unwrap();
 
-        assert_eq!(NUM_MEASURES.load(Ordering::SeqCst), 8);
+        assert_eq!(NUM_MEASURES.load(Ordering::SeqCst), 5);
     }
 
     #[test]
@@ -62,6 +62,6 @@ mod caching {
         }
 
         taffy.compute_layout(node, Size::MAX_CONTENT).unwrap();
-        assert_eq!(NUM_MEASURES.load(Ordering::SeqCst), 8);
+        assert_eq!(NUM_MEASURES.load(Ordering::SeqCst), 5);
     }
 }


### PR DESCRIPTION
# Objective

Fixes bevyengine/bevy#9841

Pass cross-axis known_dimension when computing flex item min size
(fixes sizing of children that have inherent aspect ratio (e.g. images))
