### PR TITLE
Make `slotmap` dependency compatible with `no_std` environments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ license = "MIT"
 arrayvec = { version = "0.7", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 serde = { version = "1.0", default-features = false, optional = true, features = ["serde_derive"] }
-slotmap = { version = "1.0.6", optional = true }
+slotmap = { version = "1.0.6", default-features = false, optional = true }
 grid = { version = "0.12.0", default-features = false, optional = true }
 
 ### FEATURES #################################################################
@@ -47,7 +47,7 @@ taffy_tree = ["dep:slotmap"]
 # Add serde derives to Style structs
 serde = ["dep:serde"]
 # Allow Taffy to depend on the standard library
-std = ["num-traits/std", "grid?/std", "serde?/std"]
+std = ["num-traits/std", "grid?/std", "serde?/std", "slotmap?/std"]
 # Allow Taffy to depend on the alloc library
 alloc = ["serde?/alloc"]
 # Internal featyre for debugging

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -111,6 +111,7 @@ Example usage change:
   - All types from the `node`, `data`, `layout`, `error` and `cache` modules have been moved to the  the `tree` module.
 - Fixed misspelling: `RunMode::PeformLayout` renamed into `RunMode::PerformLayout` (added missing `r`).
 - `serde` dependency has been made compatible with `no_std` environments
+- `slotmap` dependency has been made compatible with `no_std` environments
 
 ## 0.3.18
 

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -1,5 +1,9 @@
 //! Contains [TaffyTree](crate::tree::TaffyTree): the default implementation of [LayoutTree](crate::tree::LayoutTree), and the error type for Taffy.
-use slotmap::{DefaultKey, SlotMap, SparseSecondaryMap};
+use slotmap::{DefaultKey, SlotMap};
+#[cfg(feature = "std")]
+use slotmap::SparseSecondaryMap as SecondaryMap;
+#[cfg(not(feature = "std"))]
+use slotmap::SecondaryMap;
 
 use crate::geometry::Size;
 use crate::style::{AvailableSpace, Display, Style};
@@ -125,7 +129,7 @@ pub struct TaffyTree<NodeContext = ()> {
     nodes: SlotMap<DefaultKey, NodeData>,
 
     /// Functions/closures that compute the intrinsic size of leaf nodes
-    node_context_data: SparseSecondaryMap<DefaultKey, NodeContext>,
+    node_context_data: SecondaryMap<DefaultKey, NodeContext>,
 
     /// The children of each node
     ///
@@ -360,7 +364,7 @@ impl<NodeContext> TaffyTree<NodeContext> {
             nodes: SlotMap::with_capacity(capacity),
             children: SlotMap::with_capacity(capacity),
             parents: SlotMap::with_capacity(capacity),
-            node_context_data: SparseSecondaryMap::with_capacity(capacity),
+            node_context_data: SecondaryMap::with_capacity(capacity),
             config: TaffyConfig::default(),
         }
     }

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -1,9 +1,9 @@
 //! Contains [TaffyTree](crate::tree::TaffyTree): the default implementation of [LayoutTree](crate::tree::LayoutTree), and the error type for Taffy.
-use slotmap::{DefaultKey, SlotMap};
-#[cfg(feature = "std")]
-use slotmap::SparseSecondaryMap as SecondaryMap;
 #[cfg(not(feature = "std"))]
 use slotmap::SecondaryMap;
+#[cfg(feature = "std")]
+use slotmap::SparseSecondaryMap as SecondaryMap;
+use slotmap::{DefaultKey, SlotMap};
 
 use crate::geometry::Size;
 use crate::style::{AvailableSpace, Display, Style};


### PR DESCRIPTION
# Objective

As in #592, the `slotmap` dependency- used via the `taffy_tree` feature- wasn't reflecting the status of the `std` feature of `taffy`; this PR applies the same changes to the `slotmap` dependency and `std` feature.

This PR also requires switching the backer for `TaffyTree`'s node context data from [`slotmap::SparseSecondaryMap`](https://docs.rs/slotmap/latest/slotmap/struct.SparseSecondaryMap.html) to [`slotmap::SecondaryMap`](https://docs.rs/slotmap/latest/slotmap/struct.SecondaryMap.html) in `no_std` contexts.
Per the `slotmap` docs, they are perfectly compatible with each other outside of potential performance differences in certain cases- however, I would say that the possibility of being a bit slower in `no_std` contexts is better than not being able to compile at all.

## Context

#592, [slotmap#26](https://github.com/orlp/slotmap/issues/26)

## Feedback wanted

I opted to put the `cfg` switch at the top-of-file module import for brevity, as opposed to switching each individual usage.

I also opted to alias both imports to `SecondaryMap` as that seems to more accurately describe the general concept underpinning the two imports, but I can see how there is a possibility this would be misleading as it's the actual name of the `no_std` import.