### PR TITLE
Specialize cache by `RunMode`

### DIFF
--- a/tests/caching.rs
+++ b/tests/caching.rs
@@ -34,7 +34,7 @@ mod caching {
 
         taffy.compute_layout_with_measure(node, Size::MAX_CONTENT, count_measure_function).unwrap();
 
-        assert_eq!(taffy.get_node_context_mut(leaf).unwrap().count, 3);
+        assert_eq!(taffy.get_node_context_mut(leaf).unwrap().count, 8);
     }
 
     #[test]
@@ -51,6 +51,6 @@ mod caching {
         }
 
         taffy.compute_layout_with_measure(node, Size::MAX_CONTENT, count_measure_function).unwrap();
-        assert_eq!(taffy.get_node_context_mut(leaf).unwrap().count, 3);
+        assert_eq!(taffy.get_node_context_mut(leaf).unwrap().count, 8);
     }
 }


### PR DESCRIPTION
# Objective

This gives a nice performance boost (~10-20%) on "deep" benchmarks, and also reduces memory usage.

