### PR TITLE
Add `item_is_table` for block items

### DIFF
--- a/src/style/block.rs
+++ b/src/style/block.rs
@@ -1,12 +1,21 @@
 //! Style types for Block layout
 use crate::{CoreStyle, Style};
 
-/// The set of styles required for a CSS Grid item (child of a CSS Grid container)
+/// The set of styles required for a Block layout container
 pub trait BlockContainerStyle: CoreStyle {
     /// Defines which row in the grid the item should start and end at
     #[inline(always)]
     fn text_align(&self) -> TextAlign {
         Style::DEFAULT.text_align
+    }
+}
+
+/// The set of styles required for a Block layout item (child of a Block container)
+pub trait BlockItemStyle: CoreStyle {
+    /// Whether the item is a table. Table children are handled specially in block layout.
+    #[inline(always)]
+    fn is_table(&self) -> bool {
+        false
     }
 }
 

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -13,7 +13,7 @@ pub use self::alignment::{AlignContent, AlignItems, AlignSelf, JustifyContent, J
 pub use self::dimension::{AvailableSpace, Dimension, LengthPercentage, LengthPercentageAuto};
 
 #[cfg(feature = "block_layout")]
-pub use self::block::{BlockContainerStyle, TextAlign};
+pub use self::block::{BlockContainerStyle, BlockItemStyle, TextAlign};
 #[cfg(feature = "flexbox")]
 pub use self::flex::{FlexDirection, FlexWrap, FlexboxContainerStyle, FlexboxItemStyle};
 #[cfg(feature = "grid")]
@@ -330,6 +330,9 @@ impl Overflow {
 pub struct Style {
     /// What layout strategy should be used?
     pub display: Display,
+    /// Whether a child is display:table or not. This affects children of block layouts.
+    /// This should really be part of `Display`, but it is currently seperate because table layout isn't implemented
+    pub item_is_table: bool,
     /// Should size styles apply to the content box or the border box of the node
     pub box_sizing: BoxSizing,
 
@@ -456,6 +459,7 @@ impl Style {
     /// The [`Default`] layout, in a form that can be used in const functions
     pub const DEFAULT: Style = Style {
         display: Display::DEFAULT,
+        item_is_table: false,
         box_sizing: BoxSizing::BorderBox,
         overflow: Point { x: Overflow::Visible, y: Overflow::Visible },
         scrollbar_width: 0.0,
@@ -656,6 +660,22 @@ impl<T: BlockContainerStyle> BlockContainerStyle for &'_ T {
     #[inline(always)]
     fn text_align(&self) -> TextAlign {
         (*self).text_align()
+    }
+}
+
+#[cfg(feature = "block_layout")]
+impl BlockItemStyle for Style {
+    #[inline(always)]
+    fn is_table(&self) -> bool {
+        self.item_is_table
+    }
+}
+
+#[cfg(feature = "block_layout")]
+impl<T: BlockItemStyle> BlockItemStyle for &'_ T {
+    #[inline(always)]
+    fn is_table(&self) -> bool {
+        (*self).is_table()
     }
 }
 
@@ -895,6 +915,7 @@ mod tests {
 
         let old_defaults = Style {
             display: Default::default(),
+            item_is_table: false,
             box_sizing: Default::default(),
             overflow: Default::default(),
             scrollbar_width: 0.0,

--- a/src/tree/traits.rs
+++ b/src/tree/traits.rs
@@ -134,7 +134,7 @@ use crate::style::{FlexboxContainerStyle, FlexboxItemStyle};
 #[cfg(feature = "grid")]
 use crate::style::{GridContainerStyle, GridItemStyle};
 #[cfg(feature = "block_layout")]
-use crate::BlockContainerStyle;
+use crate::{BlockContainerStyle, BlockItemStyle};
 use core::ops::{Deref, DerefMut};
 
 /// This trait is Taffy's abstraction for downward tree traversal.
@@ -257,7 +257,7 @@ pub trait LayoutBlockContainer: LayoutPartialTree {
     where
         Self: 'a;
     /// The style type representing each CSS Block item's styles
-    type BlockItemStyle<'a>: CoreStyle
+    type BlockItemStyle<'a>: BlockItemStyle
     where
         Self: 'a;
 


### PR DESCRIPTION
# Objective

Table children of block nodes are treated specially: they don't get stretch-sized in the inline axis. This PR allows us to implement that behaviour.