### PR TITLE
Make TaffyView private

### DIFF
--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -51,7 +51,6 @@ mod tests {
     use super::compute_hidden_layout;
     use crate::geometry::{Point, Size};
     use crate::style::{Display, Style};
-    use crate::tree::TaffyView;
     use crate::Taffy;
 
     #[test]
@@ -74,10 +73,7 @@ mod tests {
             )
             .unwrap();
 
-        compute_hidden_layout(
-            &mut TaffyView { taffy: &mut taffy, measure_function: |_, _, _, _| Size::ZERO },
-            root.into(),
-        );
+        compute_hidden_layout(&mut taffy.as_layout_tree(), root.into());
 
         // Whatever size and display-mode the nodes had previously,
         // all layouts should resolve to ZERO due to the root's DISPLAY::NONE

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -13,7 +13,7 @@ pub use node::NodeId;
 #[cfg(feature = "taffy_tree")]
 mod taffy_tree;
 #[cfg(feature = "taffy_tree")]
-pub use taffy_tree::{Taffy, TaffyChildIter, TaffyError, TaffyResult, TaffyView};
+pub use taffy_tree::{Taffy, TaffyChildIter, TaffyError, TaffyResult};
 mod layout;
 pub use layout::{CollapsibleMarginSet, Layout, LayoutInput, LayoutOutput, RunMode, SizingMode};
 

--- a/src/tree/taffy_tree/mod.rs
+++ b/src/tree/taffy_tree/mod.rs
@@ -4,4 +4,4 @@ mod error;
 mod tree;
 
 pub use error::{TaffyError, TaffyResult};
-pub use tree::{Taffy, TaffyChildIter, TaffyView};
+pub use tree::{Taffy, TaffyChildIter};

--- a/src/tree/taffy_tree/tree.rs
+++ b/src/tree/taffy_tree/tree.rs
@@ -65,7 +65,7 @@ impl<'a> Iterator for TaffyChildIter<'a> {
 /// View over the Taffy tree that holds the tree itself along with a reference to the context
 /// and implements LayoutTree. This allows the context to be stored outside of the Taffy struct
 /// which makes the lifetimes of the context much more flexible.
-pub struct TaffyView<'t, NodeContext, MeasureFunction>
+pub(crate) struct TaffyView<'t, NodeContext, MeasureFunction>
 where
     MeasureFunction: FnMut(Size<Option<f32>>, Size<AvailableSpace>, NodeId, Option<&mut NodeContext>) -> Size<f32>,
 {
@@ -492,6 +492,12 @@ impl<NodeContext> Taffy<NodeContext> {
     pub fn print_tree(&mut self, root: NodeId) {
         let taffy_view = TaffyView { taffy: self, measure_function: |_, _, _, _| Size::ZERO };
         crate::util::print_tree(&taffy_view, root)
+    }
+
+    /// Returns an instance of LayoutTree representing the Taffy
+    #[cfg(test)]
+    pub(crate) fn as_layout_tree(&mut self) -> impl LayoutTree + '_ {
+        TaffyView { taffy: self, measure_function: |_, _, _, _| Size::ZERO }
     }
 }
 


### PR DESCRIPTION
# Objective

Make the docs clearer. `TaffyView` is an implementation detail and it doesn't need to be public.

