### PR TITLE
Prepare for v0.4.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taffy"
-version = "0.3.11"
+version = "0.4.0"
 authors = [
     "Alice Cecile <alice.i.cecile@gmail.com>",
     "Johnathan Kelley <jkelleyrtp@gmail.com>",


### PR DESCRIPTION
# Objective

Update version number and release notes in preparation for a `v0.4.0` release of Taffy.
