### PR TITLE
Fix intrinsic sizing min size

### DIFF
--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -900,7 +900,9 @@ fn determine_container_main_size(
                             .iter()
                             .map(|child| {
                                 let padding_border_sum = (child.padding + child.border).main_axis_sum(constants.dir);
-                                (child.flex_basis + child.margin.main_axis_sum(constants.dir)).max(padding_border_sum)
+                                (child.flex_basis.maybe_max(child.min_size.main(constants.dir))
+                                    + child.margin.main_axis_sum(constants.dir))
+                                .max(padding_border_sum)
                             })
                             .sum::<f32>();
                         total_target_size + line_main_axis_gap
@@ -924,7 +926,9 @@ fn determine_container_main_size(
                             .iter()
                             .map(|child| {
                                 let padding_border_sum = (child.padding + child.border).main_axis_sum(constants.dir);
-                                (child.flex_basis + child.margin.main_axis_sum(constants.dir)).max(padding_border_sum)
+                                (child.flex_basis.maybe_max(child.min_size.main(constants.dir))
+                                    + child.margin.main_axis_sum(constants.dir))
+                                .max(padding_border_sum)
                             })
                             .sum::<f32>();
                         total_target_size + line_main_axis_gap

--- a/test_fixtures/grid/grid_taffy_issue_591.html
+++ b/test_fixtures/grid/grid_taffy_issue_591.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body style="margin: 20px;">
+
+<div id="test-root" style="display: flex; width: 300px; height: 200px;">
+ <div id="outer" style="display: flex; position: absolute; top: 0; left: 0; max-width: 100px; max-height: 100px; padding: 10px; align-items: center; justify-content: center;">
+  <div id="inner" style="display: flex; min-width: 50px; min-height: 50px; padding: 10px;"></div>
+ </div>
+</div>
+
+</body>
+</html>
+
+

--- a/tests/generated/grid/grid_taffy_issue_591.rs
+++ b/tests/generated/grid/grid_taffy_issue_591.rs
@@ -1,0 +1,284 @@
+#[test]
+#[allow(non_snake_case)]
+fn grid_taffy_issue_591__border_box() {
+    #[allow(unused_imports)]
+    use taffy::{prelude::*, tree::Layout, TaffyTree};
+    let mut taffy: TaffyTree<crate::TextMeasure> = TaffyTree::new();
+    let node00 = taffy
+        .new_leaf(taffy::style::Style {
+            display: taffy::style::Display::Flex,
+            min_size: taffy::geometry::Size {
+                width: taffy::style::Dimension::Length(50f32),
+                height: taffy::style::Dimension::Length(50f32),
+            },
+            padding: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentage::Length(10f32),
+                right: taffy::style::LengthPercentage::Length(10f32),
+                top: taffy::style::LengthPercentage::Length(10f32),
+                bottom: taffy::style::LengthPercentage::Length(10f32),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node0 = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Flex,
+                position: taffy::style::Position::Absolute,
+                align_items: Some(taffy::style::AlignItems::Center),
+                justify_content: Some(taffy::style::JustifyContent::Center),
+                max_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Length(100f32),
+                    height: taffy::style::Dimension::Length(100f32),
+                },
+                padding: taffy::geometry::Rect {
+                    left: taffy::style::LengthPercentage::Length(10f32),
+                    right: taffy::style::LengthPercentage::Length(10f32),
+                    top: taffy::style::LengthPercentage::Length(10f32),
+                    bottom: taffy::style::LengthPercentage::Length(10f32),
+                },
+                inset: taffy::geometry::Rect {
+                    left: taffy::style::LengthPercentageAuto::Length(0f32),
+                    right: auto(),
+                    top: taffy::style::LengthPercentageAuto::Length(0f32),
+                    bottom: auto(),
+                },
+                ..Default::default()
+            },
+            &[node00],
+        )
+        .unwrap();
+    let node = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Flex,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Length(300f32),
+                    height: taffy::style::Dimension::Length(200f32),
+                },
+                ..Default::default()
+            },
+            &[node0],
+        )
+        .unwrap();
+    taffy.compute_layout_with_measure(node, taffy::geometry::Size::MAX_CONTENT, crate::test_measure_function).unwrap();
+    println!("\nComputed tree:");
+    taffy.print_tree(node);
+    println!();
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node).unwrap();
+    assert_eq!(size.width, 300f32, "width of node {:?}. Expected {}. Actual {}", node, 300f32, size.width);
+    assert_eq!(size.height, 200f32, "height of node {:?}. Expected {}. Actual {}", node, 200f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node, 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node, 0f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node0).unwrap();
+    assert_eq!(size.width, 70f32, "width of node {:?}. Expected {}. Actual {}", node0, 70f32, size.width);
+    assert_eq!(size.height, 70f32, "height of node {:?}. Expected {}. Actual {}", node0, 70f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node0, 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node0, 0f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node0,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node0,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node00).unwrap();
+    assert_eq!(size.width, 50f32, "width of node {:?}. Expected {}. Actual {}", node00, 50f32, size.width);
+    assert_eq!(size.height, 50f32, "height of node {:?}. Expected {}. Actual {}", node00, 50f32, size.height);
+    assert_eq!(location.x, 10f32, "x of node {:?}. Expected {}. Actual {}", node00, 10f32, location.x);
+    assert_eq!(location.y, 10f32, "y of node {:?}. Expected {}. Actual {}", node00, 10f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node00,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node00,
+        0f32,
+        layout.scroll_height()
+    );
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn grid_taffy_issue_591__content_box() {
+    #[allow(unused_imports)]
+    use taffy::{prelude::*, tree::Layout, TaffyTree};
+    let mut taffy: TaffyTree<crate::TextMeasure> = TaffyTree::new();
+    let node00 = taffy
+        .new_leaf(taffy::style::Style {
+            display: taffy::style::Display::Flex,
+            box_sizing: taffy::style::BoxSizing::ContentBox,
+            min_size: taffy::geometry::Size {
+                width: taffy::style::Dimension::Length(50f32),
+                height: taffy::style::Dimension::Length(50f32),
+            },
+            padding: taffy::geometry::Rect {
+                left: taffy::style::LengthPercentage::Length(10f32),
+                right: taffy::style::LengthPercentage::Length(10f32),
+                top: taffy::style::LengthPercentage::Length(10f32),
+                bottom: taffy::style::LengthPercentage::Length(10f32),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+    let node0 = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Flex,
+                box_sizing: taffy::style::BoxSizing::ContentBox,
+                position: taffy::style::Position::Absolute,
+                align_items: Some(taffy::style::AlignItems::Center),
+                justify_content: Some(taffy::style::JustifyContent::Center),
+                max_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Length(100f32),
+                    height: taffy::style::Dimension::Length(100f32),
+                },
+                padding: taffy::geometry::Rect {
+                    left: taffy::style::LengthPercentage::Length(10f32),
+                    right: taffy::style::LengthPercentage::Length(10f32),
+                    top: taffy::style::LengthPercentage::Length(10f32),
+                    bottom: taffy::style::LengthPercentage::Length(10f32),
+                },
+                inset: taffy::geometry::Rect {
+                    left: taffy::style::LengthPercentageAuto::Length(0f32),
+                    right: auto(),
+                    top: taffy::style::LengthPercentageAuto::Length(0f32),
+                    bottom: auto(),
+                },
+                ..Default::default()
+            },
+            &[node00],
+        )
+        .unwrap();
+    let node = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Flex,
+                box_sizing: taffy::style::BoxSizing::ContentBox,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Length(300f32),
+                    height: taffy::style::Dimension::Length(200f32),
+                },
+                ..Default::default()
+            },
+            &[node0],
+        )
+        .unwrap();
+    taffy.compute_layout_with_measure(node, taffy::geometry::Size::MAX_CONTENT, crate::test_measure_function).unwrap();
+    println!("\nComputed tree:");
+    taffy.print_tree(node);
+    println!();
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node).unwrap();
+    assert_eq!(size.width, 300f32, "width of node {:?}. Expected {}. Actual {}", node, 300f32, size.width);
+    assert_eq!(size.height, 200f32, "height of node {:?}. Expected {}. Actual {}", node, 200f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node, 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node, 0f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node0).unwrap();
+    assert_eq!(size.width, 90f32, "width of node {:?}. Expected {}. Actual {}", node0, 90f32, size.width);
+    assert_eq!(size.height, 90f32, "height of node {:?}. Expected {}. Actual {}", node0, 90f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node0, 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node0, 0f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node0,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node0,
+        0f32,
+        layout.scroll_height()
+    );
+    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
+    let layout @ Layout { size, location, .. } = taffy.layout(node00).unwrap();
+    assert_eq!(size.width, 70f32, "width of node {:?}. Expected {}. Actual {}", node00, 70f32, size.width);
+    assert_eq!(size.height, 70f32, "height of node {:?}. Expected {}. Actual {}", node00, 70f32, size.height);
+    assert_eq!(location.x, 10f32, "x of node {:?}. Expected {}. Actual {}", node00, 10f32, location.x);
+    assert_eq!(location.y, 10f32, "y of node {:?}. Expected {}. Actual {}", node00, 10f32, location.y);
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_width(),
+        0f32,
+        "scroll_width of node {:?}. Expected {}. Actual {}",
+        node00,
+        0f32,
+        layout.scroll_width()
+    );
+    #[cfg(feature = "content_size")]
+    assert_eq!(
+        layout.scroll_height(),
+        0f32,
+        "scroll_height of node {:?}. Expected {}. Actual {}",
+        node00,
+        0f32,
+        layout.scroll_height()
+    );
+}

--- a/tests/generated/grid/mod.rs
+++ b/tests/generated/grid/mod.rs
@@ -158,6 +158,8 @@ mod grid_auto_fill_fixed_size;
 #[cfg(feature = "grid")]
 mod grid_auto_fill_with_empty_auto_track;
 #[cfg(feature = "grid")]
+mod grid_auto_fit_definite_percentage;
+#[cfg(feature = "grid")]
 mod grid_auto_fit_with_empty_auto_track;
 #[cfg(feature = "grid")]
 mod grid_auto_rows;
@@ -501,6 +503,8 @@ mod grid_span_6_all_non_flex_indefinite;
 mod grid_span_6_all_non_flex_indefinite_hidden;
 #[cfg(feature = "grid")]
 mod grid_span_8_all_track_types_indefinite;
+#[cfg(feature = "grid")]
+mod grid_taffy_issue_591;
 #[cfg(feature = "grid")]
 mod grid_taffy_issue_624;
 mod taffy_issue_721;


### PR DESCRIPTION
# Objective

- Fixes #591 

`min-size` styles of flexbox items ought to be taken into account when determining the intrinsic size of Flexbox containers.