### PR TITLE
Deduplicate `track_sizing_algorithm` function

### DIFF
--- a/src/compute/grid/track_sizing.rs
+++ b/src/compute/grid/track_sizing.rs
@@ -260,7 +260,6 @@ pub(super) fn determine_if_item_crosses_flexible_or_intrinsic_tracks(
 /// Track sizing algorithm
 /// Note: Gutters are treated as empty fixed-size tracks for the purpose of the track sizing algorithm.
 #[allow(clippy::too_many_arguments)]
-#[inline(always)]
 pub(super) fn track_sizing_algorithm<Tree: LayoutPartialTree>(
     tree: &mut Tree,
     axis: AbstractAxis,
@@ -272,7 +271,7 @@ pub(super) fn track_sizing_algorithm<Tree: LayoutPartialTree>(
     axis_tracks: &mut [GridTrack],
     other_axis_tracks: &mut [GridTrack],
     items: &mut [GridItem],
-    get_track_size_estimate: impl Fn(&GridTrack, Option<f32>) -> Option<f32>,
+    get_track_size_estimate: fn(&GridTrack, Option<f32>) -> Option<f32>,
     has_baseline_aligned_item: bool,
 ) {
     // 11.4 Initialise Track sizes
@@ -297,7 +296,7 @@ pub(super) fn track_sizing_algorithm<Tree: LayoutPartialTree>(
     let gutter_alignment_adjustment = compute_alignment_gutter_adjustment(
         other_axis_alignment,
         inner_node_size.get(axis.other()),
-        &get_track_size_estimate,
+        get_track_size_estimate,
         other_axis_tracks,
     );
     if other_axis_tracks.len() > 3 {
@@ -516,7 +515,7 @@ fn resolve_intrinsic_track_sizes(
     items: &mut [GridItem],
     axis_available_grid_space: AvailableSpace,
     inner_node_size: Size<Option<f32>>,
-    get_track_size_estimate: impl Fn(&GridTrack, Option<f32>) -> Option<f32>,
+    get_track_size_estimate: fn(&GridTrack, Option<f32>) -> Option<f32>,
 ) {
     // Step 1. Shim baseline-aligned items so their intrinsic size contributions reflect their baseline alignment.
 


### PR DESCRIPTION
# Objective

Reduce binary size caused by Taffy. This roughly halves Taffy's binary footprint (from ~300kb to ~150kb). Benchmark results are neutral (seem unchanged).

## Context

Analysis done with `cargo bloat --example basic --release -n 150 | grep taffy`. Note how we were previously generating 4 copies of the `resolve_intrinsic_track_sizes` function.

**Before:**

```
7.7%   9.9%  54.0KiB     taffy taffy::compute::grid::track_sizing::resolve_intrinsic_track_sizes
 7.7%   9.8%  53.9KiB     taffy taffy::compute::grid::track_sizing::resolve_intrinsic_track_sizes
 7.7%   9.8%  53.9KiB     taffy taffy::compute::grid::track_sizing::resolve_intrinsic_track_sizes
 7.7%   9.8%  53.7KiB     taffy taffy::compute::grid::track_sizing::resolve_intrinsic_track_sizes
 4.6%   5.9%  32.6KiB     taffy taffy::compute::grid::compute_grid_layout
 3.1%   3.9%  21.4KiB     taffy taffy::compute::flexbox::compute_preliminary
 1.5%   1.9%  10.6KiB     taffy taffy::compute::block::compute_block_layout
 0.7%   0.9%   4.7KiB     taffy taffy::compute::grid::placement::place_grid_items
 0.6%   0.7%   3.9KiB     taffy taffy::compute::grid::alignment::align_and_position_item
 0.5%   0.6%   3.4KiB     taffy taffy::compute::grid::track_sizing::resolve_item_baselines
 0.2%   0.3%   1.6KiB     taffy taffy::compute::grid::types::grid_item::GridItem::min_content_contribution
 0.2%   0.3%   1.6KiB     taffy taffy::compute::grid::placement::record_grid_placement
 0.2%   0.3%   1.6KiB     taffy taffy::compute::grid::types::grid_item::GridItem::max_content_contribution
 0.2%   0.3%   1.4KiB     taffy taffy::compute::grid::explicit_grid::compute_explicit_grid_size_in_axis
 0.2%   0.2%   1.3KiB     taffy taffy::compute::leaf::compute_leaf_layout
 0.2%   0.2%   1.3KiB     taffy taffy::tree::taffy_tree::TaffyTree<NodeContext>::compute_layout_with_measure
 0.2%   0.2%   1.2KiB     taffy taffy::compute::grid::types::grid_item::GridItem::minimum_contribution
 0.2%   0.2%   1.1KiB     taffy taffy::compute::grid::types::grid_item::GridItem::known_dimensions
 0.2%   0.2%   1.1KiB     taffy taffy::compute::flexbox::calculate_flex_item
 0.1%   0.2%     948B     taffy taffy::compute::flexbox::compute_flexbox_layout
 0.1%   0.1%     832B     taffy core::panicking::assert_failed
 0.1%   0.1%     764B     taffy taffy::tree::cache::Cache::get
 0.1%   0.1%     724B    taffy? <taffy::tree::taffy_tree::TaffyError as core::fmt::Debug>::fmt
 0.1%   0.1%     712B     taffy taffy::compute::grid::alignment::align_tracks
 0.1%   0.1%     644B     taffy taffy::compute::grid::explicit_grid::create_implicit_tracks
 0.1%   0.1%     632B     taffy taffy::compute::round_layout::round_layout_inner
 0.1%   0.1%     488B     taffy taffy::compute::grid::explicit_grid::create_implicit_tracks
 0.1%   0.1%     484B     taffy taffy::compute::compute_hidden_layout
```

**After:**

```
11.1%  15.5%  58.0KiB     taffy taffy::compute::grid::track_sizing::resolve_intrinsic_track_sizes
 4.1%   5.7%  21.4KiB     taffy taffy::compute::flexbox::compute_preliminary
 3.7%   5.1%  19.2KiB     taffy taffy::compute::grid::compute_grid_layout
 2.0%   2.8%  10.6KiB     taffy taffy::compute::block::compute_block_layout
 1.6%   2.2%   8.3KiB     taffy taffy::compute::grid::track_sizing::track_sizing_algorithm
 0.9%   1.2%   4.7KiB     taffy taffy::compute::grid::placement::place_grid_items
 0.8%   1.1%   3.9KiB     taffy taffy::compute::grid::alignment::align_and_position_item
 0.3%   0.4%   1.6KiB     taffy taffy::compute::grid::types::grid_item::GridItem::min_content_contribution
 0.3%   0.4%   1.6KiB     taffy taffy::compute::grid::placement::record_grid_placement
 0.3%   0.4%   1.6KiB     taffy taffy::compute::grid::types::grid_item::GridItem::max_content_contribution
 0.3%   0.4%   1.4KiB     taffy taffy::compute::grid::explicit_grid::compute_explicit_grid_size_in_axis
 0.3%   0.4%   1.3KiB     taffy taffy::compute::leaf::compute_leaf_layout
 0.2%   0.3%   1.2KiB     taffy taffy::compute::grid::types::grid_item::GridItem::minimum_contribution
 0.2%   0.3%   1.2KiB     taffy taffy::compute::compute_root_layout
 0.2%   0.3%   1.1KiB     taffy taffy::compute::grid::types::grid_item::GridItem::known_dimensions
 0.2%   0.3%   1.1KiB     taffy taffy::compute::flexbox::calculate_flex_item
 0.2%   0.2%     948B     taffy taffy::compute::flexbox::compute_flexbox_layout
 0.2%   0.2%     832B     taffy core::panicking::assert_failed
 0.1%   0.2%     764B     taffy taffy::tree::cache::Cache::get
 0.1%   0.2%     724B    taffy? <taffy::tree::taffy_tree::TaffyError as core::fmt::Debug>::fmt
 0.1%   0.2%     712B     taffy taffy::compute::grid::alignment::align_tracks
 0.1%   0.2%     644B     taffy taffy::compute::grid::explicit_grid::create_implicit_tracks
 0.1%   0.2%     632B     taffy taffy::compute::round_layout::round_layout_inner
 0.1%   0.1%     488B     taffy taffy::compute::grid::explicit_grid::create_implicit_tracks
 0.1%   0.1%     484B     taffy taffy::compute::compute_hidden_layout
 ```
