### PR TITLE
Call measure function on leaf nodes even if the node does not have context

### DIFF
--- a/examples/custom_tree_owned_partial.rs
+++ b/examples/custom_tree_owned_partial.rs
@@ -146,25 +146,17 @@ impl taffy::LayoutPartialTree for Node {
             match node.kind {
                 NodeKind::Flexbox => compute_flexbox_layout(node, node_id, inputs),
                 NodeKind::Grid => compute_grid_layout(node, node_id, inputs),
-                NodeKind::Text => compute_leaf_layout(
-                    inputs,
-                    &node.style,
-                    Some(|known_dimensions, available_space| {
-                        text_measure_function(
-                            known_dimensions,
-                            available_space,
-                            node.text_data.as_ref().unwrap(),
-                            &font_metrics,
-                        )
-                    }),
-                ),
-                NodeKind::Image => compute_leaf_layout(
-                    inputs,
-                    &node.style,
-                    Some(|known_dimensions, _available_space| {
-                        image_measure_function(known_dimensions, node.image_data.as_ref().unwrap())
-                    }),
-                ),
+                NodeKind::Text => compute_leaf_layout(inputs, &node.style, |known_dimensions, available_space| {
+                    text_measure_function(
+                        known_dimensions,
+                        available_space,
+                        node.text_data.as_ref().unwrap(),
+                        &font_metrics,
+                    )
+                }),
+                NodeKind::Image => compute_leaf_layout(inputs, &node.style, |known_dimensions, _available_space| {
+                    image_measure_function(known_dimensions, node.image_data.as_ref().unwrap())
+                }),
             }
         })
     }

--- a/examples/custom_tree_owned_unsafe.rs
+++ b/examples/custom_tree_owned_unsafe.rs
@@ -150,25 +150,17 @@ impl LayoutPartialTree for StatelessLayoutTree {
             match node.kind {
                 NodeKind::Flexbox => compute_flexbox_layout(tree, node_id, inputs),
                 NodeKind::Grid => compute_grid_layout(tree, node_id, inputs),
-                NodeKind::Text => compute_leaf_layout(
-                    inputs,
-                    &node.style,
-                    Some(|known_dimensions, available_space| {
-                        text_measure_function(
-                            known_dimensions,
-                            available_space,
-                            node.text_data.as_ref().unwrap(),
-                            &font_metrics,
-                        )
-                    }),
-                ),
-                NodeKind::Image => compute_leaf_layout(
-                    inputs,
-                    &node.style,
-                    Some(|known_dimensions, _available_space| {
-                        image_measure_function(known_dimensions, node.image_data.as_ref().unwrap())
-                    }),
-                ),
+                NodeKind::Text => compute_leaf_layout(inputs, &node.style, |known_dimensions, available_space| {
+                    text_measure_function(
+                        known_dimensions,
+                        available_space,
+                        node.text_data.as_ref().unwrap(),
+                        &font_metrics,
+                    )
+                }),
+                NodeKind::Image => compute_leaf_layout(inputs, &node.style, |known_dimensions, _available_space| {
+                    image_measure_function(known_dimensions, node.image_data.as_ref().unwrap())
+                }),
             }
         })
     }

--- a/examples/custom_tree_vec.rs
+++ b/examples/custom_tree_vec.rs
@@ -159,25 +159,17 @@ impl taffy::LayoutPartialTree for Tree {
             match node.kind {
                 NodeKind::Flexbox => compute_flexbox_layout(tree, node_id, inputs),
                 NodeKind::Grid => compute_grid_layout(tree, node_id, inputs),
-                NodeKind::Text => compute_leaf_layout(
-                    inputs,
-                    &node.style,
-                    Some(|known_dimensions, available_space| {
-                        text_measure_function(
-                            known_dimensions,
-                            available_space,
-                            node.text_data.as_ref().unwrap(),
-                            &font_metrics,
-                        )
-                    }),
-                ),
-                NodeKind::Image => compute_leaf_layout(
-                    inputs,
-                    &node.style,
-                    Some(|known_dimensions, _available_space| {
-                        image_measure_function(known_dimensions, node.image_data.as_ref().unwrap())
-                    }),
-                ),
+                NodeKind::Text => compute_leaf_layout(inputs, &node.style, |known_dimensions, available_space| {
+                    text_measure_function(
+                        known_dimensions,
+                        available_space,
+                        node.text_data.as_ref().unwrap(),
+                        &font_metrics,
+                    )
+                }),
+                NodeKind::Image => compute_leaf_layout(inputs, &node.style, |known_dimensions, _available_space| {
+                    image_measure_function(known_dimensions, node.image_data.as_ref().unwrap())
+                }),
             }
         })
     }

--- a/tests/measure.rs
+++ b/tests/measure.rs
@@ -30,7 +30,7 @@ mod measure {
         _node_id: NodeId,
         node_context: Option<&mut AspectRatioMeasure>,
     ) -> taffy::geometry::Size<f32> {
-        let node_context = node_context.unwrap();
+        let Some(node_context) = node_context else { return Size::ZERO };
         let width = known_dimensions.width.unwrap_or(node_context.width);
         let height = known_dimensions.height.unwrap_or(width * node_context.height_ratio);
         Size { width, height }


### PR DESCRIPTION
# Objective

Allow use of measure functions in cases where extra context information is not required.

## Context

- Fixes #597

## Notes

I believe this is a strict generalisation of functionality. If users want to return a zero size for cases where context is `None` they can do this within their measure function (and as `node_context` was already an `Option<T>` they would have to have done this anyway with the existing API).
