### PR TITLE
Move cosmic-text example into it's own crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo build --examples
+      - run: cargo build -p cosmic-text-example
 
   # No features
   test-features-none:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,6 @@ debug = ["std"]
 profile = ["std"]
 
 [dev-dependencies]
-cosmic-text = "0.12"
 serde_json = "1.0.93"
 
 # Enable default features for tests and examples
@@ -100,5 +99,5 @@ members = [
     "scripts/gentest",
     "scripts/format-fixtures",
     "scripts/import-yoga-tests",
-    "benches",
+    "benches", "examples/cosmic_text",
 ]

--- a/examples/cosmic_text/Cargo.toml
+++ b/examples/cosmic_text/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "cosmic-text-example"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+taffy = { path = "../.." }
+cosmic-text = "0.12"

--- a/examples/cosmic_text/src/image.rs
+++ b/examples/cosmic_text/src/image.rs
@@ -1,0 +1,18 @@
+use taffy::geometry::Size;
+
+pub struct ImageContext {
+    pub width: f32,
+    pub height: f32,
+}
+
+pub fn image_measure_function(
+    known_dimensions: taffy::geometry::Size<Option<f32>>,
+    image_context: &ImageContext,
+) -> taffy::geometry::Size<f32> {
+    match (known_dimensions.width, known_dimensions.height) {
+        (Some(width), Some(height)) => Size { width, height },
+        (Some(width), None) => Size { width, height: (width / image_context.width) * image_context.height },
+        (None, Some(height)) => Size { width: (height / image_context.height) * image_context.width, height },
+        (None, None) => Size { width: image_context.width, height: image_context.height },
+    }
+}

--- a/examples/cosmic_text/src/main.rs
+++ b/examples/cosmic_text/src/main.rs
@@ -1,8 +1,6 @@
-mod common {
-    pub mod image;
-}
-use common::image::{image_measure_function, ImageContext};
+mod image;
 use cosmic_text::{Attrs, Buffer, FontSystem, Metrics, Shaping};
+use image::{image_measure_function, ImageContext};
 use taffy::prelude::*;
 
 pub const LOREM_IPSUM : &str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";


### PR DESCRIPTION
# Objective

Save taffy developers from compiling cosmic-text every time they run tests. Also speeds up test jobs in CI.
