### PR TITLE
add get_disjoint_node_context_mut to tree

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -93,6 +93,7 @@ Example usage change:
   - `compute_leaf_layout`
   - `compute_hidden_layout`
 - Added `insert_child_at_index()` method to the `Taffy` tree. This can be used to insert a child node at any position instead of just the end.
+- Added `get_disjoint_node_context_mut()` method to the `Taffy` tree. This can be used to safely get multiple mutable borrows at the same time.
 
 ### Removed
 

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -476,6 +476,14 @@ impl<NodeContext> TaffyTree<NodeContext> {
         self.node_context_data.get_mut(node.into())
     }
 
+    /// Gets mutable references to the the context data associated with the nodes. All keys must be valid and disjoint, otherwise None is returned.
+    pub fn get_disjoint_node_context_mut<const N: usize>(
+        &mut self,
+        keys: [NodeId; N],
+    ) -> Option<[&mut NodeContext; N]> {
+        self.node_context_data.get_disjoint_mut(keys.map(|k| k.into()))
+    }
+
     /// Adds a `child` node under the supplied `parent`
     pub fn add_child(&mut self, parent: NodeId, child: NodeId) -> TaffyResult<()> {
         let parent_key = parent.into();


### PR DESCRIPTION
Useful method when dealing with mutable borrows between a parent and child node at the same time.