### PR TITLE
Validate tag when deserializing values

### DIFF
--- a/src/style/compact_length.rs
+++ b/src/style/compact_length.rs
@@ -506,10 +506,21 @@ impl<'de> serde::Deserialize<'de> for CompactLength {
     {
         let bits: u64 = u64::deserialize(deserializer)?;
         let value = Self(CompactLengthInner::from_serialized(bits));
-        if value.is_calc() {
-            Err(serde::de::Error::custom("Cannot deserialize Calc value"))
-        } else {
+        // Note: validation intentionally excludes the CALC_TAG as deserializing calc() values is not supported
+        if matches!(
+            value.tag(),
+            CompactLength::LENGTH_TAG
+                | CompactLength::PERCENT_TAG
+                | CompactLength::AUTO_TAG
+                | CompactLength::MIN_CONTENT_TAG
+                | CompactLength::MAX_CONTENT_TAG
+                | CompactLength::FIT_CONTENT_PX_TAG
+                | CompactLength::FIT_CONTENT_PERCENT_TAG
+                | CompactLength::FR_TAG
+        ) {
             Ok(value)
+        } else {
+            Err(serde::de::Error::custom("Cannot deserialize Calc value"))
         }
     }
 }

--- a/src/style/dimension.rs
+++ b/src/style/dimension.rs
@@ -7,7 +7,7 @@ use crate::style_helpers::{FromLength, FromPercent, TaffyAuto, TaffyZero};
 ///
 /// This is commonly combined with [`Rect`], [`Point`](crate::geometry::Point) and [`Size<T>`](crate::geometry::Size).
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct LengthPercentage(pub(crate) CompactLength);
 impl TaffyZero for LengthPercentage {
     const ZERO: Self = Self(CompactLength::ZERO);
@@ -61,11 +61,27 @@ impl LengthPercentage {
     }
 }
 
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for LengthPercentage {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let inner = CompactLength::deserialize(deserializer)?;
+        // Note: validation intentionally excludes the CALC_TAG as deserializing calc() values is not supported
+        if matches!(inner.tag(), CompactLength::LENGTH_TAG | CompactLength::PERCENT_TAG) {
+            Ok(Self(inner))
+        } else {
+            Err(serde::de::Error::custom("Invalid tag"))
+        }
+    }
+}
+
 /// A unit of linear measurement
 ///
 /// This is commonly combined with [`Rect`], [`Point`](crate::geometry::Point) and [`Size<T>`](crate::geometry::Size).
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct LengthPercentageAuto(pub(crate) CompactLength);
 impl TaffyZero for LengthPercentageAuto {
     const ZERO: Self = Self(CompactLength::ZERO);
@@ -156,11 +172,27 @@ impl LengthPercentageAuto {
     }
 }
 
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for LengthPercentageAuto {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let inner = CompactLength::deserialize(deserializer)?;
+        // Note: validation intentionally excludes the CALC_TAG as deserializing calc() values is not supported
+        if matches!(inner.tag(), CompactLength::LENGTH_TAG | CompactLength::PERCENT_TAG | CompactLength::AUTO_TAG) {
+            Ok(Self(inner))
+        } else {
+            Err(serde::de::Error::custom("Invalid tag"))
+        }
+    }
+}
+
 /// A unit of linear measurement
 ///
 /// This is commonly combined with [`Rect`], [`Point`](crate::geometry::Point) and [`Size<T>`](crate::geometry::Size).
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct Dimension(pub(crate) CompactLength);
 impl TaffyZero for Dimension {
     const ZERO: Self = Self(CompactLength::ZERO);
@@ -256,6 +288,22 @@ impl Dimension {
     /// Get the raw `CompactLength` value for non-calc variants that have a numeric parameter
     pub fn value(self) -> f32 {
         self.0.value()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Dimension {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let inner = CompactLength::deserialize(deserializer)?;
+        // Note: validation intentionally excludes the CALC_TAG as deserializing calc() values is not supported
+        if matches!(inner.tag(), CompactLength::LENGTH_TAG | CompactLength::PERCENT_TAG | CompactLength::AUTO_TAG) {
+            Ok(Self(inner))
+        } else {
+            Err(serde::de::Error::custom("Invalid tag"))
+        }
     }
 }
 

--- a/src/style/grid.rs
+++ b/src/style/grid.rs
@@ -366,7 +366,7 @@ impl Default for Line<GridPlacement> {
 /// on the size of it's contents, the amount of available space, and the sizing constraint the grid is being size under.
 /// See <https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-columns>
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct MaxTrackSizingFunction(pub(crate) CompactLength);
 impl TaffyZero for MaxTrackSizingFunction {
     const ZERO: Self = Self(CompactLength::ZERO);
@@ -418,6 +418,31 @@ impl From<Dimension> for MaxTrackSizingFunction {
 impl From<MinTrackSizingFunction> for MaxTrackSizingFunction {
     fn from(input: MinTrackSizingFunction) -> Self {
         Self(input.0)
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for MaxTrackSizingFunction {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let inner = CompactLength::deserialize(deserializer)?;
+        // Note: validation intentionally excludes the CALC_TAG as deserializing calc() values is not supported
+        if matches!(
+            inner.tag(),
+            CompactLength::LENGTH_TAG
+                | CompactLength::PERCENT_TAG
+                | CompactLength::AUTO_TAG
+                | CompactLength::MIN_CONTENT_TAG
+                | CompactLength::MAX_CONTENT_TAG
+                | CompactLength::FIT_CONTENT_PX_TAG
+                | CompactLength::FIT_CONTENT_PERCENT_TAG
+                | CompactLength::FR_TAG
+        ) {
+            Ok(Self(inner))
+        } else {
+            Err(serde::de::Error::custom("Invalid tag"))
+        }
     }
 }
 
@@ -637,7 +662,7 @@ impl MaxTrackSizingFunction {
 /// on the size of it's contents, the amount of available space, and the sizing constraint the grid is being size under.
 /// See <https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-columns>
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct MinTrackSizingFunction(pub(crate) CompactLength);
 impl TaffyZero for MinTrackSizingFunction {
     const ZERO: Self = Self(CompactLength::ZERO);
@@ -674,6 +699,30 @@ impl From<LengthPercentageAuto> for MinTrackSizingFunction {
 impl From<Dimension> for MinTrackSizingFunction {
     fn from(input: Dimension) -> Self {
         Self(input.0)
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for MinTrackSizingFunction {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let inner = CompactLength::deserialize(deserializer)?;
+        // Note: validation intentionally excludes the CALC_TAG as deserializing calc() values is not supported
+        if matches!(
+            inner.tag(),
+            CompactLength::LENGTH_TAG
+                | CompactLength::PERCENT_TAG
+                | CompactLength::AUTO_TAG
+                | CompactLength::MIN_CONTENT_TAG
+                | CompactLength::MAX_CONTENT_TAG
+                | CompactLength::FIT_CONTENT_PX_TAG
+                | CompactLength::FIT_CONTENT_PERCENT_TAG
+        ) {
+            Ok(Self(inner))
+        } else {
+            Err(serde::de::Error::custom("Invalid tag"))
+        }
     }
 }
 


### PR DESCRIPTION
# Objective

- `CompactLength` and other length representations rely on values with invalid tags never been constructed. This PR enforces that invariant for values constructed via serde deserialization.
