### PR TITLE
Absolute Insets should be resolved against the container size minus border

### DIFF
--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -348,13 +348,13 @@ fn perform_final_layout_on_in_flow_children(
 
     #[cfg_attr(not(feature = "content_size"), allow(unused_mut))]
     let mut inflow_content_size = Size::ZERO;
-    let mut committed_y_offset = resolved_content_box_inset.top;
+    let mut committed_offset = Point { x: resolved_content_box_inset.left, y: resolved_content_box_inset.top };
     let mut first_child_top_margin_set = CollapsibleMarginSet::ZERO;
     let mut active_collapsible_margin_set = CollapsibleMarginSet::ZERO;
     let mut is_collapsing_with_first_margin_set = true;
     for item in items.iter_mut() {
         if item.position == Position::Absolute {
-            item.static_position.y = committed_y_offset;
+            item.static_position = committed_offset
         } else {
             let item_margin = item.margin.map(|margin| margin.resolve_to_option(container_outer_width));
             let item_non_auto_margin = item_margin.map(|m| m.unwrap_or(0.0));
@@ -420,11 +420,11 @@ fn perform_final_layout_on_in_flow_children(
             item.can_be_collapsed_through = item_layout.margins_can_collapse_through;
             item.static_position = Point {
                 x: resolved_content_box_inset.left,
-                y: committed_y_offset + active_collapsible_margin_set.resolve(),
+                y: committed_offset.y + active_collapsible_margin_set.resolve(),
             };
             let location = Point {
                 x: resolved_content_box_inset.left + inset_offset.x + resolved_margin.left,
-                y: committed_y_offset + inset_offset.y + y_margin_offset,
+                y: committed_offset.y + inset_offset.y + y_margin_offset,
             };
 
             let scrollbar_size = Size {
@@ -474,7 +474,7 @@ fn perform_final_layout_on_in_flow_children(
                     .collapse_with_set(top_margin_set)
                     .collapse_with_set(bottom_margin_set);
             } else {
-                committed_y_offset += item_layout.size.height + y_margin_offset;
+                committed_offset.y += item_layout.size.height + y_margin_offset;
                 active_collapsible_margin_set = bottom_margin_set;
             }
         }
@@ -484,8 +484,8 @@ fn perform_final_layout_on_in_flow_children(
     let bottom_y_margin_offset =
         if own_margins_collapse_with_children.end { 0.0 } else { last_child_bottom_margin_set.resolve() };
 
-    committed_y_offset += resolved_content_box_inset.bottom + bottom_y_margin_offset;
-    let content_height = f32_max(0.0, committed_y_offset);
+    committed_offset.y += resolved_content_box_inset.bottom + bottom_y_margin_offset;
+    let content_height = f32_max(0.0, committed_offset.y);
     (inflow_content_size, content_height, first_child_top_margin_set, last_child_bottom_margin_set)
 }
 
@@ -638,17 +638,18 @@ fn perform_absolute_layout_on_absolute_children(
             bottom: margin.bottom.unwrap_or(auto_margin.bottom),
         };
 
-        let item_offset = Point {
+        let location = Point {
             x: left
                 .map(|left| left + resolved_margin.left)
                 .or(right.map(|right| area_size.width - final_size.width - right - resolved_margin.right))
-                .unwrap_or(resolved_margin.left),
+                .maybe_add(area_offset.x)
+                .unwrap_or(item.static_position.x + resolved_margin.left),
             y: top
                 .map(|top| top + resolved_margin.top)
                 .or(bottom.map(|bottom| area_size.height - final_size.height - bottom - resolved_margin.bottom))
+                .maybe_add(area_offset.y)
                 .unwrap_or(item.static_position.y + resolved_margin.top),
         };
-
         // Note: axis intentionally switched here as scrollbars take up space in the opposite axis
         // to the axis in which scrolling is enabled.
         let scrollbar_size = Size {
@@ -656,7 +657,6 @@ fn perform_absolute_layout_on_absolute_children(
             height: if item.overflow.x == Overflow::Scroll { item.scrollbar_width } else { 0.0 },
         };
 
-        let location = area_offset + item_offset;
         tree.set_unrounded_layout(
             item.node_id,
             &Layout {

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -1951,16 +1951,14 @@ fn perform_absolute_layout_on_absolute_children(
             child_style.inset.bottom.maybe_resolve(inset_relative_size.height).maybe_add(constants.scrollbar_gutter.y);
 
         // Compute known dimensions from min/max/inherent size styles
-        let style_size =
-            child_style.size.maybe_resolve(constants.container_size).maybe_apply_aspect_ratio(aspect_ratio);
+        let style_size = child_style.size.maybe_resolve(inset_relative_size).maybe_apply_aspect_ratio(aspect_ratio);
         let min_size = child_style
             .min_size
-            .maybe_resolve(constants.container_size)
+            .maybe_resolve(inset_relative_size)
             .maybe_apply_aspect_ratio(aspect_ratio)
             .or(padding_border_sum.map(Some))
             .maybe_max(padding_border_sum);
-        let max_size =
-            child_style.max_size.maybe_resolve(constants.container_size).maybe_apply_aspect_ratio(aspect_ratio);
+        let max_size = child_style.max_size.maybe_resolve(inset_relative_size).maybe_apply_aspect_ratio(aspect_ratio);
         let mut known_dimensions = style_size.maybe_clamp(min_size, max_size);
 
         // Fill in width from left/right and reapply aspect ratio if:

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -482,12 +482,12 @@ pub fn compute_grid_layout(tree: &mut impl LayoutPartialTree, node: NodeId, inpu
                 bottom: maybe_row_indexes
                     .end
                     .map(|index| rows[index].offset)
-                    .unwrap_or(container_border_box.height - border.bottom),
+                    .unwrap_or(container_border_box.height - border.bottom - scrollbar_gutter.y),
                 left: maybe_col_indexes.start.map(|index| columns[index].offset).unwrap_or(border.left),
                 right: maybe_col_indexes
                     .end
                     .map(|index| columns[index].offset)
-                    .unwrap_or(container_border_box.width - border.right),
+                    .unwrap_or(container_border_box.width - border.right - scrollbar_gutter.x),
             };
             // TODO: Baseline alignment support for absolutely positioned items (should check if is actuallty specified)
             #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]

--- a/test_fixtures/block/block_absolute_resolved_insets.html
+++ b/test_fixtures/block/block_absolute_resolved_insets.html
@@ -12,74 +12,40 @@
     <body>
         <div id="test-root">
             <div
-                style="
-                    display: block;
-                    width: 200px;
-                    height: 200px;
-                    border: 20px solid;
-                    padding: 15px;
-                    position: relative;
-                "
+                style="display: block; width: 200px; height: 200px; border: 20px solid; padding: 15px; position: relative;"
             >
-                <div style="position: absolute; top: auto; left: auto"></div>
-                <div style="position: absolute; top: 0; left: 0"></div>
-                <div style="position: absolute; top: 100%; left: 100%"></div>
+                <div style="position: absolute; top: auto; left: auto;"></div>
+                <div style="position: absolute; top: 0; left: 0;"></div>
+                <div style="position: absolute; top: 100%; left: 100%;"></div>
                 <div
-                    style="position: absolute; bottom: 100%; right: 100%"
+                    style="position: absolute; bottom: 100%; right: 100%;"
                 ></div>
-                <div style="position: absolute; top: 30px; left: 30px"></div>
+                <div style="position: absolute; top: 30px; left: 30px;"></div>
                 <div
-                    style="
-                        position: absolute;
-                        top: 0;
-                        left: 0;
-                        width: 100%;
-                        height: 100%;
-                    "
+                    style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"
                 ></div>
             </div>
 
             <div
-                style="
-                    display: block;
-                    width: 200px;
-                    height: 200px;
-                    border: 20px solid;
-                    padding: 15px;
-                    overflow: scroll;
-                    position: relative;
-                "
+                style="display: block; width: 200px; height: 200px; border: 20px solid; padding: 15px; overflow: scroll; position: relative;"
             >
-                <div style="position: absolute; top: auto; left: auto"></div>
-                <div style="position: absolute; top: 0; left: 0"></div>
-                <div style="position: absolute; top: 100%; left: 100%"></div>
+                <div style="position: absolute; top: auto; left: auto;"></div>
+                <div style="position: absolute; top: 0; left: 0;"></div>
+                <div style="position: absolute; top: 100%; left: 100%;"></div>
                 <div
-                    style="position: absolute; bottom: 100%; right: 100%"
+                    style="position: absolute; bottom: 100%; right: 100%;"
                 ></div>
-                <div style="position: absolute; top: 30px; left: 30px"></div>
+                <div style="position: absolute; top: 30px; left: 30px;"></div>
                 <div
-                    style="
-                        position: absolute;
-                        top: 0;
-                        left: 0;
-                        width: 100%;
-                        height: 100%;
-                    "
+                    style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"
                 ></div>
             </div>
             <!-- Checks if "top: auto" resolves to the static y position -->
             <div
-                style="
-                    display: block;
-                    width: 200px;
-                    height: 200px;
-                    border: 20px solid;
-                    padding: 15px;
-                    position: relative;
-                "
+                style="display: block; width: 200px; height: 200px; border: 20px solid; padding: 15px; position: relative;"
             >
-                <div style="display: block; height: 10px; width: 50px"></div>
-                <div style="position: absolute; top: auto; left: auto"></div>
+                <div style="display: block; height: 10px; width: 50px;"></div>
+                <div style="position: absolute; top: auto; left: auto;"></div>
             </div>
         </div>
     </body>

--- a/test_fixtures/block/block_absolute_resolved_insets.html
+++ b/test_fixtures/block/block_absolute_resolved_insets.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <script src="../../scripts/gentest/test_helper.js"></script>
+        <link
+            rel="stylesheet"
+            type="text/css"
+            href="../../scripts/gentest/test_base_style.css"
+        />
+        <title>Test description</title>
+    </head>
+    <body>
+        <div id="test-root">
+            <div
+                style="
+                    display: block;
+                    width: 200px;
+                    height: 200px;
+                    border: 20px solid;
+                    padding: 15px;
+                    position: relative;
+                "
+            >
+                <div style="position: absolute; top: auto; left: auto"></div>
+                <div style="position: absolute; top: 0; left: 0"></div>
+                <div style="position: absolute; top: 100%; left: 100%"></div>
+                <div
+                    style="position: absolute; bottom: 100%; right: 100%"
+                ></div>
+                <div style="position: absolute; top: 30px; left: 30px"></div>
+                <div
+                    style="
+                        position: absolute;
+                        top: 0;
+                        left: 0;
+                        width: 100%;
+                        height: 100%;
+                    "
+                ></div>
+            </div>
+
+            <div
+                style="
+                    display: block;
+                    width: 200px;
+                    height: 200px;
+                    border: 20px solid;
+                    padding: 15px;
+                    overflow: scroll;
+                    position: relative;
+                "
+            >
+                <div style="position: absolute; top: auto; left: auto"></div>
+                <div style="position: absolute; top: 0; left: 0"></div>
+                <div style="position: absolute; top: 100%; left: 100%"></div>
+                <div
+                    style="position: absolute; bottom: 100%; right: 100%"
+                ></div>
+                <div style="position: absolute; top: 30px; left: 30px"></div>
+                <div
+                    style="
+                        position: absolute;
+                        top: 0;
+                        left: 0;
+                        width: 100%;
+                        height: 100%;
+                    "
+                ></div>
+            </div>
+            <!-- Checks if "top: auto" resolves to the static y position -->
+            <div
+                style="
+                    display: block;
+                    width: 200px;
+                    height: 200px;
+                    border: 20px solid;
+                    padding: 15px;
+                    position: relative;
+                "
+            >
+                <div style="display: block; height: 10px; width: 50px"></div>
+                <div style="position: absolute; top: auto; left: auto"></div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/test_fixtures/flex/absolute_resolved_insets.html
+++ b/test_fixtures/flex/absolute_resolved_insets.html
@@ -12,59 +12,32 @@
     <body>
         <div id="test-root">
             <div
-                style="
-                    display: flex;
-                    width: 200px;
-                    height: 200px;
-                    border: 20px solid;
-                    padding: 15px;
-                    position: relative;
-                "
+                style="display: flex; width: 200px; height: 200px; border: 20px solid; padding: 15px; position: relative;"
             >
-                <div style="position: absolute; top: auto; left: auto"></div>
-                <div style="position: absolute; top: 0; left: 0"></div>
-                <div style="position: absolute; top: 100%; left: 100%"></div>
+                <div style="position: absolute; top: auto; left: auto;"></div>
+                <div style="position: absolute; top: 0; left: 0;"></div>
+                <div style="position: absolute; top: 100%; left: 100%;"></div>
                 <div
-                    style="position: absolute; bottom: 100%; right: 100%"
+                    style="position: absolute; bottom: 100%; right: 100%;"
                 ></div>
-                <div style="position: absolute; top: 30px; left: 30px"></div>
+                <div style="position: absolute; top: 30px; left: 30px;"></div>
                 <div
-                    style="
-                        position: absolute;
-                        top: 0;
-                        left: 0;
-                        width: 100%;
-                        height: 100%;
-                    "
+                    style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"
                 ></div>
             </div>
 
             <div
-                style="
-                    display: flex;
-                    width: 200px;
-                    height: 200px;
-                    border: 20px solid;
-                    padding: 15px;
-                    overflow: scroll;
-                    position: relative;
-                "
+                style="display: flex; width: 200px; height: 200px; border: 20px solid; padding: 15px; overflow: scroll; position: relative;"
             >
-                <div style="position: absolute; top: auto; left: auto"></div>
-                <div style="position: absolute; top: 0; left: 0"></div>
-                <div style="position: absolute; top: 100%; left: 100%"></div>
+                <div style="position: absolute; top: auto; left: auto;"></div>
+                <div style="position: absolute; top: 0; left: 0;"></div>
+                <div style="position: absolute; top: 100%; left: 100%;"></div>
                 <div
-                    style="position: absolute; bottom: 100%; right: 100%"
+                    style="position: absolute; bottom: 100%; right: 100%;"
                 ></div>
-                <div style="position: absolute; top: 30px; left: 30px"></div>
+                <div style="position: absolute; top: 30px; left: 30px;"></div>
                 <div
-                    style="
-                        position: absolute;
-                        top: 0;
-                        left: 0;
-                        width: 100%;
-                        height: 100%;
-                    "
+                    style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"
                 ></div>
             </div>
         </div>

--- a/test_fixtures/flex/absolute_resolved_insets.html
+++ b/test_fixtures/flex/absolute_resolved_insets.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <script src="../../scripts/gentest/test_helper.js"></script>
+        <link
+            rel="stylesheet"
+            type="text/css"
+            href="../../scripts/gentest/test_base_style.css"
+        />
+        <title>Test description</title>
+    </head>
+    <body>
+        <div id="test-root">
+            <div
+                style="
+                    display: flex;
+                    width: 200px;
+                    height: 200px;
+                    border: 20px solid;
+                    padding: 15px;
+                    position: relative;
+                "
+            >
+                <div style="position: absolute; top: auto; left: auto"></div>
+                <div style="position: absolute; top: 0; left: 0"></div>
+                <div style="position: absolute; top: 100%; left: 100%"></div>
+                <div
+                    style="position: absolute; bottom: 100%; right: 100%"
+                ></div>
+                <div style="position: absolute; top: 30px; left: 30px"></div>
+                <div
+                    style="
+                        position: absolute;
+                        top: 0;
+                        left: 0;
+                        width: 100%;
+                        height: 100%;
+                    "
+                ></div>
+            </div>
+
+            <div
+                style="
+                    display: flex;
+                    width: 200px;
+                    height: 200px;
+                    border: 20px solid;
+                    padding: 15px;
+                    overflow: scroll;
+                    position: relative;
+                "
+            >
+                <div style="position: absolute; top: auto; left: auto"></div>
+                <div style="position: absolute; top: 0; left: 0"></div>
+                <div style="position: absolute; top: 100%; left: 100%"></div>
+                <div
+                    style="position: absolute; bottom: 100%; right: 100%"
+                ></div>
+                <div style="position: absolute; top: 30px; left: 30px"></div>
+                <div
+                    style="
+                        position: absolute;
+                        top: 0;
+                        left: 0;
+                        width: 100%;
+                        height: 100%;
+                    "
+                ></div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/test_fixtures/grid/grid_absolute_resolved_insets.html
+++ b/test_fixtures/grid/grid_absolute_resolved_insets.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <script src="../../scripts/gentest/test_helper.js"></script>
+        <link
+            rel="stylesheet"
+            type="text/css"
+            href="../../scripts/gentest/test_base_style.css"
+        />
+        <title>Test description</title>
+    </head>
+    <body>
+        <div id="test-root">
+            <div
+                style="
+                    display: grid;
+                    width: 200px;
+                    height: 200px;
+                    border: 20px solid;
+                    padding: 15px;
+                    position: relative;
+                "
+            >
+                <div style="position: absolute; top: auto; left: auto"></div>
+                <div style="position: absolute; top: 0; left: 0"></div>
+                <div style="position: absolute; top: 100%; left: 100%"></div>
+                <div
+                    style="position: absolute; bottom: 100%; right: 100%"
+                ></div>
+                <div style="position: absolute; top: 30px; left: 30px"></div>
+                <div
+                    style="
+                        position: absolute;
+                        top: 0;
+                        left: 0;
+                        width: 100%;
+                        height: 100%;
+                    "
+                ></div>
+            </div>
+
+            <div
+                style="
+                    display: grid;
+                    width: 200px;
+                    height: 200px;
+                    border: 20px solid;
+                    padding: 15px;
+                    overflow: scroll;
+                    position: relative;
+                "
+            >
+                <div style="position: absolute; top: auto; left: auto"></div>
+                <div style="position: absolute; top: 0; left: 0"></div>
+                <div style="position: absolute; top: 100%; left: 100%"></div>
+                <div
+                    style="position: absolute; bottom: 100%; right: 100%"
+                ></div>
+                <div style="position: absolute; top: 30px; left: 30px"></div>
+                <div
+                    style="
+                        position: absolute;
+                        top: 0;
+                        left: 0;
+                        width: 100%;
+                        height: 100%;
+                    "
+                ></div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/test_fixtures/grid/grid_absolute_resolved_insets.html
+++ b/test_fixtures/grid/grid_absolute_resolved_insets.html
@@ -12,59 +12,32 @@
     <body>
         <div id="test-root">
             <div
-                style="
-                    display: grid;
-                    width: 200px;
-                    height: 200px;
-                    border: 20px solid;
-                    padding: 15px;
-                    position: relative;
-                "
+                style="display: grid; width: 200px; height: 200px; border: 20px solid; padding: 15px; position: relative;"
             >
-                <div style="position: absolute; top: auto; left: auto"></div>
-                <div style="position: absolute; top: 0; left: 0"></div>
-                <div style="position: absolute; top: 100%; left: 100%"></div>
+                <div style="position: absolute; top: auto; left: auto;"></div>
+                <div style="position: absolute; top: 0; left: 0;"></div>
+                <div style="position: absolute; top: 100%; left: 100%;"></div>
                 <div
-                    style="position: absolute; bottom: 100%; right: 100%"
+                    style="position: absolute; bottom: 100%; right: 100%;"
                 ></div>
-                <div style="position: absolute; top: 30px; left: 30px"></div>
+                <div style="position: absolute; top: 30px; left: 30px;"></div>
                 <div
-                    style="
-                        position: absolute;
-                        top: 0;
-                        left: 0;
-                        width: 100%;
-                        height: 100%;
-                    "
+                    style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"
                 ></div>
             </div>
 
             <div
-                style="
-                    display: grid;
-                    width: 200px;
-                    height: 200px;
-                    border: 20px solid;
-                    padding: 15px;
-                    overflow: scroll;
-                    position: relative;
-                "
+                style="display: grid; width: 200px; height: 200px; border: 20px solid; padding: 15px; overflow: scroll; position: relative;"
             >
-                <div style="position: absolute; top: auto; left: auto"></div>
-                <div style="position: absolute; top: 0; left: 0"></div>
-                <div style="position: absolute; top: 100%; left: 100%"></div>
+                <div style="position: absolute; top: auto; left: auto;"></div>
+                <div style="position: absolute; top: 0; left: 0;"></div>
+                <div style="position: absolute; top: 100%; left: 100%;"></div>
                 <div
-                    style="position: absolute; bottom: 100%; right: 100%"
+                    style="position: absolute; bottom: 100%; right: 100%;"
                 ></div>
-                <div style="position: absolute; top: 30px; left: 30px"></div>
+                <div style="position: absolute; top: 30px; left: 30px;"></div>
                 <div
-                    style="
-                        position: absolute;
-                        top: 0;
-                        left: 0;
-                        width: 100%;
-                        height: 100%;
-                    "
+                    style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"
                 ></div>
             </div>
         </div>

--- a/tests/generated/block/block_absolute_resolved_insets.rs
+++ b/tests/generated/block/block_absolute_resolved_insets.rs
@@ -1,0 +1,697 @@
+#[test]
+fn block_absolute_resolved_insets() {
+    #[allow(unused_imports)]
+    use taffy::{prelude::*, tree::Layout, TaffyTree};
+    let mut taffy: TaffyTree<crate::TextMeasure> = TaffyTree::new();
+    let node00 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            inset: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Auto,
+                right: auto(),
+                top: taffy::style::LengthPercentageAuto::Auto,
+                bottom: auto(),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node01 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            inset: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Length(0f32),
+                right: auto(),
+                top: taffy::style::LengthPercentageAuto::Length(0f32),
+                bottom: auto(),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node02 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            inset: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Percent(1f32),
+                right: auto(),
+                top: taffy::style::LengthPercentageAuto::Percent(1f32),
+                bottom: auto(),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node03 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            inset: taffy::geometry::Rect {
+                left: auto(),
+                right: taffy::style::LengthPercentageAuto::Percent(1f32),
+                top: auto(),
+                bottom: taffy::style::LengthPercentageAuto::Percent(1f32),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node04 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            inset: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Length(30f32),
+                right: auto(),
+                top: taffy::style::LengthPercentageAuto::Length(30f32),
+                bottom: auto(),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node05 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            size: taffy::geometry::Size {
+                width: taffy::style::Dimension::Percent(1f32),
+                height: taffy::style::Dimension::Percent(1f32),
+            },
+            inset: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Length(0f32),
+                right: auto(),
+                top: taffy::style::LengthPercentageAuto::Length(0f32),
+                bottom: auto(),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node0 = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Block,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Length(200f32),
+                    height: taffy::style::Dimension::Length(200f32),
+                },
+                padding: taffy::geometry::Rect {
+                    left: taffy::style::LengthPercentage::Length(15f32),
+                    right: taffy::style::LengthPercentage::Length(15f32),
+                    top: taffy::style::LengthPercentage::Length(15f32),
+                    bottom: taffy::style::LengthPercentage::Length(15f32),
+                },
+                border: taffy::geometry::Rect {
+                    left: taffy::style::LengthPercentage::Length(20f32),
+                    right: taffy::style::LengthPercentage::Length(20f32),
+                    top: taffy::style::LengthPercentage::Length(20f32),
+                    bottom: taffy::style::LengthPercentage::Length(20f32),
+                },
+                ..Default::default()
+            },
+            &[node00, node01, node02, node03, node04, node05],
+        )
+        .unwrap();
+    let node10 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            inset: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Auto,
+                right: auto(),
+                top: taffy::style::LengthPercentageAuto::Auto,
+                bottom: auto(),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node11 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            inset: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Length(0f32),
+                right: auto(),
+                top: taffy::style::LengthPercentageAuto::Length(0f32),
+                bottom: auto(),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node12 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            inset: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Percent(1f32),
+                right: auto(),
+                top: taffy::style::LengthPercentageAuto::Percent(1f32),
+                bottom: auto(),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node13 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            inset: taffy::geometry::Rect {
+                left: auto(),
+                right: taffy::style::LengthPercentageAuto::Percent(1f32),
+                top: auto(),
+                bottom: taffy::style::LengthPercentageAuto::Percent(1f32),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node14 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            inset: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Length(30f32),
+                right: auto(),
+                top: taffy::style::LengthPercentageAuto::Length(30f32),
+                bottom: auto(),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node15 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            size: taffy::geometry::Size {
+                width: taffy::style::Dimension::Percent(1f32),
+                height: taffy::style::Dimension::Percent(1f32),
+            },
+            inset: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Length(0f32),
+                right: auto(),
+                top: taffy::style::LengthPercentageAuto::Length(0f32),
+                bottom: auto(),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node1 = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Block,
+                overflow: taffy::geometry::Point {
+                    x: taffy::style::Overflow::Scroll,
+                    y: taffy::style::Overflow::Scroll,
+                },
+                scrollbar_width: 15f32,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Length(200f32),
+                    height: taffy::style::Dimension::Length(200f32),
+                },
+                padding: taffy::geometry::Rect {
+                    left: taffy::style::LengthPercentage::Length(15f32),
+                    right: taffy::style::LengthPercentage::Length(15f32),
+                    top: taffy::style::LengthPercentage::Length(15f32),
+                    bottom: taffy::style::LengthPercentage::Length(15f32),
+                },
+                border: taffy::geometry::Rect {
+                    left: taffy::style::LengthPercentage::Length(20f32),
+                    right: taffy::style::LengthPercentage::Length(20f32),
+                    top: taffy::style::LengthPercentage::Length(20f32),
+                    bottom: taffy::style::LengthPercentage::Length(20f32),
+                },
+                ..Default::default()
+            },
+            &[node10, node11, node12, node13, node14, node15],
+        )
+        .unwrap();
+    let node20 = taffy
+        .new_leaf(taffy::style::Style {
+            display: taffy::style::Display::Block,
+            size: taffy::geometry::Size {
+                width: taffy::style::Dimension::Length(50f32),
+                height: taffy::style::Dimension::Length(10f32),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node21 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            inset: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Auto,
+                right: auto(),
+                top: taffy::style::LengthPercentageAuto::Auto,
+                bottom: auto(),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node2 = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Block,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Length(200f32),
+                    height: taffy::style::Dimension::Length(200f32),
+                },
+                padding: taffy::geometry::Rect {
+                    left: taffy::style::LengthPercentage::Length(15f32),
+                    right: taffy::style::LengthPercentage::Length(15f32),
+                    top: taffy::style::LengthPercentage::Length(15f32),
+                    bottom: taffy::style::LengthPercentage::Length(15f32),
+                },
+                border: taffy::geometry::Rect {
+                    left: taffy::style::LengthPercentage::Length(20f32),
+                    right: taffy::style::LengthPercentage::Length(20f32),
+                    top: taffy::style::LengthPercentage::Length(20f32),
+                    bottom: taffy::style::LengthPercentage::Length(20f32),
+                },
+                ..Default::default()
+            },
+            &[node20, node21],
+        )
+        .unwrap();
+    let node = taffy.new_with_children(taffy::style::Style { ..Default::default() }, &[node0, node1, node2]).unwrap();
+    taffy.compute_layout_with_measure(node, taffy::geometry::Size::MAX_CONTENT, crate::test_measure_function).unwrap();
+    println!("\nComputed tree:");
+    taffy.print_tree(node);
+    println!();
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node).unwrap();
+    assert_eq!(size.width, 600f32, "width of node {:?}. Expected {}. Actual {}", node, 600f32, size.width);
+    assert_eq!(size.height, 200f32, "height of node {:?}. Expected {}. Actual {}", node, 200f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node, 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node, 0f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node0).unwrap();
+    assert_eq!(size.width, 200f32, "width of node {:?}. Expected {}. Actual {}", node0, 200f32, size.width);
+    assert_eq!(size.height, 200f32, "height of node {:?}. Expected {}. Actual {}", node0, 200f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node0, 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node0, 0f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node0,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node0,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node00).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node00, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node00, 0f32, size.height);
+    assert_eq!(location.x, 35f32, "x of node {:?}. Expected {}. Actual {}", node00, 35f32, location.x);
+    assert_eq!(location.y, 35f32, "y of node {:?}. Expected {}. Actual {}", node00, 35f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node00,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node00,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node01).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node01, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node01, 0f32, size.height);
+    assert_eq!(location.x, 20f32, "x of node {:?}. Expected {}. Actual {}", node01, 20f32, location.x);
+    assert_eq!(location.y, 20f32, "y of node {:?}. Expected {}. Actual {}", node01, 20f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node01,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node01,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node02).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node02, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node02, 0f32, size.height);
+    assert_eq!(location.x, 180f32, "x of node {:?}. Expected {}. Actual {}", node02, 180f32, location.x);
+    assert_eq!(location.y, 180f32, "y of node {:?}. Expected {}. Actual {}", node02, 180f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node02,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node02,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node03).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node03, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node03, 0f32, size.height);
+    assert_eq!(location.x, 20f32, "x of node {:?}. Expected {}. Actual {}", node03, 20f32, location.x);
+    assert_eq!(location.y, 20f32, "y of node {:?}. Expected {}. Actual {}", node03, 20f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node03,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node03,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node04).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node04, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node04, 0f32, size.height);
+    assert_eq!(location.x, 50f32, "x of node {:?}. Expected {}. Actual {}", node04, 50f32, location.x);
+    assert_eq!(location.y, 50f32, "y of node {:?}. Expected {}. Actual {}", node04, 50f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node04,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node04,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node05).unwrap();
+    assert_eq!(size.width, 160f32, "width of node {:?}. Expected {}. Actual {}", node05, 160f32, size.width);
+    assert_eq!(size.height, 160f32, "height of node {:?}. Expected {}. Actual {}", node05, 160f32, size.height);
+    assert_eq!(location.x, 20f32, "x of node {:?}. Expected {}. Actual {}", node05, 20f32, location.x);
+    assert_eq!(location.y, 20f32, "y of node {:?}. Expected {}. Actual {}", node05, 20f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node05,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node05,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node1).unwrap();
+    assert_eq!(size.width, 200f32, "width of node {:?}. Expected {}. Actual {}", node1, 200f32, size.width);
+    assert_eq!(size.height, 200f32, "height of node {:?}. Expected {}. Actual {}", node1, 200f32, size.height);
+    assert_eq!(location.x, 200f32, "x of node {:?}. Expected {}. Actual {}", node1, 200f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node1, 0f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node1,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node1,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node10).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node10, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node10, 0f32, size.height);
+    assert_eq!(location.x, 35f32, "x of node {:?}. Expected {}. Actual {}", node10, 35f32, location.x);
+    assert_eq!(location.y, 35f32, "y of node {:?}. Expected {}. Actual {}", node10, 35f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node10,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node10,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node11).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node11, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node11, 0f32, size.height);
+    assert_eq!(location.x, 20f32, "x of node {:?}. Expected {}. Actual {}", node11, 20f32, location.x);
+    assert_eq!(location.y, 20f32, "y of node {:?}. Expected {}. Actual {}", node11, 20f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node11,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node11,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node12).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node12, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node12, 0f32, size.height);
+    assert_eq!(location.x, 165f32, "x of node {:?}. Expected {}. Actual {}", node12, 165f32, location.x);
+    assert_eq!(location.y, 165f32, "y of node {:?}. Expected {}. Actual {}", node12, 165f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node12,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node12,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node13).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node13, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node13, 0f32, size.height);
+    assert_eq!(location.x, 20f32, "x of node {:?}. Expected {}. Actual {}", node13, 20f32, location.x);
+    assert_eq!(location.y, 20f32, "y of node {:?}. Expected {}. Actual {}", node13, 20f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node13,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node13,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node14).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node14, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node14, 0f32, size.height);
+    assert_eq!(location.x, 50f32, "x of node {:?}. Expected {}. Actual {}", node14, 50f32, location.x);
+    assert_eq!(location.y, 50f32, "y of node {:?}. Expected {}. Actual {}", node14, 50f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node14,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node14,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node15).unwrap();
+    assert_eq!(size.width, 145f32, "width of node {:?}. Expected {}. Actual {}", node15, 145f32, size.width);
+    assert_eq!(size.height, 145f32, "height of node {:?}. Expected {}. Actual {}", node15, 145f32, size.height);
+    assert_eq!(location.x, 20f32, "x of node {:?}. Expected {}. Actual {}", node15, 20f32, location.x);
+    assert_eq!(location.y, 20f32, "y of node {:?}. Expected {}. Actual {}", node15, 20f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node15,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node15,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node2).unwrap();
+    assert_eq!(size.width, 200f32, "width of node {:?}. Expected {}. Actual {}", node2, 200f32, size.width);
+    assert_eq!(size.height, 200f32, "height of node {:?}. Expected {}. Actual {}", node2, 200f32, size.height);
+    assert_eq!(location.x, 400f32, "x of node {:?}. Expected {}. Actual {}", node2, 400f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node2, 0f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node2,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node2,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node20).unwrap();
+    assert_eq!(size.width, 50f32, "width of node {:?}. Expected {}. Actual {}", node20, 50f32, size.width);
+    assert_eq!(size.height, 10f32, "height of node {:?}. Expected {}. Actual {}", node20, 10f32, size.height);
+    assert_eq!(location.x, 35f32, "x of node {:?}. Expected {}. Actual {}", node20, 35f32, location.x);
+    assert_eq!(location.y, 35f32, "y of node {:?}. Expected {}. Actual {}", node20, 35f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node20,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node20,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node21).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node21, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node21, 0f32, size.height);
+    assert_eq!(location.x, 35f32, "x of node {:?}. Expected {}. Actual {}", node21, 35f32, location.x);
+    assert_eq!(location.y, 45f32, "y of node {:?}. Expected {}. Actual {}", node21, 45f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node21,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node21,
+        0f32,
+        layout.scroll_height()
+    );
+}

--- a/tests/generated/block/mod.rs
+++ b/tests/generated/block/mod.rs
@@ -52,6 +52,7 @@ mod block_absolute_minmax_top_left_bottom_right_min_max;
 mod block_absolute_no_styles;
 mod block_absolute_padding_border_overrides_max_size;
 mod block_absolute_padding_border_overrides_size;
+mod block_absolute_resolved_insets;
 mod block_align_baseline_child;
 mod block_align_baseline_child_margin;
 mod block_align_baseline_child_margin_percent;

--- a/tests/generated/flex/absolute_resolved_insets.rs
+++ b/tests/generated/flex/absolute_resolved_insets.rs
@@ -1,0 +1,578 @@
+#[test]
+fn absolute_resolved_insets() {
+    #[allow(unused_imports)]
+    use taffy::{prelude::*, tree::Layout, TaffyTree};
+    let mut taffy: TaffyTree<crate::TextMeasure> = TaffyTree::new();
+    let node00 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            inset: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Auto,
+                right: auto(),
+                top: taffy::style::LengthPercentageAuto::Auto,
+                bottom: auto(),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node01 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            inset: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Length(0f32),
+                right: auto(),
+                top: taffy::style::LengthPercentageAuto::Length(0f32),
+                bottom: auto(),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node02 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            inset: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Percent(1f32),
+                right: auto(),
+                top: taffy::style::LengthPercentageAuto::Percent(1f32),
+                bottom: auto(),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node03 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            inset: taffy::geometry::Rect {
+                left: auto(),
+                right: taffy::style::LengthPercentageAuto::Percent(1f32),
+                top: auto(),
+                bottom: taffy::style::LengthPercentageAuto::Percent(1f32),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node04 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            inset: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Length(30f32),
+                right: auto(),
+                top: taffy::style::LengthPercentageAuto::Length(30f32),
+                bottom: auto(),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node05 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            size: taffy::geometry::Size {
+                width: taffy::style::Dimension::Percent(1f32),
+                height: taffy::style::Dimension::Percent(1f32),
+            },
+            inset: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Length(0f32),
+                right: auto(),
+                top: taffy::style::LengthPercentageAuto::Length(0f32),
+                bottom: auto(),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node0 = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Flex,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Length(200f32),
+                    height: taffy::style::Dimension::Length(200f32),
+                },
+                padding: taffy::geometry::Rect {
+                    left: taffy::style::LengthPercentage::Length(15f32),
+                    right: taffy::style::LengthPercentage::Length(15f32),
+                    top: taffy::style::LengthPercentage::Length(15f32),
+                    bottom: taffy::style::LengthPercentage::Length(15f32),
+                },
+                border: taffy::geometry::Rect {
+                    left: taffy::style::LengthPercentage::Length(20f32),
+                    right: taffy::style::LengthPercentage::Length(20f32),
+                    top: taffy::style::LengthPercentage::Length(20f32),
+                    bottom: taffy::style::LengthPercentage::Length(20f32),
+                },
+                ..Default::default()
+            },
+            &[node00, node01, node02, node03, node04, node05],
+        )
+        .unwrap();
+    let node10 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            inset: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Auto,
+                right: auto(),
+                top: taffy::style::LengthPercentageAuto::Auto,
+                bottom: auto(),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node11 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            inset: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Length(0f32),
+                right: auto(),
+                top: taffy::style::LengthPercentageAuto::Length(0f32),
+                bottom: auto(),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node12 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            inset: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Percent(1f32),
+                right: auto(),
+                top: taffy::style::LengthPercentageAuto::Percent(1f32),
+                bottom: auto(),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node13 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            inset: taffy::geometry::Rect {
+                left: auto(),
+                right: taffy::style::LengthPercentageAuto::Percent(1f32),
+                top: auto(),
+                bottom: taffy::style::LengthPercentageAuto::Percent(1f32),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node14 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            inset: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Length(30f32),
+                right: auto(),
+                top: taffy::style::LengthPercentageAuto::Length(30f32),
+                bottom: auto(),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node15 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            size: taffy::geometry::Size {
+                width: taffy::style::Dimension::Percent(1f32),
+                height: taffy::style::Dimension::Percent(1f32),
+            },
+            inset: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Length(0f32),
+                right: auto(),
+                top: taffy::style::LengthPercentageAuto::Length(0f32),
+                bottom: auto(),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node1 = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Flex,
+                overflow: taffy::geometry::Point {
+                    x: taffy::style::Overflow::Scroll,
+                    y: taffy::style::Overflow::Scroll,
+                },
+                scrollbar_width: 15f32,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Length(200f32),
+                    height: taffy::style::Dimension::Length(200f32),
+                },
+                padding: taffy::geometry::Rect {
+                    left: taffy::style::LengthPercentage::Length(15f32),
+                    right: taffy::style::LengthPercentage::Length(15f32),
+                    top: taffy::style::LengthPercentage::Length(15f32),
+                    bottom: taffy::style::LengthPercentage::Length(15f32),
+                },
+                border: taffy::geometry::Rect {
+                    left: taffy::style::LengthPercentage::Length(20f32),
+                    right: taffy::style::LengthPercentage::Length(20f32),
+                    top: taffy::style::LengthPercentage::Length(20f32),
+                    bottom: taffy::style::LengthPercentage::Length(20f32),
+                },
+                ..Default::default()
+            },
+            &[node10, node11, node12, node13, node14, node15],
+        )
+        .unwrap();
+    let node = taffy.new_with_children(taffy::style::Style { ..Default::default() }, &[node0, node1]).unwrap();
+    taffy.compute_layout_with_measure(node, taffy::geometry::Size::MAX_CONTENT, crate::test_measure_function).unwrap();
+    println!("\nComputed tree:");
+    taffy.print_tree(node);
+    println!();
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node).unwrap();
+    assert_eq!(size.width, 400f32, "width of node {:?}. Expected {}. Actual {}", node, 400f32, size.width);
+    assert_eq!(size.height, 200f32, "height of node {:?}. Expected {}. Actual {}", node, 200f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node, 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node, 0f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node0).unwrap();
+    assert_eq!(size.width, 200f32, "width of node {:?}. Expected {}. Actual {}", node0, 200f32, size.width);
+    assert_eq!(size.height, 200f32, "height of node {:?}. Expected {}. Actual {}", node0, 200f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node0, 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node0, 0f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node0,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node0,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node00).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node00, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node00, 0f32, size.height);
+    assert_eq!(location.x, 35f32, "x of node {:?}. Expected {}. Actual {}", node00, 35f32, location.x);
+    assert_eq!(location.y, 35f32, "y of node {:?}. Expected {}. Actual {}", node00, 35f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node00,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node00,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node01).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node01, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node01, 0f32, size.height);
+    assert_eq!(location.x, 20f32, "x of node {:?}. Expected {}. Actual {}", node01, 20f32, location.x);
+    assert_eq!(location.y, 20f32, "y of node {:?}. Expected {}. Actual {}", node01, 20f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node01,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node01,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node02).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node02, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node02, 0f32, size.height);
+    assert_eq!(location.x, 180f32, "x of node {:?}. Expected {}. Actual {}", node02, 180f32, location.x);
+    assert_eq!(location.y, 180f32, "y of node {:?}. Expected {}. Actual {}", node02, 180f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node02,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node02,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node03).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node03, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node03, 0f32, size.height);
+    assert_eq!(location.x, 20f32, "x of node {:?}. Expected {}. Actual {}", node03, 20f32, location.x);
+    assert_eq!(location.y, 20f32, "y of node {:?}. Expected {}. Actual {}", node03, 20f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node03,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node03,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node04).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node04, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node04, 0f32, size.height);
+    assert_eq!(location.x, 50f32, "x of node {:?}. Expected {}. Actual {}", node04, 50f32, location.x);
+    assert_eq!(location.y, 50f32, "y of node {:?}. Expected {}. Actual {}", node04, 50f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node04,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node04,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node05).unwrap();
+    assert_eq!(size.width, 160f32, "width of node {:?}. Expected {}. Actual {}", node05, 160f32, size.width);
+    assert_eq!(size.height, 160f32, "height of node {:?}. Expected {}. Actual {}", node05, 160f32, size.height);
+    assert_eq!(location.x, 20f32, "x of node {:?}. Expected {}. Actual {}", node05, 20f32, location.x);
+    assert_eq!(location.y, 20f32, "y of node {:?}. Expected {}. Actual {}", node05, 20f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node05,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node05,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node1).unwrap();
+    assert_eq!(size.width, 200f32, "width of node {:?}. Expected {}. Actual {}", node1, 200f32, size.width);
+    assert_eq!(size.height, 200f32, "height of node {:?}. Expected {}. Actual {}", node1, 200f32, size.height);
+    assert_eq!(location.x, 200f32, "x of node {:?}. Expected {}. Actual {}", node1, 200f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node1, 0f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node1,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node1,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node10).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node10, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node10, 0f32, size.height);
+    assert_eq!(location.x, 35f32, "x of node {:?}. Expected {}. Actual {}", node10, 35f32, location.x);
+    assert_eq!(location.y, 35f32, "y of node {:?}. Expected {}. Actual {}", node10, 35f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node10,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node10,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node11).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node11, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node11, 0f32, size.height);
+    assert_eq!(location.x, 20f32, "x of node {:?}. Expected {}. Actual {}", node11, 20f32, location.x);
+    assert_eq!(location.y, 20f32, "y of node {:?}. Expected {}. Actual {}", node11, 20f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node11,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node11,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node12).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node12, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node12, 0f32, size.height);
+    assert_eq!(location.x, 165f32, "x of node {:?}. Expected {}. Actual {}", node12, 165f32, location.x);
+    assert_eq!(location.y, 165f32, "y of node {:?}. Expected {}. Actual {}", node12, 165f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node12,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node12,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node13).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node13, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node13, 0f32, size.height);
+    assert_eq!(location.x, 20f32, "x of node {:?}. Expected {}. Actual {}", node13, 20f32, location.x);
+    assert_eq!(location.y, 20f32, "y of node {:?}. Expected {}. Actual {}", node13, 20f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node13,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node13,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node14).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node14, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node14, 0f32, size.height);
+    assert_eq!(location.x, 50f32, "x of node {:?}. Expected {}. Actual {}", node14, 50f32, location.x);
+    assert_eq!(location.y, 50f32, "y of node {:?}. Expected {}. Actual {}", node14, 50f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node14,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node14,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node15).unwrap();
+    assert_eq!(size.width, 145f32, "width of node {:?}. Expected {}. Actual {}", node15, 145f32, size.width);
+    assert_eq!(size.height, 145f32, "height of node {:?}. Expected {}. Actual {}", node15, 145f32, size.height);
+    assert_eq!(location.x, 20f32, "x of node {:?}. Expected {}. Actual {}", node15, 20f32, location.x);
+    assert_eq!(location.y, 20f32, "y of node {:?}. Expected {}. Actual {}", node15, 20f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node15,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node15,
+        0f32,
+        layout.scroll_height()
+    );
+}

--- a/tests/generated/flex/mod.rs
+++ b/tests/generated/flex/mod.rs
@@ -44,6 +44,7 @@ mod absolute_minmax_top_left_bottom_right_max;
 mod absolute_minmax_top_left_bottom_right_min_max;
 mod absolute_padding_border_overrides_max_size;
 mod absolute_padding_border_overrides_size;
+mod absolute_resolved_insets;
 mod align_baseline;
 mod align_baseline_child;
 mod align_baseline_child_margin;

--- a/tests/generated/grid/grid_absolute_resolved_insets.rs
+++ b/tests/generated/grid/grid_absolute_resolved_insets.rs
@@ -1,0 +1,578 @@
+#[test]
+fn grid_absolute_resolved_insets() {
+    #[allow(unused_imports)]
+    use taffy::{prelude::*, tree::Layout, TaffyTree};
+    let mut taffy: TaffyTree<crate::TextMeasure> = TaffyTree::new();
+    let node00 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            inset: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Auto,
+                right: auto(),
+                top: taffy::style::LengthPercentageAuto::Auto,
+                bottom: auto(),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node01 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            inset: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Length(0f32),
+                right: auto(),
+                top: taffy::style::LengthPercentageAuto::Length(0f32),
+                bottom: auto(),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node02 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            inset: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Percent(1f32),
+                right: auto(),
+                top: taffy::style::LengthPercentageAuto::Percent(1f32),
+                bottom: auto(),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node03 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            inset: taffy::geometry::Rect {
+                left: auto(),
+                right: taffy::style::LengthPercentageAuto::Percent(1f32),
+                top: auto(),
+                bottom: taffy::style::LengthPercentageAuto::Percent(1f32),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node04 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            inset: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Length(30f32),
+                right: auto(),
+                top: taffy::style::LengthPercentageAuto::Length(30f32),
+                bottom: auto(),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node05 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            size: taffy::geometry::Size {
+                width: taffy::style::Dimension::Percent(1f32),
+                height: taffy::style::Dimension::Percent(1f32),
+            },
+            inset: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Length(0f32),
+                right: auto(),
+                top: taffy::style::LengthPercentageAuto::Length(0f32),
+                bottom: auto(),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node0 = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Grid,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Length(200f32),
+                    height: taffy::style::Dimension::Length(200f32),
+                },
+                padding: taffy::geometry::Rect {
+                    left: taffy::style::LengthPercentage::Length(15f32),
+                    right: taffy::style::LengthPercentage::Length(15f32),
+                    top: taffy::style::LengthPercentage::Length(15f32),
+                    bottom: taffy::style::LengthPercentage::Length(15f32),
+                },
+                border: taffy::geometry::Rect {
+                    left: taffy::style::LengthPercentage::Length(20f32),
+                    right: taffy::style::LengthPercentage::Length(20f32),
+                    top: taffy::style::LengthPercentage::Length(20f32),
+                    bottom: taffy::style::LengthPercentage::Length(20f32),
+                },
+                ..Default::default()
+            },
+            &[node00, node01, node02, node03, node04, node05],
+        )
+        .unwrap();
+    let node10 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            inset: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Auto,
+                right: auto(),
+                top: taffy::style::LengthPercentageAuto::Auto,
+                bottom: auto(),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node11 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            inset: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Length(0f32),
+                right: auto(),
+                top: taffy::style::LengthPercentageAuto::Length(0f32),
+                bottom: auto(),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node12 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            inset: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Percent(1f32),
+                right: auto(),
+                top: taffy::style::LengthPercentageAuto::Percent(1f32),
+                bottom: auto(),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node13 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            inset: taffy::geometry::Rect {
+                left: auto(),
+                right: taffy::style::LengthPercentageAuto::Percent(1f32),
+                top: auto(),
+                bottom: taffy::style::LengthPercentageAuto::Percent(1f32),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node14 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            inset: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Length(30f32),
+                right: auto(),
+                top: taffy::style::LengthPercentageAuto::Length(30f32),
+                bottom: auto(),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node15 = taffy
+        .new_leaf(taffy::style::Style {
+            position: taffy::style::Position::Absolute,
+            size: taffy::geometry::Size {
+                width: taffy::style::Dimension::Percent(1f32),
+                height: taffy::style::Dimension::Percent(1f32),
+            },
+            inset: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentageAuto::Length(0f32),
+                right: auto(),
+                top: taffy::style::LengthPercentageAuto::Length(0f32),
+                bottom: auto(),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node1 = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Grid,
+                overflow: taffy::geometry::Point {
+                    x: taffy::style::Overflow::Scroll,
+                    y: taffy::style::Overflow::Scroll,
+                },
+                scrollbar_width: 15f32,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Length(200f32),
+                    height: taffy::style::Dimension::Length(200f32),
+                },
+                padding: taffy::geometry::Rect {
+                    left: taffy::style::LengthPercentage::Length(15f32),
+                    right: taffy::style::LengthPercentage::Length(15f32),
+                    top: taffy::style::LengthPercentage::Length(15f32),
+                    bottom: taffy::style::LengthPercentage::Length(15f32),
+                },
+                border: taffy::geometry::Rect {
+                    left: taffy::style::LengthPercentage::Length(20f32),
+                    right: taffy::style::LengthPercentage::Length(20f32),
+                    top: taffy::style::LengthPercentage::Length(20f32),
+                    bottom: taffy::style::LengthPercentage::Length(20f32),
+                },
+                ..Default::default()
+            },
+            &[node10, node11, node12, node13, node14, node15],
+        )
+        .unwrap();
+    let node = taffy.new_with_children(taffy::style::Style { ..Default::default() }, &[node0, node1]).unwrap();
+    taffy.compute_layout_with_measure(node, taffy::geometry::Size::MAX_CONTENT, crate::test_measure_function).unwrap();
+    println!("\nComputed tree:");
+    taffy.print_tree(node);
+    println!();
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node).unwrap();
+    assert_eq!(size.width, 400f32, "width of node {:?}. Expected {}. Actual {}", node, 400f32, size.width);
+    assert_eq!(size.height, 200f32, "height of node {:?}. Expected {}. Actual {}", node, 200f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node, 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node, 0f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node0).unwrap();
+    assert_eq!(size.width, 200f32, "width of node {:?}. Expected {}. Actual {}", node0, 200f32, size.width);
+    assert_eq!(size.height, 200f32, "height of node {:?}. Expected {}. Actual {}", node0, 200f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node0, 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node0, 0f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node0,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node0,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node00).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node00, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node00, 0f32, size.height);
+    assert_eq!(location.x, 20f32, "x of node {:?}. Expected {}. Actual {}", node00, 20f32, location.x);
+    assert_eq!(location.y, 20f32, "y of node {:?}. Expected {}. Actual {}", node00, 20f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node00,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node00,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node01).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node01, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node01, 0f32, size.height);
+    assert_eq!(location.x, 20f32, "x of node {:?}. Expected {}. Actual {}", node01, 20f32, location.x);
+    assert_eq!(location.y, 20f32, "y of node {:?}. Expected {}. Actual {}", node01, 20f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node01,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node01,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node02).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node02, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node02, 0f32, size.height);
+    assert_eq!(location.x, 180f32, "x of node {:?}. Expected {}. Actual {}", node02, 180f32, location.x);
+    assert_eq!(location.y, 180f32, "y of node {:?}. Expected {}. Actual {}", node02, 180f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node02,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node02,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node03).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node03, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node03, 0f32, size.height);
+    assert_eq!(location.x, 20f32, "x of node {:?}. Expected {}. Actual {}", node03, 20f32, location.x);
+    assert_eq!(location.y, 20f32, "y of node {:?}. Expected {}. Actual {}", node03, 20f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node03,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node03,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node04).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node04, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node04, 0f32, size.height);
+    assert_eq!(location.x, 50f32, "x of node {:?}. Expected {}. Actual {}", node04, 50f32, location.x);
+    assert_eq!(location.y, 50f32, "y of node {:?}. Expected {}. Actual {}", node04, 50f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node04,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node04,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node05).unwrap();
+    assert_eq!(size.width, 160f32, "width of node {:?}. Expected {}. Actual {}", node05, 160f32, size.width);
+    assert_eq!(size.height, 160f32, "height of node {:?}. Expected {}. Actual {}", node05, 160f32, size.height);
+    assert_eq!(location.x, 20f32, "x of node {:?}. Expected {}. Actual {}", node05, 20f32, location.x);
+    assert_eq!(location.y, 20f32, "y of node {:?}. Expected {}. Actual {}", node05, 20f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node05,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node05,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node1).unwrap();
+    assert_eq!(size.width, 200f32, "width of node {:?}. Expected {}. Actual {}", node1, 200f32, size.width);
+    assert_eq!(size.height, 200f32, "height of node {:?}. Expected {}. Actual {}", node1, 200f32, size.height);
+    assert_eq!(location.x, 200f32, "x of node {:?}. Expected {}. Actual {}", node1, 200f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node1, 0f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node1,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node1,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node10).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node10, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node10, 0f32, size.height);
+    assert_eq!(location.x, 20f32, "x of node {:?}. Expected {}. Actual {}", node10, 20f32, location.x);
+    assert_eq!(location.y, 20f32, "y of node {:?}. Expected {}. Actual {}", node10, 20f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node10,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node10,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node11).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node11, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node11, 0f32, size.height);
+    assert_eq!(location.x, 20f32, "x of node {:?}. Expected {}. Actual {}", node11, 20f32, location.x);
+    assert_eq!(location.y, 20f32, "y of node {:?}. Expected {}. Actual {}", node11, 20f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node11,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node11,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node12).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node12, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node12, 0f32, size.height);
+    assert_eq!(location.x, 165f32, "x of node {:?}. Expected {}. Actual {}", node12, 165f32, location.x);
+    assert_eq!(location.y, 165f32, "y of node {:?}. Expected {}. Actual {}", node12, 165f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node12,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node12,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node13).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node13, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node13, 0f32, size.height);
+    assert_eq!(location.x, 20f32, "x of node {:?}. Expected {}. Actual {}", node13, 20f32, location.x);
+    assert_eq!(location.y, 20f32, "y of node {:?}. Expected {}. Actual {}", node13, 20f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node13,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node13,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node14).unwrap();
+    assert_eq!(size.width, 0f32, "width of node {:?}. Expected {}. Actual {}", node14, 0f32, size.width);
+    assert_eq!(size.height, 0f32, "height of node {:?}. Expected {}. Actual {}", node14, 0f32, size.height);
+    assert_eq!(location.x, 50f32, "x of node {:?}. Expected {}. Actual {}", node14, 50f32, location.x);
+    assert_eq!(location.y, 50f32, "y of node {:?}. Expected {}. Actual {}", node14, 50f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node14,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node14,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node15).unwrap();
+    assert_eq!(size.width, 145f32, "width of node {:?}. Expected {}. Actual {}", node15, 145f32, size.width);
+    assert_eq!(size.height, 145f32, "height of node {:?}. Expected {}. Actual {}", node15, 145f32, size.height);
+    assert_eq!(location.x, 20f32, "x of node {:?}. Expected {}. Actual {}", node15, 20f32, location.x);
+    assert_eq!(location.y, 20f32, "y of node {:?}. Expected {}. Actual {}", node15, 20f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node15,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node15,
+        0f32,
+        layout.scroll_height()
+    );
+}

--- a/tests/generated/grid/mod.rs
+++ b/tests/generated/grid/mod.rs
@@ -34,6 +34,8 @@ mod grid_absolute_layout_within_border;
 #[cfg(feature = "grid")]
 mod grid_absolute_layout_within_border_static;
 #[cfg(feature = "grid")]
+mod grid_absolute_resolved_insets;
+#[cfg(feature = "grid")]
 mod grid_absolute_row_end;
 #[cfg(feature = "grid")]
 mod grid_absolute_row_start;


### PR DESCRIPTION
# Objective
Currently, absolute insets seem to be resolved incorrectly

## Context

Right now both relative and absolute insets are resolved against the container size.
The common (and probably specified) behavior is to resolve them against `container_size - border `, and in taffy's case, I'd assume `container_size - border - scrollbar_width` when applicable

Note: Parent's padding does not seem to affect insets

### Here's a codepen example
https://codepen.io/juliascript/pen/abrJvZa

### Here's how yoga behaves

https://www.yogalayout.dev/playground?code=DwGQhgng9grgLgAgMZQHYDMCWBzAvAb3xgGcBTAdVICMARU9MGAGzmIC4E4AnGUgXz4A+AFAIEwAHJQAJqQTE4EJqQL4A7pmlwAFhwCMABgMAaBNtI5tcfUdMAHMNOmZU2G6apQusruU079AFYEARExMUkZOQUlFUJRcLE7KGJMOEw0DgByMCpiKCZ4UizjBMS4KDtswIMAUhKy8OV0awQswzqGxLENLV0EAGYTRrFzS1ah0sSBBAB6MPFZqVkRYFnwaHhBIA

### Here's the same layout from the Yoga example computed with taffy BEFORE the fix
```
TREE
└──  FLEX ROW [x: 0    y: 0    w: 100  h: 100  content_w: 145  content_h: 95   border: l:15 r:15 t:15 b:15, padding: l:10 r:10 t:10 b:10] (NodeId(4294967298))
    └──  LEAF [x: 115  y: 65   w: 30   h: 30   content_w: 0    content_h: 0    border: l:0 r:0 t:0 b:0, padding: l:0 r:0 t:0 b:0] (NodeId(4294967297))
```
(x and y ignores parent's border)

### Here's the result AFTER the fix
```
TREE
└──  FLEX ROW [x: 0    y: 0    w: 100  h: 100  content_w: 115  content_h: 80   border: l:15 r:15 t:15 b:15, padding: l:10 r:10 t:10 b:10] (NodeId(4294967298))
    └──  LEAF [x: 85   y: 50   w: 30   h: 30   content_w: 0    content_h: 0    border: l:0 r:0 t:0 b:0, padding: l:0 r:0 t:0 b:0] (NodeId(4294967297))
```

## Feedback
Looking at the code, it seems to me that the scrollbar is always assumed to be on the right or bottom, is this assumption correct?

