### PR TITLE
Add API to expose computed grid information

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,17 @@ jobs:
       - run: cargo build --no-default-features --features block_layout,std,taffy_tree
       - run: cargo test --tests --no-default-features --features block_layout,std,taffy_tree
 
+  # With detailed layout info
+  test-features-grid-detailed-info:
+    name: "Test Suite [std + grid + detailed_layout_info]"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build --no-default-features --features grid,detailed_layout_info,std
+      - run: cargo build --no-default-features --features grid,detailed_layout_info,std,taffy_tree
+      - run: cargo test --tests --no-default-features --features grid,detailed_layout_info,std,taffy_tree
+
   # With alloc feature
 
   test-features-grid-with-alloc:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ default = [
 ]
 #! ## Feature Flags
 #!
-#! ### Algorithms 
+#! ### Algorithms
 
 ## Enables the Block layout algorithm. See [`compute_block_layout`](crate::compute_block_layout).
 block_layout = []
@@ -54,6 +54,8 @@ flexbox = []
 grid = ["alloc", "dep:grid"]
 ## Causes all algorithms to compute and output a content size for each node
 content_size = []
+## Causes algorithms to stores computation info in TaffyTree, with only CSS Grid supporting this.
+computed_layout_info = ["grid"]
 
 #! ### Taffy Tree
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ default = [
     "grid",
     "block_layout",
     "content_size",
+    "detailed_layout_info",
 ]
 #! ## Feature Flags
 #!
@@ -54,8 +55,8 @@ flexbox = []
 grid = ["alloc", "dep:grid"]
 ## Causes all algorithms to compute and output a content size for each node
 content_size = []
-## Causes algorithms to stores computation info in TaffyTree, with only CSS Grid supporting this.
-computed_layout_info = []
+## Causes algorithms to stores detailed information of the nodes in TaffyTree, with only CSS Grid supporting this.
+detailed_layout_info = []
 
 #! ### Taffy Tree
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ grid = ["alloc", "dep:grid"]
 ## Causes all algorithms to compute and output a content size for each node
 content_size = []
 ## Causes algorithms to stores computation info in TaffyTree, with only CSS Grid supporting this.
-computed_layout_info = ["grid"]
+computed_layout_info = []
 
 #! ### Taffy Tree
 

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -23,7 +23,7 @@ use track_sizing::{
 };
 use types::{CellOccupancyMatrix, GridTrack};
 
-#[cfg(feature = "computed_layout_info")]
+#[cfg(feature = "detailed_layout_info")]
 use types::{GridItem, GridTrackKind, TrackCounts};
 
 pub(crate) use types::{GridCoordinate, GridLine, OriginZeroLine};
@@ -595,13 +595,13 @@ pub fn compute_grid_layout(tree: &mut impl LayoutGridContainer, node: NodeId, in
         item.y_position + item.baseline.unwrap_or(item.height)
     };
 
-    #[cfg(feature = "computed_layout_info")]
-    tree.set_computed_grid_info(
+    #[cfg(feature = "detailed_layout_info")]
+    tree.set_detailed_grid_info(
         node,
-        Box::new(ComputedGridInfo {
-            rows: ComputedGridTracksInfo::from_grid_tracks_and_track_count(final_row_counts, rows),
-            columns: ComputedGridTracksInfo::from_grid_tracks_and_track_count(final_col_counts, columns),
-            items: items.iter().map(ComputedGridItemsInfo::from_grid_item).collect(),
+        Box::new(DetailedGridInfo {
+            rows: DetailedGridTracksInfo::from_grid_tracks_and_track_count(final_row_counts, rows),
+            columns: DetailedGridTracksInfo::from_grid_tracks_and_track_count(final_col_counts, columns),
+            items: items.iter().map(DetailedGridItemsInfo::from_grid_item).collect(),
         }),
     );
 
@@ -614,20 +614,20 @@ pub fn compute_grid_layout(tree: &mut impl LayoutGridContainer, node: NodeId, in
 
 /// Information from the computation of grid
 #[derive(Debug, Clone, PartialEq)]
-#[cfg(feature = "computed_layout_info")]
-pub struct ComputedGridInfo {
+#[cfg(feature = "detailed_layout_info")]
+pub struct DetailedGridInfo {
     /// <https://drafts.csswg.org/css-grid-1/#grid-row>
-    pub rows: ComputedGridTracksInfo,
+    pub rows: DetailedGridTracksInfo,
     /// <https://drafts.csswg.org/css-grid-1/#grid-column>
-    pub columns: ComputedGridTracksInfo,
+    pub columns: DetailedGridTracksInfo,
     /// <https://drafts.csswg.org/css-grid-1/#grid-items>
-    pub items: Vec<ComputedGridItemsInfo>,
+    pub items: Vec<DetailedGridItemsInfo>,
 }
 
 /// Information from the computation of grids tracks
 #[derive(Debug, Clone, PartialEq)]
-#[cfg(feature = "computed_layout_info")]
-pub struct ComputedGridTracksInfo {
+#[cfg(feature = "detailed_layout_info")]
+pub struct DetailedGridTracksInfo {
     /// Number of leading implicit grid tracks
     pub negative_implicit_tracks: u16,
     /// Number of explicit grid tracks
@@ -641,8 +641,8 @@ pub struct ComputedGridTracksInfo {
     pub sizes: Vec<f32>,
 }
 
-#[cfg(feature = "computed_layout_info")]
-impl ComputedGridTracksInfo {
+#[cfg(feature = "detailed_layout_info")]
+impl DetailedGridTracksInfo {
     #[inline(always)]
     fn grid_track_base_size_of_kind(grid_tracks: &Vec<GridTrack>, kind: types::GridTrackKind) -> Vec<f32> {
         grid_tracks
@@ -655,20 +655,20 @@ impl ComputedGridTracksInfo {
     }
 
     fn gutters_from_grid_track_layout(grid_tracks: &Vec<GridTrack>) -> Vec<f32> {
-        ComputedGridTracksInfo::grid_track_base_size_of_kind(grid_tracks, GridTrackKind::Gutter)
+        DetailedGridTracksInfo::grid_track_base_size_of_kind(grid_tracks, GridTrackKind::Gutter)
     }
 
     fn sizes_from_grid_track_layout(grid_tracks: &Vec<GridTrack>) -> Vec<f32> {
-        ComputedGridTracksInfo::grid_track_base_size_of_kind(grid_tracks, GridTrackKind::Track)
+        DetailedGridTracksInfo::grid_track_base_size_of_kind(grid_tracks, GridTrackKind::Track)
     }
 
     fn from_grid_tracks_and_track_count(track_count: TrackCounts, grid_tracks: Vec<GridTrack>) -> Self {
-        ComputedGridTracksInfo {
+        DetailedGridTracksInfo {
             negative_implicit_tracks: track_count.negative_implicit,
             explicit_tracks: track_count.explicit,
             positive_implicit_tracks: track_count.positive_implicit,
-            gutters: ComputedGridTracksInfo::gutters_from_grid_track_layout(&grid_tracks),
-            sizes: ComputedGridTracksInfo::sizes_from_grid_track_layout(&grid_tracks),
+            gutters: DetailedGridTracksInfo::gutters_from_grid_track_layout(&grid_tracks),
+            sizes: DetailedGridTracksInfo::sizes_from_grid_track_layout(&grid_tracks),
         }
     }
 }
@@ -678,8 +678,8 @@ impl ComputedGridTracksInfo {
 /// The values is 1-indexed line numbers bounding the area.
 /// This matches the Chrome and Firefox's format as of 2nd Jan 2024.
 #[derive(Debug, Clone, PartialEq)]
-#[cfg(feature = "computed_layout_info")]
-pub struct ComputedGridItemsInfo {
+#[cfg(feature = "detailed_layout_info")]
+pub struct DetailedGridItemsInfo {
     /// row-start with 1-indexed line numbers
     pub row_start: u16,
     /// row-end with 1-indexed line numbers
@@ -691,8 +691,8 @@ pub struct ComputedGridItemsInfo {
 }
 
 /// Grid area information from the placement algorithm
-#[cfg(feature = "computed_layout_info")]
-impl ComputedGridItemsInfo {
+#[cfg(feature = "detailed_layout_info")]
+impl DetailedGridItemsInfo {
     #[inline(always)]
     fn from_grid_item(grid_item: &GridItem) -> Self {
         #[inline(always)]
@@ -700,7 +700,7 @@ impl ComputedGridItemsInfo {
             grid_track_index / 2 + 1
         }
 
-        ComputedGridItemsInfo {
+        DetailedGridItemsInfo {
             row_start: to_one_indexed_grid_line(grid_item.row_indexes.start),
             row_end: to_one_indexed_grid_line(grid_item.row_indexes.end),
             column_start: to_one_indexed_grid_line(grid_item.column_indexes.start),

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -24,8 +24,6 @@ use track_sizing::{
 use types::{CellOccupancyMatrix, GridTrack};
 
 #[cfg(feature = "computed_layout_info")]
-use crate::ComputedLayoutInfo;
-#[cfg(feature = "computed_layout_info")]
 use types::{GridItem, GridTrackKind, TrackCounts};
 
 pub(crate) use types::{GridCoordinate, GridLine, OriginZeroLine};

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -26,7 +26,7 @@ use types::{CellOccupancyMatrix, GridTrack};
 #[cfg(feature = "computed_layout_info")]
 use crate::ComputedLayoutInfo;
 #[cfg(feature = "computed_layout_info")]
-use types::{GridTrackKind, TrackCounts, GridItem};
+use types::{GridItem, GridTrackKind, TrackCounts};
 
 pub(crate) use types::{GridCoordinate, GridLine, OriginZeroLine};
 
@@ -598,11 +598,14 @@ pub fn compute_grid_layout(tree: &mut impl LayoutGridContainer, node: NodeId, in
     };
 
     #[cfg(feature = "computed_layout_info")]
-    tree.set_computed_layout_info(node, ComputedLayoutInfo::Grid(ComputedGridInfo {
-        rows: ComputedGridTracksInfo::from_grid_tracks_and_track_count(final_row_counts, rows),
-        columns: ComputedGridTracksInfo::from_grid_tracks_and_track_count(final_col_counts, columns),
-        areas: items.iter().map(ComputedGridAreaInfo::from_grid_item).collect(),
-    }));
+    tree.set_computed_layout_info(
+        node,
+        ComputedLayoutInfo::Grid(ComputedGridInfo {
+            rows: ComputedGridTracksInfo::from_grid_tracks_and_track_count(final_row_counts, rows),
+            columns: ComputedGridTracksInfo::from_grid_tracks_and_track_count(final_col_counts, columns),
+            areas: items.iter().map(ComputedGridAreaInfo::from_grid_item).collect(),
+        }),
+    );
 
     LayoutOutput::from_sizes_and_baselines(
         container_border_box,
@@ -640,20 +643,17 @@ pub struct ComputedGridTracksInfo {
     pub sizes: Vec<f32>,
 }
 
-
 #[cfg(feature = "computed_layout_info")]
 impl ComputedGridTracksInfo {
     #[inline(always)]
     fn grid_track_base_size_of_kind(grid_tracks: &Vec<GridTrack>, kind: types::GridTrackKind) -> Vec<f32> {
         grid_tracks
             .iter()
-            .filter_map(|track| {
-                match track.kind == kind {
-                    true => Some(track.base_size),
-                    false => None,
-                }
-            }
-        ).collect()
+            .filter_map(|track| match track.kind == kind {
+                true => Some(track.base_size),
+                false => None,
+            })
+            .collect()
     }
 
     #[inline(always)]

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -598,12 +598,12 @@ pub fn compute_grid_layout(tree: &mut impl LayoutGridContainer, node: NodeId, in
     };
 
     #[cfg(feature = "computed_layout_info")]
-    tree.set_computed_layout_info(
+    tree.set_computed_grid_info(
         node,
-        ComputedLayoutInfo::Grid(ComputedGridInfo {
+        Box::new(ComputedGridInfo {
             rows: ComputedGridTracksInfo::from_grid_tracks_and_track_count(final_row_counts, rows),
             columns: ComputedGridTracksInfo::from_grid_tracks_and_track_count(final_col_counts, columns),
-            areas: items.iter().map(ComputedGridAreaInfo::from_grid_item).collect(),
+            items: items.iter().map(ComputedGridItemsInfo::from_grid_item).collect(),
         }),
     );
 
@@ -622,8 +622,8 @@ pub struct ComputedGridInfo {
     pub rows: ComputedGridTracksInfo,
     /// <https://drafts.csswg.org/css-grid-1/#grid-column>
     pub columns: ComputedGridTracksInfo,
-    /// <https://drafts.csswg.org/css-grid-1/#grid-area-concept>
-    pub areas: Vec<ComputedGridAreaInfo>,
+    /// <https://drafts.csswg.org/css-grid-1/#grid-items>
+    pub items: Vec<ComputedGridItemsInfo>,
 }
 
 /// Information from the computation of grids tracks
@@ -656,17 +656,14 @@ impl ComputedGridTracksInfo {
             .collect()
     }
 
-    #[inline(always)]
     fn gutters_from_grid_track_layout(grid_tracks: &Vec<GridTrack>) -> Vec<f32> {
         ComputedGridTracksInfo::grid_track_base_size_of_kind(grid_tracks, GridTrackKind::Gutter)
     }
 
-    #[inline(always)]
     fn sizes_from_grid_track_layout(grid_tracks: &Vec<GridTrack>) -> Vec<f32> {
         ComputedGridTracksInfo::grid_track_base_size_of_kind(grid_tracks, GridTrackKind::Track)
     }
 
-    #[inline(always)]
     fn from_grid_tracks_and_track_count(track_count: TrackCounts, grid_tracks: Vec<GridTrack>) -> Self {
         ComputedGridTracksInfo {
             negative_implicit_tracks: track_count.negative_implicit,
@@ -684,7 +681,7 @@ impl ComputedGridTracksInfo {
 /// This matches the Chrome and Firefox's format as of 2nd Jan 2024.
 #[derive(Debug, Clone, PartialEq)]
 #[cfg(feature = "computed_layout_info")]
-pub struct ComputedGridAreaInfo {
+pub struct ComputedGridItemsInfo {
     /// row-start with 1-indexed line numbers
     pub row_start: u16,
     /// row-end with 1-indexed line numbers
@@ -697,7 +694,7 @@ pub struct ComputedGridAreaInfo {
 
 /// Grid area information from the placement algorithm
 #[cfg(feature = "computed_layout_info")]
-impl ComputedGridAreaInfo {
+impl ComputedGridItemsInfo {
     #[inline(always)]
     fn from_grid_item(grid_item: &GridItem) -> Self {
         #[inline(always)]
@@ -705,7 +702,7 @@ impl ComputedGridAreaInfo {
             grid_track_index / 2 + 1
         }
 
-        ComputedGridAreaInfo {
+        ComputedGridItemsInfo {
             row_start: to_one_indexed_grid_line(grid_item.row_indexes.start),
             row_end: to_one_indexed_grid_line(grid_item.row_indexes.end),
             column_start: to_one_indexed_grid_line(grid_item.column_indexes.start),

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -598,11 +598,11 @@ pub fn compute_grid_layout(tree: &mut impl LayoutGridContainer, node: NodeId, in
     #[cfg(feature = "detailed_layout_info")]
     tree.set_detailed_grid_info(
         node,
-        Box::new(DetailedGridInfo {
+        DetailedGridInfo {
             rows: DetailedGridTracksInfo::from_grid_tracks_and_track_count(final_row_counts, rows),
             columns: DetailedGridTracksInfo::from_grid_tracks_and_track_count(final_col_counts, columns),
             items: items.iter().map(DetailedGridItemsInfo::from_grid_item).collect(),
-        }),
+        },
     );
 
     LayoutOutput::from_sizes_and_baselines(
@@ -643,8 +643,9 @@ pub struct DetailedGridTracksInfo {
 
 #[cfg(feature = "detailed_layout_info")]
 impl DetailedGridTracksInfo {
+    /// Get the base_size of [`GridTrack`] with a kind [`types::GridTrackKind`]
     #[inline(always)]
-    fn grid_track_base_size_of_kind(grid_tracks: &Vec<GridTrack>, kind: types::GridTrackKind) -> Vec<f32> {
+    fn grid_track_base_size_of_kind(grid_tracks: &[GridTrack], kind: GridTrackKind) -> Vec<f32> {
         grid_tracks
             .iter()
             .filter_map(|track| match track.kind == kind {
@@ -654,14 +655,17 @@ impl DetailedGridTracksInfo {
             .collect()
     }
 
-    fn gutters_from_grid_track_layout(grid_tracks: &Vec<GridTrack>) -> Vec<f32> {
+    /// Get the sizes of the gutters
+    fn gutters_from_grid_track_layout(grid_tracks: &[GridTrack]) -> Vec<f32> {
         DetailedGridTracksInfo::grid_track_base_size_of_kind(grid_tracks, GridTrackKind::Gutter)
     }
 
-    fn sizes_from_grid_track_layout(grid_tracks: &Vec<GridTrack>) -> Vec<f32> {
+    /// Get the sizes of the tracks
+    fn sizes_from_grid_track_layout(grid_tracks: &[GridTrack]) -> Vec<f32> {
         DetailedGridTracksInfo::grid_track_base_size_of_kind(grid_tracks, GridTrackKind::Track)
     }
 
+    /// Construct DetailedGridTracksInfo from TrackCounts and GridTracks
     fn from_grid_tracks_and_track_count(track_count: TrackCounts, grid_tracks: Vec<GridTrack>) -> Self {
         DetailedGridTracksInfo {
             negative_implicit_tracks: track_count.negative_implicit,
@@ -675,26 +679,28 @@ impl DetailedGridTracksInfo {
 
 /// Grid area information from the placement algorithm
 ///
-/// The values is 1-indexed line numbers bounding the area.
+/// The values is 1-indexed grid line numbers bounding the area.
 /// This matches the Chrome and Firefox's format as of 2nd Jan 2024.
 #[derive(Debug, Clone, PartialEq)]
 #[cfg(feature = "detailed_layout_info")]
 pub struct DetailedGridItemsInfo {
-    /// row-start with 1-indexed line numbers
+    /// row-start with 1-indexed grid line numbers
     pub row_start: u16,
-    /// row-end with 1-indexed line numbers
+    /// row-end with 1-indexed grid line numbers
     pub row_end: u16,
-    /// column-start with 1-indexed line numbers
+    /// column-start with 1-indexed grid line numbers
     pub column_start: u16,
-    /// column-end with 1-indexed line numbers
+    /// column-end with 1-indexed grid line numbers
     pub column_end: u16,
 }
 
 /// Grid area information from the placement algorithm
 #[cfg(feature = "detailed_layout_info")]
 impl DetailedGridItemsInfo {
+    /// Construct from GridItems
     #[inline(always)]
     fn from_grid_item(grid_item: &GridItem) -> Self {
+        /// Conversion from the indexes of Vec<GridTrack> into 1-indexed grid line numbers. See [`GridItem::row_indexes`] or [`GridItem::column_indexes`]
         #[inline(always)]
         fn to_one_indexed_grid_line(grid_track_index: u16) -> u16 {
             grid_track_index / 2 + 1

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -275,6 +275,7 @@ pub fn compute_hidden_layout(tree: &mut (impl LayoutPartialTree + CacheTree), no
 /// A module for unified re-exports of detailed layout info structs, used by low level API
 #[cfg(feature = "detailed_layout_info")]
 pub mod detailed_info {
+    #[cfg(feature = "grid")]
     pub use super::grid::DetailedGridInfo;
 }
 

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -272,6 +272,12 @@ pub fn compute_hidden_layout(tree: &mut (impl LayoutPartialTree + CacheTree), no
     LayoutOutput::HIDDEN
 }
 
+/// A module for unified re-exports of detailed layout info structs, used by low level API
+#[cfg(feature = "computed_layout_info")]
+pub mod computed_info {
+    pub use super::grid::ComputedGridInfo;
+}
+
 #[cfg(test)]
 mod tests {
     use super::compute_hidden_layout;

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -273,9 +273,9 @@ pub fn compute_hidden_layout(tree: &mut (impl LayoutPartialTree + CacheTree), no
 }
 
 /// A module for unified re-exports of detailed layout info structs, used by low level API
-#[cfg(feature = "computed_layout_info")]
-pub mod computed_info {
-    pub use super::grid::ComputedGridInfo;
+#[cfg(feature = "detailed_layout_info")]
+pub mod detailed_info {
+    pub use super::grid::DetailedGridInfo;
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,9 +102,9 @@ pub use crate::compute::compute_flexbox_layout;
 #[cfg(feature = "grid")]
 #[doc(inline)]
 pub use crate::compute::compute_grid_layout;
-#[cfg(feature = "computed_layout_info")]
+#[cfg(feature = "detailed_layout_info")]
 #[doc(inline)]
-pub use crate::compute::computed_info::*;
+pub use crate::compute::detailed_info::*;
 #[doc(inline)]
 pub use crate::compute::{
     compute_cached_layout, compute_hidden_layout, compute_leaf_layout, compute_root_layout, round_layout,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,9 @@ pub use crate::compute::compute_flexbox_layout;
 #[cfg(feature = "grid")]
 #[doc(inline)]
 pub use crate::compute::compute_grid_layout;
+#[cfg(feature = "computed_layout_info")]
+#[doc(inline)]
+pub use crate::compute::computed_info::*;
 #[doc(inline)]
 pub use crate::compute::{
     compute_cached_layout, compute_hidden_layout, compute_leaf_layout, compute_root_layout, round_layout,

--- a/src/tree/layout.rs
+++ b/src/tree/layout.rs
@@ -4,9 +4,6 @@ use crate::style::AvailableSpace;
 use crate::style_helpers::TaffyMaxContent;
 use crate::util::sys::{f32_max, f32_min};
 
-#[cfg(feature = "detailed_layout_info")]
-use crate::compute::grid::DetailedGridInfo;
-
 /// Whether we are performing a full layout, or we merely need to size the node
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
@@ -353,7 +350,8 @@ impl Layout {
 #[derive(Debug, Clone, PartialEq)]
 pub enum DetailedLayoutInfo {
     /// Enum variant for [`DetailedGridInfo`]
-    Grid(Box<DetailedGridInfo>),
+    #[cfg(feature = "grid")]
+    Grid(Box<crate::compute::grid::DetailedGridInfo>),
     /// For node that hasn't had any detailed information yet
-    NONE,
+    None,
 }

--- a/src/tree/layout.rs
+++ b/src/tree/layout.rs
@@ -353,7 +353,7 @@ impl Layout {
 #[derive(Debug, Clone, PartialEq)]
 pub enum ComputedLayoutInfo {
     /// Enum variant for ComputedGridInfo
-    Grid(ComputedGridInfo),
+    Grid(Box<ComputedGridInfo>),
     /// For node that hasn't had any computed information yet
-    UNSPECIFIED,
+    NONE,
 }

--- a/src/tree/layout.rs
+++ b/src/tree/layout.rs
@@ -4,6 +4,9 @@ use crate::style::AvailableSpace;
 use crate::style_helpers::TaffyMaxContent;
 use crate::util::sys::{f32_max, f32_min};
 
+#[cfg(feature = "computed_layout_info")]
+use crate::compute::grid::ComputedGridInfo;
+
 /// Whether we are performing a full layout, or we merely need to size the node
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
@@ -343,4 +346,14 @@ impl Layout {
                 + self.border.bottom,
         )
     }
+}
+
+/// The additional computation information from layout algorithm
+#[cfg(feature = "computed_layout_info")]
+#[derive(Debug, Clone, PartialEq)]
+pub enum ComputedLayoutInfo {
+    /// Enum variant for ComputedGridInfo
+    Grid(ComputedGridInfo),
+    /// For node that hasn't had any computed information yet
+    UNSPECIFIED,
 }

--- a/src/tree/layout.rs
+++ b/src/tree/layout.rs
@@ -4,8 +4,8 @@ use crate::style::AvailableSpace;
 use crate::style_helpers::TaffyMaxContent;
 use crate::util::sys::{f32_max, f32_min};
 
-#[cfg(feature = "computed_layout_info")]
-use crate::compute::grid::ComputedGridInfo;
+#[cfg(feature = "detailed_layout_info")]
+use crate::compute::grid::DetailedGridInfo;
 
 /// Whether we are performing a full layout, or we merely need to size the node
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -348,12 +348,12 @@ impl Layout {
     }
 }
 
-/// The additional computation information from layout algorithm
-#[cfg(feature = "computed_layout_info")]
+/// The additional information from layout algorithm
+#[cfg(feature = "detailed_layout_info")]
 #[derive(Debug, Clone, PartialEq)]
-pub enum ComputedLayoutInfo {
-    /// Enum variant for ComputedGridInfo
-    Grid(Box<ComputedGridInfo>),
-    /// For node that hasn't had any computed information yet
+pub enum DetailedLayoutInfo {
+    /// Enum variant for [`DetailedGridInfo`]
+    Grid(Box<DetailedGridInfo>),
+    /// For node that hasn't had any detailed information yet
     NONE,
 }

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -29,5 +29,5 @@ mod taffy_tree;
 #[cfg(feature = "taffy_tree")]
 pub use taffy_tree::{TaffyError, TaffyResult, TaffyTree};
 
-#[cfg(feature = "computed_layout_info")]
-pub use layout::ComputedLayoutInfo;
+#[cfg(feature = "detailed_layout_info")]
+pub use layout::DetailedLayoutInfo;

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -28,3 +28,6 @@ pub use traits::LayoutBlockContainer;
 mod taffy_tree;
 #[cfg(feature = "taffy_tree")]
 pub use taffy_tree::{TaffyError, TaffyResult, TaffyTree};
+
+#[cfg(feature = "computed_layout_info")]
+pub use layout::ComputedLayoutInfo;

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -27,6 +27,8 @@ use crate::{compute::compute_grid_layout, LayoutGridContainer};
 
 #[cfg(feature = "computed_layout_info")]
 use crate::tree::layout::ComputedLayoutInfo;
+#[cfg(feature = "computed_layout_info")]
+use crate::compute::grid::ComputedGridInfo;
 
 /// The error Taffy generates on invalid operations
 pub type TaffyResult<T> = Result<T, TaffyError>;
@@ -120,7 +122,7 @@ impl NodeData {
             final_layout: Layout::new(),
             has_context: false,
             #[cfg(feature = "computed_layout_info")]
-            computed_layout_info: ComputedLayoutInfo::UNSPECIFIED,
+            computed_layout_info: ComputedLayoutInfo::NONE,
         }
     }
 
@@ -382,18 +384,6 @@ where
             }
         })
     }
-
-    #[inline(always)]
-    #[cfg(feature = "computed_layout_info")]
-    fn set_computed_layout_info(&mut self, node_id: NodeId, computed_layout_info: ComputedLayoutInfo) {
-        self.taffy.nodes[node_id.into()].computed_layout_info = computed_layout_info;
-    }
-
-    #[inline(always)]
-    #[cfg(feature = "computed_layout_info")]
-    fn get_computed_layout_info(&mut self, node_id: NodeId) -> &ComputedLayoutInfo {
-        &self.taffy.nodes[node_id.into()].computed_layout_info
-    }
 }
 
 impl<NodeContext, MeasureFunction> CacheTree for TaffyView<'_, NodeContext, MeasureFunction>
@@ -502,6 +492,12 @@ where
     #[inline(always)]
     fn get_grid_child_style(&self, child_node_id: NodeId) -> Self::GridItemStyle<'_> {
         &self.taffy.nodes[child_node_id.into()].style
+    }
+
+    #[inline(always)]
+    #[cfg(feature = "computed_layout_info")]
+    fn set_computed_grid_info(&mut self, node_id: NodeId, computed_grid_info: Box<ComputedGridInfo>) {
+        self.taffy.nodes[node_id.into()].computed_layout_info = ComputedLayoutInfo::Grid(computed_grid_info);
     }
 }
 

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -25,6 +25,9 @@ use crate::{compute::compute_flexbox_layout, LayoutFlexboxContainer};
 #[cfg(feature = "grid")]
 use crate::{compute::compute_grid_layout, LayoutGridContainer};
 
+#[cfg(feature = "computed_layout_info")]
+use crate::tree::layout::ComputedLayoutInfo;
+
 /// The error Taffy generates on invalid operations
 pub type TaffyResult<T> = Result<T, TaffyError>;
 
@@ -100,6 +103,10 @@ struct NodeData {
 
     /// The cached results of the layout computation
     pub(crate) cache: Cache,
+
+    /// The computation result from layout algorithm
+    #[cfg(feature = "computed_layout_info")]
+    pub(crate) computed_layout_info: ComputedLayoutInfo,
 }
 
 impl NodeData {
@@ -112,6 +119,8 @@ impl NodeData {
             unrounded_layout: Layout::new(),
             final_layout: Layout::new(),
             has_context: false,
+            #[cfg(feature = "computed_layout_info")]
+            computed_layout_info: ComputedLayoutInfo::UNSPECIFIED,
         }
     }
 
@@ -372,6 +381,18 @@ where
                 }
             }
         })
+    }
+
+    #[inline(always)]
+    #[cfg(feature = "computed_layout_info")]
+    fn set_computed_layout_info(&mut self, node_id: NodeId, computed_layout_info: ComputedLayoutInfo) {
+        self.taffy.nodes[node_id.into()].computed_layout_info = computed_layout_info;
+    }
+
+    #[inline(always)]
+    #[cfg(feature = "computed_layout_info")]
+    fn get_computed_layout_info(&mut self, node_id: NodeId) -> &ComputedLayoutInfo {
+        &self.taffy.nodes[node_id.into()].computed_layout_info
     }
 }
 

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -25,7 +25,7 @@ use crate::{compute::compute_flexbox_layout, LayoutFlexboxContainer};
 #[cfg(feature = "grid")]
 use crate::{compute::compute_grid_layout, LayoutGridContainer};
 
-#[cfg(feature = "detailed_layout_info")]
+#[cfg(all(feature = "detailed_layout_info", feature = "grid"))]
 use crate::compute::grid::DetailedGridInfo;
 #[cfg(feature = "detailed_layout_info")]
 use crate::tree::layout::DetailedLayoutInfo;
@@ -122,7 +122,7 @@ impl NodeData {
             final_layout: Layout::new(),
             has_context: false,
             #[cfg(feature = "detailed_layout_info")]
-            detailed_layout_info: DetailedLayoutInfo::NONE,
+            detailed_layout_info: DetailedLayoutInfo::None,
         }
     }
 
@@ -496,8 +496,8 @@ where
 
     #[inline(always)]
     #[cfg(feature = "detailed_layout_info")]
-    fn set_detailed_grid_info(&mut self, node_id: NodeId, detailed_grid_info: Box<DetailedGridInfo>) {
-        self.taffy.nodes[node_id.into()].detailed_layout_info = DetailedLayoutInfo::Grid(detailed_grid_info);
+    fn set_detailed_grid_info(&mut self, node_id: NodeId, detailed_grid_info: DetailedGridInfo) {
+        self.taffy.nodes[node_id.into()].detailed_layout_info = DetailedLayoutInfo::Grid(Box::new(detailed_grid_info));
     }
 }
 

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -26,9 +26,9 @@ use crate::{compute::compute_flexbox_layout, LayoutFlexboxContainer};
 use crate::{compute::compute_grid_layout, LayoutGridContainer};
 
 #[cfg(feature = "computed_layout_info")]
-use crate::tree::layout::ComputedLayoutInfo;
-#[cfg(feature = "computed_layout_info")]
 use crate::compute::grid::ComputedGridInfo;
+#[cfg(feature = "computed_layout_info")]
+use crate::tree::layout::ComputedLayoutInfo;
 
 /// The error Taffy generates on invalid operations
 pub type TaffyResult<T> = Result<T, TaffyError>;

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -25,10 +25,10 @@ use crate::{compute::compute_flexbox_layout, LayoutFlexboxContainer};
 #[cfg(feature = "grid")]
 use crate::{compute::compute_grid_layout, LayoutGridContainer};
 
-#[cfg(feature = "computed_layout_info")]
-use crate::compute::grid::ComputedGridInfo;
-#[cfg(feature = "computed_layout_info")]
-use crate::tree::layout::ComputedLayoutInfo;
+#[cfg(feature = "detailed_layout_info")]
+use crate::compute::grid::DetailedGridInfo;
+#[cfg(feature = "detailed_layout_info")]
+use crate::tree::layout::DetailedLayoutInfo;
 
 /// The error Taffy generates on invalid operations
 pub type TaffyResult<T> = Result<T, TaffyError>;
@@ -107,8 +107,8 @@ struct NodeData {
     pub(crate) cache: Cache,
 
     /// The computation result from layout algorithm
-    #[cfg(feature = "computed_layout_info")]
-    pub(crate) computed_layout_info: ComputedLayoutInfo,
+    #[cfg(feature = "detailed_layout_info")]
+    pub(crate) detailed_layout_info: DetailedLayoutInfo,
 }
 
 impl NodeData {
@@ -121,8 +121,8 @@ impl NodeData {
             unrounded_layout: Layout::new(),
             final_layout: Layout::new(),
             has_context: false,
-            #[cfg(feature = "computed_layout_info")]
-            computed_layout_info: ComputedLayoutInfo::NONE,
+            #[cfg(feature = "detailed_layout_info")]
+            detailed_layout_info: DetailedLayoutInfo::NONE,
         }
     }
 
@@ -495,9 +495,9 @@ where
     }
 
     #[inline(always)]
-    #[cfg(feature = "computed_layout_info")]
-    fn set_computed_grid_info(&mut self, node_id: NodeId, computed_grid_info: Box<ComputedGridInfo>) {
-        self.taffy.nodes[node_id.into()].computed_layout_info = ComputedLayoutInfo::Grid(computed_grid_info);
+    #[cfg(feature = "detailed_layout_info")]
+    fn set_detailed_grid_info(&mut self, node_id: NodeId, detailed_grid_info: Box<DetailedGridInfo>) {
+        self.taffy.nodes[node_id.into()].detailed_layout_info = DetailedLayoutInfo::Grid(detailed_grid_info);
     }
 }
 

--- a/src/tree/traits.rs
+++ b/src/tree/traits.rs
@@ -127,6 +127,7 @@
 //! ```
 //!
 use super::{Layout, LayoutInput, LayoutOutput, NodeId, RequestedAxis, RunMode, SizingMode};
+use crate::debug::debug_log;
 use crate::geometry::{AbsoluteAxis, Line, Size};
 use crate::style::{AvailableSpace, CoreStyle};
 #[cfg(feature = "flexbox")]
@@ -137,7 +138,7 @@ use crate::style::{GridContainerStyle, GridItemStyle};
 use crate::{BlockContainerStyle, BlockItemStyle};
 
 #[cfg(feature = "computed_layout_info")]
-use super::ComputedLayoutInfo;
+use crate::compute::grid::ComputedGridInfo;
 
 /// Taffy's abstraction for downward tree traversal.
 ///
@@ -183,14 +184,6 @@ pub trait LayoutPartialTree: TraversePartialTree {
 
     /// Compute the specified node's size or full layout given the specified constraints
     fn compute_child_layout(&mut self, node_id: NodeId, inputs: LayoutInput) -> LayoutOutput;
-
-    #[cfg(feature = "computed_layout_info")]
-    /// Set the node's computed layout information
-    fn set_computed_layout_info(&mut self, node_id: NodeId, computed_layout_info: ComputedLayoutInfo);
-
-    #[cfg(feature = "computed_layout_info")]
-    /// Get the node's computed layout information
-    fn get_computed_layout_info(&mut self, node_id: NodeId) -> &ComputedLayoutInfo;
 }
 
 /// Trait used by the `compute_cached_layout` method which allows cached layout results to be stored and retrieved.
@@ -278,6 +271,12 @@ pub trait LayoutGridContainer: LayoutPartialTree {
 
     /// Get the child's styles
     fn get_grid_child_style(&self, child_node_id: NodeId) -> Self::GridItemStyle<'_>;
+
+    /// Set the node's computed layout information
+    #[cfg(feature = "computed_layout_info")]
+    fn set_computed_grid_info(&mut self, _node_id: NodeId, _computed_layout_info: Box<ComputedGridInfo>) {
+        debug_log!("LayoutGridContainer::set_computed_layout_info called");
+    }
 }
 
 #[cfg(feature = "block_layout")]

--- a/src/tree/traits.rs
+++ b/src/tree/traits.rs
@@ -127,6 +127,7 @@
 //! ```
 //!
 use super::{Layout, LayoutInput, LayoutOutput, NodeId, RequestedAxis, RunMode, SizingMode};
+#[cfg(feature = "detailed_layout_info")]
 use crate::debug::debug_log;
 use crate::geometry::{AbsoluteAxis, Line, Size};
 use crate::style::{AvailableSpace, CoreStyle};
@@ -137,7 +138,7 @@ use crate::style::{GridContainerStyle, GridItemStyle};
 #[cfg(feature = "block_layout")]
 use crate::{BlockContainerStyle, BlockItemStyle};
 
-#[cfg(feature = "detailed_layout_info")]
+#[cfg(all(feature = "grid", feature = "detailed_layout_info"))]
 use crate::compute::grid::DetailedGridInfo;
 
 /// Taffy's abstraction for downward tree traversal.
@@ -272,9 +273,9 @@ pub trait LayoutGridContainer: LayoutPartialTree {
     /// Get the child's styles
     fn get_grid_child_style(&self, child_node_id: NodeId) -> Self::GridItemStyle<'_>;
 
-    /// Set the node's detailed layout information
+    /// Set the node's detailed grid information
     #[cfg(feature = "detailed_layout_info")]
-    fn set_detailed_grid_info(&mut self, _node_id: NodeId, _detailed_grid_info: Box<DetailedGridInfo>) {
+    fn set_detailed_grid_info(&mut self, _node_id: NodeId, _detailed_grid_info: DetailedGridInfo) {
         debug_log!("LayoutGridContainer::set_detailed_grid_info called");
     }
 }

--- a/src/tree/traits.rs
+++ b/src/tree/traits.rs
@@ -136,6 +136,9 @@ use crate::style::{GridContainerStyle, GridItemStyle};
 #[cfg(feature = "block_layout")]
 use crate::{BlockContainerStyle, BlockItemStyle};
 
+#[cfg(feature = "computed_layout_info")]
+use super::ComputedLayoutInfo;
+
 /// Taffy's abstraction for downward tree traversal.
 ///
 /// However, this trait does *not* require access to any node's other than a single container node's immediate children unless you also intend to implement `TraverseTree`.
@@ -180,6 +183,14 @@ pub trait LayoutPartialTree: TraversePartialTree {
 
     /// Compute the specified node's size or full layout given the specified constraints
     fn compute_child_layout(&mut self, node_id: NodeId, inputs: LayoutInput) -> LayoutOutput;
+
+    #[cfg(feature = "computed_layout_info")]
+    /// Set the node's computed layout information
+    fn set_computed_layout_info(&mut self, node_id: NodeId, computed_layout_info: ComputedLayoutInfo);
+
+    #[cfg(feature = "computed_layout_info")]
+    /// Get the node's computed layout information
+    fn get_computed_layout_info(&mut self, node_id: NodeId) -> &ComputedLayoutInfo;
 }
 
 /// Trait used by the `compute_cached_layout` method which allows cached layout results to be stored and retrieved.

--- a/src/tree/traits.rs
+++ b/src/tree/traits.rs
@@ -137,8 +137,8 @@ use crate::style::{GridContainerStyle, GridItemStyle};
 #[cfg(feature = "block_layout")]
 use crate::{BlockContainerStyle, BlockItemStyle};
 
-#[cfg(feature = "computed_layout_info")]
-use crate::compute::grid::ComputedGridInfo;
+#[cfg(feature = "detailed_layout_info")]
+use crate::compute::grid::DetailedGridInfo;
 
 /// Taffy's abstraction for downward tree traversal.
 ///
@@ -272,10 +272,10 @@ pub trait LayoutGridContainer: LayoutPartialTree {
     /// Get the child's styles
     fn get_grid_child_style(&self, child_node_id: NodeId) -> Self::GridItemStyle<'_>;
 
-    /// Set the node's computed layout information
-    #[cfg(feature = "computed_layout_info")]
-    fn set_computed_grid_info(&mut self, _node_id: NodeId, _computed_layout_info: Box<ComputedGridInfo>) {
-        debug_log!("LayoutGridContainer::set_computed_layout_info called");
+    /// Set the node's detailed layout information
+    #[cfg(feature = "detailed_layout_info")]
+    fn set_detailed_grid_info(&mut self, _node_id: NodeId, _detailed_grid_info: Box<DetailedGridInfo>) {
+        debug_log!("LayoutGridContainer::set_detailed_grid_info called");
     }
 }
 


### PR DESCRIPTION
# Objective

Expose computed grid layout information, which includes `grid-template` and `grid-placement`.

## Context

This changes attempts to add `LayoutPartialTree`'s API to store and get the layout information in `TaffyTree` with low level API in mind. 

## Feedback wanted

Discussion about whether the structure and information of grid layout is desirable and correct is appreciated. 

Kindly provide general review of code structure, regarding the compliance with Rust and Taffy code recommendation.




