### PR TITLE
Prepare for v0.4.2 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taffy"
-version = "0.4.1"
+version = "0.4.2"
 authors = [
     "Alice Cecile <alice.i.cecile@gmail.com>",
     "Johnathan Kelley <jkelleyrtp@gmail.com>",

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 0.4.2
+
+- Fixed: single-line flex-container should clamp the line's cross-size (#638)
+- Reduced binary footprint of Taffy from around 300kb to around 150kb (#636)
+
 ## 0.4.1
 
 - Fixed: CSS Grid track sizing not respecting growth limits in some circumstances (#624)


### PR DESCRIPTION
# Objective

Release recent alignment and binary size fixes prior to landing https://github.com/DioxusLabs/taffy/pull/635 which will be breaking.