### PR TITLE
Upgrade deny.toml to version 2

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,17 +1,14 @@
 [advisories]
+version = 2
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
-vulnerability = "deny"
-unmaintained = "deny"
 yanked = "deny"
-notice = "deny"
 ignore = [
     "RUSTSEC-2021-0145" # from criterion, used only for benchmarking
 ]
 
 [licenses]
-unlicensed = "deny"
-copyleft = "deny"
+version = 2
 allow = [
     "MIT",
     "Unicode-DFS-2016",
@@ -20,7 +17,6 @@ allow = [
     "ISC",
     "BSD-3-Clause"
 ]
-default = "deny"
 
 [bans]
 multiple-versions = "deny"


### PR DESCRIPTION
Many "deny" settings have been removed because they are now the default.

See: https://github.com/EmbarkStudios/cargo-deny/pull/611

# Objective

Fix CI