### PR TITLE
Reinstate 1.65 MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,13 @@ jobs:
   # We only run `cargo build` (not `cargo test`) so as to avoid requiring dev-dependencies to build with the MSRV
   # version. Building is likely sufficient as runtime errors varying between rust versions is very unlikely.
   build-features-msrv:
-    name: "MSRV Build [Rust 1.83]"
+    name: "MSRV Build [Rust 1.65]"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.83
+          toolchain: 1.65
       - run: cargo build
 
   build-features-debug:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
     "Nico Burns <nico@nicoburns.com>",
 ]
 edition = "2021"
-rust-version = "1.83"
+rust-version = "1.65"
 include = ["src/**/*", "examples/**/*", "Cargo.toml", "README.md"]
 description = "A flexible UI layout library "
 repository = "https://github.com/DioxusLabs/taffy"


### PR DESCRIPTION
# Objective

- Reinstate lower MSRV of Rust 1.65

## Context

- We want `const` constructors for values.
- We were using `f32::to_bits` and `f32::from_bits` for this functionality since #769
- These functions were only stabilised in Rust 1.83
- This PR inlines those functions into Taffy which allows us to reduce MSRV back to 1.65 at the cost of two lines of unsafe code.
