### PR TITLE
Prepare for v0.3.19 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taffy"
-version = "0.3.18"
+version = "0.3.19"
 authors = [
     "Alice Cecile <alice.i.cecile@gmail.com>",
     "Johnathan Kelley <jkelleyrtp@gmail.com>",

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## 0.3.19
+
+### Fixes
+
+- Fix compilation error in `evenly_sized_tracks` style helper in recent versions of rustc caused by a change/regression in type
+  inference (#643)
+
 ## 0.3.18
 
 ### Fixes


### PR DESCRIPTION
# Objective

Ensure Taffy 0.3.x compiles on recent nightly versions of rustc

## Context

- #642
- #643