### PR TITLE
Bevy compatibility tweaks

### DIFF
--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -12,7 +12,7 @@ use slotmap::{DefaultKey, Key, KeyData};
 ///
 /// Internally it is a wrapper around a u64 and a `NodeId` can be converted to and from
 /// and u64 if needed.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct NodeId(u64);
 impl NodeId {
     /// Create a new NodeId from a u64 value

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -344,7 +344,12 @@ impl<NodeContext> TaffyTree<NodeContext> {
         Ok(())
     }
 
-    /// Get's a mutable reference to the the context data associated with the node
+    /// Gets a reference to the the context data associated with the node
+    pub fn get_node_context(&self, node: NodeId) -> Option<&NodeContext> {
+        self.node_context_data.get(node.into())
+    }
+
+    /// Gets a mutable reference to the the context data associated with the node
     pub fn get_node_context_mut(&mut self, node: NodeId) -> Option<&mut NodeContext> {
         self.node_context_data.get_mut(node.into())
     }


### PR DESCRIPTION
# Objective

Fix a couple of issues that came when I tried to update Bevy to Taffy `main`.

## Changes made

- Derive `Hash` for `NodeId`. Bevy uses `NodeId` as a `HashMap` key which doesn't work without a `Hash` impl.
- Add a `get_node_context` method. We previously only have `get_node_context_mut` method, but Bevy needs to be able to check whether a node has context without having mutable access to the tree.

## Feedback wanted

None. These changes are uncontroversial.
