### PR TITLE
Don't use block layout in flexbox test

### DIFF
--- a/test_fixtures/flex/align_items_center_with_max_height_with_padding_border.html
+++ b/test_fixtures/flex/align_items_center_with_max_height_with_padding_border.html
@@ -8,7 +8,7 @@
   </title>
 </head>
 <body>
-<div id="test-root" style="display: block;">
+<div id="test-root" style="flex-direction: column;">
   <div style="display: flex; width: 100px; max-height: 100px; align-items: center; align-content: flex-start; padding: 10px; border-width: 10px;">
     <div style="height: 10px; width: 10px;"></div>
     <div style="height: 150px; width: 10px;"></div>

--- a/tests/generated/flex/align_items_center_with_max_height_with_padding_border.rs
+++ b/tests/generated/flex/align_items_center_with_max_height_with_padding_border.rs
@@ -92,7 +92,7 @@ fn align_items_center_with_max_height_with_padding_border() {
         .unwrap();
     let node = taffy
         .new_with_children(
-            taffy::style::Style { display: taffy::style::Display::Block, ..Default::default() },
+            taffy::style::Style { flex_direction: taffy::style::FlexDirection::Column, ..Default::default() },
             &[node0, node1],
         )
         .unwrap();


### PR DESCRIPTION
# Objective

This a flexbox test, however it is unnecessarily relying on block layout. Update it to only use flexbox.