### PR TITLE
"Traitify" the `Style` struct

### DIFF
--- a/examples/custom_tree_owned_partial.rs
+++ b/examples/custom_tree_owned_partial.rs
@@ -126,7 +126,12 @@ impl taffy::TraversePartialTree for Node {
 }
 
 impl taffy::LayoutPartialTree for Node {
-    fn get_style(&self, node_id: NodeId) -> &Style {
+    type CoreContainerStyle<'a> = &'a Style where
+        Self: 'a;
+
+    type CacheMut<'b> = &'b mut Cache where Self: 'b;
+
+    fn get_core_container_style(&self, node_id: NodeId) -> Self::CoreContainerStyle<'_> {
         &self.node_from_id(node_id).style
     }
 
@@ -159,6 +164,38 @@ impl taffy::LayoutPartialTree for Node {
                 }),
             }
         })
+    }
+}
+
+impl taffy::LayoutFlexboxContainer for Node {
+    type ContainerStyle<'a> = &'a Style where
+        Self: 'a;
+
+    type ItemStyle<'a> = &'a Style where
+        Self: 'a;
+
+    fn get_flexbox_container_style(&self, node_id: NodeId) -> Self::ContainerStyle<'_> {
+        &self.node_from_id(node_id).style
+    }
+
+    fn get_flexbox_child_style(&self, child_node_id: NodeId) -> Self::ItemStyle<'_> {
+        &self.node_from_id(child_node_id).style
+    }
+}
+
+impl taffy::LayoutGridContainer for Node {
+    type ContainerStyle<'a> = &'a Style where
+        Self: 'a;
+
+    type ItemStyle<'a> = &'a Style where
+        Self: 'a;
+
+    fn get_grid_container_style(&self, node_id: NodeId) -> Self::ContainerStyle<'_> {
+        &self.node_from_id(node_id).style
+    }
+
+    fn get_grid_child_style(&self, child_node_id: NodeId) -> Self::ItemStyle<'_> {
+        &self.node_from_id(child_node_id).style
     }
 }
 

--- a/examples/custom_tree_owned_partial.rs
+++ b/examples/custom_tree_owned_partial.rs
@@ -168,33 +168,33 @@ impl taffy::LayoutPartialTree for Node {
 }
 
 impl taffy::LayoutFlexboxContainer for Node {
-    type ContainerStyle<'a> = &'a Style where
+    type FlexboxContainerStyle<'a> = &'a Style where
         Self: 'a;
 
-    type ItemStyle<'a> = &'a Style where
+    type FlexboxItemStyle<'a> = &'a Style where
         Self: 'a;
 
-    fn get_flexbox_container_style(&self, node_id: NodeId) -> Self::ContainerStyle<'_> {
+    fn get_flexbox_container_style(&self, node_id: NodeId) -> Self::FlexboxContainerStyle<'_> {
         &self.node_from_id(node_id).style
     }
 
-    fn get_flexbox_child_style(&self, child_node_id: NodeId) -> Self::ItemStyle<'_> {
+    fn get_flexbox_child_style(&self, child_node_id: NodeId) -> Self::FlexboxItemStyle<'_> {
         &self.node_from_id(child_node_id).style
     }
 }
 
 impl taffy::LayoutGridContainer for Node {
-    type ContainerStyle<'a> = &'a Style where
+    type GridContainerStyle<'a> = &'a Style where
         Self: 'a;
 
-    type ItemStyle<'a> = &'a Style where
+    type GridItemStyle<'a> = &'a Style where
         Self: 'a;
 
-    fn get_grid_container_style(&self, node_id: NodeId) -> Self::ContainerStyle<'_> {
+    fn get_grid_container_style(&self, node_id: NodeId) -> Self::GridContainerStyle<'_> {
         &self.node_from_id(node_id).style
     }
 
-    fn get_grid_child_style(&self, child_node_id: NodeId) -> Self::ItemStyle<'_> {
+    fn get_grid_child_style(&self, child_node_id: NodeId) -> Self::GridItemStyle<'_> {
         &self.node_from_id(child_node_id).style
     }
 }

--- a/examples/custom_tree_owned_unsafe.rs
+++ b/examples/custom_tree_owned_unsafe.rs
@@ -172,33 +172,33 @@ impl LayoutPartialTree for StatelessLayoutTree {
 }
 
 impl taffy::LayoutFlexboxContainer for StatelessLayoutTree {
-    type ContainerStyle<'a> = &'a Style where
+    type FlexboxContainerStyle<'a> = &'a Style where
         Self: 'a;
 
-    type ItemStyle<'a> = &'a Style where
+    type FlexboxItemStyle<'a> = &'a Style where
         Self: 'a;
 
-    fn get_flexbox_container_style(&self, node_id: NodeId) -> Self::ContainerStyle<'_> {
+    fn get_flexbox_container_style(&self, node_id: NodeId) -> Self::FlexboxContainerStyle<'_> {
         unsafe { &node_from_id(node_id).style }
     }
 
-    fn get_flexbox_child_style(&self, child_node_id: NodeId) -> Self::ItemStyle<'_> {
+    fn get_flexbox_child_style(&self, child_node_id: NodeId) -> Self::FlexboxItemStyle<'_> {
         unsafe { &node_from_id(child_node_id).style }
     }
 }
 
 impl taffy::LayoutGridContainer for StatelessLayoutTree {
-    type ContainerStyle<'a> = &'a Style where
+    type GridContainerStyle<'a> = &'a Style where
         Self: 'a;
 
-    type ItemStyle<'a> = &'a Style where
+    type GridItemStyle<'a> = &'a Style where
         Self: 'a;
 
-    fn get_grid_container_style(&self, node_id: NodeId) -> Self::ContainerStyle<'_> {
+    fn get_grid_container_style(&self, node_id: NodeId) -> Self::GridContainerStyle<'_> {
         unsafe { &node_from_id(node_id).style }
     }
 
-    fn get_grid_child_style(&self, child_node_id: NodeId) -> Self::ItemStyle<'_> {
+    fn get_grid_child_style(&self, child_node_id: NodeId) -> Self::GridItemStyle<'_> {
         unsafe { &node_from_id(child_node_id).style }
     }
 }

--- a/examples/custom_tree_owned_unsafe.rs
+++ b/examples/custom_tree_owned_unsafe.rs
@@ -130,7 +130,12 @@ impl TraversePartialTree for StatelessLayoutTree {
 impl TraverseTree for StatelessLayoutTree {}
 
 impl LayoutPartialTree for StatelessLayoutTree {
-    fn get_style(&self, node_id: NodeId) -> &Style {
+    type CoreContainerStyle<'a> = &'a Style where
+        Self: 'a;
+
+    type CacheMut<'b> = &'b mut Cache where Self: 'b;
+
+    fn get_core_container_style(&self, node_id: NodeId) -> Self::CoreContainerStyle<'_> {
         unsafe { &node_from_id(node_id).style }
     }
 
@@ -163,6 +168,38 @@ impl LayoutPartialTree for StatelessLayoutTree {
                 }),
             }
         })
+    }
+}
+
+impl taffy::LayoutFlexboxContainer for StatelessLayoutTree {
+    type ContainerStyle<'a> = &'a Style where
+        Self: 'a;
+
+    type ItemStyle<'a> = &'a Style where
+        Self: 'a;
+
+    fn get_flexbox_container_style(&self, node_id: NodeId) -> Self::ContainerStyle<'_> {
+        unsafe { &node_from_id(node_id).style }
+    }
+
+    fn get_flexbox_child_style(&self, child_node_id: NodeId) -> Self::ItemStyle<'_> {
+        unsafe { &node_from_id(child_node_id).style }
+    }
+}
+
+impl taffy::LayoutGridContainer for StatelessLayoutTree {
+    type ContainerStyle<'a> = &'a Style where
+        Self: 'a;
+
+    type ItemStyle<'a> = &'a Style where
+        Self: 'a;
+
+    fn get_grid_container_style(&self, node_id: NodeId) -> Self::ContainerStyle<'_> {
+        unsafe { &node_from_id(node_id).style }
+    }
+
+    fn get_grid_child_style(&self, child_node_id: NodeId) -> Self::ItemStyle<'_> {
+        unsafe { &node_from_id(child_node_id).style }
     }
 }
 

--- a/examples/custom_tree_vec.rs
+++ b/examples/custom_tree_vec.rs
@@ -139,7 +139,12 @@ impl taffy::TraversePartialTree for Tree {
 impl taffy::TraverseTree for Tree {}
 
 impl taffy::LayoutPartialTree for Tree {
-    fn get_style(&self, node_id: NodeId) -> &Style {
+    type CoreContainerStyle<'a> = &'a Style where
+        Self: 'a;
+
+    type CacheMut<'b> = &'b mut Cache where Self: 'b;
+
+    fn get_core_container_style(&self, node_id: NodeId) -> Self::CoreContainerStyle<'_> {
         &self.node_from_id(node_id).style
     }
 
@@ -172,6 +177,38 @@ impl taffy::LayoutPartialTree for Tree {
                 }),
             }
         })
+    }
+}
+
+impl taffy::LayoutFlexboxContainer for Tree {
+    type ContainerStyle<'a> = &'a Style where
+        Self: 'a;
+
+    type ItemStyle<'a> = &'a Style where
+        Self: 'a;
+
+    fn get_flexbox_container_style(&self, node_id: NodeId) -> Self::ContainerStyle<'_> {
+        &self.node_from_id(node_id).style
+    }
+
+    fn get_flexbox_child_style(&self, child_node_id: NodeId) -> Self::ItemStyle<'_> {
+        &self.node_from_id(child_node_id).style
+    }
+}
+
+impl taffy::LayoutGridContainer for Tree {
+    type ContainerStyle<'a> = &'a Style where
+        Self: 'a;
+
+    type ItemStyle<'a> = &'a Style where
+        Self: 'a;
+
+    fn get_grid_container_style(&self, node_id: NodeId) -> Self::ContainerStyle<'_> {
+        &self.node_from_id(node_id).style
+    }
+
+    fn get_grid_child_style(&self, child_node_id: NodeId) -> Self::ItemStyle<'_> {
+        &self.node_from_id(child_node_id).style
     }
 }
 

--- a/examples/custom_tree_vec.rs
+++ b/examples/custom_tree_vec.rs
@@ -181,33 +181,33 @@ impl taffy::LayoutPartialTree for Tree {
 }
 
 impl taffy::LayoutFlexboxContainer for Tree {
-    type ContainerStyle<'a> = &'a Style where
+    type FlexboxContainerStyle<'a> = &'a Style where
         Self: 'a;
 
-    type ItemStyle<'a> = &'a Style where
+    type FlexboxItemStyle<'a> = &'a Style where
         Self: 'a;
 
-    fn get_flexbox_container_style(&self, node_id: NodeId) -> Self::ContainerStyle<'_> {
+    fn get_flexbox_container_style(&self, node_id: NodeId) -> Self::FlexboxContainerStyle<'_> {
         &self.node_from_id(node_id).style
     }
 
-    fn get_flexbox_child_style(&self, child_node_id: NodeId) -> Self::ItemStyle<'_> {
+    fn get_flexbox_child_style(&self, child_node_id: NodeId) -> Self::FlexboxItemStyle<'_> {
         &self.node_from_id(child_node_id).style
     }
 }
 
 impl taffy::LayoutGridContainer for Tree {
-    type ContainerStyle<'a> = &'a Style where
+    type GridContainerStyle<'a> = &'a Style where
         Self: 'a;
 
-    type ItemStyle<'a> = &'a Style where
+    type GridItemStyle<'a> = &'a Style where
         Self: 'a;
 
-    fn get_grid_container_style(&self, node_id: NodeId) -> Self::ContainerStyle<'_> {
+    fn get_grid_container_style(&self, node_id: NodeId) -> Self::GridContainerStyle<'_> {
         &self.node_from_id(node_id).style
     }
 
-    fn get_grid_child_style(&self, child_node_id: NodeId) -> Self::ItemStyle<'_> {
+    fn get_grid_child_style(&self, child_node_id: NodeId) -> Self::GridItemStyle<'_> {
         &self.node_from_id(child_node_id).style
     }
 }

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -179,7 +179,7 @@ fn compute_inner(tree: &mut impl LayoutBlockContainer, node_id: NodeId, inputs: 
             && border.bottom == 0.0
             && size.height.is_none(),
     };
-    let has_styles_preventing_being_collapsed_through = false//style.display != Display::Block
+    let has_styles_preventing_being_collapsed_through = !style.is_block()
         || style.overflow().x.is_scroll_container()
         || style.overflow().y.is_scroll_container()
         || style.position() == Position::Absolute

--- a/src/compute/grid/alignment.rs
+++ b/src/compute/grid/alignment.rs
@@ -2,14 +2,14 @@
 use super::types::GridTrack;
 use crate::compute::common::alignment::{apply_alignment_fallback, compute_alignment_offset};
 use crate::geometry::{InBothAbsAxis, Line, Point, Rect, Size};
-use crate::style::{AlignContent, AlignItems, AlignSelf, AvailableSpace, Overflow, Position};
-use crate::tree::{Layout, LayoutPartialTree, LayoutPartialTreeExt, NodeId, SizingMode};
+use crate::style::{AlignContent, AlignItems, AlignSelf, AvailableSpace, CoreStyle, GridItemStyle, Overflow, Position};
+use crate::tree::{Layout, LayoutPartialTreeExt, NodeId, SizingMode};
 use crate::util::sys::f32_max;
 use crate::util::{MaybeMath, MaybeResolve, ResolveOrZero};
 
 #[cfg(feature = "content_size")]
 use crate::compute::common::content_size::compute_content_size_contribution;
-use crate::BoxSizing;
+use crate::{BoxSizing, LayoutGridContainer};
 
 /// Align the grid tracks within the grid according to the align-content (rows) or
 /// justify-content (columns) property. This only does anything if the size of the
@@ -57,7 +57,7 @@ pub(super) fn align_tracks(
 
 /// Align and size a grid item into it's final position
 pub(super) fn align_and_position_item(
-    tree: &mut impl LayoutPartialTree,
+    tree: &mut impl LayoutGridContainer,
     node: NodeId,
     order: u32,
     grid_area: Rect<f32>,
@@ -66,36 +66,39 @@ pub(super) fn align_and_position_item(
 ) -> (Size<f32>, f32, f32) {
     let grid_area_size = Size { width: grid_area.right - grid_area.left, height: grid_area.bottom - grid_area.top };
 
-    let style = tree.get_style(node);
+    let style = tree.get_grid_child_style(node);
 
-    let overflow = style.overflow;
-    let scrollbar_width = style.scrollbar_width;
-    let aspect_ratio = style.aspect_ratio;
-    let justify_self = style.justify_self;
-    let align_self = style.align_self;
+    let overflow = style.overflow();
+    let scrollbar_width = style.scrollbar_width();
+    let aspect_ratio = style.aspect_ratio();
+    let justify_self = style.justify_self();
+    let align_self = style.align_self();
 
-    let position = style.position;
-    let inset_horizontal = style.inset.horizontal_components().map(|size| size.resolve_to_option(grid_area_size.width));
-    let inset_vertical = style.inset.vertical_components().map(|size| size.resolve_to_option(grid_area_size.height));
-    let padding = style.padding.map(|p| p.resolve_or_zero(Some(grid_area_size.width)));
-    let border = style.border.map(|p| p.resolve_or_zero(Some(grid_area_size.width)));
+    let position = style.position();
+    let inset_horizontal =
+        style.inset().horizontal_components().map(|size| size.resolve_to_option(grid_area_size.width));
+    let inset_vertical = style.inset().vertical_components().map(|size| size.resolve_to_option(grid_area_size.height));
+    let padding = style.padding().map(|p| p.resolve_or_zero(Some(grid_area_size.width)));
+    let border = style.border().map(|p| p.resolve_or_zero(Some(grid_area_size.width)));
     let padding_border_size = (padding + border).sum_axes();
+
     let box_sizing_adjustment =
-        if style.box_sizing == BoxSizing::ContentBox { padding_border_size } else { Size::ZERO };
+        if style.box_sizing() == BoxSizing::ContentBox { padding_border_size } else { Size::ZERO };
+
     let inherent_size = style
-        .size
+        .size()
         .maybe_resolve(grid_area_size)
         .maybe_apply_aspect_ratio(aspect_ratio)
         .maybe_add(box_sizing_adjustment);
     let min_size = style
-        .min_size
+        .min_size()
         .maybe_resolve(grid_area_size)
         .maybe_add(box_sizing_adjustment)
         .or(padding_border_size.map(Some))
         .maybe_max(padding_border_size)
         .maybe_apply_aspect_ratio(aspect_ratio);
     let max_size = style
-        .max_size
+        .max_size()
         .maybe_resolve(grid_area_size)
         .maybe_apply_aspect_ratio(aspect_ratio)
         .maybe_add(box_sizing_adjustment);
@@ -123,7 +126,7 @@ pub(super) fn align_and_position_item(
 
     // Note: This is not a bug. It is part of the CSS spec that both horizontal and vertical margins
     // resolve against the WIDTH of the grid area.
-    let margin = style.margin.map(|margin| margin.resolve_to_option(grid_area_size.width));
+    let margin = style.margin().map(|margin| margin.resolve_to_option(grid_area_size.width));
 
     let grid_area_minus_item_margins_size = Size {
         width: grid_area_size.width.maybe_sub(margin.left).maybe_sub(margin.right),
@@ -187,6 +190,7 @@ pub(super) fn align_and_position_item(
     let Size { width, height } = Size { width, height }.maybe_clamp(min_size, max_size);
 
     // Layout node
+    drop(style);
     let layout_output = tree.perform_child_layout(
         node,
         Size { width, height },

--- a/src/compute/grid/explicit_grid.rs
+++ b/src/compute/grid/explicit_grid.rs
@@ -2,18 +2,19 @@
 //! This mainly consists of evaluating GridAutoTracks
 use super::types::{GridTrack, TrackCounts};
 use crate::geometry::{AbsoluteAxis, Size};
-use crate::style::{GridTrackRepetition, LengthPercentage, NonRepeatedTrackSizingFunction, Style, TrackSizingFunction};
+use crate::style::{GridTrackRepetition, LengthPercentage, NonRepeatedTrackSizingFunction, TrackSizingFunction};
 use crate::style_helpers::TaffyAuto;
-use crate::util::sys::{GridTrackVec, Vec};
+use crate::util::sys::Vec;
 use crate::util::MaybeMath;
 use crate::util::ResolveOrZero;
+use crate::GridContainerStyle;
 
 #[cfg(not(feature = "std"))]
 use num_traits::float::FloatCore;
 
 /// Compute the number of rows and columns in the explicit grid
 pub(crate) fn compute_explicit_grid_size_in_axis(
-    style: &Style,
+    style: &impl GridContainerStyle,
     inner_container_size: Size<Option<f32>>,
     axis: AbsoluteAxis,
 ) -> u16 {
@@ -93,7 +94,7 @@ pub(crate) fn compute_explicit_grid_size_in_axis(
     //   - then the number of repetitions is the smallest possible positive integer that fulfills that minimum requirement
     // Otherwise, the specified track list repeats only once.
     let size_is_maximum =
-        style.size.get_abs(axis).into_option().is_some() || style.max_size.get_abs(axis).into_option().is_some();
+        style.size().get_abs(axis).into_option().is_some() || style.max_size().get_abs(axis).into_option().is_some();
 
     // Determine the number of repetitions
     let num_repetitions: u16 = match inner_container_size.get_abs(axis) {
@@ -128,7 +129,7 @@ pub(crate) fn compute_explicit_grid_size_in_axis(
                     }
                 })
                 .sum();
-            let gap_size = style.gap.get_abs(axis).resolve_or_zero(Some(inner_container_size));
+            let gap_size = style.gap().get_abs(axis).resolve_or_zero(Some(inner_container_size));
 
             // Compute the amount of space that a single repetition of the repeated track list takes
             let per_repetition_track_used_space: f32 = repetition_definition
@@ -176,7 +177,7 @@ pub(crate) fn compute_explicit_grid_size_in_axis(
 pub(super) fn initialize_grid_tracks(
     tracks: &mut Vec<GridTrack>,
     counts: TrackCounts,
-    track_template: &GridTrackVec<TrackSizingFunction>,
+    track_template: &[TrackSizingFunction],
     auto_tracks: &[NonRepeatedTrackSizingFunction],
     gap: LengthPercentage,
     track_has_items: impl Fn(usize) -> bool,

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -89,8 +89,6 @@ pub fn compute_grid_layout(tree: &mut impl LayoutGridContainer, node: NodeId, in
     let align_items = style.align_items();
     let justify_items = style.justify_items();
 
-    drop(style);
-
     let constrained_available_space = known_dimensions
         .or(preferred_size)
         .map(|size| size.map(AvailableSpace::Definite))
@@ -196,6 +194,8 @@ pub fn compute_grid_layout(tree: &mut impl LayoutGridContainer, node: NodeId, in
         style.gap().height,
         |row_index| cell_occupancy_matrix.row_is_occupied(row_index),
     );
+
+    drop(style);
 
     // 6. Track Sizing
 

--- a/src/compute/grid/types/grid_item.rs
+++ b/src/compute/grid/types/grid_item.rs
@@ -5,11 +5,11 @@ use crate::geometry::AbstractAxis;
 use crate::geometry::{Line, Point, Rect, Size};
 use crate::style::{
     AlignItems, AlignSelf, AvailableSpace, Dimension, LengthPercentageAuto, MaxTrackSizingFunction,
-    MinTrackSizingFunction, Overflow, Style,
+    MinTrackSizingFunction, Overflow,
 };
 use crate::tree::{LayoutPartialTree, LayoutPartialTreeExt, NodeId, SizingMode};
 use crate::util::{MaybeMath, MaybeResolve, ResolveOrZero};
-use crate::{BoxSizing, LengthPercentage};
+use crate::{BoxSizing, GridItemStyle, LengthPercentage};
 use core::ops::Range;
 
 /// Represents a single grid item
@@ -93,11 +93,11 @@ pub(in super::super) struct GridItem {
 
 impl GridItem {
     /// Create a new item given a concrete placement in both axes
-    pub fn new_with_placement_style_and_order(
+    pub fn new_with_placement_style_and_order<S: GridItemStyle>(
         node: NodeId,
         col_span: Line<OriginZeroLine>,
         row_span: Line<OriginZeroLine>,
-        style: &Style,
+        style: S,
         parent_align_items: AlignItems,
         parent_justify_items: AlignItems,
         source_order: u16,
@@ -107,17 +107,17 @@ impl GridItem {
             source_order,
             row: row_span,
             column: col_span,
-            overflow: style.overflow,
-            box_sizing: style.box_sizing,
-            size: style.size,
-            min_size: style.min_size,
-            max_size: style.max_size,
-            aspect_ratio: style.aspect_ratio,
-            padding: style.padding,
-            border: style.border,
-            margin: style.margin,
-            align_self: style.align_self.unwrap_or(parent_align_items),
-            justify_self: style.justify_self.unwrap_or(parent_justify_items),
+            overflow: style.overflow(),
+            box_sizing: style.box_sizing(),
+            size: style.size(),
+            min_size: style.min_size(),
+            max_size: style.max_size(),
+            aspect_ratio: style.aspect_ratio(),
+            padding: style.padding(),
+            border: style.border(),
+            margin: style.margin(),
+            align_self: style.align_self().unwrap_or(parent_align_items),
+            justify_self: style.justify_self().unwrap_or(parent_justify_items),
             baseline: None,
             baseline_shim: 0.0,
             row_indexes: Line { start: 0, end: 0 }, // Properly initialised later

--- a/src/compute/leaf.rs
+++ b/src/compute/leaf.rs
@@ -1,20 +1,20 @@
 //! Computes size using styles and measure functions
 
 use crate::geometry::{Point, Size};
-use crate::style::{AvailableSpace, Display, Overflow, Position, Style};
+use crate::style::{AvailableSpace, Overflow, Position};
 use crate::tree::{CollapsibleMarginSet, RunMode};
 use crate::tree::{LayoutInput, LayoutOutput, SizingMode};
 use crate::util::debug::debug_log;
 use crate::util::sys::f32_max;
 use crate::util::MaybeMath;
 use crate::util::{MaybeResolve, ResolveOrZero};
-use crate::BoxSizing;
+use crate::{BoxSizing, CoreStyle};
 use core::unreachable;
 
 /// Compute the size of a leaf node (node with no children)
 pub fn compute_leaf_layout<MeasureFunction>(
     inputs: LayoutInput,
-    style: &Style,
+    style: &impl CoreStyle,
     measure_function: MeasureFunction,
 ) -> LayoutOutput
 where
@@ -24,12 +24,12 @@ where
 
     // Note: both horizontal and vertical percentage padding/borders are resolved against the container's inline size (i.e. width).
     // This is not a bug, but is how CSS is specified (see: https://developer.mozilla.org/en-US/docs/Web/CSS/padding#values)
-    let margin = style.margin.resolve_or_zero(parent_size.width);
-    let padding = style.padding.resolve_or_zero(parent_size.width);
-    let border = style.border.resolve_or_zero(parent_size.width);
+    let margin = style.margin().resolve_or_zero(parent_size.width);
+    let padding = style.padding().resolve_or_zero(parent_size.width);
+    let border = style.border().resolve_or_zero(parent_size.width);
     let padding_border = padding + border;
     let pb_sum = padding_border.sum_axes();
-    let box_sizing_adjustment = if style.box_sizing == BoxSizing::ContentBox { pb_sum } else { Size::ZERO };
+    let box_sizing_adjustment = if style.box_sizing() == BoxSizing::ContentBox { pb_sum } else { Size::ZERO };
 
     // Resolve node's preferred/min/max sizes (width/heights) against the available space (percentages resolve to pixel values)
     // For ContentSize mode, we pretend that the node has no size styles as these should be ignored.
@@ -41,18 +41,18 @@ where
             (node_size, node_min_size, node_max_size, None)
         }
         SizingMode::InherentSize => {
-            let aspect_ratio = style.aspect_ratio;
+            let aspect_ratio = style.aspect_ratio();
             let style_size = style
-                .size
+                .size()
                 .maybe_resolve(parent_size)
                 .maybe_apply_aspect_ratio(aspect_ratio)
                 .maybe_add(box_sizing_adjustment);
             let style_min_size = style
-                .min_size
+                .min_size()
                 .maybe_resolve(parent_size)
                 .maybe_apply_aspect_ratio(aspect_ratio)
                 .maybe_add(box_sizing_adjustment);
-            let style_max_size = style.max_size.maybe_resolve(parent_size).maybe_add(box_sizing_adjustment);
+            let style_max_size = style.max_size().maybe_resolve(parent_size).maybe_add(box_sizing_adjustment);
 
             let node_size = known_dimensions.or(style_size);
             (node_size, style_min_size, style_max_size, aspect_ratio)
@@ -62,8 +62,8 @@ where
     // Scrollbar gutters are reserved when the `overflow` property is set to `Overflow::Scroll`.
     // However, the axis are switched (transposed) because a node that scrolls vertically needs
     // *horizontal* space to be reserved for a scrollbar
-    let scrollbar_gutter = style.overflow.transpose().map(|overflow| match overflow {
-        Overflow::Scroll => style.scrollbar_width,
+    let scrollbar_gutter = style.overflow().transpose().map(|overflow| match overflow {
+        Overflow::Scroll => style.scrollbar_width(),
         _ => 0.0,
     });
     // TODO: make side configurable based on the `direction` property
@@ -71,15 +71,10 @@ where
     content_box_inset.right += scrollbar_gutter.x;
     content_box_inset.bottom += scrollbar_gutter.y;
 
-    #[cfg(feature = "block_layout")]
-    let is_block = style.display == Display::Block;
-    #[cfg(not(feature = "block_layout"))]
-    let is_block = false;
-
-    let has_styles_preventing_being_collapsed_through = !is_block
-        || style.overflow.x.is_scroll_container()
-        || style.overflow.y.is_scroll_container()
-        || style.position == Position::Absolute
+    let has_styles_preventing_being_collapsed_through = !style.is_block()
+        || style.overflow().x.is_scroll_container()
+        || style.overflow().y.is_scroll_container()
+        || style.position() == Position::Absolute
         || padding.top > 0.0
         || padding.bottom > 0.0
         || border.top > 0.0

--- a/src/style/flex.rs
+++ b/src/style/flex.rs
@@ -1,4 +1,70 @@
 //! Style types for Flexbox layout
+use super::{AlignContent, AlignItems, AlignSelf, CoreStyle, Dimension, JustifyContent, LengthPercentage, Style};
+use crate::geometry::Size;
+
+/// The set of styles required for a Flexbox container
+pub trait FlexboxContainerStyle: CoreStyle {
+    /// Which direction does the main axis flow in?
+    #[inline(always)]
+    fn flex_direction(&self) -> FlexDirection {
+        Style::DEFAULT.flex_direction
+    }
+    /// Should elements wrap, or stay in a single line?
+    #[inline(always)]
+    fn flex_wrap(&self) -> FlexWrap {
+        Style::DEFAULT.flex_wrap
+    }
+
+    /// How large should the gaps between items in a grid or flex container be?
+    #[inline(always)]
+    fn gap(&self) -> Size<LengthPercentage> {
+        Style::DEFAULT.gap
+    }
+
+    // Alignment properties
+
+    /// How should content contained within this item be aligned in the cross/block axis
+    #[inline(always)]
+    fn align_content(&self) -> Option<AlignContent> {
+        Style::DEFAULT.align_content
+    }
+    /// How this node's children aligned in the cross/block axis?
+    #[inline(always)]
+    fn align_items(&self) -> Option<AlignItems> {
+        Style::DEFAULT.align_items
+    }
+    /// How this node's children should be aligned in the inline axis
+    #[inline(always)]
+    fn justify_content(&self) -> Option<JustifyContent> {
+        Style::DEFAULT.justify_content
+    }
+}
+
+/// The set of styles required for a Flexbox item (child of a Flexbox container)
+pub trait FlexboxItemStyle: CoreStyle {
+    /// Sets the initial main axis size of the item
+    #[inline(always)]
+    fn flex_basis(&self) -> Dimension {
+        Style::DEFAULT.flex_basis
+    }
+    /// The relative rate at which this item grows when it is expanding to fill space
+    #[inline(always)]
+    fn flex_grow(&self) -> f32 {
+        Style::DEFAULT.flex_grow
+    }
+    /// The relative rate at which this item shrinks when it is contracting to fit into space
+    #[inline(always)]
+    fn flex_shrink(&self) -> f32 {
+        Style::DEFAULT.flex_shrink
+    }
+
+    /// How this node should be aligned in the cross/block axis
+    /// Falls back to the parents [`AlignItems`] if not set
+    #[inline(always)]
+    fn align_self(&self) -> Option<AlignSelf> {
+        Style::DEFAULT.align_self
+    }
+}
 
 use crate::geometry::AbsoluteAxis;
 

--- a/src/style/grid.rs
+++ b/src/style/grid.rs
@@ -1,12 +1,96 @@
 //! Style types for CSS Grid layout
-use super::{AlignContent, LengthPercentage, Style};
+use super::{AlignContent, AlignItems, AlignSelf, CoreStyle, JustifyContent, LengthPercentage, Style};
 use crate::compute::grid::{GridCoordinate, GridLine, OriginZeroLine};
-use crate::geometry::{AbsoluteAxis, AbstractAxis};
-use crate::geometry::{Line, MinMax};
+use crate::geometry::{AbsoluteAxis, AbstractAxis, Line, MinMax, Size};
 use crate::style_helpers::*;
 use crate::util::sys::GridTrackVec;
 use core::cmp::{max, min};
 use core::convert::Infallible;
+
+/// The set of styles required for a CSS Grid container
+pub trait GridContainerStyle: CoreStyle {
+    /// Defines the track sizing functions (heights) of the grid rows
+    #[inline(always)]
+    fn grid_template_rows(&self) -> &[TrackSizingFunction] {
+        &[]
+    }
+    /// Defines the track sizing functions (widths) of the grid columns
+    #[inline(always)]
+    fn grid_template_columns(&self) -> &[TrackSizingFunction] {
+        &[]
+    }
+    /// Defines the size of implicitly created rows
+    #[inline(always)]
+    fn grid_auto_rows(&self) -> &[NonRepeatedTrackSizingFunction] {
+        &[]
+    }
+    /// Defined the size of implicitly created columns
+    #[inline(always)]
+    fn grid_auto_columns(&self) -> &[NonRepeatedTrackSizingFunction] {
+        &[]
+    }
+    /// Controls how items get placed into the grid for auto-placed items
+    #[inline(always)]
+    fn grid_auto_flow(&self) -> GridAutoFlow {
+        Style::DEFAULT.grid_auto_flow
+    }
+
+    /// How large should the gaps between items in a grid or flex container be?
+    #[inline(always)]
+    fn gap(&self) -> Size<LengthPercentage> {
+        Style::DEFAULT.gap
+    }
+
+    // Alignment properties
+
+    /// How should content contained within this item be aligned in the cross/block axis
+    #[inline(always)]
+    fn align_content(&self) -> Option<AlignContent> {
+        Style::DEFAULT.align_content
+    }
+    /// How should contained within this item be aligned in the main/inline axis
+    #[inline(always)]
+    fn justify_content(&self) -> Option<JustifyContent> {
+        Style::DEFAULT.justify_content
+    }
+    /// How this node's children aligned in the cross/block axis?
+    #[inline(always)]
+    fn align_items(&self) -> Option<AlignItems> {
+        Style::DEFAULT.align_items
+    }
+    /// How this node's children should be aligned in the inline axis
+    #[inline(always)]
+    fn justify_items(&self) -> Option<AlignItems> {
+        Style::DEFAULT.justify_items
+    }
+}
+
+/// The set of styles required for a CSS Grid item (child of a CSS Grid container)
+pub trait GridItemStyle: CoreStyle {
+    /// Defines which row in the grid the item should start and end at
+    #[inline(always)]
+    fn grid_row(&self) -> Line<GridPlacement> {
+        Style::DEFAULT.grid_row
+    }
+    /// Defines which column in the grid the item should start and end at
+    #[inline(always)]
+    fn grid_column(&self) -> Line<GridPlacement> {
+        Style::DEFAULT.grid_column
+    }
+
+    /// How this node should be aligned in the cross/block axis
+    /// Falls back to the parents [`AlignItems`] if not set
+    #[inline(always)]
+    fn align_self(&self) -> Option<AlignSelf> {
+        Style::DEFAULT.align_self
+    }
+    /// How this node should be aligned in the inline axis
+    /// Falls back to the parents [`super::JustifyItems`] if not set
+    #[inline(always)]
+    fn justify_self(&self) -> Option<AlignSelf> {
+        Style::DEFAULT.justify_self
+    }
+}
 
 /// Controls whether grid items are placed row-wise or column-wise. And whether the sparse or dense packing algorithm is used.
 ///

--- a/src/style/grid.rs
+++ b/src/style/grid.rs
@@ -63,6 +63,24 @@ pub trait GridContainerStyle: CoreStyle {
     fn justify_items(&self) -> Option<AlignItems> {
         Style::DEFAULT.justify_items
     }
+
+    /// Get a grid item's row or column placement depending on the axis passed
+    #[inline(always)]
+    fn grid_template_tracks(&self, axis: AbsoluteAxis) -> &[TrackSizingFunction] {
+        match axis {
+            AbsoluteAxis::Horizontal => self.grid_template_columns(),
+            AbsoluteAxis::Vertical => self.grid_template_rows(),
+        }
+    }
+
+    /// Get a grid container's align-content or justify-content alignment depending on the axis passed
+    #[inline(always)]
+    fn grid_align_content(&self, axis: AbstractAxis) -> AlignContent {
+        match axis {
+            AbstractAxis::Inline => self.justify_content().unwrap_or(AlignContent::Stretch),
+            AbstractAxis::Block => self.align_content().unwrap_or(AlignContent::Stretch),
+        }
+    }
 }
 
 /// The set of styles required for a CSS Grid item (child of a CSS Grid container)
@@ -89,6 +107,15 @@ pub trait GridItemStyle: CoreStyle {
     #[inline(always)]
     fn justify_self(&self) -> Option<AlignSelf> {
         Style::DEFAULT.justify_self
+    }
+
+    /// Get a grid item's row or column placement depending on the axis passed
+    #[inline(always)]
+    fn grid_placement(&self, axis: AbsoluteAxis) -> Line<GridPlacement> {
+        match axis {
+            AbsoluteAxis::Horizontal => self.grid_column(),
+            AbsoluteAxis::Vertical => self.grid_row(),
+        }
     }
 }
 
@@ -682,32 +709,5 @@ impl FromFlex for TrackSizingFunction {
 impl From<MinMax<MinTrackSizingFunction, MaxTrackSizingFunction>> for TrackSizingFunction {
     fn from(input: MinMax<MinTrackSizingFunction, MaxTrackSizingFunction>) -> Self {
         Self::Single(input)
-    }
-}
-
-// Grid extensions to the Style struct
-impl Style {
-    /// Get a grid item's row or column placement depending on the axis passed
-    pub(crate) fn grid_template_tracks(&self, axis: AbsoluteAxis) -> &GridTrackVec<TrackSizingFunction> {
-        match axis {
-            AbsoluteAxis::Horizontal => &self.grid_template_columns,
-            AbsoluteAxis::Vertical => &self.grid_template_rows,
-        }
-    }
-
-    /// Get a grid item's row or column placement depending on the axis passed
-    pub(crate) fn grid_placement(&self, axis: AbsoluteAxis) -> Line<GridPlacement> {
-        match axis {
-            AbsoluteAxis::Horizontal => self.grid_column,
-            AbsoluteAxis::Vertical => self.grid_row,
-        }
-    }
-
-    /// Get a grid container's align-content or justify-content alignment depending on the axis passed
-    pub(crate) fn grid_align_content(&self, axis: AbstractAxis) -> AlignContent {
-        match axis {
-            AbstractAxis::Inline => self.justify_content.unwrap_or(AlignContent::Stretch),
-            AbstractAxis::Block => self.align_content.unwrap_or(AlignContent::Stretch),
-        }
     }
 }

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -9,7 +9,7 @@ pub use self::alignment::{AlignContent, AlignItems, AlignSelf, JustifyContent, J
 pub use self::dimension::{AvailableSpace, Dimension, LengthPercentage, LengthPercentageAuto};
 
 #[cfg(feature = "flexbox")]
-pub use self::flex::{FlexDirection, FlexWrap};
+pub use self::flex::{FlexDirection, FlexWrap, FlexboxContainerStyle, FlexboxItemStyle};
 
 #[cfg(feature = "grid")]
 mod grid;
@@ -17,8 +17,8 @@ mod grid;
 pub(crate) use self::grid::{GenericGridPlacement, OriginZeroGridPlacement};
 #[cfg(feature = "grid")]
 pub use self::grid::{
-    GridAutoFlow, GridPlacement, GridTrackRepetition, MaxTrackSizingFunction, MinTrackSizingFunction,
-    NonRepeatedTrackSizingFunction, TrackSizingFunction,
+    GridAutoFlow, GridContainerStyle, GridItemStyle, GridPlacement, GridTrackRepetition, MaxTrackSizingFunction,
+    MinTrackSizingFunction, NonRepeatedTrackSizingFunction, TrackSizingFunction,
 };
 use crate::geometry::{Point, Rect, Size};
 
@@ -28,6 +28,93 @@ use crate::geometry::Line;
 use crate::style_helpers;
 #[cfg(feature = "grid")]
 use crate::util::sys::GridTrackVec;
+
+/// The core set of styles that are shared between all CSS layout nodes
+///
+/// Note that all methods come with a default implementation which simply returns the default value for that style property
+/// but this is a just a convenience to save on boilerplate for styles that your implementation doesn't support. You will need
+/// to override the default implementation for each style property that your style type actually supports.
+pub trait CoreStyle {
+    /// Which box generation mode should be used
+    #[inline(always)]
+    fn box_generation_mode(&self) -> BoxGenerationMode {
+        BoxGenerationMode::DEFAULT
+    }
+    /// Is block layout?
+    #[inline(always)]
+    fn is_block(&self) -> bool {
+        false
+    }
+    /// Which box do size styles apply to
+    #[inline(always)]
+    fn box_sizing(&self) -> BoxSizing {
+        BoxSizing::BorderBox
+    }
+
+    // Overflow properties
+    /// How children overflowing their container should affect layout
+    #[inline(always)]
+    fn overflow(&self) -> Point<Overflow> {
+        Style::DEFAULT.overflow
+    }
+    /// How much space (in points) should be reserved for the scrollbars of `Overflow::Scroll` and `Overflow::Auto` nodes.
+    #[inline(always)]
+    fn scrollbar_width(&self) -> f32 {
+        0.0
+    }
+
+    // Position properties
+    /// What should the `position` value of this struct use as a base offset?
+    #[inline(always)]
+    fn position(&self) -> Position {
+        Style::DEFAULT.position
+    }
+    /// How should the position of this element be tweaked relative to the layout defined?
+    #[inline(always)]
+    fn inset(&self) -> Rect<LengthPercentageAuto> {
+        Style::DEFAULT.inset
+    }
+
+    // Size properies
+    /// Sets the initial size of the item
+    #[inline(always)]
+    fn size(&self) -> Size<Dimension> {
+        Style::DEFAULT.size
+    }
+    /// Controls the minimum size of the item
+    #[inline(always)]
+    fn min_size(&self) -> Size<Dimension> {
+        Style::DEFAULT.min_size
+    }
+    /// Controls the maximum size of the item
+    #[inline(always)]
+    fn max_size(&self) -> Size<Dimension> {
+        Style::DEFAULT.max_size
+    }
+    /// Sets the preferred aspect ratio for the item
+    /// The ratio is calculated as width divided by height.
+    #[inline(always)]
+    fn aspect_ratio(&self) -> Option<f32> {
+        Style::DEFAULT.aspect_ratio
+    }
+
+    // Spacing Properties
+    /// How large should the margin be on each side?
+    #[inline(always)]
+    fn margin(&self) -> Rect<LengthPercentageAuto> {
+        Style::DEFAULT.margin
+    }
+    /// How large should the padding be on each side?
+    #[inline(always)]
+    fn padding(&self) -> Rect<LengthPercentage> {
+        Style::DEFAULT.padding
+    }
+    /// How large should the border be on each side?
+    #[inline(always)]
+    fn border(&self) -> Rect<LengthPercentage> {
+        Style::DEFAULT.border
+    }
+}
 
 /// Sets the layout used for the children of this node
 ///
@@ -44,26 +131,32 @@ pub enum Display {
     /// The children will follow the CSS Grid layout algorithm
     #[cfg(feature = "grid")]
     Grid,
-    /// The children will not be laid out, and will follow absolute positioning
+    /// The node is hidden, and it's children will also be hidden
     None,
 }
 
 impl Display {
-    /// The default of Display.
+    /// The default Display mode
     #[cfg(feature = "flexbox")]
     pub const DEFAULT: Display = Display::Flex;
 
-    /// The default of Display.
+    /// The default Display mode
     #[cfg(all(feature = "grid", not(feature = "flexbox")))]
     pub const DEFAULT: Display = Display::Grid;
 
-    /// The default of Display.
+    /// The default Display mode
     #[cfg(all(feature = "block_layout", not(feature = "flexbox"), not(feature = "grid")))]
     pub const DEFAULT: Display = Display::Block;
 
-    /// The default of Display.
+    /// The default Display mode
     #[cfg(all(not(feature = "flexbox"), not(feature = "grid"), not(feature = "block_layout")))]
     pub const DEFAULT: Display = Display::None;
+}
+
+impl Default for Display {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
 }
 
 impl core::fmt::Display for Display {
@@ -80,7 +173,23 @@ impl core::fmt::Display for Display {
     }
 }
 
-impl Default for Display {
+/// An abstracted version of the CSS `display` property where any value other than "none" is represented by "normal"
+/// See: <https://www.w3.org/TR/css-display-3/#box-generation>
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum BoxGenerationMode {
+    /// The node generates a box in the regular way
+    Normal,
+    /// The node and it's descendants generate no boxes (they are hidden)
+    None,
+}
+
+impl BoxGenerationMode {
+    /// The default of BoxGenerationMode
+    pub const DEFAULT: BoxGenerationMode = BoxGenerationMode::Normal;
+}
+
+impl Default for BoxGenerationMode {
     fn default() -> Self {
         Self::DEFAULT
     }
@@ -306,11 +415,11 @@ pub struct Style {
     #[cfg(feature = "flexbox")]
     pub flex_shrink: f32,
 
-    // Grid container properties
-    /// Defines the track sizing functions (widths) of the grid rows
+    // Grid container properies
+    /// Defines the track sizing functions (heights) of the grid rows
     #[cfg(feature = "grid")]
     pub grid_template_rows: GridTrackVec<TrackSizingFunction>,
-    /// Defines the track sizing functions (heights) of the grid columns
+    /// Defines the track sizing functions (widths) of the grid columns
     #[cfg(feature = "grid")]
     pub grid_template_columns: GridTrackVec<TrackSizingFunction>,
     /// Defines the size of implicitly created rows
@@ -395,6 +504,352 @@ impl Style {
 impl Default for Style {
     fn default() -> Self {
         Style::DEFAULT
+    }
+}
+
+impl CoreStyle for Style {
+    #[inline(always)]
+    fn box_generation_mode(&self) -> BoxGenerationMode {
+        match self.display {
+            Display::None => BoxGenerationMode::None,
+            _ => BoxGenerationMode::Normal,
+        }
+    }
+    #[inline(always)]
+    #[cfg(feature = "block_layout")]
+    fn is_block(&self) -> bool {
+        matches!(self.display, Display::Block)
+    }
+    #[inline(always)]
+    fn box_sizing(&self) -> BoxSizing {
+        self.box_sizing
+    }
+    #[inline(always)]
+    fn overflow(&self) -> Point<Overflow> {
+        self.overflow
+    }
+    #[inline(always)]
+    fn scrollbar_width(&self) -> f32 {
+        self.scrollbar_width
+    }
+    #[inline(always)]
+    fn position(&self) -> Position {
+        self.position
+    }
+    #[inline(always)]
+    fn inset(&self) -> Rect<LengthPercentageAuto> {
+        self.inset
+    }
+    #[inline(always)]
+    fn size(&self) -> Size<Dimension> {
+        self.size
+    }
+    #[inline(always)]
+    fn min_size(&self) -> Size<Dimension> {
+        self.min_size
+    }
+    #[inline(always)]
+    fn max_size(&self) -> Size<Dimension> {
+        self.max_size
+    }
+    #[inline(always)]
+    fn aspect_ratio(&self) -> Option<f32> {
+        self.aspect_ratio
+    }
+    #[inline(always)]
+    fn margin(&self) -> Rect<LengthPercentageAuto> {
+        self.margin
+    }
+    #[inline(always)]
+    fn padding(&self) -> Rect<LengthPercentage> {
+        self.padding
+    }
+    #[inline(always)]
+    fn border(&self) -> Rect<LengthPercentage> {
+        self.border
+    }
+}
+
+impl<T: CoreStyle> CoreStyle for &'_ T {
+    #[inline(always)]
+    fn box_generation_mode(&self) -> BoxGenerationMode {
+        (*self).box_generation_mode()
+    }
+    #[inline(always)]
+    fn is_block(&self) -> bool {
+        (*self).is_block()
+    }
+    #[inline(always)]
+    fn box_sizing(&self) -> BoxSizing {
+        (*self).box_sizing()
+    }
+    #[inline(always)]
+    fn overflow(&self) -> Point<Overflow> {
+        (*self).overflow()
+    }
+    #[inline(always)]
+    fn scrollbar_width(&self) -> f32 {
+        (*self).scrollbar_width()
+    }
+    #[inline(always)]
+    fn position(&self) -> Position {
+        (*self).position()
+    }
+    #[inline(always)]
+    fn inset(&self) -> Rect<LengthPercentageAuto> {
+        (*self).inset()
+    }
+    #[inline(always)]
+    fn size(&self) -> Size<Dimension> {
+        (*self).size()
+    }
+    #[inline(always)]
+    fn min_size(&self) -> Size<Dimension> {
+        (*self).min_size()
+    }
+    #[inline(always)]
+    fn max_size(&self) -> Size<Dimension> {
+        (*self).max_size()
+    }
+    #[inline(always)]
+    fn aspect_ratio(&self) -> Option<f32> {
+        (*self).aspect_ratio()
+    }
+    #[inline(always)]
+    fn margin(&self) -> Rect<LengthPercentageAuto> {
+        (*self).margin()
+    }
+    #[inline(always)]
+    fn padding(&self) -> Rect<LengthPercentage> {
+        (*self).padding()
+    }
+    #[inline(always)]
+    fn border(&self) -> Rect<LengthPercentage> {
+        (*self).border()
+    }
+}
+
+#[cfg(feature = "flexbox")]
+impl FlexboxContainerStyle for &Style {
+    #[inline(always)]
+    fn flex_direction(&self) -> FlexDirection {
+        self.flex_direction
+    }
+    #[inline(always)]
+    fn flex_wrap(&self) -> FlexWrap {
+        self.flex_wrap
+    }
+    #[inline(always)]
+    fn gap(&self) -> Size<LengthPercentage> {
+        self.gap
+    }
+    #[inline(always)]
+    fn align_content(&self) -> Option<AlignContent> {
+        self.align_content
+    }
+    #[inline(always)]
+    fn align_items(&self) -> Option<AlignItems> {
+        self.align_items
+    }
+    #[inline(always)]
+    fn justify_content(&self) -> Option<JustifyContent> {
+        self.justify_content
+    }
+}
+
+#[cfg(feature = "flexbox")]
+impl<T: FlexboxContainerStyle> FlexboxContainerStyle for &'_ T {
+    #[inline(always)]
+    fn flex_direction(&self) -> FlexDirection {
+        (*self).flex_direction()
+    }
+    #[inline(always)]
+    fn flex_wrap(&self) -> FlexWrap {
+        (*self).flex_wrap()
+    }
+    #[inline(always)]
+    fn gap(&self) -> Size<LengthPercentage> {
+        (*self).gap()
+    }
+    #[inline(always)]
+    fn align_content(&self) -> Option<AlignContent> {
+        (*self).align_content()
+    }
+    #[inline(always)]
+    fn align_items(&self) -> Option<AlignItems> {
+        (*self).align_items()
+    }
+    #[inline(always)]
+    fn justify_content(&self) -> Option<JustifyContent> {
+        (*self).justify_content()
+    }
+}
+
+#[cfg(feature = "flexbox")]
+impl FlexboxItemStyle for Style {
+    #[inline(always)]
+    fn flex_basis(&self) -> Dimension {
+        self.flex_basis
+    }
+    #[inline(always)]
+    fn flex_grow(&self) -> f32 {
+        self.flex_grow
+    }
+    #[inline(always)]
+    fn flex_shrink(&self) -> f32 {
+        self.flex_shrink
+    }
+    #[inline(always)]
+    fn align_self(&self) -> Option<AlignSelf> {
+        self.align_self
+    }
+}
+
+#[cfg(feature = "flexbox")]
+impl<T: FlexboxItemStyle> FlexboxItemStyle for &'_ T {
+    #[inline(always)]
+    fn flex_basis(&self) -> Dimension {
+        (*self).flex_basis()
+    }
+    #[inline(always)]
+    fn flex_grow(&self) -> f32 {
+        (*self).flex_grow()
+    }
+    #[inline(always)]
+    fn flex_shrink(&self) -> f32 {
+        (*self).flex_shrink()
+    }
+    #[inline(always)]
+    fn align_self(&self) -> Option<AlignSelf> {
+        (*self).align_self()
+    }
+}
+
+#[cfg(feature = "grid")]
+impl GridContainerStyle for Style {
+    #[inline(always)]
+    fn grid_template_rows(&self) -> &[TrackSizingFunction] {
+        &self.grid_template_rows
+    }
+    #[inline(always)]
+    fn grid_template_columns(&self) -> &[TrackSizingFunction] {
+        &self.grid_template_columns
+    }
+    #[inline(always)]
+    fn grid_auto_rows(&self) -> &[NonRepeatedTrackSizingFunction] {
+        &self.grid_auto_rows
+    }
+    #[inline(always)]
+    fn grid_auto_columns(&self) -> &[NonRepeatedTrackSizingFunction] {
+        &self.grid_auto_columns
+    }
+    #[inline(always)]
+    fn grid_auto_flow(&self) -> GridAutoFlow {
+        self.grid_auto_flow
+    }
+    #[inline(always)]
+    fn gap(&self) -> Size<LengthPercentage> {
+        self.gap
+    }
+    #[inline(always)]
+    fn align_content(&self) -> Option<AlignContent> {
+        self.align_content
+    }
+    #[inline(always)]
+    fn justify_content(&self) -> Option<JustifyContent> {
+        self.justify_content
+    }
+    #[inline(always)]
+    fn align_items(&self) -> Option<AlignItems> {
+        self.align_items
+    }
+    #[inline(always)]
+    fn justify_items(&self) -> Option<AlignItems> {
+        self.justify_items
+    }
+}
+
+#[cfg(feature = "grid")]
+impl<T: GridContainerStyle> GridContainerStyle for &'_ T {
+    #[inline(always)]
+    fn grid_template_rows(&self) -> &[TrackSizingFunction] {
+        &(*self).grid_template_rows()
+    }
+    #[inline(always)]
+    fn grid_template_columns(&self) -> &[TrackSizingFunction] {
+        &(*self).grid_template_columns()
+    }
+    #[inline(always)]
+    fn grid_auto_rows(&self) -> &[NonRepeatedTrackSizingFunction] {
+        &(*self).grid_auto_rows()
+    }
+    #[inline(always)]
+    fn grid_auto_columns(&self) -> &[NonRepeatedTrackSizingFunction] {
+        &(*self).grid_auto_columns()
+    }
+    #[inline(always)]
+    fn grid_auto_flow(&self) -> GridAutoFlow {
+        (*self).grid_auto_flow()
+    }
+    #[inline(always)]
+    fn gap(&self) -> Size<LengthPercentage> {
+        (*self).gap()
+    }
+    #[inline(always)]
+    fn align_content(&self) -> Option<AlignContent> {
+        (*self).align_content()
+    }
+    #[inline(always)]
+    fn justify_content(&self) -> Option<JustifyContent> {
+        (*self).justify_content()
+    }
+    #[inline(always)]
+    fn align_items(&self) -> Option<AlignItems> {
+        (*self).align_items()
+    }
+    #[inline(always)]
+    fn justify_items(&self) -> Option<AlignItems> {
+        (*self).justify_items()
+    }
+}
+
+#[cfg(feature = "grid")]
+impl GridItemStyle for &'_ Style {
+    #[inline(always)]
+    fn grid_row(&self) -> Line<GridPlacement> {
+        self.grid_row
+    }
+    #[inline(always)]
+    fn grid_column(&self) -> Line<GridPlacement> {
+        self.grid_column
+    }
+    #[inline(always)]
+    fn align_self(&self) -> Option<AlignSelf> {
+        self.align_self
+    }
+    #[inline(always)]
+    fn justify_self(&self) -> Option<AlignSelf> {
+        self.justify_self
+    }
+}
+
+#[cfg(feature = "grid")]
+impl<T: GridItemStyle> GridItemStyle for &'_ T {
+    #[inline(always)]
+    fn grid_row(&self) -> Line<GridPlacement> {
+        (*self).grid_row()
+    }
+    #[inline(always)]
+    fn grid_column(&self) -> Line<GridPlacement> {
+        (*self).grid_column()
+    }
+    #[inline(always)]
+    fn align_self(&self) -> Option<AlignSelf> {
+        (*self).align_self()
+    }
+    #[inline(always)]
+    fn justify_self(&self) -> Option<AlignSelf> {
+        (*self).justify_self()
     }
 }
 

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -773,19 +773,19 @@ impl GridContainerStyle for Style {
 impl<T: GridContainerStyle> GridContainerStyle for &'_ T {
     #[inline(always)]
     fn grid_template_rows(&self) -> &[TrackSizingFunction] {
-        &(*self).grid_template_rows()
+        (*self).grid_template_rows()
     }
     #[inline(always)]
     fn grid_template_columns(&self) -> &[TrackSizingFunction] {
-        &(*self).grid_template_columns()
+        (*self).grid_template_columns()
     }
     #[inline(always)]
     fn grid_auto_rows(&self) -> &[NonRepeatedTrackSizingFunction] {
-        &(*self).grid_auto_rows()
+        (*self).grid_auto_rows()
     }
     #[inline(always)]
     fn grid_auto_columns(&self) -> &[NonRepeatedTrackSizingFunction] {
-        &(*self).grid_auto_columns()
+        (*self).grid_auto_columns()
     }
     #[inline(always)]
     fn grid_auto_flow(&self) -> GridAutoFlow {

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -13,10 +13,16 @@ pub use cache::Cache;
 pub use layout::{CollapsibleMarginSet, Layout, LayoutInput, LayoutOutput, RequestedAxis, RunMode, SizingMode};
 pub use node::NodeId;
 pub(crate) use traits::LayoutPartialTreeExt;
-pub use traits::{
-    LayoutBlockContainer, LayoutFlexboxContainer, LayoutGridContainer, LayoutPartialTree, PrintTree, RoundTree,
-    TraversePartialTree, TraverseTree,
-};
+pub use traits::{LayoutPartialTree, PrintTree, RoundTree, TraversePartialTree, TraverseTree};
+
+#[cfg(feature = "flexbox")]
+pub use traits::LayoutFlexboxContainer;
+
+#[cfg(feature = "grid")]
+pub use traits::LayoutGridContainer;
+
+#[cfg(feature = "block_layout")]
+pub use traits::LayoutBlockContainer;
 
 #[cfg(feature = "taffy_tree")]
 mod taffy_tree;

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -13,7 +13,10 @@ pub use cache::Cache;
 pub use layout::{CollapsibleMarginSet, Layout, LayoutInput, LayoutOutput, RequestedAxis, RunMode, SizingMode};
 pub use node::NodeId;
 pub(crate) use traits::LayoutPartialTreeExt;
-pub use traits::{LayoutPartialTree, PrintTree, RoundTree, TraversePartialTree, TraverseTree};
+pub use traits::{
+    LayoutBlockContainer, LayoutFlexboxContainer, LayoutGridContainer, LayoutPartialTree, PrintTree, RoundTree,
+    TraversePartialTree, TraverseTree,
+};
 
 #[cfg(feature = "taffy_tree")]
 mod taffy_tree;

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -14,16 +14,15 @@ use crate::tree::{
 use crate::util::debug::{debug_log, debug_log_node};
 use crate::util::sys::{new_vec_with_capacity, ChildrenVec, Vec};
 
-#[cfg(feature = "block_layout")]
-use crate::compute::compute_block_layout;
-#[cfg(feature = "flexbox")]
-use crate::compute::compute_flexbox_layout;
-#[cfg(feature = "grid")]
-use crate::compute::compute_grid_layout;
 use crate::compute::{
     compute_cached_layout, compute_hidden_layout, compute_leaf_layout, compute_root_layout, round_layout,
 };
-use crate::{LayoutBlockContainer, LayoutFlexboxContainer, LayoutGridContainer};
+#[cfg(feature = "block_layout")]
+use crate::{compute::compute_block_layout, LayoutBlockContainer};
+#[cfg(feature = "flexbox")]
+use crate::{compute::compute_flexbox_layout, LayoutFlexboxContainer};
+#[cfg(feature = "grid")]
+use crate::{compute::compute_grid_layout, LayoutGridContainer};
 
 /// The error Taffy generates on invalid operations
 pub type TaffyResult<T> = Result<T, TaffyError>;
@@ -341,6 +340,7 @@ where
     }
 }
 
+#[cfg(feature = "block_layout")]
 impl<'t, NodeContext, MeasureFunction> LayoutBlockContainer for TaffyView<'t, NodeContext, MeasureFunction>
 where
     MeasureFunction:
@@ -360,6 +360,7 @@ where
     }
 }
 
+#[cfg(feature = "flexbox")]
 impl<'t, NodeContext, MeasureFunction> LayoutFlexboxContainer for TaffyView<'t, NodeContext, MeasureFunction>
 where
     MeasureFunction:
@@ -379,6 +380,7 @@ where
     }
 }
 
+#[cfg(feature = "grid")]
 impl<'t, NodeContext, MeasureFunction> LayoutGridContainer for TaffyView<'t, NodeContext, MeasureFunction>
 where
     MeasureFunction:

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -273,6 +273,7 @@ where
         FnMut(Size<Option<f32>>, Size<AvailableSpace>, NodeId, Option<&mut NodeContext>, &Style) -> Size<f32>,
 {
     type CoreContainerStyle<'a> = &'a Style where Self : 'a;
+    type CacheMut<'b> = &'b mut Cache where Self : 'b;
 
     #[inline(always)]
     fn get_core_container_style(&self, node_id: NodeId) -> Self::CoreContainerStyle<'_> {

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -383,11 +383,11 @@ where
     MeasureFunction:
         FnMut(Size<Option<f32>>, Size<AvailableSpace>, NodeId, Option<&mut NodeContext>, &Style) -> Size<f32>,
 {
-    type ContainerStyle = Style;
+    type ContainerStyle<'a> = &'a Style where Self: 'a;
     type ItemStyle<'a> = &'a Style where Self: 'a;
 
     #[inline(always)]
-    fn get_grid_container_style(&self, node_id: NodeId) -> &Self::ContainerStyle {
+    fn get_grid_container_style(&self, node_id: NodeId) -> Self::ContainerStyle<'_> {
         &self.taffy.nodes[node_id.into()].style
     }
 

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -346,16 +346,16 @@ where
     MeasureFunction:
         FnMut(Size<Option<f32>>, Size<AvailableSpace>, NodeId, Option<&mut NodeContext>, &Style) -> Size<f32>,
 {
-    type ContainerStyle<'a> = &'a Style where Self: 'a;
-    type ItemStyle<'a> = &'a Style where Self: 'a;
+    type BlockContainerStyle<'a> = &'a Style where Self: 'a;
+    type BlockItemStyle<'a> = &'a Style where Self: 'a;
 
     #[inline(always)]
-    fn get_block_container_style(&self, node_id: NodeId) -> Self::ContainerStyle<'_> {
+    fn get_block_container_style(&self, node_id: NodeId) -> Self::BlockContainerStyle<'_> {
         self.get_core_container_style(node_id)
     }
 
     #[inline(always)]
-    fn get_block_child_style(&self, child_node_id: NodeId) -> Self::ItemStyle<'_> {
+    fn get_block_child_style(&self, child_node_id: NodeId) -> Self::BlockItemStyle<'_> {
         self.get_core_container_style(child_node_id)
     }
 }
@@ -366,16 +366,16 @@ where
     MeasureFunction:
         FnMut(Size<Option<f32>>, Size<AvailableSpace>, NodeId, Option<&mut NodeContext>, &Style) -> Size<f32>,
 {
-    type ContainerStyle<'a> = &'a Style where Self: 'a;
-    type ItemStyle<'a> = &'a Style where Self: 'a;
+    type FlexboxContainerStyle<'a> = &'a Style where Self: 'a;
+    type FlexboxItemStyle<'a> = &'a Style where Self: 'a;
 
     #[inline(always)]
-    fn get_flexbox_container_style(&self, node_id: NodeId) -> Self::ContainerStyle<'_> {
+    fn get_flexbox_container_style(&self, node_id: NodeId) -> Self::FlexboxContainerStyle<'_> {
         &self.taffy.nodes[node_id.into()].style
     }
 
     #[inline(always)]
-    fn get_flexbox_child_style(&self, child_node_id: NodeId) -> Self::ItemStyle<'_> {
+    fn get_flexbox_child_style(&self, child_node_id: NodeId) -> Self::FlexboxItemStyle<'_> {
         &self.taffy.nodes[child_node_id.into()].style
     }
 }
@@ -386,16 +386,16 @@ where
     MeasureFunction:
         FnMut(Size<Option<f32>>, Size<AvailableSpace>, NodeId, Option<&mut NodeContext>, &Style) -> Size<f32>,
 {
-    type ContainerStyle<'a> = &'a Style where Self: 'a;
-    type ItemStyle<'a> = &'a Style where Self: 'a;
+    type GridContainerStyle<'a> = &'a Style where Self: 'a;
+    type GridItemStyle<'a> = &'a Style where Self: 'a;
 
     #[inline(always)]
-    fn get_grid_container_style(&self, node_id: NodeId) -> Self::ContainerStyle<'_> {
+    fn get_grid_container_style(&self, node_id: NodeId) -> Self::GridContainerStyle<'_> {
         &self.taffy.nodes[node_id.into()].style
     }
 
     #[inline(always)]
-    fn get_grid_child_style(&self, child_node_id: NodeId) -> Self::ItemStyle<'_> {
+    fn get_grid_child_style(&self, child_node_id: NodeId) -> Self::GridItemStyle<'_> {
         &self.taffy.nodes[child_node_id.into()].style
     }
 }

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -271,9 +271,11 @@ where
     MeasureFunction:
         FnMut(Size<Option<f32>>, Size<AvailableSpace>, NodeId, Option<&mut NodeContext>, &Style) -> Size<f32>,
 {
+    type CoreContainerStyle<'a> = &'a Style where Self : 'a;
+
     #[inline(always)]
-    fn get_style(&self, node: NodeId) -> &Style {
-        &self.taffy.nodes[node.into()].style
+    fn get_core_container_style(&self, node_id: NodeId) -> Self::CoreContainerStyle<'_> {
+        &self.taffy.nodes[node_id.into()].style
     }
 
     #[inline(always)]

--- a/src/tree/traits.rs
+++ b/src/tree/traits.rs
@@ -133,6 +133,7 @@ use crate::style::{AvailableSpace, CoreStyle};
 use crate::style::{FlexboxContainerStyle, FlexboxItemStyle};
 #[cfg(feature = "grid")]
 use crate::style::{GridContainerStyle, GridItemStyle};
+use core::ops::{Deref, DerefMut};
 
 /// This trait is Taffy's abstraction for downward tree traversal.
 /// However, this trait does *not* require access to any node's other than a single container node's immediate children unless you also intend to implement `TraverseTree`.
@@ -167,6 +168,12 @@ pub trait LayoutPartialTree: TraversePartialTree {
     where
         Self: 'a;
 
+    /// A mutable reference to the cache. This is an associated type to allow for different
+    /// types of mutable reference such as mutex or refcell guards
+    type CacheMut<'b>: Deref<Target = Cache> + DerefMut
+    where
+        Self: 'b;
+
     /// Get core style
     fn get_core_container_style(&self, node_id: NodeId) -> Self::CoreContainerStyle<'_>;
 
@@ -174,7 +181,7 @@ pub trait LayoutPartialTree: TraversePartialTree {
     fn set_unrounded_layout(&mut self, node_id: NodeId, layout: &Layout);
 
     /// Get a mutable reference to the [`Cache`] for this node.
-    fn get_cache_mut(&mut self, node_id: NodeId) -> &mut Cache;
+    fn get_cache_mut(&mut self, node_id: NodeId) -> Self::CacheMut<'_>;
 
     /// Compute the specified node's size or full layout given the specified constraints
     fn compute_child_layout(&mut self, node_id: NodeId, inputs: LayoutInput) -> LayoutOutput;

--- a/src/tree/traits.rs
+++ b/src/tree/traits.rs
@@ -128,7 +128,11 @@
 //!
 use super::{Cache, Layout, LayoutInput, LayoutOutput, NodeId, RequestedAxis, RunMode, SizingMode};
 use crate::geometry::{AbsoluteAxis, Line, Size};
-use crate::style::{AvailableSpace, Style};
+use crate::style::{AvailableSpace, CoreStyle};
+#[cfg(feature = "flexbox")]
+use crate::style::{FlexboxContainerStyle, FlexboxItemStyle};
+#[cfg(feature = "grid")]
+use crate::style::{GridContainerStyle, GridItemStyle};
 
 /// This trait is Taffy's abstraction for downward tree traversal.
 /// However, this trait does *not* require access to any node's other than a single container node's immediate children unless you also intend to implement `TraverseTree`.
@@ -157,8 +161,14 @@ pub trait TraverseTree: TraversePartialTree {}
 /// Note that this trait extends [`TraversePartialTree`] (not [`TraverseTree`]). Taffy's algorithm implementations have been designed such that they can be used for a laying out a single
 /// node that only has access to it's immediate children.
 pub trait LayoutPartialTree: TraversePartialTree {
-    /// Get a reference to the [`Style`] for this node.
-    fn get_style(&self, node_id: NodeId) -> &Style;
+    /// The style type representing the core container styles that all containers should have
+    /// Used when laying out the root node of a tree
+    type CoreContainerStyle<'a>: CoreStyle
+    where
+        Self: 'a;
+
+    /// Get core style
+    fn get_core_container_style(&self, node_id: NodeId) -> Self::CoreContainerStyle<'_>;
 
     /// Set the node's unrounded layout
     fn set_unrounded_layout(&mut self, node_id: NodeId, layout: &Layout);
@@ -189,6 +199,62 @@ pub trait PrintTree: TraverseTree {
     fn get_debug_label(&self, node_id: NodeId) -> &'static str;
     /// Get a reference to the node's final layout
     fn get_final_layout(&self, node_id: NodeId) -> &Layout;
+}
+
+#[cfg(feature = "flexbox")]
+/// Extends [`LayoutPartialTree`] with getters for the styles required for Flexbox layout
+pub trait LayoutFlexboxContainer: LayoutPartialTree {
+    /// The style type representing the Flexbox container's styles
+    type ContainerStyle<'a>: FlexboxContainerStyle
+    where
+        Self: 'a;
+    /// The style type representing each Flexbox item's styles
+    type ItemStyle<'a>: FlexboxItemStyle
+    where
+        Self: 'a;
+
+    /// Get the container's styles
+    fn get_flexbox_container_style(&self, node_id: NodeId) -> Self::ContainerStyle<'_>;
+
+    /// Get the child's styles
+    fn get_flexbox_child_style(&self, child_node_id: NodeId) -> Self::ItemStyle<'_>;
+}
+
+#[cfg(feature = "grid")]
+/// Extends [`LayoutPartialTree`] with getters for the styles required for CSS Grid layout
+pub trait LayoutGridContainer: LayoutPartialTree {
+    /// The style type representing the CSS Grid container's styles
+    type ContainerStyle: GridContainerStyle + Clone;
+
+    /// The style type representing each CSS Grid item's styles
+    type ItemStyle<'a>: GridItemStyle
+    where
+        Self: 'a;
+
+    /// Get the container's styles
+    fn get_grid_container_style(&self, node_id: NodeId) -> &Self::ContainerStyle;
+
+    /// Get the child's styles
+    fn get_grid_child_style(&self, child_node_id: NodeId) -> Self::ItemStyle<'_>;
+}
+
+#[cfg(feature = "block_layout")]
+/// Extends [`LayoutPartialTree`] with getters for the styles required for CSS Block layout
+pub trait LayoutBlockContainer: LayoutPartialTree {
+    /// The style type representing the CSS Block container's styles
+    type ContainerStyle<'a>: CoreStyle
+    where
+        Self: 'a;
+    /// The style type representing each CSS Block item's styles
+    type ItemStyle<'a>: CoreStyle
+    where
+        Self: 'a;
+
+    /// Get the container's styles
+    fn get_block_container_style(&self, node_id: NodeId) -> Self::ContainerStyle<'_>;
+
+    /// Get the child's styles
+    fn get_block_child_style(&self, child_node_id: NodeId) -> Self::ItemStyle<'_>;
 }
 
 // --- PRIVATE TRAITS

--- a/src/tree/traits.rs
+++ b/src/tree/traits.rs
@@ -212,58 +212,58 @@ pub trait PrintTree: TraverseTree {
 /// Extends [`LayoutPartialTree`] with getters for the styles required for Flexbox layout
 pub trait LayoutFlexboxContainer: LayoutPartialTree {
     /// The style type representing the Flexbox container's styles
-    type ContainerStyle<'a>: FlexboxContainerStyle
+    type FlexboxContainerStyle<'a>: FlexboxContainerStyle
     where
         Self: 'a;
     /// The style type representing each Flexbox item's styles
-    type ItemStyle<'a>: FlexboxItemStyle
+    type FlexboxItemStyle<'a>: FlexboxItemStyle
     where
         Self: 'a;
 
     /// Get the container's styles
-    fn get_flexbox_container_style(&self, node_id: NodeId) -> Self::ContainerStyle<'_>;
+    fn get_flexbox_container_style(&self, node_id: NodeId) -> Self::FlexboxContainerStyle<'_>;
 
     /// Get the child's styles
-    fn get_flexbox_child_style(&self, child_node_id: NodeId) -> Self::ItemStyle<'_>;
+    fn get_flexbox_child_style(&self, child_node_id: NodeId) -> Self::FlexboxItemStyle<'_>;
 }
 
 #[cfg(feature = "grid")]
 /// Extends [`LayoutPartialTree`] with getters for the styles required for CSS Grid layout
 pub trait LayoutGridContainer: LayoutPartialTree {
     /// The style type representing the CSS Grid container's styles
-    type ContainerStyle<'a>: GridContainerStyle
+    type GridContainerStyle<'a>: GridContainerStyle
     where
         Self: 'a;
 
     /// The style type representing each CSS Grid item's styles
-    type ItemStyle<'a>: GridItemStyle
+    type GridItemStyle<'a>: GridItemStyle
     where
         Self: 'a;
 
     /// Get the container's styles
-    fn get_grid_container_style(&self, node_id: NodeId) -> Self::ContainerStyle<'_>;
+    fn get_grid_container_style(&self, node_id: NodeId) -> Self::GridContainerStyle<'_>;
 
     /// Get the child's styles
-    fn get_grid_child_style(&self, child_node_id: NodeId) -> Self::ItemStyle<'_>;
+    fn get_grid_child_style(&self, child_node_id: NodeId) -> Self::GridItemStyle<'_>;
 }
 
 #[cfg(feature = "block_layout")]
 /// Extends [`LayoutPartialTree`] with getters for the styles required for CSS Block layout
 pub trait LayoutBlockContainer: LayoutPartialTree {
     /// The style type representing the CSS Block container's styles
-    type ContainerStyle<'a>: CoreStyle
+    type BlockContainerStyle<'a>: CoreStyle
     where
         Self: 'a;
     /// The style type representing each CSS Block item's styles
-    type ItemStyle<'a>: CoreStyle
+    type BlockItemStyle<'a>: CoreStyle
     where
         Self: 'a;
 
     /// Get the container's styles
-    fn get_block_container_style(&self, node_id: NodeId) -> Self::ContainerStyle<'_>;
+    fn get_block_container_style(&self, node_id: NodeId) -> Self::BlockContainerStyle<'_>;
 
     /// Get the child's styles
-    fn get_block_child_style(&self, child_node_id: NodeId) -> Self::ItemStyle<'_>;
+    fn get_block_child_style(&self, child_node_id: NodeId) -> Self::BlockItemStyle<'_>;
 }
 
 // --- PRIVATE TRAITS

--- a/src/tree/traits.rs
+++ b/src/tree/traits.rs
@@ -224,7 +224,9 @@ pub trait LayoutFlexboxContainer: LayoutPartialTree {
 /// Extends [`LayoutPartialTree`] with getters for the styles required for CSS Grid layout
 pub trait LayoutGridContainer: LayoutPartialTree {
     /// The style type representing the CSS Grid container's styles
-    type ContainerStyle: GridContainerStyle + Clone;
+    type ContainerStyle<'a>: GridContainerStyle
+    where
+        Self: 'a;
 
     /// The style type representing each CSS Grid item's styles
     type ItemStyle<'a>: GridItemStyle
@@ -232,7 +234,7 @@ pub trait LayoutGridContainer: LayoutPartialTree {
         Self: 'a;
 
     /// Get the container's styles
-    fn get_grid_container_style(&self, node_id: NodeId) -> &Self::ContainerStyle;
+    fn get_grid_container_style(&self, node_id: NodeId) -> Self::ContainerStyle<'_>;
 
     /// Get the child's styles
     fn get_grid_child_style(&self, child_node_id: NodeId) -> Self::ItemStyle<'_>;


### PR DESCRIPTION
# Objective

Allow users of Taffy to bring their own style representation(s).

## Context

While we have support for custom node tree representations, we currently enforce usage of a concrete style representation. Additionally, that style representation is shared across all algorithms and thus must include the styles for Flexbox, CSS Grid and Block layout, making it quite large. A problem which will only get worse if non-css algorithms are supported in future.

## Feedback wanted

- Feedback on the trait hierarchy design

## Todo
- [x] Figure out how to handle the `Display` style. Algorithms typically only need to know whether the `Display` is `None` or not. I am considering creating a new enum with just `None` and `Normal` (name tbd) variants for this purpose. This would need to be extended with `Contents` if we implement that, but would never need to know about individual algorithms. See also: https://github.com/DioxusLabs/taffy/issues/115
- [x] Maybe: Blanket impl of the style traits for &T if they are implemented for T
- [x] Update the Flexbox algorithm to use the new traits
- [x] Update the CSS Grid algorithm to use the new traits
- [x] Update the Block algorithm to use the new traits
- [x] Update the Leaf algorithm to use the new traits
- [x] ~Remove the `get_style` method from the base `PartialLayoutTree` trait~ Turns out this is still required for root layout
- [x] Test implementing new traits for stylo types
- [x] Fix examples
