### PR TITLE
Improve interaction of abspos children of block containers with margin collapsing

### DIFF
--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -551,8 +551,8 @@ fn perform_final_layout_on_in_flow_children(
                 y_offset_for_absolute = committed_y_offset + item_layout.size.height + y_margin_offset;
             } else {
                 committed_y_offset += item_layout.size.height + y_margin_offset;
-                y_offset_for_absolute = committed_y_offset;
                 active_collapsible_margin_set = bottom_margin_set;
+                y_offset_for_absolute = committed_y_offset + active_collapsible_margin_set.resolve();
             }
         }
     }


### PR DESCRIPTION
# Objective

Fixes  ~40 WPT tests css-flexbox and ~70 in css-grid that incidentally rely on this feature (because they use absolute positioning to position one div under another)
