### PR TITLE
Pass axis information when measuring a child's size

### DIFF
--- a/src/compute/grid/types/grid_item.rs
+++ b/src/compute/grid/types/grid_item.rs
@@ -347,9 +347,9 @@ impl GridItem {
                 None => AvailableSpace::MinContent,
             }),
             SizingMode::InherentSize,
+            axis.as_abs_naive(),
             Line::FALSE,
         )
-        .get(axis)
     }
 
     /// Retrieve the item's min content contribution from the cache or compute it using the provided parameters
@@ -386,9 +386,9 @@ impl GridItem {
                 None => AvailableSpace::MaxContent,
             }),
             SizingMode::InherentSize,
+            axis.as_abs_naive(),
             Line::FALSE,
         )
-        .get(axis)
     }
 
     /// Retrieve the item's max content contribution from the cache or compute it using the provided parameters

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -61,10 +61,21 @@ pub enum AbstractAxis {
 
 impl AbstractAxis {
     /// Returns the other variant of the enum
+    #[inline]
     pub fn other(&self) -> AbstractAxis {
         match *self {
             AbstractAxis::Inline => AbstractAxis::Block,
             AbstractAxis::Block => AbstractAxis::Inline,
+        }
+    }
+
+    /// Convert an `AbstractAxis` into an `AbsoluteAxis` naively assuming that the Inline axis is Horizontal
+    /// This is currently always true, but will change if Taffy ever implements the `writing_mode` property
+    #[inline]
+    pub fn as_abs_naive(&self) -> AbsoluteAxis {
+        match self {
+            AbstractAxis::Inline => AbsoluteAxis::Horizontal,
+            AbstractAxis::Block => AbsoluteAxis::Vertical,
         }
     }
 }

--- a/src/style/flex.rs
+++ b/src/style/flex.rs
@@ -1,5 +1,7 @@
 //! Style types for Flexbox layout
 
+use crate::geometry::AbsoluteAxis;
+
 /// Controls whether flex items are forced onto one line or can wrap onto multiple lines.
 ///
 /// Defaults to [`FlexWrap::NoWrap`]
@@ -77,6 +79,24 @@ impl FlexDirection {
     /// Is the direction [`FlexDirection::RowReverse`] or [`FlexDirection::ColumnReverse`]?
     pub(crate) fn is_reverse(self) -> bool {
         matches!(self, Self::RowReverse | Self::ColumnReverse)
+    }
+
+    #[inline]
+    /// The `AbsoluteAxis` that corresponds to the main axis
+    pub(crate) fn main_axis(self) -> AbsoluteAxis {
+        match self {
+            Self::Row | Self::RowReverse => AbsoluteAxis::Horizontal,
+            Self::Column | Self::ColumnReverse => AbsoluteAxis::Vertical,
+        }
+    }
+
+    #[inline]
+    /// The `AbsoluteAxis` that corresponds to the cross axis
+    pub(crate) fn cross_axis(self) -> AbsoluteAxis {
+        match self {
+            Self::Row | Self::RowReverse => AbsoluteAxis::Vertical,
+            Self::Column | Self::ColumnReverse => AbsoluteAxis::Horizontal,
+        }
     }
 }
 


### PR DESCRIPTION
# Objective

This enables Taffy to be integrated with Xilem.

See: https://github.com/linebender/xilem/pull/140

## Changes made

- Add `RequestedAxis` enum
- Add `axis: RequestedAxis` parameter to child measurement and plumb through to various places

## Feedback wanted

- API design review
- Should we split apart the `compute_child_layout` methods on the `PartialLayoutTree` trait? Because the `axis` parameter is only really relevant to the "measure child" case rather than "perform layout" case. Also, the "measure child" case could return `f32` instead of `LayoutOutput` in that case. Which would also reduce cache size.
