### PR TITLE
Pass cross-axis known_dimension when computing flex item min size

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -50,6 +50,12 @@ Example usage change:
   - All types from the `node`, `data`, `layout`, `error` and `cache` modules have been moved to the  the `tree` module.
 - Fixed misspelling: `RunMode::PeformLayout` renamed into `RunMode::PerformLayout` (added missing `r`).
 
+## 0.3.14
+
+### Fixes
+
+- Flex: Fix issue where constraints were not being propagated, causing nodes with inherent aspect-ratio (typically images) to not apply that aspect-ratio (#545) (Fixes bevyengine/bevy#9841)
+
 ## 0.3.13
 
 ### Fixes


### PR DESCRIPTION
# Objective

Fixes bevyengine/bevy#9841

Pass cross-axis known_dimension when computing flex item min size
(fixes sizing of children that have inherent aspect ratio (e.g. images))

## Context

I would like to add a gentest for this case. However, it requires extending the gentest harness to handle images, and I would like to avoid conflicts with https://github.com/DioxusLabs/taffy/pull/490 which also modifies that harness (and I suspect would be a pain to rebase on top of other changes). So I propose to create an issue (https://github.com/DioxusLabs/taffy/issues/546) for the test, merge just the fix, and then add the test once #490 lands.

I also intend to backport this to 0.3.x seeing as it's so small and it has been reported by a Bevy user. So I've stuck the changelog entry under 0.3.14.

## Feedback wanted

Does this seem like a reasonable approach?

P.S. The only really meaningful change in this diff is the very bottom line. The rest is just moving code higher up the function to avoid recomputing a value. And removing a redundant `.clamp()` that was being called on an already-clamped value.
