### PR TITLE
floor alignment offset

### DIFF
--- a/src/compute/common/alignment.rs
+++ b/src/compute/common/alignment.rs
@@ -49,6 +49,7 @@ pub(crate) fn compute_alignment_offset(
             AlignContent::SpaceBetween => free_space / (num_items - 1) as f32,
             AlignContent::SpaceAround => free_space / num_items as f32,
             AlignContent::SpaceEvenly => free_space / (num_items + 1) as f32,
-        }).max(0.0)
+        })
+        .max(0.0)
     }
 }

--- a/src/compute/common/alignment.rs
+++ b/src/compute/common/alignment.rs
@@ -39,7 +39,7 @@ pub(crate) fn compute_alignment_offset(
             AlignContent::SpaceEvenly => free_space / (num_items + 1) as f32,
         }
     } else {
-        gap + match alignment_mode {
+        (gap + match alignment_mode {
             AlignContent::Start => 0.0,
             AlignContent::FlexStart => 0.0,
             AlignContent::End => 0.0,
@@ -49,6 +49,6 @@ pub(crate) fn compute_alignment_offset(
             AlignContent::SpaceBetween => free_space / (num_items - 1) as f32,
             AlignContent::SpaceAround => free_space / num_items as f32,
             AlignContent::SpaceEvenly => free_space / (num_items + 1) as f32,
-        }
+        }).max(0.0)
     }
 }


### PR DESCRIPTION
# Objective

correct space-xxx behaviour for cramped containers.

## Context

i noticed a difference in layout between chrome and firefox vs taffy (via bevy) when the computed alignment for non-first items returns a negative value. it seems to be corrected by flooring the offset at zero.

i don't know for sure if the floor should be with the `gap` or without, i assumed with. 

screenshots below for containers with `justify-content` set to each space-xxx mode
note the "modified" screenshots still show differences in the last two columns where the height is a negative number of px - i am not sure if there's a good spec for that, but i can work around it by just supplying `Auto` if the input is negative.

space-between original
![space-between original](https://github.com/DioxusLabs/taffy/assets/50659922/f970778a-b4d4-4f6e-9952-ee703b05c7c7)
modified
![space-between modified](https://github.com/DioxusLabs/taffy/assets/50659922/2671ce5f-17fb-4f49-add1-455b5fa20a7e)

space-evenly original
![space=-evenly original](https://github.com/DioxusLabs/taffy/assets/50659922/1b2a8987-c1ce-49cd-b0c6-d701ee48385a)
modified
![space-evenly modified](https://github.com/DioxusLabs/taffy/assets/50659922/d1f82d08-ba62-4945-a805-1fe6e274791c)

space-around original
![space-around original](https://github.com/DioxusLabs/taffy/assets/50659922/ba75fb19-63fc-4d64-a576-a3fe0b011609)
modified
![space-around modified](https://github.com/DioxusLabs/taffy/assets/50659922/a0910c2f-97ee-4428-be89-359314a914d6)
