### PR TITLE
TaffyTree mark_dirty optimization

### DIFF
--- a/examples/custom_tree_owned_partial.rs
+++ b/examples/custom_tree_owned_partial.rs
@@ -207,7 +207,7 @@ impl CacheTree for Node {
     }
 
     fn cache_clear(&mut self, node_id: NodeId) {
-        self.node_from_id_mut(node_id).cache.clear()
+        self.node_from_id_mut(node_id).cache.clear();
     }
 }
 

--- a/examples/custom_tree_owned_unsafe.rs
+++ b/examples/custom_tree_owned_unsafe.rs
@@ -204,7 +204,7 @@ impl CacheTree for StatelessLayoutTree {
     }
 
     fn cache_clear(&mut self, node_id: NodeId) {
-        unsafe { node_from_id_mut(node_id) }.cache.clear()
+        unsafe { node_from_id_mut(node_id) }.cache.clear();
     }
 }
 

--- a/examples/custom_tree_vec.rs
+++ b/examples/custom_tree_vec.rs
@@ -213,7 +213,7 @@ impl CacheTree for Tree {
     }
 
     fn cache_clear(&mut self, node_id: NodeId) {
-        self.node_from_id_mut(node_id).cache.clear()
+        self.node_from_id_mut(node_id).cache.clear();
     }
 }
 

--- a/src/tree/cache.rs
+++ b/src/tree/cache.rs
@@ -26,9 +26,8 @@ pub struct Cache {
     final_layout_entry: Option<CacheEntry<LayoutOutput>>,
     /// The cache entries for the node's preliminary size measurements
     measure_entries: [Option<CacheEntry<Size<f32>>>; CACHE_SIZE],
-
-    /// Is cleared
-    is_cleared: bool,
+    /// Marks if all cache entries have been cleared
+    cleared: bool,
 }
 
 impl Default for Cache {
@@ -40,7 +39,7 @@ impl Default for Cache {
 impl Cache {
     /// Create a new empty cache
     pub const fn new() -> Self {
-        Self { final_layout_entry: None, measure_entries: [None; CACHE_SIZE], is_cleared: true }
+        Self { final_layout_entry: None, measure_entries: [None; CACHE_SIZE], cleared: true }
     }
 
     /// Return the cache slot to cache the current computed result in
@@ -163,11 +162,11 @@ impl Cache {
     ) {
         match run_mode {
             RunMode::PerformLayout => {
-                self.is_cleared = false;
+                self.cleared = false;
                 self.final_layout_entry = Some(CacheEntry { known_dimensions, available_space, content: layout_output })
             }
             RunMode::ComputeSize => {
-                self.is_cleared = false;
+                self.cleared = false;
                 let cache_slot = Self::compute_cache_slot(known_dimensions, available_space);
                 self.measure_entries[cache_slot] =
                     Some(CacheEntry { known_dimensions, available_space, content: layout_output.size });
@@ -176,12 +175,12 @@ impl Cache {
         }
     }
 
-    /// Clear all cache entries and report if they were already cleared
+    /// Clear all cache entries and reports if they were already cleared
     pub fn clear(&mut self) -> bool {
-        if self.is_cleared {
+        if self.cleared {
             return true;
         }
-        self.is_cleared = true;
+        self.cleared = true;
         self.final_layout_entry = None;
         self.measure_entries = [None; CACHE_SIZE];
         return false;

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -9,7 +9,7 @@ mod layout;
 mod node;
 pub mod traits;
 
-pub use cache::Cache;
+pub use cache::{Cache, ClearState};
 pub use layout::{CollapsibleMarginSet, Layout, LayoutInput, LayoutOutput, RequestedAxis, RunMode, SizingMode};
 pub use node::NodeId;
 pub(crate) use traits::LayoutPartialTreeExt;

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -129,7 +129,7 @@ impl NodeData {
     /// Marks a node and all of its ancestors as requiring relayout
     ///
     /// This clears any cached data and signals that the data must be recomputed.
-    /// If the node was already dirty, returns true
+    /// If the node was already marked as dirty, returns true
     #[inline]
     pub fn mark_dirty(&mut self) -> bool {
         self.cache.clear()
@@ -834,18 +834,16 @@ impl<NodeContext> TaffyTree<NodeContext> {
     }
 
     /// Marks the layout of this node and its ancestors as outdated
-    ///
-    /// WARNING: this may stack-overflow if the tree contains a cycle
     pub fn mark_dirty(&mut self, node: NodeId) -> TaffyResult<()> {
-        /// WARNING: this will stack-overflow if the tree contains a cycle
         fn mark_dirty_recursive(
             nodes: &mut SlotMap<DefaultKey, NodeData>,
             parents: &SlotMap<DefaultKey, Option<NodeId>>,
             node_key: DefaultKey,
         ) {
             if nodes[node_key].mark_dirty() {
-                // Node was already dirty.
-                // No need to visit ancestors.
+                // Node was already marked as dirty.
+                // No need to visit ancestors
+                // as they should be marked as dirty already.
                 return;
             }
 

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -129,8 +129,9 @@ impl NodeData {
     /// Marks a node and all of its ancestors as requiring relayout
     ///
     /// This clears any cached data and signals that the data must be recomputed.
+    /// If the node was already dirty, returns true
     #[inline]
-    pub fn mark_dirty(&mut self) {
+    pub fn mark_dirty(&mut self) -> bool {
         self.cache.clear()
     }
 }
@@ -226,7 +227,7 @@ impl<NodeContext> CacheTree for TaffyTree<NodeContext> {
     }
 
     fn cache_clear(&mut self, node_id: NodeId) {
-        self.nodes[node_id.into()].cache.clear()
+        self.nodes[node_id.into()].cache.clear();
     }
 }
 
@@ -419,7 +420,7 @@ where
     }
 
     fn cache_clear(&mut self, node_id: NodeId) {
-        self.taffy.nodes[node_id.into()].cache.clear()
+        self.taffy.nodes[node_id.into()].cache.clear();
     }
 }
 
@@ -842,7 +843,11 @@ impl<NodeContext> TaffyTree<NodeContext> {
             parents: &SlotMap<DefaultKey, Option<NodeId>>,
             node_key: DefaultKey,
         ) {
-            nodes[node_key].mark_dirty();
+            if nodes[node_key].mark_dirty() {
+                // Node was already dirty.
+                // No need to visit ancestors.
+                return;
+            }
 
             if let Some(Some(node)) = parents.get(node_key) {
                 mark_dirty_recursive(nodes, parents, (*node).into());


### PR DESCRIPTION
# Objective

Why did you make this PR?

Fixes https://github.com/DioxusLabs/taffy/issues/800

## Context

Mark if cache has been cleared. It should hold true that if node is dirty(cleared) then all ancestors of it are dirty(cleared) too and therefore all ancestors do not need to be visited repeatedly.

## Feedback wanted

Cache is used in other structures too and I am not 100% sure that assumption holds and is correctly updated during layout calculations.  (See hidden elements, but for them this should still be correct due to sub-tree being hidden).


Feel free to edit branch if minor fixes are needed.