### PR TITLE
Include examples in Cargo.toml package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 edition = "2021"
 rust-version = "1.65"
-include = ["src/**/*", "Cargo.toml", "README.md"]
+include = ["src/**/*", "examples/**/*", "Cargo.toml", "README.md"]
 description = "A flexible UI layout library "
 repository = "https://github.com/DioxusLabs/taffy"
 keywords = ["cross-platform", "layout", "flexbox", "css-grid", "grid"]


### PR DESCRIPTION
# Objective

This is required for the crate to build/publish correctly with the new "scrape examples" documentation feature.