### PR TITLE
Implement `calc()` in the low-level API

### DIFF
--- a/examples/custom_tree_owned_partial.rs
+++ b/examples/custom_tree_owned_partial.rs
@@ -146,6 +146,10 @@ impl taffy::LayoutPartialTree for Node {
         self.node_from_id_mut(node_id).layout = *layout
     }
 
+    fn resolve_calc_value(&self, _val: u64, _basis: f32) -> f32 {
+        0.0
+    }
+
     fn compute_child_layout(&mut self, node_id: NodeId, inputs: taffy::tree::LayoutInput) -> taffy::tree::LayoutOutput {
         compute_cached_layout(self, node_id, inputs, |parent, node_id, inputs| {
             let node = parent.node_from_id_mut(node_id);
@@ -154,17 +158,27 @@ impl taffy::LayoutPartialTree for Node {
             match node.kind {
                 NodeKind::Flexbox => compute_flexbox_layout(node, node_id, inputs),
                 NodeKind::Grid => compute_grid_layout(node, node_id, inputs),
-                NodeKind::Text => compute_leaf_layout(inputs, &node.style, |known_dimensions, available_space| {
-                    text_measure_function(
-                        known_dimensions,
-                        available_space,
-                        node.text_data.as_ref().unwrap(),
-                        &font_metrics,
-                    )
-                }),
-                NodeKind::Image => compute_leaf_layout(inputs, &node.style, |known_dimensions, _available_space| {
-                    image_measure_function(known_dimensions, node.image_data.as_ref().unwrap())
-                }),
+                NodeKind::Text => compute_leaf_layout(
+                    inputs,
+                    &node.style,
+                    |_val, _basis| 0.0,
+                    |known_dimensions, available_space| {
+                        text_measure_function(
+                            known_dimensions,
+                            available_space,
+                            node.text_data.as_ref().unwrap(),
+                            &font_metrics,
+                        )
+                    },
+                ),
+                NodeKind::Image => compute_leaf_layout(
+                    inputs,
+                    &node.style,
+                    |_val, _basis| 0.0,
+                    |known_dimensions, _available_space| {
+                        image_measure_function(known_dimensions, node.image_data.as_ref().unwrap())
+                    },
+                ),
             }
         })
     }

--- a/examples/custom_tree_vec.rs
+++ b/examples/custom_tree_vec.rs
@@ -152,25 +152,39 @@ impl taffy::LayoutPartialTree for Tree {
         self.node_from_id_mut(node_id).unrounded_layout = *layout;
     }
 
+    fn resolve_calc_value(&self, _val: u64, _basis: f32) -> f32 {
+        0.0
+    }
+
     fn compute_child_layout(&mut self, node_id: NodeId, inputs: taffy::tree::LayoutInput) -> taffy::tree::LayoutOutput {
         compute_cached_layout(self, node_id, inputs, |tree, node_id, inputs| {
-            let node = tree.node_from_id_mut(node_id);
+            let node = &mut tree.nodes[usize::from(node_id)];
             let font_metrics = FontMetrics { char_width: 10.0, char_height: 10.0 };
 
             match node.kind {
                 NodeKind::Flexbox => compute_flexbox_layout(tree, node_id, inputs),
                 NodeKind::Grid => compute_grid_layout(tree, node_id, inputs),
-                NodeKind::Text => compute_leaf_layout(inputs, &node.style, |known_dimensions, available_space| {
-                    text_measure_function(
-                        known_dimensions,
-                        available_space,
-                        node.text_data.as_ref().unwrap(),
-                        &font_metrics,
-                    )
-                }),
-                NodeKind::Image => compute_leaf_layout(inputs, &node.style, |known_dimensions, _available_space| {
-                    image_measure_function(known_dimensions, node.image_data.as_ref().unwrap())
-                }),
+                NodeKind::Text => compute_leaf_layout(
+                    inputs,
+                    &node.style,
+                    |_val, _basis| 0.0,
+                    |known_dimensions, available_space| {
+                        text_measure_function(
+                            known_dimensions,
+                            available_space,
+                            node.text_data.as_ref().unwrap(),
+                            &font_metrics,
+                        )
+                    },
+                ),
+                NodeKind::Image => compute_leaf_layout(
+                    inputs,
+                    &node.style,
+                    |_val, _basis| 0.0,
+                    |known_dimensions, _available_space| {
+                        image_measure_function(known_dimensions, node.image_data.as_ref().unwrap())
+                    },
+                ),
             }
         })
     }

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -66,26 +66,26 @@ pub fn compute_root_layout(tree: &mut impl LayoutPartialTree, root: NodeId, avai
         if style.is_block() {
             // Pull these out earlier to avoid borrowing issues
             let aspect_ratio = style.aspect_ratio();
-            let margin = style.margin().resolve_or_zero(parent_size.width);
-            let padding = style.padding().resolve_or_zero(parent_size.width);
-            let border = style.border().resolve_or_zero(parent_size.width);
+            let margin = style.margin().resolve_or_zero(parent_size.width, |val, basis| tree.calc(val, basis));
+            let padding = style.padding().resolve_or_zero(parent_size.width, |val, basis| tree.calc(val, basis));
+            let border = style.border().resolve_or_zero(parent_size.width, |val, basis| tree.calc(val, basis));
             let padding_border_size = (padding + border).sum_axes();
             let box_sizing_adjustment =
                 if style.box_sizing() == BoxSizing::ContentBox { padding_border_size } else { Size::ZERO };
 
             let min_size = style
                 .min_size()
-                .maybe_resolve(parent_size)
+                .maybe_resolve(parent_size, |val, basis| tree.calc(val, basis))
                 .maybe_apply_aspect_ratio(aspect_ratio)
                 .maybe_add(box_sizing_adjustment);
             let max_size = style
                 .max_size()
-                .maybe_resolve(parent_size)
+                .maybe_resolve(parent_size, |val, basis| tree.calc(val, basis))
                 .maybe_apply_aspect_ratio(aspect_ratio)
                 .maybe_add(box_sizing_adjustment);
             let clamped_style_size = style
                 .size()
-                .maybe_resolve(parent_size)
+                .maybe_resolve(parent_size, |val, basis| tree.calc(val, basis))
                 .maybe_apply_aspect_ratio(aspect_ratio)
                 .maybe_add(box_sizing_adjustment)
                 .maybe_clamp(min_size, max_size);
@@ -123,9 +123,12 @@ pub fn compute_root_layout(tree: &mut impl LayoutPartialTree, root: NodeId, avai
     );
 
     let style = tree.get_core_container_style(root);
-    let padding = style.padding().resolve_or_zero(available_space.width.into_option());
-    let border = style.border().resolve_or_zero(available_space.width.into_option());
-    let margin = style.margin().resolve_or_zero(available_space.width.into_option());
+    let padding =
+        style.padding().resolve_or_zero(available_space.width.into_option(), |val, basis| tree.calc(val, basis));
+    let border =
+        style.border().resolve_or_zero(available_space.width.into_option(), |val, basis| tree.calc(val, basis));
+    let margin =
+        style.margin().resolve_or_zero(available_space.width.into_option(), |val, basis| tree.calc(val, basis));
     let scrollbar_size = Size {
         width: if style.overflow().y == Overflow::Scroll { style.scrollbar_width() } else { 0.0 },
         height: if style.overflow().x == Overflow::Scroll { style.scrollbar_width() } else { 0.0 },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,6 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(unsafe_code)]
-#![forbid(unsafe_code)]
 #![warn(missing_docs)]
 #![warn(clippy::missing_docs_in_private_items)]
 

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -336,6 +336,11 @@ where
     }
 
     #[inline(always)]
+    fn resolve_calc_value(&self, _val: u64, _basis: f32) -> f32 {
+        0.0
+    }
+
+    #[inline(always)]
     fn compute_child_layout(&mut self, node: NodeId, inputs: LayoutInput) -> LayoutOutput {
         // If RunMode is PerformHiddenLayout then this indicates that an ancestor node is `Display::None`
         // and thus that we should lay out this node using hidden layout regardless of it's own display style.
@@ -379,7 +384,8 @@ where
                     let measure_function = |known_dimensions, available_space| {
                         (tree.measure_function)(known_dimensions, available_space, node, node_context, style)
                     };
-                    compute_leaf_layout(inputs, style, measure_function)
+                    // TODO: implement calc() in high-level API
+                    compute_leaf_layout(inputs, style, |_, _| 0.0, measure_function)
                 }
             }
         })

--- a/src/tree/traits.rs
+++ b/src/tree/traits.rs
@@ -180,6 +180,9 @@ pub trait LayoutPartialTree: TraversePartialTree {
     /// Get core style
     fn get_core_container_style(&self, node_id: NodeId) -> Self::CoreContainerStyle<'_>;
 
+    /// Resolve calc value
+    fn resolve_calc_value(&self, val: u64, basis: f32) -> f32;
+
     /// Set the node's unrounded layout
     fn set_unrounded_layout(&mut self, node_id: NodeId, layout: &Layout);
 
@@ -359,6 +362,12 @@ pub(crate) trait LayoutPartialTreeExt: LayoutPartialTree {
                 vertical_margins_are_collapsible,
             },
         )
+    }
+
+    /// Alias to `resolve_calc_value` with a shorter function name
+    #[inline(always)]
+    fn calc(&self, val: u64, basis: f32) -> f32 {
+        self.resolve_calc_value(val, basis)
     }
 }
 


### PR DESCRIPTION
# Objective

`calc()` is super-useful for creating advanced layouts. This PR implements `calc()` in the low-level API. Notably this excludes the actual evaluation of `calc()` expressions. Blitz and Servo can both use [Stylo](https://github.com/servo/stylo) for this.

A built-in implementation of `calc()` expressions in Taffy is considered desirable, but is left as a follow-up.

## Context

- Part of #225 
- Depends on https://github.com/DioxusLabs/taffy/pull/769

## Notes

The performance impact discussed in https://github.com/DioxusLabs/taffy/pull/769 also applies to this PR, but there appears to be no additional performance impact compared with https://github.com/DioxusLabs/taffy/pull/769.

## Feedback wanted

- General code review
