### PR TITLE
Fix calculation of `auto-fill`/`auto-fit` repetition count when container has a definite percentage size

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## Unreleased
+
+### Fixes
+
+- Fix calculation of `auto-fill`/`auto-fit` repetition count when container has a definite percentage size (#722)
+
 ## 0.6.0
 
 ### Highlights

--- a/src/compute/grid/explicit_grid.rs
+++ b/src/compute/grid/explicit_grid.rs
@@ -7,7 +7,7 @@ use crate::style_helpers::TaffyAuto;
 use crate::util::sys::Vec;
 use crate::util::MaybeMath;
 use crate::util::ResolveOrZero;
-use crate::GridContainerStyle;
+use crate::{GridContainerStyle, MaybeResolve};
 
 #[cfg(not(feature = "std"))]
 use num_traits::float::FloatCore;
@@ -91,8 +91,10 @@ pub(crate) fn compute_explicit_grid_size_in_axis(
     // Otherwise, if the grid container has a definite min size in the relevant axis:
     //   - then the number of repetitions is the smallest possible positive integer that fulfills that minimum requirement
     // Otherwise, the specified track list repeats only once.
-    let size_is_maximum =
-        style.size().get_abs(axis).into_option().is_some() || style.max_size().get_abs(axis).into_option().is_some();
+    let style_size_is_definite = style.size().get_abs(axis).maybe_resolve(inner_container_size.get_abs(axis)).is_some();
+    let style_max_size_is_definite =
+        style.max_size().get_abs(axis).maybe_resolve(inner_container_size.get_abs(axis)).is_some();
+    let size_is_maximum = style_size_is_definite | style_max_size_is_definite;
 
     // Determine the number of repetitions
     let num_repetitions: u16 = match inner_container_size.get_abs(axis) {

--- a/test_fixtures/grid/grid_auto_fit_definite_percentage.html
+++ b/test_fixtures/grid/grid_auto_fit_definite_percentage.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="height: 300px; width: 730px;">
+  <div style="display: grid; width: 100%; height: 100%; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 10px; padding: 10px; background-color: yellow;">
+    <div style="display: block; background-color: teal;"></div>
+    <div style="display: block; background-color: pink;"></div>
+    <div style="display: block; background-color: royalblue;"></div>
+    <div style="display: block; background-color: violet;"></div>
+    <div style="display: block; background-color: beige;"></div>
+    <div style="display: block; background-color: burlywood;"></div>
+    <div style="display: block; background-color: lightslategrey;"></div>
+    <div style="display: block; background-color: lightseagreen;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/taffy_issue_721.html
+++ b/test_fixtures/grid/taffy_issue_721.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="height: 300px; width: 730px;">
+  <div style="display: grid; width: 100%; height: 100%; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 10px; padding: 10px; background-color: yellow;">
+    <div style="display: block; background-color: teal;"></div>
+    <div style="display: block; background-color: pink;"></div>
+    <div style="display: block; background-color: royalblue;"></div>
+    <div style="display: block; background-color: violet;"></div>
+    <div style="display: block; background-color: beige;"></div>
+    <div style="display: block; background-color: burlywood;"></div>
+    <div style="display: block; background-color: lightslategrey;"></div>
+    <div style="display: block; background-color: lightseagreen;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/generated/grid/mod.rs
+++ b/tests/generated/grid/mod.rs
@@ -503,3 +503,4 @@ mod grid_span_6_all_non_flex_indefinite_hidden;
 mod grid_span_8_all_track_types_indefinite;
 #[cfg(feature = "grid")]
 mod grid_taffy_issue_624;
+mod taffy_issue_721;

--- a/tests/generated/grid/taffy_issue_721.rs
+++ b/tests/generated/grid/taffy_issue_721.rs
@@ -1,0 +1,655 @@
+#[test]
+#[allow(non_snake_case)]
+fn taffy_issue_721__border_box() {
+    #[allow(unused_imports)]
+    use taffy::{prelude::*, tree::Layout, TaffyTree};
+    let mut taffy: TaffyTree<crate::TextMeasure> = TaffyTree::new();
+    let node00 =
+        taffy.new_leaf(taffy::style::Style { display: taffy::style::Display::Block, ..Default::default() }).unwrap();
+    let node01 =
+        taffy.new_leaf(taffy::style::Style { display: taffy::style::Display::Block, ..Default::default() }).unwrap();
+    let node02 =
+        taffy.new_leaf(taffy::style::Style { display: taffy::style::Display::Block, ..Default::default() }).unwrap();
+    let node03 =
+        taffy.new_leaf(taffy::style::Style { display: taffy::style::Display::Block, ..Default::default() }).unwrap();
+    let node04 =
+        taffy.new_leaf(taffy::style::Style { display: taffy::style::Display::Block, ..Default::default() }).unwrap();
+    let node05 =
+        taffy.new_leaf(taffy::style::Style { display: taffy::style::Display::Block, ..Default::default() }).unwrap();
+    let node06 =
+        taffy.new_leaf(taffy::style::Style { display: taffy::style::Display::Block, ..Default::default() }).unwrap();
+    let node07 =
+        taffy.new_leaf(taffy::style::Style { display: taffy::style::Display::Block, ..Default::default() }).unwrap();
+    let node0 = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Grid,
+                gap: taffy::geometry::Size {
+                    width: taffy::style::LengthPercentage::Length(10f32),
+                    height: taffy::style::LengthPercentage::Length(10f32),
+                },
+                grid_template_columns: vec![repeat(
+                    GridTrackRepetition::AutoFill,
+                    vec![minmax(length(150f32), fr(1f32))],
+                )],
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(1f32),
+                    height: taffy::style::Dimension::Percent(1f32),
+                },
+                padding: taffy::geometry::Rect {
+                    left: taffy::style::LengthPercentage::Length(10f32),
+                    right: taffy::style::LengthPercentage::Length(10f32),
+                    top: taffy::style::LengthPercentage::Length(10f32),
+                    bottom: taffy::style::LengthPercentage::Length(10f32),
+                },
+                ..Default::default()
+            },
+            &[node00, node01, node02, node03, node04, node05, node06, node07],
+        )
+        .unwrap();
+    let node = taffy
+        .new_with_children(
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Length(730f32),
+                    height: taffy::style::Dimension::Length(300f32),
+                },
+                ..Default::default()
+            },
+            &[node0],
+        )
+        .unwrap();
+    taffy.compute_layout_with_measure(node, taffy::geometry::Size::MAX_CONTENT, crate::test_measure_function).unwrap();
+    println!("\nComputed tree:");
+    taffy.print_tree(node);
+    println!();
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node).unwrap();
+    assert_eq!(size.width, 730f32, "width of node {:?}. Expected {}. Actual {}", node, 730f32, size.width);
+    assert_eq!(size.height, 300f32, "height of node {:?}. Expected {}. Actual {}", node, 300f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node, 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node, 0f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node0).unwrap();
+    assert_eq!(size.width, 730f32, "width of node {:?}. Expected {}. Actual {}", node0, 730f32, size.width);
+    assert_eq!(size.height, 300f32, "height of node {:?}. Expected {}. Actual {}", node0, 300f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node0, 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node0, 0f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node0,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node0,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node00).unwrap();
+    assert_eq!(size.width, 170f32, "width of node {:?}. Expected {}. Actual {}", node00, 170f32, size.width);
+    assert_eq!(size.height, 135f32, "height of node {:?}. Expected {}. Actual {}", node00, 135f32, size.height);
+    assert_eq!(location.x, 10f32, "x of node {:?}. Expected {}. Actual {}", node00, 10f32, location.x);
+    assert_eq!(location.y, 10f32, "y of node {:?}. Expected {}. Actual {}", node00, 10f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node00,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node00,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node01).unwrap();
+    assert_eq!(size.width, 170f32, "width of node {:?}. Expected {}. Actual {}", node01, 170f32, size.width);
+    assert_eq!(size.height, 135f32, "height of node {:?}. Expected {}. Actual {}", node01, 135f32, size.height);
+    assert_eq!(location.x, 190f32, "x of node {:?}. Expected {}. Actual {}", node01, 190f32, location.x);
+    assert_eq!(location.y, 10f32, "y of node {:?}. Expected {}. Actual {}", node01, 10f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node01,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node01,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node02).unwrap();
+    assert_eq!(size.width, 170f32, "width of node {:?}. Expected {}. Actual {}", node02, 170f32, size.width);
+    assert_eq!(size.height, 135f32, "height of node {:?}. Expected {}. Actual {}", node02, 135f32, size.height);
+    assert_eq!(location.x, 370f32, "x of node {:?}. Expected {}. Actual {}", node02, 370f32, location.x);
+    assert_eq!(location.y, 10f32, "y of node {:?}. Expected {}. Actual {}", node02, 10f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node02,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node02,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node03).unwrap();
+    assert_eq!(size.width, 170f32, "width of node {:?}. Expected {}. Actual {}", node03, 170f32, size.width);
+    assert_eq!(size.height, 135f32, "height of node {:?}. Expected {}. Actual {}", node03, 135f32, size.height);
+    assert_eq!(location.x, 550f32, "x of node {:?}. Expected {}. Actual {}", node03, 550f32, location.x);
+    assert_eq!(location.y, 10f32, "y of node {:?}. Expected {}. Actual {}", node03, 10f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node03,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node03,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node04).unwrap();
+    assert_eq!(size.width, 170f32, "width of node {:?}. Expected {}. Actual {}", node04, 170f32, size.width);
+    assert_eq!(size.height, 135f32, "height of node {:?}. Expected {}. Actual {}", node04, 135f32, size.height);
+    assert_eq!(location.x, 10f32, "x of node {:?}. Expected {}. Actual {}", node04, 10f32, location.x);
+    assert_eq!(location.y, 155f32, "y of node {:?}. Expected {}. Actual {}", node04, 155f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node04,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node04,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node05).unwrap();
+    assert_eq!(size.width, 170f32, "width of node {:?}. Expected {}. Actual {}", node05, 170f32, size.width);
+    assert_eq!(size.height, 135f32, "height of node {:?}. Expected {}. Actual {}", node05, 135f32, size.height);
+    assert_eq!(location.x, 190f32, "x of node {:?}. Expected {}. Actual {}", node05, 190f32, location.x);
+    assert_eq!(location.y, 155f32, "y of node {:?}. Expected {}. Actual {}", node05, 155f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node05,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node05,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node06).unwrap();
+    assert_eq!(size.width, 170f32, "width of node {:?}. Expected {}. Actual {}", node06, 170f32, size.width);
+    assert_eq!(size.height, 135f32, "height of node {:?}. Expected {}. Actual {}", node06, 135f32, size.height);
+    assert_eq!(location.x, 370f32, "x of node {:?}. Expected {}. Actual {}", node06, 370f32, location.x);
+    assert_eq!(location.y, 155f32, "y of node {:?}. Expected {}. Actual {}", node06, 155f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node06,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node06,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node07).unwrap();
+    assert_eq!(size.width, 170f32, "width of node {:?}. Expected {}. Actual {}", node07, 170f32, size.width);
+    assert_eq!(size.height, 135f32, "height of node {:?}. Expected {}. Actual {}", node07, 135f32, size.height);
+    assert_eq!(location.x, 550f32, "x of node {:?}. Expected {}. Actual {}", node07, 550f32, location.x);
+    assert_eq!(location.y, 155f32, "y of node {:?}. Expected {}. Actual {}", node07, 155f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node07,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node07,
+        0f32,
+        layout.scroll_height()
+    );
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn taffy_issue_721__content_box() {
+    #[allow(unused_imports)]
+    use taffy::{prelude::*, tree::Layout, TaffyTree};
+    let mut taffy: TaffyTree<crate::TextMeasure> = TaffyTree::new();
+    let node00 = taffy
+        .new_leaf(taffy::style::Style {
+            display: taffy::style::Display::Block,
+            box_sizing: taffy::style::BoxSizing::ContentBox,
+            ..Default::default()
+        })
+        .unwrap();
+    let node01 = taffy
+        .new_leaf(taffy::style::Style {
+            display: taffy::style::Display::Block,
+            box_sizing: taffy::style::BoxSizing::ContentBox,
+            ..Default::default()
+        })
+        .unwrap();
+    let node02 = taffy
+        .new_leaf(taffy::style::Style {
+            display: taffy::style::Display::Block,
+            box_sizing: taffy::style::BoxSizing::ContentBox,
+            ..Default::default()
+        })
+        .unwrap();
+    let node03 = taffy
+        .new_leaf(taffy::style::Style {
+            display: taffy::style::Display::Block,
+            box_sizing: taffy::style::BoxSizing::ContentBox,
+            ..Default::default()
+        })
+        .unwrap();
+    let node04 = taffy
+        .new_leaf(taffy::style::Style {
+            display: taffy::style::Display::Block,
+            box_sizing: taffy::style::BoxSizing::ContentBox,
+            ..Default::default()
+        })
+        .unwrap();
+    let node05 = taffy
+        .new_leaf(taffy::style::Style {
+            display: taffy::style::Display::Block,
+            box_sizing: taffy::style::BoxSizing::ContentBox,
+            ..Default::default()
+        })
+        .unwrap();
+    let node06 = taffy
+        .new_leaf(taffy::style::Style {
+            display: taffy::style::Display::Block,
+            box_sizing: taffy::style::BoxSizing::ContentBox,
+            ..Default::default()
+        })
+        .unwrap();
+    let node07 = taffy
+        .new_leaf(taffy::style::Style {
+            display: taffy::style::Display::Block,
+            box_sizing: taffy::style::BoxSizing::ContentBox,
+            ..Default::default()
+        })
+        .unwrap();
+    let node0 = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Grid,
+                box_sizing: taffy::style::BoxSizing::ContentBox,
+                gap: taffy::geometry::Size {
+                    width: taffy::style::LengthPercentage::Length(10f32),
+                    height: taffy::style::LengthPercentage::Length(10f32),
+                },
+                grid_template_columns: vec![repeat(
+                    GridTrackRepetition::AutoFill,
+                    vec![minmax(length(150f32), fr(1f32))],
+                )],
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(1f32),
+                    height: taffy::style::Dimension::Percent(1f32),
+                },
+                padding: taffy::geometry::Rect {
+                    left: taffy::style::LengthPercentage::Length(10f32),
+                    right: taffy::style::LengthPercentage::Length(10f32),
+                    top: taffy::style::LengthPercentage::Length(10f32),
+                    bottom: taffy::style::LengthPercentage::Length(10f32),
+                },
+                ..Default::default()
+            },
+            &[node00, node01, node02, node03, node04, node05, node06, node07],
+        )
+        .unwrap();
+    let node = taffy
+        .new_with_children(
+            taffy::style::Style {
+                box_sizing: taffy::style::BoxSizing::ContentBox,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Length(730f32),
+                    height: taffy::style::Dimension::Length(300f32),
+                },
+                ..Default::default()
+            },
+            &[node0],
+        )
+        .unwrap();
+    taffy.compute_layout_with_measure(node, taffy::geometry::Size::MAX_CONTENT, crate::test_measure_function).unwrap();
+    println!("\nComputed tree:");
+    taffy.print_tree(node);
+    println!();
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node).unwrap();
+    assert_eq!(size.width, 730f32, "width of node {:?}. Expected {}. Actual {}", node, 730f32, size.width);
+    assert_eq!(size.height, 300f32, "height of node {:?}. Expected {}. Actual {}", node, 300f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node, 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node, 0f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        20f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node,
+        20f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node0).unwrap();
+    assert_eq!(size.width, 730f32, "width of node {:?}. Expected {}. Actual {}", node0, 730f32, size.width);
+    assert_eq!(size.height, 320f32, "height of node {:?}. Expected {}. Actual {}", node0, 320f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node0, 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node0, 0f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node0,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node0,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node00).unwrap();
+    assert_eq!(size.width, 170f32, "width of node {:?}. Expected {}. Actual {}", node00, 170f32, size.width);
+    assert_eq!(size.height, 145f32, "height of node {:?}. Expected {}. Actual {}", node00, 145f32, size.height);
+    assert_eq!(location.x, 10f32, "x of node {:?}. Expected {}. Actual {}", node00, 10f32, location.x);
+    assert_eq!(location.y, 10f32, "y of node {:?}. Expected {}. Actual {}", node00, 10f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node00,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node00,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node01).unwrap();
+    assert_eq!(size.width, 170f32, "width of node {:?}. Expected {}. Actual {}", node01, 170f32, size.width);
+    assert_eq!(size.height, 145f32, "height of node {:?}. Expected {}. Actual {}", node01, 145f32, size.height);
+    assert_eq!(location.x, 190f32, "x of node {:?}. Expected {}. Actual {}", node01, 190f32, location.x);
+    assert_eq!(location.y, 10f32, "y of node {:?}. Expected {}. Actual {}", node01, 10f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node01,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node01,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node02).unwrap();
+    assert_eq!(size.width, 170f32, "width of node {:?}. Expected {}. Actual {}", node02, 170f32, size.width);
+    assert_eq!(size.height, 145f32, "height of node {:?}. Expected {}. Actual {}", node02, 145f32, size.height);
+    assert_eq!(location.x, 370f32, "x of node {:?}. Expected {}. Actual {}", node02, 370f32, location.x);
+    assert_eq!(location.y, 10f32, "y of node {:?}. Expected {}. Actual {}", node02, 10f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node02,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node02,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node03).unwrap();
+    assert_eq!(size.width, 170f32, "width of node {:?}. Expected {}. Actual {}", node03, 170f32, size.width);
+    assert_eq!(size.height, 145f32, "height of node {:?}. Expected {}. Actual {}", node03, 145f32, size.height);
+    assert_eq!(location.x, 550f32, "x of node {:?}. Expected {}. Actual {}", node03, 550f32, location.x);
+    assert_eq!(location.y, 10f32, "y of node {:?}. Expected {}. Actual {}", node03, 10f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node03,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node03,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node04).unwrap();
+    assert_eq!(size.width, 170f32, "width of node {:?}. Expected {}. Actual {}", node04, 170f32, size.width);
+    assert_eq!(size.height, 145f32, "height of node {:?}. Expected {}. Actual {}", node04, 145f32, size.height);
+    assert_eq!(location.x, 10f32, "x of node {:?}. Expected {}. Actual {}", node04, 10f32, location.x);
+    assert_eq!(location.y, 165f32, "y of node {:?}. Expected {}. Actual {}", node04, 165f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node04,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node04,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node05).unwrap();
+    assert_eq!(size.width, 170f32, "width of node {:?}. Expected {}. Actual {}", node05, 170f32, size.width);
+    assert_eq!(size.height, 145f32, "height of node {:?}. Expected {}. Actual {}", node05, 145f32, size.height);
+    assert_eq!(location.x, 190f32, "x of node {:?}. Expected {}. Actual {}", node05, 190f32, location.x);
+    assert_eq!(location.y, 165f32, "y of node {:?}. Expected {}. Actual {}", node05, 165f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node05,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node05,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node06).unwrap();
+    assert_eq!(size.width, 170f32, "width of node {:?}. Expected {}. Actual {}", node06, 170f32, size.width);
+    assert_eq!(size.height, 145f32, "height of node {:?}. Expected {}. Actual {}", node06, 145f32, size.height);
+    assert_eq!(location.x, 370f32, "x of node {:?}. Expected {}. Actual {}", node06, 370f32, location.x);
+    assert_eq!(location.y, 165f32, "y of node {:?}. Expected {}. Actual {}", node06, 165f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node06,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node06,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node07).unwrap();
+    assert_eq!(size.width, 170f32, "width of node {:?}. Expected {}. Actual {}", node07, 170f32, size.width);
+    assert_eq!(size.height, 145f32, "height of node {:?}. Expected {}. Actual {}", node07, 145f32, size.height);
+    assert_eq!(location.x, 550f32, "x of node {:?}. Expected {}. Actual {}", node07, 550f32, location.x);
+    assert_eq!(location.y, 165f32, "y of node {:?}. Expected {}. Actual {}", node07, 165f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node07,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node07,
+        0f32,
+        layout.scroll_height()
+    );
+}


### PR DESCRIPTION
# Objective

- Fixes #721

Previously, when computing the repetition count for auto repetitions, Taffy was only checking whether the container had a fixed pixel size or max-size. Taffy now correctly also checks for a percentage which resolves against a definite size.
