### PR TITLE
Move cargo config aliases to justfile.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,0 @@
-[alias]
-gentest = "run --release --package gentest --"
-import-yoga-tests = "run --package import-yoga-tests --"
-format-fixtures = "run --package format-fixtures --"
-xbench = "bench --package taffy_benchmarks"

--- a/justfile
+++ b/justfile
@@ -1,0 +1,17 @@
+gentest:
+  cargo run --release --package gentest --
+
+import-yoga-tests:
+  cargo run --package import-yoga-tests --
+
+format-fixtures:
+  cargo run --package format-fixtures --
+
+bench:
+  cargo bench --package taffy_benchmarks
+
+clippy:
+  cargo +nightly clippy --workspace
+
+fmt:
+  cargo fmt --all


### PR DESCRIPTION
# Objective

This means that we don't have to have `.cargo/config` committed, which allows people to use that file to customize their build without conflicts.
