### PR TITLE
Move `NodeData` struct into `taffy_tree` module

### DIFF
--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -216,11 +216,11 @@ mod tests {
 
         // Whatever size and display-mode the nodes had previously,
         // all layouts should resolve to ZERO due to the root's DISPLAY::NONE
-        for (node, _) in taffy.nodes.iter().filter(|(node, _)| *node != root.into()) {
-            if let Ok(layout) = taffy.layout(node.into()) {
-                assert_eq!(layout.size, Size::zero());
-                assert_eq!(layout.location, Point::zero());
-            }
+
+        for node in [root, child_00, child_01, grandchild_00, grandchild_01, grandchild_02] {
+            let layout = taffy.layout(node.into()).unwrap();
+            assert_eq!(layout.size, Size::zero());
+            assert_eq!(layout.location, Point::zero());
         }
     }
 }

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -5,17 +5,17 @@ use crate::style::{AvailableSpace, Style};
 
 // Submodules
 mod cache;
-pub use cache::Cache;
+mod layout;
 mod node;
-#[cfg(feature = "taffy_tree")]
-use node::NodeData;
+
+pub use cache::Cache;
+pub use layout::{CollapsibleMarginSet, Layout, LayoutInput, LayoutOutput, RequestedAxis, RunMode, SizingMode};
 pub use node::NodeId;
+
 #[cfg(feature = "taffy_tree")]
 mod taffy_tree;
 #[cfg(feature = "taffy_tree")]
 pub use taffy_tree::{TaffyError, TaffyResult, TaffyTree};
-mod layout;
-pub use layout::{CollapsibleMarginSet, Layout, LayoutInput, LayoutOutput, RequestedAxis, RunMode, SizingMode};
 
 /// This if the core abstraction in Taffy. Any type that *correctly* implements `PartialLayoutTree` can be laid out using Taffy's algorithms.
 ///

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -1,9 +1,6 @@
 //! UI node types and related data structures.
 //!
 //! Layouts are composed of multiple nodes, which live in a tree-like data structure.
-use crate::style::Style;
-use crate::tree::Cache;
-use crate::tree::Layout;
 
 #[cfg(feature = "taffy_tree")]
 use slotmap::{DefaultKey, Key, KeyData};
@@ -59,49 +56,5 @@ impl From<NodeId> for DefaultKey {
     #[inline]
     fn from(key: NodeId) -> Self {
         KeyData::from_ffi(key.0).into()
-    }
-}
-
-/// Layout information for a given [`Node`](crate::node::Node)
-///
-/// Stored in a [`TaffyTree`].
-pub(crate) struct NodeData {
-    /// The layout strategy used by this node
-    pub(crate) style: Style,
-
-    /// The always unrounded results of the layout computation. We must store this separately from the rounded
-    /// layout to avoid errors from rounding already-rounded values. See <https://github.com/DioxusLabs/taffy/issues/501>.
-    pub(crate) unrounded_layout: Layout,
-
-    /// The final results of the layout computation.
-    /// These may be rounded or unrounded depending on what the `use_rounding` config setting is set to.
-    pub(crate) final_layout: Layout,
-
-    /// Should we try and measure this node?
-    pub(crate) needs_measure: bool,
-
-    /// The cached results of the layout computation
-    pub(crate) cache: Cache,
-}
-
-impl NodeData {
-    /// Create the data for a new node
-    #[must_use]
-    pub const fn new(style: Style) -> Self {
-        Self {
-            style,
-            cache: Cache::new(),
-            unrounded_layout: Layout::new(),
-            final_layout: Layout::new(),
-            needs_measure: false,
-        }
-    }
-
-    /// Marks a node and all of its parents (recursively) as dirty
-    ///
-    /// This clears any cached data and signals that the data must be recomputed.
-    #[inline]
-    pub fn mark_dirty(&mut self) {
-        self.cache.clear()
     }
 }


### PR DESCRIPTION
# Objective

Better code organisation. This struct is only used in the taffy_tree module, and can be made private if it also defined within this module.