### PR TITLE
Remove clippy lint ignores

### DIFF
--- a/scripts/gentest/src/main.rs
+++ b/scripts/gentest/src/main.rs
@@ -1,6 +1,3 @@
-// This is a spurious warning. See https://github.com/rust-lang/rust-clippy/issues/13535
-#![allow(clippy::needless_return)]
-
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -80,9 +77,6 @@ async fn main() {
 
     info!("starting webdriver instance");
     let webdriver_url = "http://localhost:4444";
-
-    // TODO: call `.wait()` at an appropriate time (probably at the end of the process?)
-    #[allow(clippy::zombie_processes)]
     let mut webdriver_handle = Command::new("chromedriver")
         .arg("--port=4444")
         .spawn()
@@ -107,6 +101,7 @@ async fn main() {
 
     info!("killing webdriver instance...");
     webdriver_handle.kill().unwrap();
+    webdriver_handle.wait().unwrap();
 
     info!("generating test sources and concatenating...");
 


### PR DESCRIPTION
# Objective

Fix clippy lints properly rather than ignoring. In one case the ignore was to work around a clippy bug which has now been fixed.