### PR TITLE
Upgrade cosmic_text example to cosmic-text 0.11.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ debug = ["std"]
 profile = ["std"]
 
 [dev-dependencies]
-cosmic-text = "0.10.0"
+cosmic-text = "0.11.2"
 serde_json = "1.0.93"
 
 # Enable default features for tests and examples

--- a/examples/cosmic_text.rs
+++ b/examples/cosmic_text.rs
@@ -34,7 +34,7 @@ impl CosmicTextContext {
         self.buffer.set_size(font_system, width_constraint, f32::INFINITY);
 
         // Compute layout
-        self.buffer.shape_until_scroll(font_system);
+        self.buffer.shape_until_scroll(font_system, false);
 
         // Determine measured size of text
         let (width, total_lines) = self


### PR DESCRIPTION
# Objective

Keep example up to date with latest library version.

## Context

Dependabot notified us of this (https://github.com/DioxusLabs/taffy/pull/614) but a small code change was also required.