### PR TITLE
Feature flag calc values

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,15 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo build --no-default-features --features std,taffy_tree,grid,flexbox,block_layout
+      - run: cargo test --tests --no-default-features --features std,taffy_tree,grid,flexbox,block_layout,calc
+
+  test-features-default-except-calc:
+    name: "Test Suite [default except calc]"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build --no-default-features --features std,taffy_tree,grid,flexbox,block_layout
       - run: cargo test --tests --no-default-features --features std,taffy_tree,grid,flexbox,block_layout
 
   test-features-no-grid-nor-flexbox:
@@ -92,7 +101,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo build --no-default-features --features std
       - run: cargo build --no-default-features --features std,taffy_tree
-      - run: cargo test --tests --no-default-features --features std,taffy_tree
+      - run: cargo test --tests --no-default-features --features std,taffy_tree,calc
 
   # With std feature
   test-features-flexbox:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ default = [
     "flexbox",
     "grid",
     "block_layout",
+    "calc",
     "content_size",
     "detailed_layout_info",
 ]
@@ -53,6 +54,8 @@ block_layout = []
 flexbox = []
 ## Enables the CSS Grid layout algorithm. See [`compute_grid_layout`](crate::compute_grid_layout).
 grid = ["alloc", "dep:grid"]
+## Enables calc() values for all layout algorithms
+calc = []
 ## Causes all algorithms to compute and output a content size for each node
 content_size = []
 ## Causes algorithms to stores detailed information of the nodes in TaffyTree, with only CSS Grid supporting this.

--- a/src/compute/grid/track_sizing.rs
+++ b/src/compute/grid/track_sizing.rs
@@ -612,6 +612,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                         track.base_size
                     }
                     // Handle calc() like percentage
+                    #[cfg(feature = "calc")]
                     _ if track.min_track_sizing_function.0.is_calc() => {
                         if axis_inner_node_size.is_none() {
                             f32_max(track.base_size, item_sizer.min_content_contribution(item))

--- a/src/style/dimension.rs
+++ b/src/style/dimension.rs
@@ -43,6 +43,7 @@ impl LengthPercentage {
     ///
     /// The low 3 bits are used as a tag value and will be returned as 0.
     #[inline(always)]
+    #[cfg(feature = "calc")]
     pub fn calc(ptr: *const ()) -> Self {
         Self(CompactLength::calc(ptr))
     }
@@ -133,6 +134,7 @@ impl LengthPercentageAuto {
     ///
     /// The low 3 bits are used as a tag value and will be returned as 0.
     #[inline]
+    #[cfg(feature = "calc")]
     pub fn calc(ptr: *const ()) -> Self {
         Self(CompactLength::calc(ptr))
     }
@@ -160,6 +162,7 @@ impl LengthPercentageAuto {
             CompactLength::LENGTH_TAG => Some(self.0.value()),
             CompactLength::PERCENT_TAG => Some(context * self.0.value()),
             CompactLength::AUTO_TAG => None,
+            #[cfg(feature = "calc")]
             _ if self.0.is_calc() => Some(calc_resolver(self.0.calc_value(), context)),
             _ => unreachable!("LengthPercentageAuto values cannot be constructed with other tags"),
         }
@@ -249,6 +252,7 @@ impl Dimension {
     ///
     /// The low 3 bits are used as a tag value and will be returned as 0.
     #[inline]
+    #[cfg(feature = "calc")]
     pub fn calc(ptr: *const ()) -> Self {
         Self(CompactLength::calc(ptr))
     }

--- a/src/style/grid.rs
+++ b/src/style/grid.rs
@@ -524,6 +524,7 @@ impl MaxTrackSizingFunction {
     ///
     /// The low 3 bits are used as a tag value and will be returned as 0.
     #[inline]
+    #[cfg(feature = "calc")]
     pub fn calc(ptr: *const ()) -> Self {
         Self(CompactLength::calc(ptr))
     }
@@ -597,6 +598,7 @@ impl MaxTrackSizingFunction {
         match self.0.tag() {
             CompactLength::LENGTH_TAG => true,
             CompactLength::PERCENT_TAG => parent_size.is_some(),
+            #[cfg(feature = "calc")]
             _ if self.0.is_calc() => parent_size.is_some(),
             _ => false,
         }
@@ -614,6 +616,7 @@ impl MaxTrackSizingFunction {
         match self.0.tag() {
             CompactLength::LENGTH_TAG => Some(self.0.value()),
             CompactLength::PERCENT_TAG => parent_size.map(|size| self.0.value() * size),
+            #[cfg(feature = "calc")]
             _ if self.0.is_calc() => parent_size.map(|size| calc_resolver(self.0.calc_value(), size)),
             _ => None,
         }
@@ -768,6 +771,7 @@ impl MinTrackSizingFunction {
     ///
     /// The low 3 bits are used as a tag value and will be returned as 0.
     #[inline]
+    #[cfg(feature = "calc")]
     pub fn calc(ptr: *const ()) -> Self {
         Self(CompactLength::calc(ptr))
     }
@@ -833,6 +837,7 @@ impl MinTrackSizingFunction {
         match self.0.tag() {
             CompactLength::LENGTH_TAG => Some(self.0.value()),
             CompactLength::PERCENT_TAG => parent_size.map(|size| self.0.value() * size),
+            #[cfg(feature = "calc")]
             _ if self.0.is_calc() => parent_size.map(|size| calc_resolver(self.0.calc_value(), size)),
             _ => None,
         }
@@ -852,7 +857,14 @@ impl MinTrackSizingFunction {
     /// Whether the track sizing functions depends on the size of the parent node
     #[inline(always)]
     pub fn uses_percentage(self) -> bool {
-        matches!(self.0.tag(), CompactLength::PERCENT_TAG) || self.0.is_calc()
+        #[cfg(feature = "calc")]
+        {
+            matches!(self.0.tag(), CompactLength::PERCENT_TAG) || self.0.is_calc()
+        }
+        #[cfg(not(feature = "calc"))]
+        {
+            matches!(self.0.tag(), CompactLength::PERCENT_TAG)
+        }
     }
 }
 

--- a/src/tree/traits.rs
+++ b/src/tree/traits.rs
@@ -181,7 +181,12 @@ pub trait LayoutPartialTree: TraversePartialTree {
     fn get_core_container_style(&self, node_id: NodeId) -> Self::CoreContainerStyle<'_>;
 
     /// Resolve calc value
-    fn resolve_calc_value(&self, val: *const (), basis: f32) -> f32;
+    #[inline(always)]
+    fn resolve_calc_value(&self, val: *const (), basis: f32) -> f32 {
+        let _ = val;
+        let _ = basis;
+        0.0
+    }
 
     /// Set the node's unrounded layout
     fn set_unrounded_layout(&mut self, node_id: NodeId, layout: &Layout);
@@ -366,8 +371,16 @@ pub(crate) trait LayoutPartialTreeExt: LayoutPartialTree {
 
     /// Alias to `resolve_calc_value` with a shorter function name
     #[inline(always)]
+    #[cfg(feature = "calc")]
     fn calc(&self, val: *const (), basis: f32) -> f32 {
         self.resolve_calc_value(val, basis)
+    }
+
+    /// Alias to `resolve_calc_value` with a shorter function name
+    #[inline(always)]
+    #[cfg(not(feature = "calc"))]
+    fn calc(&self, _val: *const (), _basis: f32) -> f32 {
+        0.0
     }
 }
 

--- a/src/util/resolve.rs
+++ b/src/util/resolve.rs
@@ -32,6 +32,7 @@ impl MaybeResolve<Option<f32>, Option<f32>> for LengthPercentage {
         match self.0.tag() {
             CompactLength::LENGTH_TAG => Some(self.0.value()),
             CompactLength::PERCENT_TAG => context.map(|dim| dim * self.0.value()),
+            #[cfg(feature = "calc")]
             _ if self.0.is_calc() => context.map(|dim| calc(self.0.calc_value(), dim)),
             _ => unreachable!(),
         }
@@ -46,6 +47,7 @@ impl MaybeResolve<Option<f32>, Option<f32>> for LengthPercentageAuto {
             CompactLength::AUTO_TAG => None,
             CompactLength::LENGTH_TAG => Some(self.0.value()),
             CompactLength::PERCENT_TAG => context.map(|dim| dim * self.0.value()),
+            #[cfg(feature = "calc")]
             _ if self.0.is_calc() => context.map(|dim| calc(self.0.calc_value(), dim)),
             _ => unreachable!(),
         }
@@ -61,6 +63,7 @@ impl MaybeResolve<Option<f32>, Option<f32>> for Dimension {
             CompactLength::AUTO_TAG => None,
             CompactLength::LENGTH_TAG => Some(self.0.value()),
             CompactLength::PERCENT_TAG => context.map(|dim| dim * self.0.value()),
+            #[cfg(feature = "calc")]
             _ if self.0.is_calc() => context.map(|dim| calc(self.0.calc_value(), dim)),
             _ => unreachable!(),
         }


### PR DESCRIPTION
# Objective

Following our usual "pay for what you use" philosophy, this allows `calc()` to be disabled.