### PR TITLE
Update release notes for 0.3.16 release

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -106,6 +106,12 @@ Example usage change:
   - All types from the `node`, `data`, `layout`, `error` and `cache` modules have been moved to the  the `tree` module.
 - Fixed misspelling: `RunMode::PeformLayout` renamed into `RunMode::PerformLayout` (added missing `r`).
 
+## 0.3.16
+
+### Fixes
+
+- Improve performance of flexbox columns
+
 ## 0.3.15
 
 ### Fixes


### PR DESCRIPTION
# Objective

Sync release notes from `0.3.x` branch to `main` following the `0.3.16` release.