### PR TITLE
Make `serde` dependency compatible with `no_std` environments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ license = "MIT"
 [dependencies]
 arrayvec = { version = "0.7", default-features = false }
 num-traits = { version = "0.2", default-features = false }
-serde = { version = "1.0", optional = true, features = ["serde_derive"] }
+serde = { version = "1.0", default-features = false, optional = true, features = ["serde_derive"] }
 slotmap = { version = "1.0.6", optional = true }
 grid = { version = "0.12.0", default-features = false, optional = true }
 
@@ -47,9 +47,9 @@ taffy_tree = ["dep:slotmap"]
 # Add serde derives to Style structs
 serde = ["dep:serde"]
 # Allow Taffy to depend on the standard library
-std = ["num-traits/std", "grid?/std"]
+std = ["num-traits/std", "grid?/std", "serde?/std"]
 # Allow Taffy to depend on the alloc library
-alloc = []
+alloc = ["serde?/alloc"]
 # Internal featyre for debugging
 debug = ["std"]
 # Internal feature for profiling

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -110,6 +110,7 @@ Example usage change:
   - The debug module is no longer public. The `print_tree` function is now accesible under `util`.
   - All types from the `node`, `data`, `layout`, `error` and `cache` modules have been moved to the  the `tree` module.
 - Fixed misspelling: `RunMode::PeformLayout` renamed into `RunMode::PerformLayout` (added missing `r`).
+- `serde` dependency has been made compatible with `no_std` environments
 
 ## 0.3.18
 


### PR DESCRIPTION
Feature `serde` of `taffy` was rigidly set to depend on the `serde` crate with its default features (ie: `std`) enabled- this meant that despite disabling the `std` feature in `taffy` it still would not compile for `no_std` targets when the `serde` feature was enabled.

This was a straightforward fix, simply opting out of `serde` default features and selectively re-enabling them alongside the corresponding `taffy` features.

See here for a quick reference affirming Serde `no_std` compatibility: https://serde.rs/no-std.html