### PR TITLE
Impl debug, clone for Cache

### DIFF
--- a/src/tree/cache.rs
+++ b/src/tree/cache.rs
@@ -19,6 +19,7 @@ pub(crate) struct CacheEntry<T> {
 }
 
 /// A cache for caching the results of a sizing a Grid Item or Flexbox Item
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct Cache {
     /// The cache entry for the node's final layout


### PR DESCRIPTION
# Objective

Make it easier to embed `Cache` inside types that implement `Debug` and/or `Clone`.