### PR TITLE
Apply latest (nightly) rustfmt (format associated types with GATs)

### DIFF
--- a/examples/custom_tree_owned_partial.rs
+++ b/examples/custom_tree_owned_partial.rs
@@ -133,10 +133,15 @@ impl taffy::TraversePartialTree for Node {
 }
 
 impl taffy::LayoutPartialTree for Node {
-    type CoreContainerStyle<'a> = &'a Style where
+    type CoreContainerStyle<'a>
+        = &'a Style
+    where
         Self: 'a;
 
-    type CacheMut<'b> = &'b mut Cache where Self: 'b;
+    type CacheMut<'b>
+        = &'b mut Cache
+    where
+        Self: 'b;
 
     fn get_core_container_style(&self, node_id: NodeId) -> Self::CoreContainerStyle<'_> {
         &self.node_from_id(node_id).style
@@ -175,10 +180,14 @@ impl taffy::LayoutPartialTree for Node {
 }
 
 impl taffy::LayoutFlexboxContainer for Node {
-    type FlexboxContainerStyle<'a> = &'a Style where
+    type FlexboxContainerStyle<'a>
+        = &'a Style
+    where
         Self: 'a;
 
-    type FlexboxItemStyle<'a> = &'a Style where
+    type FlexboxItemStyle<'a>
+        = &'a Style
+    where
         Self: 'a;
 
     fn get_flexbox_container_style(&self, node_id: NodeId) -> Self::FlexboxContainerStyle<'_> {
@@ -191,10 +200,14 @@ impl taffy::LayoutFlexboxContainer for Node {
 }
 
 impl taffy::LayoutGridContainer for Node {
-    type GridContainerStyle<'a> = &'a Style where
+    type GridContainerStyle<'a>
+        = &'a Style
+    where
         Self: 'a;
 
-    type GridItemStyle<'a> = &'a Style where
+    type GridItemStyle<'a>
+        = &'a Style
+    where
         Self: 'a;
 
     fn get_grid_container_style(&self, node_id: NodeId) -> Self::GridContainerStyle<'_> {

--- a/examples/custom_tree_owned_unsafe.rs
+++ b/examples/custom_tree_owned_unsafe.rs
@@ -130,10 +130,15 @@ impl TraversePartialTree for StatelessLayoutTree {
 impl TraverseTree for StatelessLayoutTree {}
 
 impl LayoutPartialTree for StatelessLayoutTree {
-    type CoreContainerStyle<'a> = &'a Style where
+    type CoreContainerStyle<'a>
+        = &'a Style
+    where
         Self: 'a;
 
-    type CacheMut<'b> = &'b mut Cache where Self: 'b;
+    type CacheMut<'b>
+        = &'b mut Cache
+    where
+        Self: 'b;
 
     fn get_core_container_style(&self, node_id: NodeId) -> Self::CoreContainerStyle<'_> {
         unsafe { &node_from_id(node_id).style }
@@ -172,10 +177,14 @@ impl LayoutPartialTree for StatelessLayoutTree {
 }
 
 impl taffy::LayoutFlexboxContainer for StatelessLayoutTree {
-    type FlexboxContainerStyle<'a> = &'a Style where
+    type FlexboxContainerStyle<'a>
+        = &'a Style
+    where
         Self: 'a;
 
-    type FlexboxItemStyle<'a> = &'a Style where
+    type FlexboxItemStyle<'a>
+        = &'a Style
+    where
         Self: 'a;
 
     fn get_flexbox_container_style(&self, node_id: NodeId) -> Self::FlexboxContainerStyle<'_> {
@@ -188,10 +197,14 @@ impl taffy::LayoutFlexboxContainer for StatelessLayoutTree {
 }
 
 impl taffy::LayoutGridContainer for StatelessLayoutTree {
-    type GridContainerStyle<'a> = &'a Style where
+    type GridContainerStyle<'a>
+        = &'a Style
+    where
         Self: 'a;
 
-    type GridItemStyle<'a> = &'a Style where
+    type GridItemStyle<'a>
+        = &'a Style
+    where
         Self: 'a;
 
     fn get_grid_container_style(&self, node_id: NodeId) -> Self::GridContainerStyle<'_> {

--- a/examples/custom_tree_vec.rs
+++ b/examples/custom_tree_vec.rs
@@ -139,10 +139,15 @@ impl taffy::TraversePartialTree for Tree {
 impl taffy::TraverseTree for Tree {}
 
 impl taffy::LayoutPartialTree for Tree {
-    type CoreContainerStyle<'a> = &'a Style where
+    type CoreContainerStyle<'a>
+        = &'a Style
+    where
         Self: 'a;
 
-    type CacheMut<'b> = &'b mut Cache where Self: 'b;
+    type CacheMut<'b>
+        = &'b mut Cache
+    where
+        Self: 'b;
 
     fn get_core_container_style(&self, node_id: NodeId) -> Self::CoreContainerStyle<'_> {
         &self.node_from_id(node_id).style
@@ -181,10 +186,14 @@ impl taffy::LayoutPartialTree for Tree {
 }
 
 impl taffy::LayoutFlexboxContainer for Tree {
-    type FlexboxContainerStyle<'a> = &'a Style where
+    type FlexboxContainerStyle<'a>
+        = &'a Style
+    where
         Self: 'a;
 
-    type FlexboxItemStyle<'a> = &'a Style where
+    type FlexboxItemStyle<'a>
+        = &'a Style
+    where
         Self: 'a;
 
     fn get_flexbox_container_style(&self, node_id: NodeId) -> Self::FlexboxContainerStyle<'_> {
@@ -197,10 +206,14 @@ impl taffy::LayoutFlexboxContainer for Tree {
 }
 
 impl taffy::LayoutGridContainer for Tree {
-    type GridContainerStyle<'a> = &'a Style where
+    type GridContainerStyle<'a>
+        = &'a Style
+    where
         Self: 'a;
 
-    type GridItemStyle<'a> = &'a Style where
+    type GridItemStyle<'a>
+        = &'a Style
+    where
         Self: 'a;
 
     fn get_grid_container_style(&self, node_id: NodeId) -> Self::GridContainerStyle<'_> {

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -777,8 +777,14 @@ impl<T: FlexboxItemStyle> FlexboxItemStyle for &'_ T {
 
 #[cfg(feature = "grid")]
 impl GridContainerStyle for Style {
-    type TemplateTrackList<'a> = &'a [TrackSizingFunction] where Self: 'a;
-    type AutoTrackList<'a> = &'a [NonRepeatedTrackSizingFunction] where Self: 'a;
+    type TemplateTrackList<'a>
+        = &'a [TrackSizingFunction]
+    where
+        Self: 'a;
+    type AutoTrackList<'a>
+        = &'a [NonRepeatedTrackSizingFunction]
+    where
+        Self: 'a;
 
     #[inline(always)]
     fn grid_template_rows(&self) -> &[TrackSizingFunction] {
@@ -824,8 +830,14 @@ impl GridContainerStyle for Style {
 
 #[cfg(feature = "grid")]
 impl<T: GridContainerStyle> GridContainerStyle for &'_ T {
-    type TemplateTrackList<'a> = T::TemplateTrackList<'a> where Self: 'a;
-    type AutoTrackList<'a> = T::AutoTrackList<'a> where Self: 'a;
+    type TemplateTrackList<'a>
+        = T::TemplateTrackList<'a>
+    where
+        Self: 'a;
+    type AutoTrackList<'a>
+        = T::AutoTrackList<'a>
+    where
+        Self: 'a;
 
     #[inline(always)]
     fn grid_template_rows(&self) -> Self::TemplateTrackList<'_> {

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -166,7 +166,10 @@ impl Iterator for TaffyTreeChildIter<'_> {
 
 // TraversePartialTree impl for TaffyTree
 impl<NodeContext> TraversePartialTree for TaffyTree<NodeContext> {
-    type ChildIter<'a> = TaffyTreeChildIter<'a> where Self: 'a;
+    type ChildIter<'a>
+        = TaffyTreeChildIter<'a>
+    where
+        Self: 'a;
 
     #[inline(always)]
     fn child_ids(&self, parent_node_id: NodeId) -> Self::ChildIter<'_> {
@@ -243,7 +246,10 @@ where
     MeasureFunction:
         FnMut(Size<Option<f32>>, Size<AvailableSpace>, NodeId, Option<&mut NodeContext>, &Style) -> Size<f32>,
 {
-    type ChildIter<'a> = TaffyTreeChildIter<'a> where Self: 'a;
+    type ChildIter<'a>
+        = TaffyTreeChildIter<'a>
+    where
+        Self: 'a;
 
     #[inline(always)]
     fn child_ids(&self, parent_node_id: NodeId) -> Self::ChildIter<'_> {
@@ -274,8 +280,14 @@ where
     MeasureFunction:
         FnMut(Size<Option<f32>>, Size<AvailableSpace>, NodeId, Option<&mut NodeContext>, &Style) -> Size<f32>,
 {
-    type CoreContainerStyle<'a> = &'a Style where Self : 'a;
-    type CacheMut<'b> = &'b mut Cache where Self : 'b;
+    type CoreContainerStyle<'a>
+        = &'a Style
+    where
+        Self: 'a;
+    type CacheMut<'b>
+        = &'b mut Cache
+    where
+        Self: 'b;
 
     #[inline(always)]
     fn get_core_container_style(&self, node_id: NodeId) -> Self::CoreContainerStyle<'_> {
@@ -349,8 +361,14 @@ where
     MeasureFunction:
         FnMut(Size<Option<f32>>, Size<AvailableSpace>, NodeId, Option<&mut NodeContext>, &Style) -> Size<f32>,
 {
-    type BlockContainerStyle<'a> = &'a Style where Self: 'a;
-    type BlockItemStyle<'a> = &'a Style where Self: 'a;
+    type BlockContainerStyle<'a>
+        = &'a Style
+    where
+        Self: 'a;
+    type BlockItemStyle<'a>
+        = &'a Style
+    where
+        Self: 'a;
 
     #[inline(always)]
     fn get_block_container_style(&self, node_id: NodeId) -> Self::BlockContainerStyle<'_> {
@@ -369,8 +387,14 @@ where
     MeasureFunction:
         FnMut(Size<Option<f32>>, Size<AvailableSpace>, NodeId, Option<&mut NodeContext>, &Style) -> Size<f32>,
 {
-    type FlexboxContainerStyle<'a> = &'a Style where Self: 'a;
-    type FlexboxItemStyle<'a> = &'a Style where Self: 'a;
+    type FlexboxContainerStyle<'a>
+        = &'a Style
+    where
+        Self: 'a;
+    type FlexboxItemStyle<'a>
+        = &'a Style
+    where
+        Self: 'a;
 
     #[inline(always)]
     fn get_flexbox_container_style(&self, node_id: NodeId) -> Self::FlexboxContainerStyle<'_> {
@@ -389,8 +413,14 @@ where
     MeasureFunction:
         FnMut(Size<Option<f32>>, Size<AvailableSpace>, NodeId, Option<&mut NodeContext>, &Style) -> Size<f32>,
 {
-    type GridContainerStyle<'a> = &'a Style where Self: 'a;
-    type GridItemStyle<'a> = &'a Style where Self: 'a;
+    type GridContainerStyle<'a>
+        = &'a Style
+    where
+        Self: 'a;
+    type GridItemStyle<'a>
+        = &'a Style
+    where
+        Self: 'a;
 
     #[inline(always)]
     fn get_grid_container_style(&self, node_id: NodeId) -> Self::GridContainerStyle<'_> {

--- a/taffy_stylo/src/arc.rs
+++ b/taffy_stylo/src/arc.rs
@@ -175,8 +175,14 @@ impl taffy::FlexboxItemStyle for TaffyStyloStyle {
 }
 
 impl taffy::GridContainerStyle for TaffyStyloStyle {
-    type TemplateTrackList<'a> = Vec<taffy::TrackSizingFunction> where Self: 'a;
-    type AutoTrackList<'a> = Vec<taffy::NonRepeatedTrackSizingFunction> where Self: 'a;
+    type TemplateTrackList<'a>
+        = Vec<taffy::TrackSizingFunction>
+    where
+        Self: 'a;
+    type AutoTrackList<'a>
+        = Vec<taffy::NonRepeatedTrackSizingFunction>
+    where
+        Self: 'a;
 
     #[inline]
     fn grid_template_rows(&self) -> Self::TemplateTrackList<'_> {

--- a/taffy_stylo/src/borrowed.rs
+++ b/taffy_stylo/src/borrowed.rs
@@ -174,8 +174,14 @@ impl taffy::FlexboxItemStyle for TaffyStyloStyleRef<'_> {
 }
 
 impl taffy::GridContainerStyle for TaffyStyloStyleRef<'_> {
-    type TemplateTrackList<'a> = Vec<taffy::TrackSizingFunction> where Self: 'a;
-    type AutoTrackList<'a> = Vec<taffy::NonRepeatedTrackSizingFunction> where Self: 'a;
+    type TemplateTrackList<'a>
+        = Vec<taffy::TrackSizingFunction>
+    where
+        Self: 'a;
+    type AutoTrackList<'a>
+        = Vec<taffy::NonRepeatedTrackSizingFunction>
+    where
+        Self: 'a;
 
     #[inline]
     fn grid_template_rows(&self) -> Self::TemplateTrackList<'_> {


### PR DESCRIPTION
# Objective

Reduce incidental diff from incoming PRs using nightly rustfmt (stable rust currently doesn't format these sections of code at all, so there is no conflict).

## Context

I don't really like this formatting (seems very verbose), but it's not going to be practical to use formatting other than what rustfmt produces, and there doesn't seem to be a config option for this atm.
