### PR TITLE
feat: derive Debug and PartialEq for tree types

### DIFF
--- a/src/tree/cache.rs
+++ b/src/tree/cache.rs
@@ -7,7 +7,7 @@ use crate::tree::{LayoutOutput, RunMode};
 const CACHE_SIZE: usize = 9;
 
 /// Cached intermediate layout results
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 pub(crate) struct CacheEntry<T> {
     /// The initial cached size of the node itself
@@ -19,7 +19,7 @@ pub(crate) struct CacheEntry<T> {
 }
 
 /// A cache for caching the results of a sizing a Grid Item or Flexbox Item
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct Cache {
     /// The cache entry for the node's final layout

--- a/src/tree/layout.rs
+++ b/src/tree/layout.rs
@@ -75,7 +75,7 @@ impl CollapsibleMarginSet {
 }
 
 /// An axis that layout algorithms can be requested to compute a size for
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 pub enum RequestedAxis {
     /// The horizontal axis
@@ -106,7 +106,7 @@ impl TryFrom<RequestedAxis> for AbsoluteAxis {
 }
 
 /// A struct containing the inputs constraints/hints for laying out a node, which are passed in by the parent
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct LayoutInput {
     /// Whether we only need to know the Node's size, or whe
@@ -156,7 +156,7 @@ impl LayoutInput {
 /// children that may be text nodes. See <https://www.w3.org/TR/css-writing-modes-3/#intro-baselines> for details.
 /// If your node does not have a baseline (or you are unsure how to compute it), then simply return `Point::NONE`
 /// for the first_baselines field
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct LayoutOutput {
     /// The size of the node
@@ -221,7 +221,7 @@ impl LayoutOutput {
 }
 
 /// The final result of a layout algorithm for a single node.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct Layout {
     /// The relative ordering of the node

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -66,6 +66,7 @@ impl core::fmt::Display for TaffyError {
 impl std::error::Error for TaffyError {}
 
 /// Global configuration values for a TaffyTree instance
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct TaffyConfig {
     /// Whether to round layout values
     pub(crate) use_rounding: bool,
@@ -80,6 +81,7 @@ impl Default for TaffyConfig {
 /// Layout information for a given [`Node`](crate::node::Node)
 ///
 /// Stored in a [`TaffyTree`].
+#[derive(Debug, Clone, PartialEq)]
 struct NodeData {
     /// The layout strategy used by this node
     pub(crate) style: Style,
@@ -123,7 +125,8 @@ impl NodeData {
 
 /// An entire tree of UI nodes. The entry point to Taffy's high-level API.
 ///
-/// Allows you to build a tree of UI nodes, run Taffy's layout algorithms over that tree, and then access the resultant layout.
+/// Allows you to build a tree of UI nodes, run Taffy's layout algorithms over that tree, and then access the resultant layout.]
+#[derive(Debug, Clone)]
 pub struct TaffyTree<NodeContext = ()> {
     /// The [`NodeData`] for each node stored in this tree
     nodes: SlotMap<DefaultKey, NodeData>,


### PR DESCRIPTION
This makes it possible to store a TaffyTree in a struct that derives
the Debug and Clone traits

# Objective

I wanted to create a struct that stored a TaffyTree, but was unable to as the struct derived Debug and Clone.
Rather than switch to a manual implementation, it makes sense to derive Debug in Taffy.
Additionally several types were missing PartialEq implementations.

## Context

## Feedback wanted

