### PR TITLE
Fix case where Taffy allowed margins to collapse through an element when it shouldn't have

### DIFF
--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -186,7 +186,9 @@ fn compute_inner(tree: &mut impl LayoutBlockContainer, node_id: NodeId, inputs: 
         || padding.top > 0.0
         || padding.bottom > 0.0
         || border.top > 0.0
-        || border.bottom > 0.0;
+        || border.bottom > 0.0
+        || matches!(size.height, Some(h) if h > 0.0)
+        || matches!(min_size.height, Some(h) if h > 0.0);
 
     drop(style);
 

--- a/src/compute/leaf.rs
+++ b/src/compute/leaf.rs
@@ -78,7 +78,9 @@ where
         || padding.top > 0.0
         || padding.bottom > 0.0
         || border.top > 0.0
-        || border.bottom > 0.0;
+        || border.bottom > 0.0
+        || matches!(node_size.height, Some(h) if h > 0.0)
+        || matches!(node_min_size.height, Some(h) if h > 0.0);
 
     debug_log!("LEAF");
     debug_log!("node_size", dbg:node_size);


### PR DESCRIPTION
# Objective

Fix case where Taffy allowed margins to collapse through an element when it shouldn't have

## Context

Fixes horizontal separator div on servo.org in blitz
