### PR TITLE
Convert mutable layout getters to layout setters

### DIFF
--- a/examples/custom_layout_tree_owned.rs
+++ b/examples/custom_layout_tree_owned.rs
@@ -130,8 +130,8 @@ impl PartialLayoutTree for StatelessLayoutTree {
         unsafe { &node_from_id(node_id).style }
     }
 
-    fn get_unrounded_layout_mut(&mut self, node_id: NodeId) -> &mut Layout {
-        unsafe { &mut node_from_id_mut(node_id).unrounded_layout }
+    fn set_unrounded_layout(&mut self, node_id: NodeId, layout: &Layout) {
+        unsafe { node_from_id_mut(node_id).unrounded_layout = *layout };
     }
 
     fn get_cache_mut(&mut self, node_id: NodeId) -> &mut Cache {
@@ -171,6 +171,10 @@ impl PartialLayoutTree for StatelessLayoutTree {
 }
 
 impl LayoutTree for StatelessLayoutTree {
+    fn get_unrounded_layout(&self, node_id: NodeId) -> &Layout {
+        unsafe { &node_from_id_mut(node_id).unrounded_layout }
+    }
+
     fn get_final_layout(&self, node_id: NodeId) -> &Layout {
         unsafe { &node_from_id(node_id).final_layout }
     }

--- a/examples/custom_layout_tree_owned.rs
+++ b/examples/custom_layout_tree_owned.rs
@@ -179,8 +179,8 @@ impl LayoutTree for StatelessLayoutTree {
         unsafe { &node_from_id(node_id).final_layout }
     }
 
-    fn get_final_layout_mut(&mut self, node_id: NodeId) -> &mut Layout {
-        unsafe { &mut node_from_id_mut(node_id).final_layout }
+    fn set_final_layout(&mut self, node_id: NodeId, layout: &Layout) {
+        unsafe { node_from_id_mut(node_id).final_layout = *layout }
     }
 }
 

--- a/examples/custom_layout_tree_vec.rs
+++ b/examples/custom_layout_tree_vec.rs
@@ -140,8 +140,8 @@ impl PartialLayoutTree for Tree {
         &self.node_from_id(node_id).style
     }
 
-    fn get_unrounded_layout_mut(&mut self, node_id: NodeId) -> &mut Layout {
-        &mut self.node_from_id_mut(node_id).unrounded_layout
+    fn set_unrounded_layout(&mut self, node_id: NodeId, layout: &Layout) {
+        self.node_from_id_mut(node_id).unrounded_layout = *layout;
     }
 
     fn get_cache_mut(&mut self, node_id: NodeId) -> &mut Cache {
@@ -181,6 +181,10 @@ impl PartialLayoutTree for Tree {
 }
 
 impl LayoutTree for Tree {
+    fn get_unrounded_layout(&self, node_id: NodeId) -> &Layout {
+        &self.node_from_id(node_id).unrounded_layout
+    }
+
     fn get_final_layout(&self, node_id: NodeId) -> &Layout {
         &self.node_from_id(node_id).final_layout
     }

--- a/examples/custom_layout_tree_vec.rs
+++ b/examples/custom_layout_tree_vec.rs
@@ -189,8 +189,8 @@ impl LayoutTree for Tree {
         &self.node_from_id(node_id).final_layout
     }
 
-    fn get_final_layout_mut(&mut self, node_id: NodeId) -> &mut Layout {
-        &mut self.node_from_id_mut(node_id).final_layout
+    fn set_final_layout(&mut self, node_id: NodeId, layout: &Layout) {
+        self.node_from_id_mut(node_id).final_layout = *layout;
     }
 }
 

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -213,7 +213,7 @@ fn compute_inner(tree: &mut impl PartialLayoutTree, node_id: NodeId, inputs: Lay
     for order in 0..len {
         let child = tree.get_child_id(node_id, order);
         if tree.get_style(child).display == Display::None {
-            *tree.get_unrounded_layout_mut(child) = Layout::with_order(order as u32);
+            tree.set_unrounded_layout(child, &Layout::with_order(order as u32));
             tree.perform_child_layout(
                 child,
                 Size::NONE,
@@ -428,16 +428,19 @@ fn perform_final_layout_on_in_flow_children(
                 height: if item.overflow.x == Overflow::Scroll { item.scrollbar_width } else { 0.0 },
             };
 
-            *tree.get_unrounded_layout_mut(item.node_id) = Layout {
-                order: item.order,
-                size: item_layout.size,
-                #[cfg(feature = "content_size")]
-                content_size: item_layout.content_size,
-                scrollbar_size,
-                location,
-                padding: item.padding,
-                border: item.border,
-            };
+            tree.set_unrounded_layout(
+                item.node_id,
+                &Layout {
+                    order: item.order,
+                    size: item_layout.size,
+                    #[cfg(feature = "content_size")]
+                    content_size: item_layout.content_size,
+                    scrollbar_size,
+                    location,
+                    padding: item.padding,
+                    border: item.border,
+                },
+            );
 
             #[cfg(feature = "content_size")]
             {
@@ -650,16 +653,19 @@ fn perform_absolute_layout_on_absolute_children(
         };
 
         let location = area_offset + item_offset;
-        *tree.get_unrounded_layout_mut(item.node_id) = Layout {
-            order: item.order,
-            size: final_size,
-            #[cfg(feature = "content_size")]
-            content_size: layout_output.content_size,
-            scrollbar_size,
-            location,
-            padding,
-            border,
-        };
+        tree.set_unrounded_layout(
+            item.node_id,
+            &Layout {
+                order: item.order,
+                size: final_size,
+                #[cfg(feature = "content_size")]
+                content_size: layout_output.content_size,
+                scrollbar_size,
+                location,
+                padding,
+                border,
+            },
+        );
 
         #[cfg(feature = "content_size")]
         {

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -337,7 +337,7 @@ fn compute_preliminary(tree: &mut impl PartialLayoutTree, node: NodeId, inputs: 
     for order in 0..len {
         let child = tree.get_child_id(node, order);
         if tree.get_style(child).display == Display::None {
-            *tree.get_unrounded_layout_mut(child) = Layout::with_order(order as u32);
+            tree.set_unrounded_layout(child, &Layout::with_order(order as u32));
             tree.perform_child_layout(
                 child,
                 Size::NONE,
@@ -1767,16 +1767,19 @@ fn calculate_flex_item(
         height: if item.overflow.x == Overflow::Scroll { item.scrollbar_width } else { 0.0 },
     };
 
-    *tree.get_unrounded_layout_mut(item.node) = Layout {
-        order: item.order,
-        size,
-        #[cfg(feature = "content_size")]
-        content_size,
-        scrollbar_size,
-        location,
-        padding: item.padding,
-        border: item.border,
-    };
+    tree.set_unrounded_layout(
+        item.node,
+        &Layout {
+            order: item.order,
+            size,
+            #[cfg(feature = "content_size")]
+            content_size,
+            scrollbar_size,
+            location,
+            padding: item.padding,
+            border: item.border,
+        },
+    );
 
     *total_offset_main += item.offset_main + item.margin.main_axis_sum(direction) + size.main(direction);
 
@@ -2095,16 +2098,19 @@ fn perform_absolute_layout_on_absolute_children(
             width: if overflow.y == Overflow::Scroll { scrollbar_width } else { 0.0 },
             height: if overflow.x == Overflow::Scroll { scrollbar_width } else { 0.0 },
         };
-        *tree.get_unrounded_layout_mut(child) = Layout {
-            order: order as u32,
-            size: final_size,
-            #[cfg(feature = "content_size")]
-            content_size: layout_output.content_size,
-            scrollbar_size,
-            location,
-            padding,
-            border,
-        };
+        tree.set_unrounded_layout(
+            child,
+            &Layout {
+                order: order as u32,
+                size: final_size,
+                #[cfg(feature = "content_size")]
+                content_size: layout_output.content_size,
+                scrollbar_size,
+                location,
+                padding,
+                border,
+            },
+        );
 
         #[cfg(feature = "content_size")]
         {

--- a/src/compute/grid/alignment.rs
+++ b/src/compute/grid/alignment.rs
@@ -60,7 +60,7 @@ pub(super) fn align_and_position_item(
     grid_area: Rect<f32>,
     container_alignment_styles: InBothAbsAxis<Option<AlignItems>>,
     baseline_shim: f32,
-) -> Size<f32> {
+) -> (Size<f32>, f32, f32) {
     let grid_area_size = Size { width: grid_area.right - grid_area.left, height: grid_area.bottom - grid_area.top };
 
     let style = tree.get_style(node);
@@ -209,16 +209,19 @@ pub(super) fn align_and_position_item(
         height: if overflow.x == Overflow::Scroll { scrollbar_width } else { 0.0 },
     };
 
-    *tree.get_unrounded_layout_mut(node) = Layout {
-        order,
-        location: Point { x, y },
-        size: Size { width, height },
-        #[cfg(feature = "content_size")]
-        content_size: layout_output.content_size,
-        scrollbar_size,
-        padding,
-        border,
-    };
+    tree.set_unrounded_layout(
+        node,
+        &Layout {
+            order,
+            location: Point { x, y },
+            size: Size { width, height },
+            #[cfg(feature = "content_size")]
+            content_size: layout_output.content_size,
+            scrollbar_size,
+            padding,
+            border,
+        },
+    );
 
     #[cfg(feature = "content_size")]
     let contribution =
@@ -226,7 +229,7 @@ pub(super) fn align_and_position_item(
     #[cfg(not(feature = "content_size"))]
     let contribution = Size::ZERO;
 
-    contribution
+    (contribution, y, height)
 }
 
 /// Align and size a grid item along a single axis

--- a/src/compute/grid/types/grid_item.rs
+++ b/src/compute/grid/types/grid_item.rs
@@ -77,6 +77,11 @@ pub(in super::super) struct GridItem {
     pub minimum_contribution_cache: Size<Option<f32>>,
     /// Cache for the max-content size
     pub max_content_contribution_cache: Size<Option<f32>>,
+
+    /// Final y position. Used to compute baseline alignment for the container.
+    pub y_position: f32,
+    /// Final height. Used to compute baseline alignment for the container.
+    pub height: f32,
 }
 
 impl GridItem {
@@ -115,6 +120,8 @@ impl GridItem {
             min_content_contribution_cache: Size::NONE,
             max_content_contribution_cache: Size::NONE,
             minimum_contribution_cache: Size::NONE,
+            y_position: 0.0,
+            height: 0.0,
         }
     }
 

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -52,17 +52,19 @@ pub fn compute_layout(tree: &mut impl PartialLayoutTree, root: NodeId, available
         height: if style.overflow.x == Overflow::Scroll { style.scrollbar_width } else { 0.0 },
     };
 
-    let layout = Layout {
-        order: 0,
-        location: Point::ZERO,
-        size: output.size,
-        #[cfg(feature = "content_size")]
-        content_size: output.content_size,
-        scrollbar_size,
-        padding,
-        border,
-    };
-    *tree.get_unrounded_layout_mut(root) = layout;
+    tree.set_unrounded_layout(
+        root,
+        &Layout {
+            order: 0,
+            location: Point::ZERO,
+            size: output.size,
+            #[cfg(feature = "content_size")]
+            content_size: output.content_size,
+            scrollbar_size,
+            padding,
+            border,
+        },
+    );
 }
 
 /// Updates the stored layout of the provided `node` and its children
@@ -115,7 +117,7 @@ pub fn round_layout(tree: &mut impl LayoutTree, node_id: NodeId) {
 
     /// Recursive function to apply rounding to all descendents
     fn round_layout_inner(tree: &mut impl LayoutTree, node_id: NodeId, cumulative_x: f32, cumulative_y: f32) {
-        let unrounded_layout = *tree.get_unrounded_layout_mut(node_id);
+        let unrounded_layout = *tree.get_unrounded_layout(node_id);
         let layout = tree.get_final_layout_mut(node_id);
 
         let cumulative_x = cumulative_x + unrounded_layout.location.x;
@@ -170,7 +172,7 @@ pub fn round_layout(tree: &mut impl LayoutTree, node_id: NodeId) {
 pub fn compute_hidden_layout(tree: &mut impl PartialLayoutTree, node: NodeId) -> LayoutOutput {
     // Clear cache and set zeroed-out layout for the node
     tree.get_cache_mut(node).clear();
-    *tree.get_unrounded_layout_mut(node) = Layout::with_order(0);
+    tree.set_unrounded_layout(node, &Layout::with_order(0));
 
     // Perform hidden layout on all children
     for index in 0..tree.child_count(node) {

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -118,7 +118,7 @@ pub fn round_layout(tree: &mut impl LayoutTree, node_id: NodeId) {
     /// Recursive function to apply rounding to all descendents
     fn round_layout_inner(tree: &mut impl LayoutTree, node_id: NodeId, cumulative_x: f32, cumulative_y: f32) {
         let unrounded_layout = *tree.get_unrounded_layout(node_id);
-        let layout = tree.get_final_layout_mut(node_id);
+        let mut layout = unrounded_layout;
 
         let cumulative_x = cumulative_x + unrounded_layout.location.x;
         let cumulative_y = cumulative_y + unrounded_layout.location.y;
@@ -143,7 +143,9 @@ pub fn round_layout(tree: &mut impl LayoutTree, node_id: NodeId) {
             - round(cumulative_y + unrounded_layout.size.height - unrounded_layout.padding.bottom);
 
         #[cfg(feature = "content_size")]
-        round_content_size(layout, unrounded_layout.content_size, cumulative_x, cumulative_y);
+        round_content_size(&mut layout, unrounded_layout.content_size, cumulative_x, cumulative_y);
+
+        tree.set_final_layout(node_id, &layout);
 
         let child_count = tree.child_count(node_id);
         for index in 0..child_count {

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -40,8 +40,8 @@ pub trait PartialLayoutTree {
     /// Get a reference to the [`Style`] for this node.
     fn get_style(&self, node_id: NodeId) -> &Style;
 
-    /// Get a mutable reference to the node's unrounded layout
-    fn get_unrounded_layout_mut(&mut self, node_id: NodeId) -> &mut Layout;
+    /// Set the node's unrounded layout
+    fn set_unrounded_layout(&mut self, node_id: NodeId, layout: &Layout);
 
     /// Get a mutable reference to the [`Cache`] for this node.
     fn get_cache_mut(&mut self, node_id: NodeId) -> &mut Cache;
@@ -53,6 +53,8 @@ pub trait PartialLayoutTree {
 /// Extends [`PartialLayoutTree`] with an additional guarantee: that the child/children methods can be used to recurse
 /// infinitely down the tree. Enables Taffy's rounding and debug printing methods to be used.
 pub trait LayoutTree: PartialLayoutTree {
+    /// Get the node's unrounded layout
+    fn get_unrounded_layout(&self, node_id: NodeId) -> &Layout;
     /// Get a reference to the node's final layout
     fn get_final_layout(&self, node_id: NodeId) -> &Layout;
     /// Get a mutable reference to the node's final layout

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -58,7 +58,7 @@ pub trait LayoutTree: PartialLayoutTree {
     /// Get a reference to the node's final layout
     fn get_final_layout(&self, node_id: NodeId) -> &Layout;
     /// Get a mutable reference to the node's final layout
-    fn get_final_layout_mut(&mut self, node_id: NodeId) -> &mut Layout;
+    fn set_final_layout(&mut self, node_id: NodeId, layout: &Layout);
 }
 
 /// A private trait which allows us to add extra convenience methods to types which implement

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -153,8 +153,8 @@ where
     }
 
     #[inline(always)]
-    fn get_unrounded_layout_mut(&mut self, node: NodeId) -> &mut Layout {
-        &mut self.taffy.nodes[node.into()].unrounded_layout
+    fn set_unrounded_layout(&mut self, node_id: NodeId, layout: &Layout) {
+        self.taffy.nodes[node_id.into()].unrounded_layout = *layout;
     }
 
     #[inline(always)]
@@ -212,6 +212,11 @@ impl<'t, NodeContext, MeasureFunction> LayoutTree for TaffyView<'t, NodeContext,
 where
     MeasureFunction: FnMut(Size<Option<f32>>, Size<AvailableSpace>, NodeId, Option<&mut NodeContext>) -> Size<f32>,
 {
+    #[inline(always)]
+    fn get_unrounded_layout(&self, node: NodeId) -> &Layout {
+        &self.taffy.nodes[node.into()].unrounded_layout
+    }
+
     #[inline(always)]
     fn get_final_layout(&self, node: NodeId) -> &Layout {
         &self.taffy.nodes[node.into()].final_layout

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -223,8 +223,8 @@ where
     }
 
     #[inline(always)]
-    fn get_final_layout_mut(&mut self, node: NodeId) -> &mut Layout {
-        &mut self.taffy.nodes[node.into()].final_layout
+    fn set_final_layout(&mut self, node_id: NodeId, layout: &Layout) {
+        self.taffy.nodes[node_id.into()].final_layout = *layout;
     }
 }
 


### PR DESCRIPTION
# Objective

This makes it easier to integrate with Taffy as:

- It means you don't necessarily have to store the layout as a `taffy::Layout` struct
- It allows you to run logic just after the layout is set

It also makes it clear that Taffy's algorithms do not read from the layout (and removes the one case where they did!).

## Context

This change is motivated by the Xilem integration https://github.com/linebender/xilem/pull/140
