### PR TITLE
Split tree traits

### DIFF
--- a/examples/custom_tree_owned.rs
+++ b/examples/custom_tree_owned.rs
@@ -5,7 +5,7 @@ mod common {
 use common::image::{image_measure_function, ImageContext};
 use common::text::{text_measure_function, FontMetrics, TextContext, WritingMode, LOREM_IPSUM};
 use taffy::{
-    compute_cached_layout, compute_flexbox_layout, compute_grid_layout, compute_layout, compute_leaf_layout,
+    compute_cached_layout, compute_flexbox_layout, compute_grid_layout, compute_leaf_layout, compute_root_layout,
     prelude::*, Cache, Layout, Style,
 };
 
@@ -77,7 +77,7 @@ impl Node {
 
     pub fn compute_layout(&mut self, available_space: Size<AvailableSpace>) {
         let root_node_id = unsafe { self.as_id() };
-        compute_layout(&mut StatelessLayoutTree, root_node_id, available_space);
+        compute_root_layout(&mut StatelessLayoutTree, root_node_id, available_space);
     }
 }
 

--- a/examples/custom_tree_owned_unsafe.rs
+++ b/examples/custom_tree_owned_unsafe.rs
@@ -7,7 +7,7 @@ use common::text::{text_measure_function, FontMetrics, TextContext, WritingMode,
 use taffy::tree::Cache;
 use taffy::util::print_tree;
 use taffy::{
-    compute_cached_layout, compute_flexbox_layout, compute_grid_layout, compute_layout, compute_leaf_layout,
+    compute_cached_layout, compute_flexbox_layout, compute_grid_layout, compute_leaf_layout, compute_root_layout,
     prelude::*, round_layout,
 };
 
@@ -81,7 +81,7 @@ impl Node {
 
     pub fn compute_layout(&mut self, available_space: Size<AvailableSpace>, use_rounding: bool) {
         let root_node_id = unsafe { self.as_id() };
-        compute_layout(&mut StatelessLayoutTree, root_node_id, available_space);
+        compute_root_layout(&mut StatelessLayoutTree, root_node_id, available_space);
         if use_rounding {
             round_layout(&mut StatelessLayoutTree, root_node_id)
         }

--- a/examples/custom_tree_owned_unsafe.rs
+++ b/examples/custom_tree_owned_unsafe.rs
@@ -1,0 +1,219 @@
+mod common {
+    pub mod image;
+    pub mod text;
+}
+use common::image::{image_measure_function, ImageContext};
+use common::text::{text_measure_function, FontMetrics, TextContext, WritingMode, LOREM_IPSUM};
+use taffy::tree::Cache;
+use taffy::util::print_tree;
+use taffy::{
+    compute_cached_layout, compute_flexbox_layout, compute_grid_layout, compute_layout, compute_leaf_layout,
+    prelude::*, round_layout,
+};
+
+#[derive(Debug, Copy, Clone)]
+#[allow(dead_code)]
+enum NodeKind {
+    Flexbox,
+    Grid,
+    Text,
+    Image,
+}
+
+struct Node {
+    kind: NodeKind,
+    style: Style,
+    text_data: Option<TextContext>,
+    image_data: Option<ImageContext>,
+    cache: Cache,
+    unrounded_layout: Layout,
+    final_layout: Layout,
+    children: Vec<Node>,
+}
+
+impl Default for Node {
+    fn default() -> Self {
+        Node {
+            kind: NodeKind::Flexbox,
+            style: Style::default(),
+            text_data: None,
+            image_data: None,
+            cache: Cache::new(),
+            unrounded_layout: Layout::with_order(0),
+            final_layout: Layout::with_order(0),
+            children: Vec::new(),
+        }
+    }
+}
+
+#[allow(dead_code)]
+impl Node {
+    pub fn new_row(style: Style) -> Node {
+        Node {
+            kind: NodeKind::Flexbox,
+            style: Style { display: Display::Flex, flex_direction: FlexDirection::Row, ..style },
+            ..Node::default()
+        }
+    }
+    pub fn new_column(style: Style) -> Node {
+        Node {
+            kind: NodeKind::Flexbox,
+            style: Style { display: Display::Flex, flex_direction: FlexDirection::Column, ..style },
+            ..Node::default()
+        }
+    }
+    pub fn new_grid(style: Style) -> Node {
+        Node { kind: NodeKind::Grid, style: Style { display: Display::Grid, ..style }, ..Node::default() }
+    }
+    pub fn new_text(style: Style, text_data: TextContext) -> Node {
+        Node { kind: NodeKind::Text, style, text_data: Some(text_data), ..Node::default() }
+    }
+    pub fn new_image(style: Style, image_data: ImageContext) -> Node {
+        Node { kind: NodeKind::Image, style, image_data: Some(image_data), ..Node::default() }
+    }
+    pub fn append_child(&mut self, node: Node) {
+        self.children.push(node);
+    }
+
+    unsafe fn as_id(&self) -> NodeId {
+        NodeId::from(self as *const Node as usize)
+    }
+
+    pub fn compute_layout(&mut self, available_space: Size<AvailableSpace>, use_rounding: bool) {
+        let root_node_id = unsafe { self.as_id() };
+        compute_layout(&mut StatelessLayoutTree, root_node_id, available_space);
+        if use_rounding {
+            round_layout(&mut StatelessLayoutTree, root_node_id)
+        }
+    }
+
+    pub fn print_tree(&mut self) {
+        print_tree(&mut StatelessLayoutTree, unsafe { self.as_id() });
+    }
+}
+
+struct ChildIter<'a>(std::slice::Iter<'a, Node>);
+impl<'a> Iterator for ChildIter<'a> {
+    type Item = NodeId;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|c| NodeId::from(c as *const Node as usize))
+    }
+}
+
+#[inline(always)]
+unsafe fn node_from_id<'a>(node_id: NodeId) -> &'a Node {
+    &*(usize::from(node_id) as *const Node)
+}
+
+#[inline(always)]
+unsafe fn node_from_id_mut<'a>(node_id: NodeId) -> &'a mut Node {
+    &mut *(usize::from(node_id) as *mut Node)
+}
+
+struct StatelessLayoutTree;
+impl TraversePartialTree for StatelessLayoutTree {
+    type ChildIter<'a> = ChildIter<'a>;
+
+    fn child_ids(&self, node_id: NodeId) -> Self::ChildIter<'_> {
+        unsafe { ChildIter(node_from_id(node_id).children.iter()) }
+    }
+
+    fn child_count(&self, node_id: NodeId) -> usize {
+        unsafe { node_from_id(node_id).children.len() }
+    }
+
+    fn get_child_id(&self, node_id: NodeId, index: usize) -> NodeId {
+        unsafe { node_from_id(node_id).children[index].as_id() }
+    }
+}
+
+impl TraverseTree for StatelessLayoutTree {}
+
+impl LayoutPartialTree for StatelessLayoutTree {
+    fn get_style(&self, node_id: NodeId) -> &Style {
+        unsafe { &node_from_id(node_id).style }
+    }
+
+    fn set_unrounded_layout(&mut self, node_id: NodeId, layout: &Layout) {
+        unsafe { node_from_id_mut(node_id).unrounded_layout = *layout };
+    }
+
+    fn get_cache_mut(&mut self, node_id: NodeId) -> &mut Cache {
+        unsafe { &mut node_from_id_mut(node_id).cache }
+    }
+
+    fn compute_child_layout(&mut self, node_id: NodeId, inputs: taffy::tree::LayoutInput) -> taffy::tree::LayoutOutput {
+        compute_cached_layout(self, node_id, inputs, |tree, node_id, inputs| {
+            let node = unsafe { node_from_id_mut(node_id) };
+            let font_metrics = FontMetrics { char_width: 10.0, char_height: 10.0 };
+
+            match node.kind {
+                NodeKind::Flexbox => compute_flexbox_layout(tree, node_id, inputs),
+                NodeKind::Grid => compute_grid_layout(tree, node_id, inputs),
+                NodeKind::Text => compute_leaf_layout(
+                    inputs,
+                    &node.style,
+                    Some(|known_dimensions, available_space| {
+                        text_measure_function(
+                            known_dimensions,
+                            available_space,
+                            node.text_data.as_ref().unwrap(),
+                            &font_metrics,
+                        )
+                    }),
+                ),
+                NodeKind::Image => compute_leaf_layout(
+                    inputs,
+                    &node.style,
+                    Some(|known_dimensions, _available_space| {
+                        image_measure_function(known_dimensions, node.image_data.as_ref().unwrap())
+                    }),
+                ),
+            }
+        })
+    }
+}
+
+impl RoundTree for StatelessLayoutTree {
+    fn get_unrounded_layout(&self, node_id: NodeId) -> &Layout {
+        unsafe { &node_from_id_mut(node_id).unrounded_layout }
+    }
+
+    fn set_final_layout(&mut self, node_id: NodeId, layout: &Layout) {
+        unsafe { node_from_id_mut(node_id).final_layout = *layout }
+    }
+}
+
+impl PrintTree for StatelessLayoutTree {
+    fn get_debug_label(&self, node_id: NodeId) -> &'static str {
+        match unsafe { node_from_id(node_id).kind } {
+            NodeKind::Flexbox => "FLEX",
+            NodeKind::Grid => "GRID",
+            NodeKind::Text => "TEXT",
+            NodeKind::Image => "IMAGE",
+        }
+    }
+
+    fn get_final_layout(&self, node_id: NodeId) -> &Layout {
+        unsafe { &node_from_id(node_id).final_layout }
+    }
+}
+
+fn main() -> Result<(), taffy::TaffyError> {
+    let mut root = Node::new_column(Style::DEFAULT);
+
+    let text_node = Node::new_text(
+        Style::default(),
+        TextContext { text_content: LOREM_IPSUM.into(), writing_mode: WritingMode::Horizontal },
+    );
+    root.append_child(text_node);
+
+    let image_node = Node::new_image(Style::default(), ImageContext { width: 400.0, height: 300.0 });
+    root.append_child(image_node);
+
+    // Compute layout and print result
+    root.compute_layout(Size::MAX_CONTENT, true);
+    root.print_tree();
+
+    Ok(())
+}

--- a/examples/custom_tree_vec.rs
+++ b/examples/custom_tree_vec.rs
@@ -6,7 +6,7 @@ use common::image::{image_measure_function, ImageContext};
 use common::text::{text_measure_function, FontMetrics, TextContext, WritingMode, LOREM_IPSUM};
 use taffy::util::print_tree;
 use taffy::{
-    compute_cached_layout, compute_flexbox_layout, compute_grid_layout, compute_layout, compute_leaf_layout,
+    compute_cached_layout, compute_flexbox_layout, compute_grid_layout, compute_leaf_layout, compute_root_layout,
     prelude::*, round_layout, Cache,
 };
 
@@ -101,7 +101,7 @@ impl Tree {
     }
 
     pub fn compute_layout(&mut self, root: usize, available_space: Size<AvailableSpace>, use_rounding: bool) {
-        compute_layout(self, NodeId::from(root), available_space);
+        compute_root_layout(self, NodeId::from(root), available_space);
         if use_rounding {
             round_layout(self, NodeId::from(root))
         }

--- a/examples/custom_tree_vec.rs
+++ b/examples/custom_tree_vec.rs
@@ -4,11 +4,10 @@ mod common {
 }
 use common::image::{image_measure_function, ImageContext};
 use common::text::{text_measure_function, FontMetrics, TextContext, WritingMode, LOREM_IPSUM};
-use taffy::tree::{Cache, PartialLayoutTree};
 use taffy::util::print_tree;
 use taffy::{
     compute_cached_layout, compute_flexbox_layout, compute_grid_layout, compute_layout, compute_leaf_layout,
-    prelude::*, round_layout,
+    prelude::*, round_layout, Cache,
 };
 
 #[derive(Debug, Copy, Clone)]
@@ -121,7 +120,7 @@ impl<'a> Iterator for ChildIter<'a> {
     }
 }
 
-impl PartialLayoutTree for Tree {
+impl taffy::TraversePartialTree for Tree {
     type ChildIter<'a> = ChildIter<'a>;
 
     fn child_ids(&self, node_id: NodeId) -> Self::ChildIter<'_> {
@@ -135,7 +134,11 @@ impl PartialLayoutTree for Tree {
     fn get_child_id(&self, node_id: NodeId, index: usize) -> NodeId {
         NodeId::from(self.node_from_id(node_id).children[index])
     }
+}
 
+impl taffy::TraverseTree for Tree {}
+
+impl taffy::LayoutPartialTree for Tree {
     fn get_style(&self, node_id: NodeId) -> &Style {
         &self.node_from_id(node_id).style
     }
@@ -180,17 +183,28 @@ impl PartialLayoutTree for Tree {
     }
 }
 
-impl LayoutTree for Tree {
+impl taffy::RoundTree for Tree {
     fn get_unrounded_layout(&self, node_id: NodeId) -> &Layout {
         &self.node_from_id(node_id).unrounded_layout
     }
 
-    fn get_final_layout(&self, node_id: NodeId) -> &Layout {
-        &self.node_from_id(node_id).final_layout
-    }
-
     fn set_final_layout(&mut self, node_id: NodeId, layout: &Layout) {
         self.node_from_id_mut(node_id).final_layout = *layout;
+    }
+}
+
+impl taffy::PrintTree for Tree {
+    fn get_debug_label(&self, node_id: NodeId) -> &'static str {
+        match self.node_from_id(node_id).kind {
+            NodeKind::Flexbox => "FLEX",
+            NodeKind::Grid => "GRID",
+            NodeKind::Text => "TEXT",
+            NodeKind::Image => "IMAGE",
+        }
+    }
+
+    fn get_final_layout(&self, node_id: NodeId) -> &Layout {
+        &self.node_from_id(node_id).final_layout
     }
 }
 

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -3,7 +3,7 @@ use crate::geometry::{Line, Point, Rect, Size};
 use crate::style::{AvailableSpace, Display, LengthPercentageAuto, Overflow, Position};
 use crate::style_helpers::TaffyMaxContent;
 use crate::tree::{CollapsibleMarginSet, Layout, LayoutInput, LayoutOutput, RunMode, SizingMode};
-use crate::tree::{NodeId, PartialLayoutTree, PartialLayoutTreeExt};
+use crate::tree::{LayoutPartialTree, LayoutPartialTreeExt, NodeId};
 use crate::util::debug::debug_log;
 use crate::util::sys::f32_max;
 use crate::util::sys::Vec;
@@ -56,8 +56,8 @@ struct BlockItem {
     can_be_collapsed_through: bool,
 }
 
-/// Computes the layout of [`PartialLayoutTree`] according to the block layout algorithm
-pub fn compute_block_layout(tree: &mut impl PartialLayoutTree, node_id: NodeId, inputs: LayoutInput) -> LayoutOutput {
+/// Computes the layout of [`LayoutPartialTree`] according to the block layout algorithm
+pub fn compute_block_layout(tree: &mut impl LayoutPartialTree, node_id: NodeId, inputs: LayoutInput) -> LayoutOutput {
     let LayoutInput { known_dimensions, parent_size, available_space, run_mode, .. } = inputs;
     let style = tree.get_style(node_id);
 
@@ -103,8 +103,8 @@ pub fn compute_block_layout(tree: &mut impl PartialLayoutTree, node_id: NodeId, 
     compute_inner(tree, node_id, LayoutInput { known_dimensions: styled_based_known_dimensions, ..inputs })
 }
 
-/// Computes the layout of [`PartialLayoutTree`] according to the block layout algorithm
-fn compute_inner(tree: &mut impl PartialLayoutTree, node_id: NodeId, inputs: LayoutInput) -> LayoutOutput {
+/// Computes the layout of [`LayoutPartialTree`] according to the block layout algorithm
+fn compute_inner(tree: &mut impl LayoutPartialTree, node_id: NodeId, inputs: LayoutInput) -> LayoutOutput {
     let LayoutInput {
         known_dimensions, parent_size, available_space, run_mode, vertical_margins_are_collapsible, ..
     } = inputs;
@@ -258,7 +258,7 @@ fn compute_inner(tree: &mut impl PartialLayoutTree, node_id: NodeId, inputs: Lay
 /// Create a `Vec` of `BlockItem` structs where each item in the `Vec` represents a child of the current node
 #[inline]
 fn generate_item_list(
-    tree: &impl PartialLayoutTree,
+    tree: &impl LayoutPartialTree,
     node: NodeId,
     node_inner_size: Size<Option<f32>>,
 ) -> Vec<BlockItem> {
@@ -298,7 +298,7 @@ fn generate_item_list(
 /// Compute the content-based width in the case that the width of the container is not known
 #[inline]
 fn determine_content_based_container_width(
-    tree: &mut impl PartialLayoutTree,
+    tree: &mut impl LayoutPartialTree,
     items: &[BlockItem],
     available_width: AvailableSpace,
 ) -> f32 {
@@ -333,7 +333,7 @@ fn determine_content_based_container_width(
 /// Compute each child's final size and position
 #[inline]
 fn perform_final_layout_on_in_flow_children(
-    tree: &mut impl PartialLayoutTree,
+    tree: &mut impl LayoutPartialTree,
     items: &mut [BlockItem],
     container_outer_width: f32,
     content_box_inset: Rect<f32>,
@@ -488,7 +488,7 @@ fn perform_final_layout_on_in_flow_children(
 /// Perform absolute layout on all absolutely positioned children.
 #[inline]
 fn perform_absolute_layout_on_absolute_children(
-    tree: &mut impl PartialLayoutTree,
+    tree: &mut impl LayoutPartialTree,
     items: &[BlockItem],
     area_size: Size<f32>,
     area_offset: Point<f32>,

--- a/src/compute/grid/alignment.rs
+++ b/src/compute/grid/alignment.rs
@@ -3,7 +3,7 @@ use super::types::GridTrack;
 use crate::compute::common::alignment::compute_alignment_offset;
 use crate::geometry::{InBothAbsAxis, Line, Point, Rect, Size};
 use crate::style::{AlignContent, AlignItems, AlignSelf, AvailableSpace, Overflow, Position};
-use crate::tree::{Layout, NodeId, PartialLayoutTree, PartialLayoutTreeExt, SizingMode};
+use crate::tree::{Layout, LayoutPartialTree, LayoutPartialTreeExt, NodeId, SizingMode};
 use crate::util::sys::f32_max;
 use crate::util::{MaybeMath, MaybeResolve, ResolveOrZero};
 
@@ -54,7 +54,7 @@ pub(super) fn align_tracks(
 
 /// Align and size a grid item into it's final position
 pub(super) fn align_and_position_item(
-    tree: &mut impl PartialLayoutTree,
+    tree: &mut impl LayoutPartialTree,
     node: NodeId,
     order: u32,
     grid_area: Rect<f32>,

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -5,7 +5,7 @@ use crate::geometry::{Line, Point, Rect, Size};
 use crate::style::{AlignContent, AlignItems, AlignSelf, AvailableSpace, Display, Overflow, Position};
 use crate::style_helpers::*;
 use crate::tree::{Layout, LayoutInput, LayoutOutput, RunMode, SizingMode};
-use crate::tree::{NodeId, PartialLayoutTree, PartialLayoutTreeExt};
+use crate::tree::{LayoutPartialTree, LayoutPartialTreeExt, NodeId};
 use crate::util::debug::debug_log;
 use crate::util::sys::{f32_max, GridTrackVec, Vec};
 use crate::util::MaybeMath;
@@ -35,7 +35,7 @@ mod util;
 ///   - Placing items (which also resolves the implicit grid)
 ///   - Track (row/column) sizing
 ///   - Alignment & Final item placement
-pub fn compute_grid_layout(tree: &mut impl PartialLayoutTree, node: NodeId, inputs: LayoutInput) -> LayoutOutput {
+pub fn compute_grid_layout(tree: &mut impl LayoutPartialTree, node: NodeId, inputs: LayoutInput) -> LayoutOutput {
     let LayoutInput { known_dimensions, parent_size, available_space, run_mode, .. } = inputs;
 
     let get_child_styles_iter = |node| tree.child_ids(node).map(|child_node: NodeId| tree.get_style(child_node));

--- a/src/compute/grid/track_sizing.rs
+++ b/src/compute/grid/track_sizing.rs
@@ -6,7 +6,7 @@ use crate::style::{
     AlignContent, AlignSelf, AvailableSpace, LengthPercentage, MaxTrackSizingFunction, MinTrackSizingFunction,
 };
 use crate::style_helpers::TaffyMinContent;
-use crate::tree::{PartialLayoutTree, PartialLayoutTreeExt, SizingMode};
+use crate::tree::{LayoutPartialTree, LayoutPartialTreeExt, SizingMode};
 use crate::util::sys::{f32_max, f32_min, Vec};
 use crate::util::{MaybeMath, ResolveOrZero};
 use core::cmp::Ordering;
@@ -67,7 +67,7 @@ impl ItemBatcher {
 /// don't have to be passed around all over the place below. It then has methods that implement the intrinsic sizing computations
 struct IntrisicSizeMeasurer<'tree, 'oat, Tree, EstimateFunction>
 where
-    Tree: PartialLayoutTree,
+    Tree: LayoutPartialTree,
     EstimateFunction: Fn(&GridTrack, Option<f32>) -> Option<f32>,
 {
     /// The layout tree
@@ -85,7 +85,7 @@ where
 
 impl<'tree, 'oat, Tree, EstimateFunction> IntrisicSizeMeasurer<'tree, 'oat, Tree, EstimateFunction>
 where
-    Tree: PartialLayoutTree,
+    Tree: LayoutPartialTree,
     EstimateFunction: Fn(&GridTrack, Option<f32>) -> Option<f32>,
 {
     /// Compute the available_space to be passed to the child sizing functions
@@ -261,7 +261,7 @@ pub(super) fn determine_if_item_crosses_flexible_or_intrinsic_tracks(
 /// Note: Gutters are treated as empty fixed-size tracks for the purpose of the track sizing algorithm.
 #[allow(clippy::too_many_arguments)]
 #[inline(always)]
-pub(super) fn track_sizing_algorithm<Tree: PartialLayoutTree>(
+pub(super) fn track_sizing_algorithm<Tree: LayoutPartialTree>(
     tree: &mut Tree,
     axis: AbstractAxis,
     axis_min_size: Option<f32>,
@@ -436,7 +436,7 @@ fn initialize_track_sizes(axis_tracks: &mut [GridTrack], axis_inner_node_size: O
 
 /// 11.5.1 Shim baseline-aligned items so their intrinsic size contributions reflect their baseline alignment.
 fn resolve_item_baselines(
-    tree: &mut impl PartialLayoutTree,
+    tree: &mut impl LayoutPartialTree,
     axis: AbstractAxis,
     items: &mut [GridItem],
     inner_node_size: Size<Option<f32>>,
@@ -509,7 +509,7 @@ fn resolve_item_baselines(
 /// 11.5 Resolve Intrinsic Track Sizes
 #[allow(clippy::too_many_arguments)]
 fn resolve_intrinsic_track_sizes(
-    tree: &mut impl PartialLayoutTree,
+    tree: &mut impl LayoutPartialTree,
     axis: AbstractAxis,
     axis_tracks: &mut [GridTrack],
     other_axis_tracks: &[GridTrack],
@@ -1138,7 +1138,7 @@ fn maximise_tracks(
 #[allow(clippy::too_many_arguments)]
 #[inline(always)]
 fn expand_flexible_tracks(
-    tree: &mut impl PartialLayoutTree,
+    tree: &mut impl LayoutPartialTree,
     axis: AbstractAxis,
     axis_tracks: &mut [GridTrack],
     items: &mut [GridItem],

--- a/src/compute/grid/types/grid_item.rs
+++ b/src/compute/grid/types/grid_item.rs
@@ -7,7 +7,7 @@ use crate::style::{
     AlignItems, AlignSelf, AvailableSpace, Dimension, LengthPercentageAuto, MaxTrackSizingFunction,
     MinTrackSizingFunction, Overflow, Style,
 };
-use crate::tree::{NodeId, PartialLayoutTree, PartialLayoutTreeExt, SizingMode};
+use crate::tree::{LayoutPartialTree, LayoutPartialTreeExt, NodeId, SizingMode};
 use crate::util::{MaybeMath, MaybeResolve, ResolveOrZero};
 use core::ops::Range;
 
@@ -340,7 +340,7 @@ impl GridItem {
     pub fn min_content_contribution(
         &self,
         axis: AbstractAxis,
-        tree: &mut impl PartialLayoutTree,
+        tree: &mut impl LayoutPartialTree,
         available_space: Size<Option<f32>>,
         inner_node_size: Size<Option<f32>>,
     ) -> f32 {
@@ -364,7 +364,7 @@ impl GridItem {
     pub fn min_content_contribution_cached(
         &mut self,
         axis: AbstractAxis,
-        tree: &mut impl PartialLayoutTree,
+        tree: &mut impl LayoutPartialTree,
         available_space: Size<Option<f32>>,
         inner_node_size: Size<Option<f32>>,
     ) -> f32 {
@@ -379,7 +379,7 @@ impl GridItem {
     pub fn max_content_contribution(
         &self,
         axis: AbstractAxis,
-        tree: &mut impl PartialLayoutTree,
+        tree: &mut impl LayoutPartialTree,
         available_space: Size<Option<f32>>,
         inner_node_size: Size<Option<f32>>,
     ) -> f32 {
@@ -403,7 +403,7 @@ impl GridItem {
     pub fn max_content_contribution_cached(
         &mut self,
         axis: AbstractAxis,
-        tree: &mut impl PartialLayoutTree,
+        tree: &mut impl LayoutPartialTree,
         available_space: Size<Option<f32>>,
         inner_node_size: Size<Option<f32>>,
     ) -> f32 {
@@ -423,7 +423,7 @@ impl GridItem {
     /// See: https://www.w3.org/TR/css-grid-1/#min-size-auto
     pub fn minimum_contribution(
         &mut self,
-        tree: &mut impl PartialLayoutTree,
+        tree: &mut impl LayoutPartialTree,
         axis: AbstractAxis,
         axis_tracks: &[GridTrack],
         known_dimensions: Size<Option<f32>>,
@@ -482,7 +482,7 @@ impl GridItem {
     #[inline(always)]
     pub fn minimum_contribution_cached(
         &mut self,
-        tree: &mut impl PartialLayoutTree,
+        tree: &mut impl LayoutPartialTree,
         axis: AbstractAxis,
         axis_tracks: &[GridTrack],
         known_dimensions: Size<Option<f32>>,

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -1,4 +1,8 @@
-//! The layout algorithms themselves
+//! Low-level access to the layout algorithms themselves
+//!
+//! All of the functions in this module except `round_layout` operate on the [`LayoutPartialTree`] trait. See the [`crate::tree::traits`] module for details on how to implement this trait.
+//!
+//! For a higher-level API, see the [`TaffyTree`](crate::TaffyTree) struct.
 
 pub(crate) mod common;
 pub(crate) mod leaf;
@@ -26,14 +30,14 @@ pub use self::grid::compute_grid_layout;
 use crate::geometry::{Line, Point, Size};
 use crate::style::{AvailableSpace, Overflow};
 use crate::tree::{
-    Layout, LayoutInput, LayoutOutput, LayoutTree, NodeId, PartialLayoutTree, PartialLayoutTreeExt, SizingMode,
+    Layout, LayoutInput, LayoutOutput, LayoutPartialTree, LayoutPartialTreeExt, NodeId, RoundTree, SizingMode,
 };
 use crate::util::debug::{debug_log, debug_log_node, debug_pop_node, debug_push_node};
 use crate::util::sys::round;
 use crate::util::ResolveOrZero;
 
 /// Updates the stored layout of the provided `node` and its children
-pub fn compute_layout(tree: &mut impl PartialLayoutTree, root: NodeId, available_space: Size<AvailableSpace>) {
+pub fn compute_layout(tree: &mut impl LayoutPartialTree, root: NodeId, available_space: Size<AvailableSpace>) {
     // Recursively compute node layout
     let output = tree.perform_child_layout(
         root,
@@ -67,9 +71,11 @@ pub fn compute_layout(tree: &mut impl PartialLayoutTree, root: NodeId, available
     );
 }
 
-/// Updates the stored layout of the provided `node` and its children
+/// Attempts to find a cached layout for the specified node and layout inputs.
+///
+/// Uses the provided closure to compute the layout (and then stores the result in the cache) if no cached layout is found.
 #[inline(always)]
-pub fn compute_cached_layout<Tree: PartialLayoutTree + ?Sized, ComputeFunction>(
+pub fn compute_cached_layout<Tree: LayoutPartialTree + ?Sized, ComputeFunction>(
     tree: &mut Tree,
     node: NodeId,
     inputs: LayoutInput,
@@ -101,7 +107,7 @@ where
     computed_size_and_baselines
 }
 
-/// Rounds the calculated [`Layout`] to exact pixel values
+/// Rounds the calculated layout to exact pixel values
 ///
 /// In order to ensure that no gaps in the layout are introduced we:
 ///   - Always round based on the cumulative x/y coordinates (relative to the viewport) rather than
@@ -112,11 +118,11 @@ where
 ///
 /// In order to prevent innacuracies caused by rounding already-rounded values, we read from `unrounded_layout`
 /// and write to `final_layout`.
-pub fn round_layout(tree: &mut impl LayoutTree, node_id: NodeId) {
+pub fn round_layout(tree: &mut impl RoundTree, node_id: NodeId) {
     return round_layout_inner(tree, node_id, 0.0, 0.0);
 
     /// Recursive function to apply rounding to all descendents
-    fn round_layout_inner(tree: &mut impl LayoutTree, node_id: NodeId, cumulative_x: f32, cumulative_y: f32) {
+    fn round_layout_inner(tree: &mut impl RoundTree, node_id: NodeId, cumulative_x: f32, cumulative_y: f32) {
         let unrounded_layout = *tree.get_unrounded_layout(node_id);
         let mut layout = unrounded_layout;
 
@@ -171,7 +177,7 @@ pub fn round_layout(tree: &mut impl LayoutTree, node_id: NodeId) {
 
 /// Creates a layout for this node and its children, recursively.
 /// Each hidden node has zero size and is placed at the origin
-pub fn compute_hidden_layout(tree: &mut impl PartialLayoutTree, node: NodeId) -> LayoutOutput {
+pub fn compute_hidden_layout(tree: &mut impl LayoutPartialTree, node: NodeId) -> LayoutOutput {
     // Clear cache and set zeroed-out layout for the node
     tree.get_cache_mut(node).clear();
     tree.set_unrounded_layout(node, &Layout::with_order(0));

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -36,8 +36,8 @@ use crate::util::debug::{debug_log, debug_log_node, debug_pop_node, debug_push_n
 use crate::util::sys::round;
 use crate::util::ResolveOrZero;
 
-/// Updates the stored layout of the provided `node` and its children
-pub fn compute_layout(tree: &mut impl LayoutPartialTree, root: NodeId, available_space: Size<AvailableSpace>) {
+/// Compute layout for the root node in the tree
+pub fn compute_root_layout(tree: &mut impl LayoutPartialTree, root: NodeId, available_space: Size<AvailableSpace>) {
     // Recursively compute node layout
     let output = tree.perform_child_layout(
         root,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@ pub use crate::compute::compute_flexbox_layout;
 pub use crate::compute::compute_grid_layout;
 #[doc(inline)]
 pub use crate::compute::{
-    compute_cached_layout, compute_hidden_layout, compute_layout, compute_leaf_layout, round_layout,
+    compute_cached_layout, compute_hidden_layout, compute_leaf_layout, compute_root_layout, round_layout,
 };
 #[doc(inline)]
 pub use crate::style::Style;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //!
 //! ### High-level API
 //!
-//! The high-level API** consists of the [`TaffyTree`] struct which contains a tree implementation and provides methods that allow you to construct
+//! The high-level API consists of the [`TaffyTree`] struct which contains a tree implementation and provides methods that allow you to construct
 //! a tree of UI nodes. Once constructed, you can call the [`compute_layout_with_measure`](crate::TaffyTree::compute_layout_with_measure) method to compute the layout (passing in a "measure function" closure which is used to compute the size of leaf nodes), and then access
 //! the layout of each node using the [`layout`](crate::TaffyTree::layout) method.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,12 +44,12 @@
 //!
 //! ### Low-level API
 //!
-//! The low-level API consists of a set of traits (notably the [`LayoutPartialTree`] trait) which define an interface behind which you must implement your own
-//! tree implementation, and a set of functions such as [`compute_flexbox_layout`] and [`compute_grid_layout`] which implement the layout algorithms (for a single node at a time), and are designed to be flexible
+//! The low-level API consists of a [set of traits](crate::tree::traits) (notably the [`LayoutPartialTree`] trait) which define an interface behind which you must implement your own
+//! tree implementation, and a [set of functions](crate::compute) such as [`compute_flexbox_layout`] and [`compute_grid_layout`] which implement the layout algorithms (for a single node at a time), and are designed to be flexible
 //! and easy to integrate into a wider layout or UI system.
 //!
 //! When using this API, you must handle node storage, caching, and dispatching to the correct layout algorithm for a given node yourself.
-//! See the [`LayoutPartialTree`] trait for more details on this API.
+//! See the [`crate::tree::traits`] module for more details on this API.
 //!
 //! Examples which show usage of the high-level API are:
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,12 +44,12 @@
 //!
 //! ### Low-level API
 //!
-//! The low-level API consists of a set of traits (notably the [`PartialLayoutTree`] trait) which define an interface behind which you must implement your own
+//! The low-level API consists of a set of traits (notably the [`LayoutPartialTree`] trait) which define an interface behind which you must implement your own
 //! tree implementation, and a set of functions such as [`compute_flexbox_layout`] and [`compute_grid_layout`] which implement the layout algorithms (for a single node at a time), and are designed to be flexible
 //! and easy to integrate into a wider layout or UI system.
 //!
 //! When using this API, you must handle node storage, caching, and dispatching to the correct layout algorithm for a given node yourself.
-//! See the [`PartialLayoutTree`] trait for more details on this API.
+//! See the [`LayoutPartialTree`] trait for more details on this API.
 //!
 //! Examples which show usage of the high-level API are:
 //!
@@ -103,11 +103,11 @@ pub use crate::compute::{
 };
 #[doc(inline)]
 pub use crate::style::Style;
+#[doc(inline)]
+pub use crate::tree::traits::*;
 #[cfg(feature = "taffy_tree")]
 #[doc(inline)]
 pub use crate::tree::TaffyTree;
-#[doc(inline)]
-pub use crate::tree::{LayoutTree, PartialLayoutTree};
 #[cfg(feature = "std")]
 #[doc(inline)]
 pub use crate::util::print_tree;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -10,7 +10,7 @@ pub use crate::{
         auto, fit_content, length, max_content, min_content, percent, zero, FromFlex, FromLength, FromPercent,
         TaffyAuto, TaffyFitContent, TaffyMaxContent, TaffyMinContent, TaffyZero,
     },
-    tree::{Layout, LayoutTree, NodeId},
+    tree::{Layout, LayoutPartialTree, NodeId, PrintTree, RoundTree, TraversePartialTree, TraverseTree},
 };
 
 #[cfg(feature = "flexbox")]

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1,122 +1,21 @@
-//! Contains both [a high-level interface to Taffy](crate::TaffyTree) using a ready-made node tree, and [a trait for defining a custom node trees](crate::tree::LayoutTree) / utility types to help with that.
-
-use crate::geometry::{AbsoluteAxis, Line, Size};
-use crate::style::{AvailableSpace, Style};
+//! Contains both a high-level interface to Taffy using a ready-made node tree, and a set of traits for defining custom node trees.
+//!
+//! - For documentation on the high-level API, see the [`TaffyTree`] struct.
+//! - For documentation on the low-level trait-based API, see the [`traits`] module.
 
 // Submodules
 mod cache;
 mod layout;
 mod node;
+pub mod traits;
 
 pub use cache::Cache;
 pub use layout::{CollapsibleMarginSet, Layout, LayoutInput, LayoutOutput, RequestedAxis, RunMode, SizingMode};
 pub use node::NodeId;
+pub(crate) use traits::LayoutPartialTreeExt;
+pub use traits::{LayoutPartialTree, PrintTree, RoundTree, TraversePartialTree, TraverseTree};
 
 #[cfg(feature = "taffy_tree")]
 mod taffy_tree;
 #[cfg(feature = "taffy_tree")]
 pub use taffy_tree::{TaffyError, TaffyResult, TaffyTree};
-
-/// This if the core abstraction in Taffy. Any type that *correctly* implements `PartialLayoutTree` can be laid out using Taffy's algorithms.
-///
-/// The type implementing `PartialLayoutTree` would typically be an entire tree of nodes (or a view over an entire tree of nodes).
-/// However, `PartialLayoutTree` and Taffy's algorithm implementations have been designed such that they can be used for a laying out a single
-/// node that only has access to it's immediate children.
-pub trait PartialLayoutTree {
-    /// Type representing an iterator of the children of a node
-    type ChildIter<'a>: Iterator<Item = NodeId>
-    where
-        Self: 'a;
-
-    /// Get the list of children IDs for the given node
-    fn child_ids(&self, parent_node_id: NodeId) -> Self::ChildIter<'_>;
-
-    /// Get the number of children for the given node
-    fn child_count(&self, parent_node_id: NodeId) -> usize;
-
-    /// Get a specific child of a node, where the index represents the nth child
-    fn get_child_id(&self, parent_node_id: NodeId, child_index: usize) -> NodeId;
-
-    /// Get a reference to the [`Style`] for this node.
-    fn get_style(&self, node_id: NodeId) -> &Style;
-
-    /// Set the node's unrounded layout
-    fn set_unrounded_layout(&mut self, node_id: NodeId, layout: &Layout);
-
-    /// Get a mutable reference to the [`Cache`] for this node.
-    fn get_cache_mut(&mut self, node_id: NodeId) -> &mut Cache;
-
-    /// Compute the specified node's size or full layout given the specified constraints
-    fn compute_child_layout(&mut self, node_id: NodeId, inputs: LayoutInput) -> LayoutOutput;
-}
-
-/// Extends [`PartialLayoutTree`] with an additional guarantee: that the child/children methods can be used to recurse
-/// infinitely down the tree. Enables Taffy's rounding and debug printing methods to be used.
-pub trait LayoutTree: PartialLayoutTree {
-    /// Get the node's unrounded layout
-    fn get_unrounded_layout(&self, node_id: NodeId) -> &Layout;
-    /// Get a reference to the node's final layout
-    fn get_final_layout(&self, node_id: NodeId) -> &Layout;
-    /// Get a mutable reference to the node's final layout
-    fn set_final_layout(&mut self, node_id: NodeId, layout: &Layout);
-}
-
-/// A private trait which allows us to add extra convenience methods to types which implement
-/// LayoutTree without making those methods public.
-pub(crate) trait PartialLayoutTreeExt: PartialLayoutTree {
-    /// Compute the size of the node given the specified constraints
-    #[inline(always)]
-    #[allow(clippy::too_many_arguments)]
-    fn measure_child_size(
-        &mut self,
-        node_id: NodeId,
-        known_dimensions: Size<Option<f32>>,
-        parent_size: Size<Option<f32>>,
-        available_space: Size<AvailableSpace>,
-        sizing_mode: SizingMode,
-        axis: AbsoluteAxis,
-        vertical_margins_are_collapsible: Line<bool>,
-    ) -> f32 {
-        self.compute_child_layout(
-            node_id,
-            LayoutInput {
-                known_dimensions,
-                parent_size,
-                available_space,
-                sizing_mode,
-                axis: axis.into(),
-                run_mode: RunMode::ComputeSize,
-                vertical_margins_are_collapsible,
-            },
-        )
-        .size
-        .get_abs(axis)
-    }
-
-    /// Perform a full layout on the node given the specified constraints
-    #[inline(always)]
-    fn perform_child_layout(
-        &mut self,
-        node_id: NodeId,
-        known_dimensions: Size<Option<f32>>,
-        parent_size: Size<Option<f32>>,
-        available_space: Size<AvailableSpace>,
-        sizing_mode: SizingMode,
-        vertical_margins_are_collapsible: Line<bool>,
-    ) -> LayoutOutput {
-        self.compute_child_layout(
-            node_id,
-            LayoutInput {
-                known_dimensions,
-                parent_size,
-                available_space,
-                sizing_mode,
-                axis: RequestedAxis::Both,
-                run_mode: RunMode::PerformLayout,
-                vertical_margins_are_collapsible,
-            },
-        )
-    }
-}
-
-impl<T: PartialLayoutTree> PartialLayoutTreeExt for T {}

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -17,7 +17,9 @@ use crate::compute::compute_block_layout;
 use crate::compute::compute_flexbox_layout;
 #[cfg(feature = "grid")]
 use crate::compute::compute_grid_layout;
-use crate::compute::{compute_cached_layout, compute_hidden_layout, compute_layout, compute_leaf_layout, round_layout};
+use crate::compute::{
+    compute_cached_layout, compute_hidden_layout, compute_leaf_layout, compute_root_layout, round_layout,
+};
 
 /// The error Taffy generates on invalid operations
 pub type TaffyResult<T> = Result<T, TaffyError>;
@@ -652,7 +654,7 @@ impl<NodeContext> TaffyTree<NodeContext> {
     {
         let use_rounding = self.config.use_rounding;
         let mut taffy_view = TaffyView { taffy: self, measure_function };
-        compute_layout(&mut taffy_view, node_id, available_space);
+        compute_root_layout(&mut taffy_view, node_id, available_space);
         if use_rounding {
             round_layout(&mut taffy_view, node_id);
         }

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -9,7 +9,6 @@ use crate::tree::{
 };
 use crate::util::debug::{debug_log, debug_log_node};
 use crate::util::sys::{new_vec_with_capacity, ChildrenVec, Vec};
-use crate::FlexDirection;
 
 #[cfg(feature = "block_layout")]
 use crate::compute::compute_block_layout;
@@ -195,10 +194,13 @@ impl<NodeContext> PrintTree for TaffyTree<NodeContext> {
             #[cfg(feature = "block_layout")]
             (_, Display::Block) => "BLOCK",
             #[cfg(feature = "flexbox")]
-            (_, Display::Flex) => match node.style.flex_direction {
-                FlexDirection::Row | FlexDirection::RowReverse => "FLEX ROW",
-                FlexDirection::Column | FlexDirection::ColumnReverse => "FLEX COL",
-            },
+            (_, Display::Flex) => {
+                use crate::FlexDirection;
+                match node.style.flex_direction {
+                    FlexDirection::Row | FlexDirection::RowReverse => "FLEX ROW",
+                    FlexDirection::Column | FlexDirection::ColumnReverse => "FLEX COL",
+                }
+            }
             #[cfg(feature = "grid")]
             (_, Display::Grid) => "GRID",
         }

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -3,9 +3,13 @@ use slotmap::{DefaultKey, SlotMap, SparseSecondaryMap};
 
 use crate::geometry::Size;
 use crate::style::{AvailableSpace, Display, Style};
-use crate::tree::{Cache, Layout, LayoutInput, LayoutOutput, LayoutTree, NodeId, PartialLayoutTree, RunMode};
+use crate::tree::{
+    Cache, Layout, LayoutInput, LayoutOutput, LayoutPartialTree, NodeId, PrintTree, RoundTree, RunMode,
+    TraversePartialTree, TraverseTree,
+};
 use crate::util::debug::{debug_log, debug_log_node};
 use crate::util::sys::{new_vec_with_capacity, ChildrenVec, Vec};
+use crate::FlexDirection;
 
 #[cfg(feature = "block_layout")]
 use crate::compute::compute_block_layout;
@@ -143,12 +147,64 @@ impl Default for TaffyTree {
 }
 
 /// Iterator that wraps a slice of nodes, lazily converting them to u64
-pub(crate) struct TaffyChildIter<'a>(core::slice::Iter<'a, NodeId>);
-impl<'a> Iterator for TaffyChildIter<'a> {
+pub struct TaffyTreeChildIter<'a>(core::slice::Iter<'a, NodeId>);
+impl<'a> Iterator for TaffyTreeChildIter<'a> {
     type Item = NodeId;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next().copied()
+    }
+}
+
+// TraversePartialTree impl for TaffyTree
+impl<NodeContext> TraversePartialTree for TaffyTree<NodeContext> {
+    type ChildIter<'a> = TaffyTreeChildIter<'a> where Self: 'a;
+
+    #[inline(always)]
+    fn child_ids(&self, parent_node_id: NodeId) -> Self::ChildIter<'_> {
+        TaffyTreeChildIter(self.children[parent_node_id.into()].iter())
+    }
+
+    #[inline(always)]
+    fn child_count(&self, parent_node_id: NodeId) -> usize {
+        self.children[parent_node_id.into()].len()
+    }
+
+    #[inline(always)]
+    fn get_child_id(&self, parent_node_id: NodeId, id: usize) -> NodeId {
+        self.children[parent_node_id.into()][id]
+    }
+}
+
+// TraverseTree impl for TaffyTree
+impl<NodeContext> TraverseTree for TaffyTree<NodeContext> {}
+
+// PrintTree impl for TaffyTree
+impl<NodeContext> PrintTree for TaffyTree<NodeContext> {
+    #[inline(always)]
+    fn get_debug_label(&self, node_id: NodeId) -> &'static str {
+        let node = &self.nodes[node_id.into()];
+        let display = node.style.display;
+        let num_children = self.child_count(node_id);
+
+        match (num_children, display) {
+            (_, Display::None) => "NONE",
+            (0, _) => "LEAF",
+            #[cfg(feature = "block_layout")]
+            (_, Display::Block) => "BLOCK",
+            #[cfg(feature = "flexbox")]
+            (_, Display::Flex) => match node.style.flex_direction {
+                FlexDirection::Row | FlexDirection::RowReverse => "FLEX ROW",
+                FlexDirection::Column | FlexDirection::ColumnReverse => "FLEX COL",
+            },
+            #[cfg(feature = "grid")]
+            (_, Display::Grid) => "GRID",
+        }
+    }
+
+    #[inline(always)]
+    fn get_final_layout(&self, node_id: NodeId) -> &Layout {
+        &self.nodes[node_id.into()].final_layout
     }
 }
 
@@ -165,27 +221,40 @@ where
     pub(crate) measure_function: MeasureFunction,
 }
 
-impl<'t, NodeContext, MeasureFunction> PartialLayoutTree for TaffyView<'t, NodeContext, MeasureFunction>
+// TraversePartialTree impl for TaffyView
+impl<'t, NodeContext, MeasureFunction> TraversePartialTree for TaffyView<'t, NodeContext, MeasureFunction>
 where
     MeasureFunction: FnMut(Size<Option<f32>>, Size<AvailableSpace>, NodeId, Option<&mut NodeContext>) -> Size<f32>,
 {
-    type ChildIter<'a> = TaffyChildIter<'a> where Self: 'a;
+    type ChildIter<'a> = TaffyTreeChildIter<'a> where Self: 'a;
 
     #[inline(always)]
-    fn child_ids(&self, node: NodeId) -> Self::ChildIter<'_> {
-        TaffyChildIter(self.taffy.children[node.into()].iter())
+    fn child_ids(&self, parent_node_id: NodeId) -> Self::ChildIter<'_> {
+        self.taffy.child_ids(parent_node_id)
     }
 
     #[inline(always)]
-    fn child_count(&self, node: NodeId) -> usize {
-        self.taffy.children[node.into()].len()
+    fn child_count(&self, parent_node_id: NodeId) -> usize {
+        self.taffy.child_count(parent_node_id)
     }
 
     #[inline(always)]
-    fn get_child_id(&self, node: NodeId, id: usize) -> NodeId {
-        self.taffy.children[node.into()][id]
+    fn get_child_id(&self, parent_node_id: NodeId, child_index: usize) -> NodeId {
+        self.taffy.get_child_id(parent_node_id, child_index)
     }
+}
 
+// TraverseTree impl for TaffyView
+impl<'t, NodeContext, MeasureFunction> TraverseTree for TaffyView<'t, NodeContext, MeasureFunction> where
+    MeasureFunction: FnMut(Size<Option<f32>>, Size<AvailableSpace>, NodeId, Option<&mut NodeContext>) -> Size<f32>
+{
+}
+
+// LayoutPartialTree impl for TaffyView
+impl<'t, NodeContext, MeasureFunction> LayoutPartialTree for TaffyView<'t, NodeContext, MeasureFunction>
+where
+    MeasureFunction: FnMut(Size<Option<f32>>, Size<AvailableSpace>, NodeId, Option<&mut NodeContext>) -> Size<f32>,
+{
     #[inline(always)]
     fn get_style(&self, node: NodeId) -> &Style {
         &self.taffy.nodes[node.into()].style
@@ -252,18 +321,14 @@ where
     }
 }
 
-impl<'t, NodeContext, MeasureFunction> LayoutTree for TaffyView<'t, NodeContext, MeasureFunction>
+// RoundTree impl for TaffyView
+impl<'t, NodeContext, MeasureFunction> RoundTree for TaffyView<'t, NodeContext, MeasureFunction>
 where
     MeasureFunction: FnMut(Size<Option<f32>>, Size<AvailableSpace>, NodeId, Option<&mut NodeContext>) -> Size<f32>,
 {
     #[inline(always)]
     fn get_unrounded_layout(&self, node: NodeId) -> &Layout {
         &self.taffy.nodes[node.into()].unrounded_layout
-    }
-
-    #[inline(always)]
-    fn get_final_layout(&self, node: NodeId) -> &Layout {
-        &self.taffy.nodes[node.into()].final_layout
     }
 
     #[inline(always)]
@@ -520,11 +585,6 @@ impl<NodeContext> TaffyTree<NodeContext> {
         self.nodes.len()
     }
 
-    /// Returns the number of children of the `parent` node
-    pub fn child_count(&self, parent: NodeId) -> TaffyResult<usize> {
-        Ok(self.children[parent.into()].len())
-    }
-
     /// Returns a list of children that belong to the parent node
     pub fn children(&self, parent: NodeId) -> TaffyResult<Vec<NodeId>> {
         Ok(self.children[parent.into()].iter().copied().collect::<_>())
@@ -607,13 +667,12 @@ impl<NodeContext> TaffyTree<NodeContext> {
     /// Prints a debug representation of the tree's layout
     #[cfg(feature = "std")]
     pub fn print_tree(&mut self, root: NodeId) {
-        let taffy_view = TaffyView { taffy: self, measure_function: |_, _, _, _| Size::ZERO };
-        crate::util::print_tree(&taffy_view, root)
+        crate::util::print_tree(self, root)
     }
 
     /// Returns an instance of LayoutTree representing the TaffyTree
     #[cfg(test)]
-    pub(crate) fn as_layout_tree(&mut self) -> impl LayoutTree + '_ {
+    pub(crate) fn as_layout_tree(&mut self) -> impl LayoutPartialTree + '_ {
         TaffyView { taffy: self, measure_function: |_, _, _, _| Size::ZERO }
     }
 }
@@ -665,7 +724,7 @@ mod tests {
         let node = res.unwrap();
 
         // node should be in the taffy tree and have no children
-        assert!(taffy.child_count(node).unwrap() == 0);
+        assert!(taffy.child_count(node) == 0);
     }
 
     #[test]
@@ -677,7 +736,7 @@ mod tests {
         let node = res.unwrap();
 
         // node should be in the taffy tree and have no children
-        assert!(taffy.child_count(node).unwrap() == 0);
+        assert!(taffy.child_count(node) == 0);
     }
 
     /// Test that new_with_children works as expected
@@ -689,7 +748,7 @@ mod tests {
         let node = taffy.new_with_children(Style::default(), &[child0, child1]).unwrap();
 
         // node should have two children
-        assert_eq!(taffy.child_count(node).unwrap(), 2);
+        assert_eq!(taffy.child_count(node), 2);
         assert_eq!(taffy.children(node).unwrap()[0], child0);
         assert_eq!(taffy.children(node).unwrap()[1], child1);
     }
@@ -765,15 +824,15 @@ mod tests {
     fn add_child() {
         let mut taffy: TaffyTree<()> = TaffyTree::new();
         let node = taffy.new_leaf(Style::default()).unwrap();
-        assert_eq!(taffy.child_count(node).unwrap(), 0);
+        assert_eq!(taffy.child_count(node), 0);
 
         let child0 = taffy.new_leaf(Style::default()).unwrap();
         taffy.add_child(node, child0).unwrap();
-        assert_eq!(taffy.child_count(node).unwrap(), 1);
+        assert_eq!(taffy.child_count(node), 1);
 
         let child1 = taffy.new_leaf(Style::default()).unwrap();
         taffy.add_child(node, child1).unwrap();
-        assert_eq!(taffy.child_count(node).unwrap(), 2);
+        assert_eq!(taffy.child_count(node), 2);
     }
 
     #[test]
@@ -785,19 +844,19 @@ mod tests {
         let child2 = taffy.new_leaf(Style::default()).unwrap();
 
         let node = taffy.new_leaf(Style::default()).unwrap();
-        assert_eq!(taffy.child_count(node).unwrap(), 0);
+        assert_eq!(taffy.child_count(node), 0);
 
         taffy.insert_child_at_index(node, 0, child0).unwrap();
-        assert_eq!(taffy.child_count(node).unwrap(), 1);
+        assert_eq!(taffy.child_count(node), 1);
         assert_eq!(taffy.children(node).unwrap()[0], child0);
 
         taffy.insert_child_at_index(node, 0, child1).unwrap();
-        assert_eq!(taffy.child_count(node).unwrap(), 2);
+        assert_eq!(taffy.child_count(node), 2);
         assert_eq!(taffy.children(node).unwrap()[0], child1);
         assert_eq!(taffy.children(node).unwrap()[1], child0);
 
         taffy.insert_child_at_index(node, 1, child2).unwrap();
-        assert_eq!(taffy.child_count(node).unwrap(), 3);
+        assert_eq!(taffy.child_count(node), 3);
         assert_eq!(taffy.children(node).unwrap()[0], child1);
         assert_eq!(taffy.children(node).unwrap()[1], child2);
         assert_eq!(taffy.children(node).unwrap()[2], child0);
@@ -811,7 +870,7 @@ mod tests {
         let child1 = taffy.new_leaf(Style::default()).unwrap();
         let node = taffy.new_with_children(Style::default(), &[child0, child1]).unwrap();
 
-        assert_eq!(taffy.child_count(node).unwrap(), 2);
+        assert_eq!(taffy.child_count(node), 2);
         assert_eq!(taffy.children(node).unwrap()[0], child0);
         assert_eq!(taffy.children(node).unwrap()[1], child1);
 
@@ -819,7 +878,7 @@ mod tests {
         let child3 = taffy.new_leaf(Style::default()).unwrap();
         taffy.set_children(node, &[child2, child3]).unwrap();
 
-        assert_eq!(taffy.child_count(node).unwrap(), 2);
+        assert_eq!(taffy.child_count(node), 2);
         assert_eq!(taffy.children(node).unwrap()[0], child2);
         assert_eq!(taffy.children(node).unwrap()[1], child3);
     }
@@ -832,14 +891,14 @@ mod tests {
         let child1 = taffy.new_leaf(Style::default()).unwrap();
         let node = taffy.new_with_children(Style::default(), &[child0, child1]).unwrap();
 
-        assert_eq!(taffy.child_count(node).unwrap(), 2);
+        assert_eq!(taffy.child_count(node), 2);
 
         taffy.remove_child(node, child0).unwrap();
-        assert_eq!(taffy.child_count(node).unwrap(), 1);
+        assert_eq!(taffy.child_count(node), 1);
         assert_eq!(taffy.children(node).unwrap()[0], child1);
 
         taffy.remove_child(node, child1).unwrap();
-        assert_eq!(taffy.child_count(node).unwrap(), 0);
+        assert_eq!(taffy.child_count(node), 0);
     }
 
     #[test]
@@ -849,14 +908,14 @@ mod tests {
         let child1 = taffy.new_leaf(Style::default()).unwrap();
         let node = taffy.new_with_children(Style::default(), &[child0, child1]).unwrap();
 
-        assert_eq!(taffy.child_count(node).unwrap(), 2);
+        assert_eq!(taffy.child_count(node), 2);
 
         taffy.remove_child_at_index(node, 0).unwrap();
-        assert_eq!(taffy.child_count(node).unwrap(), 1);
+        assert_eq!(taffy.child_count(node), 1);
         assert_eq!(taffy.children(node).unwrap()[0], child1);
 
         taffy.remove_child_at_index(node, 0).unwrap();
-        assert_eq!(taffy.child_count(node).unwrap(), 0);
+        assert_eq!(taffy.child_count(node), 0);
     }
 
     // Related to: https://github.com/DioxusLabs/taffy/issues/510
@@ -883,11 +942,11 @@ mod tests {
         let child1 = taffy.new_leaf(Style::default()).unwrap();
 
         let node = taffy.new_with_children(Style::default(), &[child0]).unwrap();
-        assert_eq!(taffy.child_count(node).unwrap(), 1);
+        assert_eq!(taffy.child_count(node), 1);
         assert_eq!(taffy.children(node).unwrap()[0], child0);
 
         taffy.replace_child_at_index(node, 0, child1).unwrap();
-        assert_eq!(taffy.child_count(node).unwrap(), 1);
+        assert_eq!(taffy.child_count(node), 1);
         assert_eq!(taffy.children(node).unwrap()[0], child1);
     }
     #[test]
@@ -909,9 +968,9 @@ mod tests {
         let child1 = taffy.new_leaf(Style::default()).unwrap();
         let node = taffy.new_with_children(Style::default(), &[child0, child1]).unwrap();
 
-        assert!(if let Ok(count) = taffy.child_count(node) { count == 2 } else { false });
-        assert!(if let Ok(count) = taffy.child_count(child0) { count == 0 } else { false });
-        assert!(if let Ok(count) = taffy.child_count(child1) { count == 0 } else { false });
+        assert!(taffy.child_count(node) == 2);
+        assert!(taffy.child_count(child0) == 0);
+        assert!(taffy.child_count(child1) == 0);
     }
 
     #[allow(clippy::vec_init_then_push)]

--- a/src/tree/traits.rs
+++ b/src/tree/traits.rs
@@ -1,0 +1,127 @@
+//! The abstractions that make up the core of Taffy's low-level API
+use super::{Cache, Layout, LayoutInput, LayoutOutput, NodeId, RequestedAxis, RunMode, SizingMode};
+use crate::geometry::{AbsoluteAxis, Line, Size};
+use crate::style::{AvailableSpace, Style};
+
+/// This trait is Taffy's abstraction for downward tree traversal.
+/// However, this trait does *not* require access to any node's other than a single container node's immediate children unless you also intend to implement `TraverseTree`.
+pub trait TraversePartialTree {
+    /// Type representing an iterator of the children of a node
+    type ChildIter<'a>: Iterator<Item = NodeId>
+    where
+        Self: 'a;
+
+    /// Get the list of children IDs for the given node
+    fn child_ids(&self, parent_node_id: NodeId) -> Self::ChildIter<'_>;
+
+    /// Get the number of children for the given node
+    fn child_count(&self, parent_node_id: NodeId) -> usize;
+
+    /// Get a specific child of a node, where the index represents the nth child
+    fn get_child_id(&self, parent_node_id: NodeId, child_index: usize) -> NodeId;
+}
+
+/// A marker trait which extends `TraversePartialTree` with the additional guarantee that the child/children methods can be used to recurse
+/// infinitely down the tree. Is required by the `RoundTree` and the `PrintTree` traits.
+pub trait TraverseTree: TraversePartialTree {}
+
+/// Any type that implements [`LayoutPartialTree`] can be laid out using [Taffy's algorithms](crate::compute)
+///
+/// Note that this trait extends [`TraversePartialTree`] (not [`TraverseTree`]). Taffy's algorithm implementations have been designed such that they can be used for a laying out a single
+/// node that only has access to it's immediate children.
+pub trait LayoutPartialTree: TraversePartialTree {
+    /// Get a reference to the [`Style`] for this node.
+    fn get_style(&self, node_id: NodeId) -> &Style;
+
+    /// Set the node's unrounded layout
+    fn set_unrounded_layout(&mut self, node_id: NodeId, layout: &Layout);
+
+    /// Get a mutable reference to the [`Cache`] for this node.
+    fn get_cache_mut(&mut self, node_id: NodeId) -> &mut Cache;
+
+    /// Compute the specified node's size or full layout given the specified constraints
+    fn compute_child_layout(&mut self, node_id: NodeId, inputs: LayoutInput) -> LayoutOutput;
+}
+
+/// Trait used by the `round_layout` method which takes a tree of unrounded float-valued layouts and performs
+/// rounding to snap the values to the pixel grid.
+///
+/// As indicated by it's dependence on `TraverseTree`, it required full recursive access to the tree.
+pub trait RoundTree: TraverseTree {
+    /// Get the node's unrounded layout
+    fn get_unrounded_layout(&self, node_id: NodeId) -> &Layout;
+    /// Get a reference to the node's final layout
+    fn set_final_layout(&mut self, node_id: NodeId, layout: &Layout);
+}
+
+/// Trait used by the `print_tree` method which prints a debug representation
+///
+/// As indicated by it's dependence on `TraverseTree`, it required full recursive access to the tree.
+pub trait PrintTree: TraverseTree {
+    /// Get a debug label for the node (typically the type of node: flexbox, grid, text, image, etc)
+    fn get_debug_label(&self, node_id: NodeId) -> &'static str;
+    /// Get a reference to the node's final layout
+    fn get_final_layout(&self, node_id: NodeId) -> &Layout;
+}
+
+// --- PRIVATE TRAITS
+
+/// A private trait which allows us to add extra convenience methods to types which implement
+/// LayoutTree without making those methods public.
+pub(crate) trait LayoutPartialTreeExt: LayoutPartialTree {
+    /// Compute the size of the node given the specified constraints
+    #[inline(always)]
+    #[allow(clippy::too_many_arguments)]
+    fn measure_child_size(
+        &mut self,
+        node_id: NodeId,
+        known_dimensions: Size<Option<f32>>,
+        parent_size: Size<Option<f32>>,
+        available_space: Size<AvailableSpace>,
+        sizing_mode: SizingMode,
+        axis: AbsoluteAxis,
+        vertical_margins_are_collapsible: Line<bool>,
+    ) -> f32 {
+        self.compute_child_layout(
+            node_id,
+            LayoutInput {
+                known_dimensions,
+                parent_size,
+                available_space,
+                sizing_mode,
+                axis: axis.into(),
+                run_mode: RunMode::ComputeSize,
+                vertical_margins_are_collapsible,
+            },
+        )
+        .size
+        .get_abs(axis)
+    }
+
+    /// Perform a full layout on the node given the specified constraints
+    #[inline(always)]
+    fn perform_child_layout(
+        &mut self,
+        node_id: NodeId,
+        known_dimensions: Size<Option<f32>>,
+        parent_size: Size<Option<f32>>,
+        available_space: Size<AvailableSpace>,
+        sizing_mode: SizingMode,
+        vertical_margins_are_collapsible: Line<bool>,
+    ) -> LayoutOutput {
+        self.compute_child_layout(
+            node_id,
+            LayoutInput {
+                known_dimensions,
+                parent_size,
+                available_space,
+                sizing_mode,
+                axis: RequestedAxis::Both,
+                run_mode: RunMode::PerformLayout,
+                vertical_margins_are_collapsible,
+            },
+        )
+    }
+}
+
+impl<T: LayoutPartialTree> LayoutPartialTreeExt for T {}

--- a/src/util/debug.rs
+++ b/src/util/debug.rs
@@ -1,81 +1,9 @@
 #![allow(dead_code)]
 
-use crate::tree::NodeId;
-use crate::{style, LayoutTree};
-
 #[cfg(any(feature = "debug", feature = "profile"))]
 use core::fmt::{Debug, Display, Write};
 #[cfg(any(feature = "debug", feature = "profile"))]
 use std::sync::Mutex;
-
-/// Prints a debug representation of the computed layout for a tree of nodes, starting with the passed root node.
-#[cfg(feature = "std")]
-pub fn print_tree(tree: &impl LayoutTree, root: NodeId) {
-    println!("TREE");
-    print_node(tree, root, false, String::new());
-}
-
-#[cfg(feature = "std")]
-fn print_node(tree: &impl LayoutTree, node: NodeId, has_sibling: bool, lines_string: String) {
-    let layout = &tree.get_final_layout(node);
-    let style = &tree.get_style(node);
-    let num_children = tree.child_count(node);
-
-    let display = match (num_children, style.display) {
-        (_, style::Display::None) => "NONE",
-        (0, _) => "LEAF",
-        #[cfg(feature = "block_layout")]
-        (_, style::Display::Block) => "BLOCK",
-        #[cfg(feature = "flexbox")]
-        (_, style::Display::Flex) => "FLEX",
-        #[cfg(feature = "grid")]
-        (_, style::Display::Grid) => "GRID",
-    };
-
-    let fork_string = if has_sibling { "├── " } else { "└── " };
-    #[cfg(feature = "content_size")]
-    println!(
-            "{lines}{fork} {display} [x: {x:<4} y: {y:<4} w: {width:<4} h: {height:<4} content_w: {content_width:<4} content_h: {content_height:<4} border: l:{bl} r:{br} t:{bt} b:{bb}, padding: l:{pl} r:{pr} t:{pt} b:{pb}] ({key:?})",
-            lines = lines_string,
-            fork = fork_string,
-            display = display,
-            x = layout.location.x,
-            y = layout.location.y,
-            width = layout.size.width,
-            height = layout.size.height,
-            content_width = layout.content_size.width,
-            content_height = layout.content_size.height,
-            bl = layout.border.left,
-            br = layout.border.right,
-            bt = layout.border.top,
-            bb = layout.border.bottom,
-            pl = layout.padding.left,
-            pr = layout.padding.right,
-            pt = layout.padding.top,
-            pb = layout.padding.bottom,
-            key = node,
-        );
-    #[cfg(not(feature = "content_size"))]
-    println!(
-        "{lines}{fork} {display} [x: {x:<4} y: {y:<4} width: {width:<4} height: {height:<4}] ({key:?})",
-        lines = lines_string,
-        fork = fork_string,
-        display = display,
-        x = layout.location.x,
-        y = layout.location.y,
-        width = layout.size.width,
-        height = layout.size.height,
-        key = node,
-    );
-    let bar = if has_sibling { "│   " } else { "    " };
-    let new_string = lines_string + bar;
-
-    // Recurse into children
-    for (index, child) in tree.child_ids(node).enumerate() {
-        let has_sibling = index < num_children - 1;
-        print_node(tree, child, has_sibling, new_string.clone());
-    }
-}
 
 #[doc(hidden)]
 #[cfg(any(feature = "debug", feature = "profile"))]

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,13 +1,16 @@
 //! Helpful misc. utilities such as a function to debug print a tree
-
 mod math;
-pub(crate) use math::MaybeMath;
 mod resolve;
-pub(crate) use resolve::{MaybeResolve, ResolveOrZero};
 pub(crate) mod sys;
+
+pub(crate) use math::MaybeMath;
+pub(crate) use resolve::{MaybeResolve, ResolveOrZero};
 
 #[doc(hidden)]
 #[macro_use]
 pub(crate) mod debug;
+
 #[cfg(feature = "std")]
-pub use debug::print_tree;
+mod print;
+#[cfg(feature = "std")]
+pub use print::print_tree;

--- a/src/util/print.rs
+++ b/src/util/print.rs
@@ -45,7 +45,7 @@ pub fn print_tree(tree: &impl PrintTree, root: NodeId) {
             y = layout.location.y,
             width = layout.size.width,
             height = layout.size.height,
-            key = node,
+            key = node_id,
         );
         let bar = if has_sibling { "│   " } else { "    " };
         let new_string = lines_string + bar;

--- a/src/util/print.rs
+++ b/src/util/print.rs
@@ -1,0 +1,59 @@
+//! Contains the print_tree function for printing a debug representation of the tree
+use crate::tree::{NodeId, PrintTree};
+
+/// Prints a debug representation of the computed layout for a tree of nodes, starting with the passed root node.
+pub fn print_tree(tree: &impl PrintTree, root: NodeId) {
+    println!("TREE");
+    print_node(tree, root, false, String::new());
+
+    /// Recursive function that prints each node in the tree
+    fn print_node(tree: &impl PrintTree, node_id: NodeId, has_sibling: bool, lines_string: String) {
+        let layout = &tree.get_final_layout(node_id);
+        let display = tree.get_debug_label(node_id);
+        let num_children = tree.child_count(node_id);
+
+        let fork_string = if has_sibling { "├── " } else { "└── " };
+        #[cfg(feature = "content_size")]
+        println!(
+                "{lines}{fork} {display} [x: {x:<4} y: {y:<4} w: {width:<4} h: {height:<4} content_w: {content_width:<4} content_h: {content_height:<4} border: l:{bl} r:{br} t:{bt} b:{bb}, padding: l:{pl} r:{pr} t:{pt} b:{pb}] ({key:?})",
+                lines = lines_string,
+                fork = fork_string,
+                display = display,
+                x = layout.location.x,
+                y = layout.location.y,
+                width = layout.size.width,
+                height = layout.size.height,
+                content_width = layout.content_size.width,
+                content_height = layout.content_size.height,
+                bl = layout.border.left,
+                br = layout.border.right,
+                bt = layout.border.top,
+                bb = layout.border.bottom,
+                pl = layout.padding.left,
+                pr = layout.padding.right,
+                pt = layout.padding.top,
+                pb = layout.padding.bottom,
+                key = node_id,
+            );
+        #[cfg(not(feature = "content_size"))]
+        println!(
+            "{lines}{fork} {display} [x: {x:<4} y: {y:<4} width: {width:<4} height: {height:<4}] ({key:?})",
+            lines = lines_string,
+            fork = fork_string,
+            display = display,
+            x = layout.location.x,
+            y = layout.location.y,
+            width = layout.size.width,
+            height = layout.size.height,
+            key = node,
+        );
+        let bar = if has_sibling { "│   " } else { "    " };
+        let new_string = lines_string + bar;
+
+        // Recurse into children
+        for (index, child) in tree.child_ids(node_id).enumerate() {
+            let has_sibling = index < num_children - 1;
+            print_node(tree, child, has_sibling, new_string.clone());
+        }
+    }
+}


### PR DESCRIPTION
# Objective

- Fixes https://github.com/DioxusLabs/taffy/issues/569

## Context

With the existing trait setup the `print_tree` function requires `&mut self` which is silly.

## Feedback wanted

- Does this trait structure seem reasonable.
