### PR TITLE
fix:  single-line flex-container should clamp the line's cross-size

### DIFF
--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -1396,6 +1396,16 @@ fn calculate_cross_size(flex_lines: &mut [FlexLine], node_size: Size<Option<f32>
                 })
                 .fold(0.0, |acc, x| acc.max(x));
         }
+        //  If the flex container is single-line, then clamp the line’s cross-size to be within the container’s computed min and max cross sizes.
+        if flex_lines.len() == 1 {
+            let cross_axis_padding_border = constants.content_box_inset.cross_axis_sum(constants.dir);
+            let cross_min_size = constants.min_size.cross(constants.dir);
+            let cross_max_size = constants.max_size.cross(constants.dir);
+            flex_lines[0].cross_size = flex_lines[0].cross_size.maybe_clamp(
+                cross_min_size.maybe_sub(cross_axis_padding_border),
+                cross_max_size.maybe_sub(cross_axis_padding_border),
+            );
+        }
     }
 }
 

--- a/test_fixtures/flex/align_items_center_with_min_height_with_align_content_flex_start.html
+++ b/test_fixtures/flex/align_items_center_with_min_height_with_align_content_flex_start.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 100px; min-height: 100px; align-items: center; align-content: flex-start">
+  <div style="height: 10px; width: 10px;"></div>
+  <div style="height: 20px; width: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/generated/flex/align_items_center_with_min_height_with_align_content_flex_start.rs
+++ b/tests/generated/flex/align_items_center_with_min_height_with_align_content_flex_start.rs
@@ -1,0 +1,112 @@
+#[test]
+fn align_items_center_with_min_height_with_align_content_flex_start() {
+    #[allow(unused_imports)]
+    use taffy::{prelude::*, tree::Layout, TaffyTree};
+    let mut taffy: TaffyTree<crate::TextMeasure> = TaffyTree::new();
+    let node0 = taffy
+        .new_leaf(taffy::style::Style {
+            size: taffy::geometry::Size {
+                width: taffy::style::Dimension::Length(10f32),
+                height: taffy::style::Dimension::Length(10f32),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node1 = taffy
+        .new_leaf(taffy::style::Style {
+            size: taffy::geometry::Size {
+                width: taffy::style::Dimension::Length(10f32),
+                height: taffy::style::Dimension::Length(20f32),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node = taffy
+        .new_with_children(
+            taffy::style::Style {
+                align_items: Some(taffy::style::AlignItems::Center),
+                align_content: Some(taffy::style::AlignContent::FlexStart),
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Length(100f32), height: auto() },
+                min_size: taffy::geometry::Size { width: auto(), height: taffy::style::Dimension::Length(100f32) },
+                ..Default::default()
+            },
+            &[node0, node1],
+        )
+        .unwrap();
+    taffy.compute_layout_with_measure(node, taffy::geometry::Size::MAX_CONTENT, crate::test_measure_function).unwrap();
+    println!("\nComputed tree:");
+    taffy.print_tree(node);
+    println!();
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node).unwrap();
+    assert_eq!(size.width, 100f32, "width of node {:?}. Expected {}. Actual {}", node, 100f32, size.width);
+    assert_eq!(size.height, 100f32, "height of node {:?}. Expected {}. Actual {}", node, 100f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node, 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node, 0f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node0).unwrap();
+    assert_eq!(size.width, 10f32, "width of node {:?}. Expected {}. Actual {}", node0, 10f32, size.width);
+    assert_eq!(size.height, 10f32, "height of node {:?}. Expected {}. Actual {}", node0, 10f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node0, 0f32, location.x);
+    assert_eq!(location.y, 45f32, "y of node {:?}. Expected {}. Actual {}", node0, 45f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node0,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node0,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node1).unwrap();
+    assert_eq!(size.width, 10f32, "width of node {:?}. Expected {}. Actual {}", node1, 10f32, size.width);
+    assert_eq!(size.height, 20f32, "height of node {:?}. Expected {}. Actual {}", node1, 20f32, size.height);
+    assert_eq!(location.x, 10f32, "x of node {:?}. Expected {}. Actual {}", node1, 10f32, location.x);
+    assert_eq!(location.y, 40f32, "y of node {:?}. Expected {}. Actual {}", node1, 40f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node1,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node1,
+        0f32,
+        layout.scroll_height()
+    );
+}

--- a/tests/generated/flex/mod.rs
+++ b/tests/generated/flex/mod.rs
@@ -126,6 +126,7 @@ mod align_items_center_justify_content_center;
 mod align_items_center_min_max_with_padding;
 mod align_items_center_with_child_margin;
 mod align_items_center_with_child_top;
+mod align_items_center_with_min_height_with_align_content_flex_start;
 mod align_items_flex_end;
 mod align_items_flex_end_child_with_margin_bigger_than_parent;
 mod align_items_flex_end_child_without_margin_bigger_than_parent;


### PR DESCRIPTION
# Objective

In Taffy, missing a step when calculate the cross size of each flex line.

``` 
//  If the flex container is single-line, then clamp the line’s cross-size to be within the container’s computed min and max cross sizes.
```