### PR TITLE
`unrounded_layout` helper method

### DIFF
--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -796,8 +796,8 @@ impl<NodeContext> TaffyTree<NodeContext> {
     }
 
     /// Returns this node layout with unrounded values relative to its parent.
-    pub fn unrounded_layout(&self, node: NodeId) -> TaffyResult<&Layout> {
-        Ok(&self.nodes[node.into()].unrounded_layout)
+    pub fn unrounded_layout(&self, node: NodeId) -> &Layout {
+        &self.nodes[node.into()].unrounded_layout
     }
 
     /// Marks the layout of this node and its ancestors as outdated

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -795,6 +795,11 @@ impl<NodeContext> TaffyTree<NodeContext> {
         }
     }
 
+    /// Returns this node layout with unrounded values relative to its parent.
+    pub fn unrounded_layout(&self, node: NodeId) -> TaffyResult<&Layout> {
+        Ok(&self.nodes[node.into()].unrounded_layout)
+    }
+
     /// Marks the layout of this node and its ancestors as outdated
     ///
     /// WARNING: this may stack-overflow if the tree contains a cycle


### PR DESCRIPTION
# Objective

It doesn't seem like you can directly access the unrounded node layout, you need to do something annoying like:
```rust
self.taffy.disable_rounding();
let unrounded_layout = self.taffy.layout(*taffy_node).unwrap();
self.taffy.enable_rounding();
```
This PR adds a helper method `unrounded_layout` to `TaffyTree`  that returns a reference to the unrounded node layout values so that you can get them without toggling the rounding state for the whole tree each time.



