### PR TITLE
Regenerate tests

### DIFF
--- a/tests/generated/flex/align_flex_start_with_stretching_children.rs
+++ b/tests/generated/flex/align_flex_start_with_stretching_children.rs
@@ -8,7 +8,12 @@ fn align_flex_start_with_stretching_children() {
     let node00 = taffy
         .new_with_children(taffy::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[node000])
         .unwrap();
-    let node0 = taffy.new_with_children(taffy::style::Style { ..Default::default() }, &[node00]).unwrap();
+    let node0 = taffy
+        .new_with_children(
+            taffy::style::Style { align_items: Some(taffy::style::AlignItems::Stretch), ..Default::default() },
+            &[node00],
+        )
+        .unwrap();
     let node = taffy
         .new_with_children(
             taffy::style::Style {


### PR DESCRIPTION
# Objective

Ensure generated code is up to date with source files.

## Context

Generation was not done as part of #611 

CC: @waywardmonkeys. To ensure this doesn't happen in future, you need to run `cargo gentest` to regenerate the tests after following the setup instructions in CONTRIBUTING.md. We should also add a CI check for this, but it's non-trivial as it involves running Chrome/Chromium in CI.