### PR TITLE
Grid: Respect growth limits when distributing space to base sizes

### DIFF
--- a/src/compute/grid/track_sizing.rs
+++ b/src/compute/grid/track_sizing.rs
@@ -680,7 +680,8 @@ fn resolve_intrinsic_track_sizes(
             let tracks = &mut axis_tracks[item.track_range_excluding_lines(axis)];
             if space > 0.0 {
                 if item.overflow.get(axis).is_scroll_container() {
-                    let fit_content_limit = move |track: &GridTrack| track.fit_content_limit(axis_inner_node_size);
+                    let fit_content_limit =
+                        move |track: &GridTrack| track.fit_content_limited_growth_limit(axis_inner_node_size);
                     distribute_item_space_to_base_size(
                         is_flex,
                         use_flex_factor_for_distribution,
@@ -697,7 +698,7 @@ fn resolve_intrinsic_track_sizes(
                         space,
                         tracks,
                         has_intrinsic_min_track_sizing_function,
-                        |_| f32::INFINITY,
+                        |track| track.growth_limit,
                         IntrinsicContributionType::Minimum,
                     );
                 }
@@ -717,7 +718,8 @@ fn resolve_intrinsic_track_sizes(
             let tracks = &mut axis_tracks[item.track_range_excluding_lines(axis)];
             if space > 0.0 {
                 if item.overflow.get(axis).is_scroll_container() {
-                    let fit_content_limit = move |track: &GridTrack| track.fit_content_limit(axis_inner_node_size);
+                    let fit_content_limit =
+                        move |track: &GridTrack| track.fit_content_limited_growth_limit(axis_inner_node_size);
                     distribute_item_space_to_base_size(
                         is_flex,
                         use_flex_factor_for_distribution,
@@ -734,7 +736,7 @@ fn resolve_intrinsic_track_sizes(
                         space,
                         tracks,
                         has_min_or_max_content_min_track_sizing_function,
-                        |_| f32::INFINITY,
+                        |track| track.growth_limit,
                         IntrinsicContributionType::Minimum,
                     );
                 }
@@ -831,7 +833,7 @@ fn resolve_intrinsic_track_sizes(
                     space,
                     tracks,
                     has_max_content_min_track_sizing_function,
-                    |_| f32::INFINITY,
+                    |track| track.growth_limit,
                     IntrinsicContributionType::Maximum,
                 );
             }

--- a/test_fixtures/grid/grid_taffy_issue_624.html
+++ b/test_fixtures/grid/grid_taffy_issue_624.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 320px; height: 640px; grid-template-columns: auto auto 1fr; grid-template-rows: auto auto auto 1fr; justify-content: start; justify-items: start;">
+  <div style="background: #59c4f6; width: 100px; height: 50px; grid-row: 1 / span 2; grid-column: 1;"></div>
+  <div style="background: #63c466; width: 40px; height: 30px; grid-row: 1 / span 2; grid-column: 2 / span 2;"></div>
+  <div style="background: #feb43f; width: 120px; height: 20px; grid-row: 3 / span 1; grid-column: 1 / span 2;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/generated/grid/grid_taffy_issue_624.rs
+++ b/tests/generated/grid/grid_taffy_issue_624.rs
@@ -1,0 +1,156 @@
+#[test]
+fn grid_taffy_issue_624() {
+    #[allow(unused_imports)]
+    use taffy::{prelude::*, tree::Layout, TaffyTree};
+    let mut taffy: TaffyTree<crate::TextMeasure> = TaffyTree::new();
+    let node0 = taffy
+        .new_leaf(taffy::style::Style {
+            grid_row: taffy::geometry::Line { start: line(1i16), end: taffy::style::GridPlacement::Span(2u16) },
+            grid_column: taffy::geometry::Line { start: line(1i16), end: taffy::style::GridPlacement::Auto },
+            size: taffy::geometry::Size {
+                width: taffy::style::Dimension::Length(100f32),
+                height: taffy::style::Dimension::Length(50f32),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node1 = taffy
+        .new_leaf(taffy::style::Style {
+            grid_row: taffy::geometry::Line { start: line(1i16), end: taffy::style::GridPlacement::Span(2u16) },
+            grid_column: taffy::geometry::Line { start: line(2i16), end: taffy::style::GridPlacement::Span(2u16) },
+            size: taffy::geometry::Size {
+                width: taffy::style::Dimension::Length(40f32),
+                height: taffy::style::Dimension::Length(30f32),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node2 = taffy
+        .new_leaf(taffy::style::Style {
+            grid_row: taffy::geometry::Line { start: line(3i16), end: taffy::style::GridPlacement::Span(1u16) },
+            grid_column: taffy::geometry::Line { start: line(1i16), end: taffy::style::GridPlacement::Span(2u16) },
+            size: taffy::geometry::Size {
+                width: taffy::style::Dimension::Length(120f32),
+                height: taffy::style::Dimension::Length(20f32),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Grid,
+                justify_items: Some(taffy::style::JustifyItems::Start),
+                justify_content: Some(taffy::style::JustifyContent::Start),
+                grid_template_rows: vec![auto(), auto(), auto(), fr(1f32)],
+                grid_template_columns: vec![auto(), auto(), fr(1f32)],
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Length(320f32),
+                    height: taffy::style::Dimension::Length(640f32),
+                },
+                ..Default::default()
+            },
+            &[node0, node1, node2],
+        )
+        .unwrap();
+    taffy.compute_layout_with_measure(node, taffy::geometry::Size::MAX_CONTENT, crate::test_measure_function).unwrap();
+    println!("\nComputed tree:");
+    taffy.print_tree(node);
+    println!();
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node).unwrap();
+    assert_eq!(size.width, 320f32, "width of node {:?}. Expected {}. Actual {}", node, 320f32, size.width);
+    assert_eq!(size.height, 640f32, "height of node {:?}. Expected {}. Actual {}", node, 640f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node, 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node, 0f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node0).unwrap();
+    assert_eq!(size.width, 100f32, "width of node {:?}. Expected {}. Actual {}", node0, 100f32, size.width);
+    assert_eq!(size.height, 50f32, "height of node {:?}. Expected {}. Actual {}", node0, 50f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node0, 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node0, 0f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node0,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node0,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node1).unwrap();
+    assert_eq!(size.width, 40f32, "width of node {:?}. Expected {}. Actual {}", node1, 40f32, size.width);
+    assert_eq!(size.height, 30f32, "height of node {:?}. Expected {}. Actual {}", node1, 30f32, size.height);
+    assert_eq!(location.x, 100f32, "x of node {:?}. Expected {}. Actual {}", node1, 100f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node1, 0f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node1,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node1,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node2).unwrap();
+    assert_eq!(size.width, 120f32, "width of node {:?}. Expected {}. Actual {}", node2, 120f32, size.width);
+    assert_eq!(size.height, 20f32, "height of node {:?}. Expected {}. Actual {}", node2, 20f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node2, 0f32, location.x);
+    assert_eq!(location.y, 50f32, "y of node {:?}. Expected {}. Actual {}", node2, 50f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node2,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node2,
+        0f32,
+        layout.scroll_height()
+    );
+}

--- a/tests/generated/grid/mod.rs
+++ b/tests/generated/grid/mod.rs
@@ -500,3 +500,5 @@ mod grid_span_6_all_non_flex_indefinite;
 mod grid_span_6_all_non_flex_indefinite_hidden;
 #[cfg(feature = "grid")]
 mod grid_span_8_all_track_types_indefinite;
+#[cfg(feature = "grid")]
+mod grid_taffy_issue_624;


### PR DESCRIPTION
# Objective

Fixes #624

This is correctness fix for content-sizing grid tracks. It turns out that we weren't respecting growth limits when distributing  space to base sizes. I suspect that this was disabled at some point to fix another bug as the code contains a limit function which was previously set to Infinity. But simply setting the growth limit as the limit function appears to pass all existing tests while fixing this bug.

## Context

https://github.com/w3c/csswg-drafts/issues/10095
