### PR TITLE
Add `DEFAULT` constant to LayoutOutput

### DIFF
--- a/src/tree/layout.rs
+++ b/src/tree/layout.rs
@@ -189,6 +189,9 @@ impl LayoutOutput {
         margins_can_collapse_through: false,
     };
 
+    /// A blank layout output
+    pub const DEFAULT: Self = Self::HIDDEN;
+
     /// Constructor to create a `LayoutOutput` from just the size and baselines
     pub fn from_sizes_and_baselines(
         size: Size<f32>,


### PR DESCRIPTION
# Objective

Useful for using as `..LayoutOutput::DEFAULT`.