### PR TITLE
Fix `clippy::too_long_first_doc_paragraph` lint

### DIFF
--- a/src/style/alignment.rs
+++ b/src/style/alignment.rs
@@ -35,14 +35,16 @@ pub enum AlignItems {
 ///
 /// [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-items)
 pub type JustifyItems = AlignItems;
-/// Used to control how the specified nodes is aligned.
+/// Controls alignment of an individual node
+///
 /// Overrides the parent Node's `AlignItems` property.
 /// For Flexbox it controls alignment in the cross axis
 /// For Grid it controls alignment in the block axis
 ///
 /// [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/align-self)
 pub type AlignSelf = AlignItems;
-/// Used to control how the specified nodes is aligned.
+/// Controls alignment of an individual node
+///
 /// Overrides the parent Node's `JustifyItems` property.
 /// Does not apply to Flexbox, and will be ignored if specified on a flex child
 /// For Grid it controls alignment in the inline axis

--- a/src/style/grid.rs
+++ b/src/style/grid.rs
@@ -561,7 +561,8 @@ impl MinTrackSizingFunction {
     }
 }
 
-/// The sizing function for a grid track (row/column) (either auto-track or template track)
+/// The sizing function for a grid track (row/column)
+///
 /// May either be a MinMax variant which specifies separate values for the min-/max- track sizing functions
 /// or a scalar value which applies to both track sizing functions.
 pub type NonRepeatedTrackSizingFunction = MinMax<MinTrackSizingFunction, MaxTrackSizingFunction>;

--- a/src/tree/traits.rs
+++ b/src/tree/traits.rs
@@ -137,7 +137,8 @@ use crate::style::{GridContainerStyle, GridItemStyle};
 use crate::{BlockContainerStyle, BlockItemStyle};
 use core::ops::{Deref, DerefMut};
 
-/// This trait is Taffy's abstraction for downward tree traversal.
+/// Taffy's abstraction for downward tree traversal.
+///
 /// However, this trait does *not* require access to any node's other than a single container node's immediate children unless you also intend to implement `TraverseTree`.
 pub trait TraversePartialTree {
     /// Type representing an iterator of the children of a node
@@ -155,7 +156,9 @@ pub trait TraversePartialTree {
     fn get_child_id(&self, parent_node_id: NodeId, child_index: usize) -> NodeId;
 }
 
-/// A marker trait which extends `TraversePartialTree` with the additional guarantee that the child/children methods can be used to recurse
+/// A marker trait which extends `TraversePartialTree`
+///
+/// Implementing this trait implies the additional guarantee that the child/children methods can be used to recurse
 /// infinitely down the tree. Is required by the `RoundTree` and the `PrintTree` traits.
 pub trait TraverseTree: TraversePartialTree {}
 


### PR DESCRIPTION
# Objective

Ensure that Taffy passes the latest clippy.