### PR TITLE
Implement FlexContainerStyle for Style as well as &Style

### DIFF
--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -660,7 +660,7 @@ impl<T: BlockContainerStyle> BlockContainerStyle for &'_ T {
 }
 
 #[cfg(feature = "flexbox")]
-impl FlexboxContainerStyle for &Style {
+impl FlexboxContainerStyle for Style {
     #[inline(always)]
     fn flex_direction(&self) -> FlexDirection {
         self.flex_direction


### PR DESCRIPTION
# Objective

There was a typo in the trait impl causing it to be implemented for `&Style` rather than `Style`.