### PR TITLE
Introduced a builder pattern interface (#275)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ detailed_layout_info = []
 ## Use strict provenance APIs for pointer manipulation. Using this feature requires Rust 1.84 or higher.
 strict_provenance = []
 ## Expose a builder pattern interface to construct layout tree
-builder = ["alloc"]
+builder = []
 
 #! ### Taffy Tree
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ default = [
     "calc",
     "content_size",
     "detailed_layout_info",
+    "builder"
 ]
 #! ## Feature Flags
 #!
@@ -62,6 +63,8 @@ content_size = []
 detailed_layout_info = []
 ## Use strict provenance APIs for pointer manipulation. Using this feature requires Rust 1.84 or higher.
 strict_provenance = []
+## Expose a builder pattern interface to construct layout tree
+builder = ["alloc"]
 
 #! ### Taffy Tree
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,9 @@ pub use crate::compute::{
 };
 #[doc(inline)]
 pub use crate::style::Style;
+#[cfg(feature = "builder")]
+#[doc(inline)]
+pub use crate::style::StyleBuilder;
 #[doc(inline)]
 pub use crate::tree::traits::*;
 #[cfg(feature = "taffy_tree")]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -30,4 +30,4 @@ pub use crate::style_helpers::{
 pub use crate::TaffyTree;
 
 #[cfg(feature = "builder")]
-pub use crate::style::{NodeIdRef, StyleBuilder};
+pub use crate::style::StyleBuilder;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -28,3 +28,6 @@ pub use crate::style_helpers::{
 
 #[cfg(feature = "taffy_tree")]
 pub use crate::TaffyTree;
+
+#[cfg(feature = "builder")]
+pub use crate::style::{NodeIdRef, StyleBuilder};

--- a/src/style/builder.rs
+++ b/src/style/builder.rs
@@ -1,0 +1,378 @@
+//! A builder pattern interface to facilitate the creation of [`super::Style`]
+use super::{
+    AlignContent, AlignItems, AlignSelf, BoxSizing, Dimension, Display, JustifyContent, LengthPercentage,
+    LengthPercentageAuto, Overflow, Position, Style,
+};
+use crate::sys::Rc;
+use crate::{util::sys::Vec, Line, NodeId, Point, Rect, Size};
+use core::cell::Cell;
+
+#[cfg(feature = "flexbox")]
+use super::{FlexDirection, FlexWrap};
+#[cfg(feature = "taffy_tree")]
+use crate::{TaffyResult, TaffyTree};
+#[cfg(feature = "grid")]
+use {
+    super::{GridAutoFlow, GridPlacement, NonRepeatedTrackSizingFunction, TrackSizingFunction},
+    crate::sys::GridTrackVec,
+};
+
+/// `NodeIdRef` can be passed to a [`StyleBuilder`] so that caller can later
+/// retrieve the [`NodeId`] of a built tree node.
+#[derive(Debug, Clone, Default)]
+pub struct NodeIdRef(Rc<Cell<Option<NodeId>>>);
+
+impl NodeIdRef {
+    /// Create an empty [`NodeIdRef`].
+    pub fn new() -> Self {
+        Self(Rc::new(Cell::new(None)))
+    }
+
+    /// Set the [`NodeId`].
+    fn set(&self, node_id: NodeId) {
+        self.0.set(Some(node_id));
+    }
+
+    /// Get a copy of the inner [`NodeId`], if any is present.
+    pub fn get(&self) -> Option<NodeId> {
+        self.0.get()
+    }
+}
+
+/// Given a builder name and associated fields, generate the following :
+/// * A struct of the given name, with the following fields
+///     * `children`: a vec of child builder
+///     * `node_id_ref`: a field holding a [`Option<NodeIdRef>`], wich allow for retrieving the [`NodeId`] of the built node
+///     * A [`Option<_>`] field for each provided field
+/// * An `impl`` block containing the following :
+///     * A method named after the provided field, used to set said field
+///     * A `build_style` method, used to generate a [`Style`](super::Style) based on data stored in the builder
+macro_rules! gen_builder {
+    ($builder:ident, $(($field:ident: $type:ty $(, cfg: $($cfg:tt)+)?)),* $(,)?) => {
+        /// Use [`StyleBuilder`] to construct a tree of nested style nodes.
+        ///
+        /// Example :
+        /// ```rust
+        /// # use taffy::prelude::*;
+        /// let mut builder_tree: TaffyTree<()> = TaffyTree::new();
+        /// let header_node_handle = NodeIdRef::new();
+        /// let body_node_handle = NodeIdRef::new();
+        ///
+        /// let builder_root_node = StyleBuilder::new()
+        ///     .flex_direction(FlexDirection::Column)
+        ///     .size(Size { width: length(800.0), height: length(600.0) })
+        ///     .child(
+        ///         StyleBuilder::new().width(length(800.0)).height(length(100.0)).node_id_ref(header_node_handle.clone()),
+        ///     )
+        ///     .child(
+        ///         StyleBuilder::new()
+        ///             .width(length(800.0))
+        ///             .height(auto())
+        ///             .flex_grow(1.0)
+        ///             .node_id_ref(body_node_handle.clone()),
+        ///     )
+        ///     .build(&mut builder_tree)
+        ///     .unwrap();
+        ///
+        /// builder_tree.compute_layout(builder_root_node, Size::MAX_CONTENT).unwrap();
+        /// ```
+        #[derive(Debug, Default)]
+        pub struct $builder<'a> {
+            children: Vec<&'a StyleBuilder<'a>>,
+            node_id_ref: Option<NodeIdRef>,
+            $(
+                $(#[cfg($($cfg)+)])?
+                $field: Option<$type>,
+            )*
+        }
+
+        impl<'a> $builder<'a> {
+            $(
+                $(#[cfg($($cfg)+)])?
+                #[doc = concat!("Will set the `", stringify!($field), "` field to the provided value in the")]
+                #[doc = "\nresulting [`Style`](super::Style) when the [`build`](StyleBuilder::build) method is called."]
+                #[doc = concat!("\n\nSee [`Style::", stringify!($field), "`](super::Style::", stringify!($field), ").")]
+                pub fn $field(&mut self, $field: impl Into<$type>) -> &mut Self {
+                    self.$field = Some($field.into());
+                    self
+                }
+            )*
+
+            /// Build an [`Style`](super::Style) based on provided cconfiguration.
+            /// Calling this without setting any field results in
+            /// [`Style::default()`](super::Style::default)
+            pub fn build_style(&self) -> Style {
+                let mut style = Style::default();
+
+                $(
+                    $(#[cfg($($cfg)+)])?
+                    if let Some(ref value) = self.$field {
+                        style.$field = Clone::clone(value);
+                    }
+                )*
+
+                style
+            }
+        }
+    };
+}
+
+gen_builder!(
+    StyleBuilder,
+    (display: Display),
+    (item_is_table: bool),
+    (box_sizing: BoxSizing),
+    (overflow: Point<Overflow>),
+    (scrollbar_width: f32),
+    (position: Position),
+    (inset: Rect<LengthPercentageAuto>),
+    (size: Size<Dimension>),
+    (min_size: Size<Dimension>),
+    (max_size: Size<Dimension>),
+    (aspect_ratio: Option<f32>),
+    (margin: Rect<LengthPercentageAuto>),
+    (padding: Rect<LengthPercentage>),
+    (border: Rect<LengthPercentage>),
+    (align_items: Option<AlignItems>, cfg: any(feature = "flexbox", feature = "grid")),
+    (align_self: Option<AlignSelf>, cfg: any(feature = "flexbox", feature = "grid")),
+    (justify_items: Option<AlignItems>, cfg: feature = "grid"),
+    (justify_self: Option<AlignSelf>, cfg: feature = "grid"),
+    (align_content: Option<AlignContent>, cfg: any(feature = "flexbox", feature = "grid")),
+    (justify_content: Option<JustifyContent>, cfg: any(feature = "flexbox", feature = "grid")),
+    (gap: Size<LengthPercentage>, cfg: any(feature = "flexbox", feature = "grid")),
+    (text_align: super::TextAlign, cfg: feature = "block_layout"),
+    (flex_direction: FlexDirection, cfg: feature = "flexbox"),
+    (flex_wrap: FlexWrap, cfg: feature = "flexbox"),
+    (flex_basis: Dimension, cfg: feature = "flexbox"),
+    (flex_grow: f32, cfg: feature = "flexbox"),
+    (flex_shrink: f32, cfg: feature = "flexbox"),
+    (grid_template_rows: GridTrackVec<TrackSizingFunction>, cfg: feature = "grid"),
+    (grid_template_columns: GridTrackVec<TrackSizingFunction>, cfg: feature = "grid"),
+    (grid_auto_rows: GridTrackVec<NonRepeatedTrackSizingFunction>, cfg: feature = "grid"),
+    (grid_auto_columns: GridTrackVec<NonRepeatedTrackSizingFunction>, cfg: feature = "grid"),
+    (grid_auto_flow: GridAutoFlow, cfg: feature = "grid"),
+    (grid_row: Line<GridPlacement>, cfg: feature = "grid"),
+    (grid_column: Line<GridPlacement>, cfg: feature = "grid"),
+);
+
+impl<'a> StyleBuilder<'a> {
+    /// Create a new [`StyleBuilder`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[cfg(feature = "flexbox")]
+    /// Create a new [`StyleBuilder`], pre-configured to use [`FlexDirection::Row`]
+    pub fn row() -> Self {
+        let mut row = Self::new();
+        row.flex_direction(FlexDirection::Row);
+        row
+    }
+
+    #[cfg(feature = "flexbox")]
+    /// Create a new [`StyleBuilder`], pre-configured to use [`FlexDirection::Column`]
+    pub fn column() -> Self {
+        let mut column = Self::new();
+        column.flex_direction(FlexDirection::Column);
+        column
+    }
+
+    /// Add a child [`StyleBuilder`] to this builder. Calling this method does not result
+    /// in the child [`StyleBuilder`] being built until the [`StyleBuilder::build`] method
+    /// is invoke on this builder.
+    pub fn child(&'a mut self, style_builder: &'a StyleBuilder) -> &'a mut StyleBuilder<'a> {
+        self.children.push(style_builder);
+        self
+    }
+
+    #[cfg(feature = "taffy_tree")]
+    /// Create a new node for this builder and all child builder stored within.
+    /// This is done by creating a new node in the provided [`TaffyTree`].
+    /// Return a [`TaffyResult<NodeId>`] for the root node. Child [`NodeId`] can be
+    /// retrieved once [`build`](StyleBuilder::build) is invoked via setting a [`NodeIdRef`]
+    /// in each of the desired child [`StyleBuilder`]
+    pub fn build(&self, tree: &mut TaffyTree) -> TaffyResult<NodeId> {
+        let style = self.build_style();
+        let node_id = tree.new_leaf(style)?;
+
+        if let Some(node_id_ref) = self.node_id_ref.as_ref() {
+            node_id_ref.set(node_id);
+        }
+
+        let children_node_ids = self.children.iter().map(|child| child.build(tree)).collect::<Result<Vec<_>, _>>()?;
+
+        tree.set_children(node_id, &children_node_ids)?;
+
+        Ok(node_id)
+    }
+
+    /// This setter can be used to set a [`NodeIdRef`]. If this is set,
+    /// the [`NodeIdRef`] can be used to retrieved to [`NodeId`] of the node
+    /// built via the [`build`](StyleBuilder::build) method
+    /// Example:
+    /// ```rust
+    /// # use taffy::prelude::*;
+    ///
+    /// let mut tree: TaffyTree<()> = TaffyTree::new();
+    /// let child_node_id_ref = NodeIdRef::new();
+    ///
+    /// let root_node_id = StyleBuilder::new()
+    ///     .display(Display::Block)
+    ///     .child(
+    ///         StyleBuilder::new()
+    ///             .display(Display::Block)
+    ///             .node_id_ref(child_node_id_ref.clone())
+    ///     )
+    ///     .build(&mut tree)
+    ///     .unwrap();
+    ///
+    /// tree.compute_layout(root_node_id, Size::MAX_CONTENT).unwrap();
+    ///
+    /// assert!(
+    ///     matches!(
+    ///         child_node_id_ref.get(),
+    ///         Some(_)
+    ///     )
+    /// );
+    ///
+    /// tree.layout(child_node_id_ref.get().unwrap()).unwrap();
+    /// ```
+    pub fn node_id_ref(&'a mut self, node_id_ref: NodeIdRef) -> &'a mut StyleBuilder<'a> {
+        self.node_id_ref = Some(node_id_ref);
+        self
+    }
+
+    /// Shorthand method to set the width of the resulting [`Style`]
+    pub fn width(&'a mut self, width: Dimension) -> &'a mut StyleBuilder<'a> {
+        match self.size {
+            Some(size) => {
+                self.size = Some(Size { width, ..size });
+            }
+            None => self.size = Some(Size { width, ..Style::DEFAULT.size }),
+        }
+        self
+    }
+
+    /// Shorthand method to set the height of the resulting [`Style`]
+    pub fn height(&'a mut self, height: Dimension) -> &'a mut StyleBuilder<'a> {
+        match self.size {
+            Some(size) => {
+                self.size = Some(Size { height, ..size });
+            }
+            None => self.size = Some(Size { height, ..Style::DEFAULT.size }),
+        }
+        self
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[cfg(feature = "flexbox")]
+    use crate::FlexDirection;
+
+    use crate::{
+        prelude::{auto, length, TaffyMaxContent},
+        style::builder::NodeIdRef,
+        Size, TaffyTree,
+    };
+
+    use super::{Style, StyleBuilder};
+
+    #[test]
+    fn builder_defaults_match_defaults() {
+        assert_eq!(StyleBuilder::default().build_style(), Style::default())
+    }
+
+    #[test]
+    #[cfg(feature = "flexbox")]
+    fn readme_example() {
+        let mut tree: TaffyTree<()> = TaffyTree::new();
+        let header_node = tree
+            .new_leaf(Style { size: Size { width: length(800.0), height: length(100.0) }, ..Default::default() })
+            .unwrap();
+
+        let body_node = tree
+            .new_leaf(Style {
+                size: Size { width: length(800.0), height: auto() },
+                flex_grow: 1.0,
+                ..Default::default()
+            })
+            .unwrap();
+
+        let root_node = tree
+            .new_with_children(
+                Style {
+                    flex_direction: FlexDirection::Column,
+                    size: Size { width: length(800.0), height: length(600.0) },
+                    ..Default::default()
+                },
+                &[header_node, body_node],
+            )
+            .unwrap();
+
+        tree.compute_layout(root_node, Size::MAX_CONTENT).unwrap();
+
+        let mut builder_tree: TaffyTree<()> = TaffyTree::new();
+        let header_node_handle = NodeIdRef::new();
+        let body_node_handle = NodeIdRef::new();
+
+        let builder_root_node = StyleBuilder::new()
+            .flex_direction(FlexDirection::Column)
+            .size(Size { width: length(800.0), height: length(600.0) })
+            .child(
+                StyleBuilder::new().width(length(800.0)).height(length(100.0)).node_id_ref(header_node_handle.clone()),
+            )
+            .child(
+                StyleBuilder::new()
+                    .width(length(800.0))
+                    .height(auto())
+                    .flex_grow(1.0)
+                    .node_id_ref(body_node_handle.clone()),
+            )
+            .build(&mut builder_tree)
+            .unwrap();
+
+        builder_tree.compute_layout(builder_root_node, Size::MAX_CONTENT).unwrap();
+
+        assert_eq!(
+            tree.layout(root_node).unwrap().size.width,
+            builder_tree.layout(builder_root_node).unwrap().size.width
+        );
+        assert_eq!(
+            tree.layout(root_node).unwrap().size.height,
+            builder_tree.layout(builder_root_node).unwrap().size.height
+        );
+        assert_eq!(
+            tree.layout(header_node).unwrap().size.width,
+            builder_tree.layout(header_node_handle.get().unwrap()).unwrap().size.width
+        );
+        assert_eq!(
+            tree.layout(header_node).unwrap().size.height,
+            builder_tree.layout(header_node_handle.get().unwrap()).unwrap().size.height
+        );
+        assert_eq!(
+            tree.layout(body_node).unwrap().size.width,
+            builder_tree.layout(body_node_handle.get().unwrap()).unwrap().size.width
+        );
+        assert_eq!(
+            tree.layout(body_node).unwrap().size.height,
+            builder_tree.layout(body_node_handle.get().unwrap()).unwrap().size.height
+        );
+    }
+
+    #[test]
+    fn row() {
+        assert_eq!(
+            StyleBuilder::row().build_style(),
+            Style { flex_direction: FlexDirection::Row, ..Default::default() }
+        )
+    }
+
+    #[test]
+    fn column() {
+        assert_eq!(
+            StyleBuilder::column().build_style(),
+            Style { flex_direction: FlexDirection::Column, ..Default::default() }
+        )
+    }
+}

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -21,7 +21,7 @@ pub use self::dimension::{Dimension, LengthPercentage, LengthPercentageAuto};
 #[cfg(feature = "block_layout")]
 pub use self::block::{BlockContainerStyle, BlockItemStyle, TextAlign};
 #[cfg(feature = "builder")]
-pub use self::builder::{NodeIdRef, StyleBuilder};
+pub use self::builder::StyleBuilder;
 #[cfg(feature = "flexbox")]
 pub use self::flex::{FlexDirection, FlexWrap, FlexboxContainerStyle, FlexboxItemStyle};
 #[cfg(feature = "grid")]

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -6,6 +6,8 @@ mod dimension;
 
 #[cfg(feature = "block_layout")]
 mod block;
+#[cfg(feature = "builder")]
+mod builder;
 #[cfg(feature = "flexbox")]
 mod flex;
 #[cfg(feature = "grid")]
@@ -18,6 +20,8 @@ pub use self::dimension::{Dimension, LengthPercentage, LengthPercentageAuto};
 
 #[cfg(feature = "block_layout")]
 pub use self::block::{BlockContainerStyle, BlockItemStyle, TextAlign};
+#[cfg(feature = "builder")]
+pub use self::builder::{NodeIdRef, StyleBuilder};
 #[cfg(feature = "flexbox")]
 pub use self::flex::{FlexDirection, FlexWrap, FlexboxContainerStyle, FlexboxItemStyle};
 #[cfg(feature = "grid")]

--- a/src/util/sys.rs
+++ b/src/util/sys.rs
@@ -22,6 +22,8 @@ mod std {
     #[cfg(feature = "grid")]
     /// A vector of grid tracks
     pub(crate) type GridTrackVec<A> = std::vec::Vec<A>;
+    /// Rc
+    pub(crate) type Rc<A> = std::rc::Rc<A>;
 
     /// Creates a new vector with the capacity for the specified number of items before it must be resized
     #[must_use]
@@ -83,6 +85,8 @@ mod alloc {
     #[cfg(feature = "grid")]
     /// A vector of grid tracks
     pub(crate) type GridTrackVec<A> = alloc::vec::Vec<A>;
+    /// Rc
+    pub(crate) type Rc<A> = alloc::rc::Rc<A>;
 
     /// Creates a new vector with the capacity for the specified number of items before it must be resized
     #[must_use]

--- a/src/util/sys.rs
+++ b/src/util/sys.rs
@@ -22,8 +22,6 @@ mod std {
     #[cfg(feature = "grid")]
     /// A vector of grid tracks
     pub(crate) type GridTrackVec<A> = std::vec::Vec<A>;
-    /// Rc
-    pub(crate) type Rc<A> = std::rc::Rc<A>;
 
     /// Creates a new vector with the capacity for the specified number of items before it must be resized
     #[must_use]
@@ -85,8 +83,6 @@ mod alloc {
     #[cfg(feature = "grid")]
     /// A vector of grid tracks
     pub(crate) type GridTrackVec<A> = alloc::vec::Vec<A>;
-    /// Rc
-    pub(crate) type Rc<A> = alloc::rc::Rc<A>;
 
     /// Creates a new vector with the capacity for the specified number of items before it must be resized
     #[must_use]


### PR DESCRIPTION
# Objective

Fixes #275 by providing a builder pattern interface to create nested styles which can then be "materialize" (made concrete? not sure of the lingo to use here) into tree nodes by passing a `TaffyTree` into the `build` method of the builder.

> **Changes that will affect external library users must update RELEASES.md before they will be merged.**

Might be good to update the RELEASE.md since this adds a new API to interact with Taffy. Happy to add this to this PR if required!

## Context

* Per the discussion on  #275, I focused my efforts on providing a user-friendly interface that does not require the caller to use macros or closures. 
* To avoid repeating myself, I implemented a declarative macro (`gen_builder!`, taking suggestions for a better name) to generate the builder. This macro takes a name for the resulting struct and a list of  `Style` fields that should be available on the builder. Each field can also be marked with a `cfg` entry, useful for conditional compilation based on features.
* So far all fields are made available on the builder. I also added shortcuts for `width` and `height` and 2 constructors, `column` and `row` that are presets for the appropriate `FlexDirection`.
* I took the approach that `StyleBuilder` should take in references to other `StyleBuilder` as children. This avoids having to build children style in advance and has the advantage of being consistent across root and child styles.

## Feedback wanted

* I wasn't sure about how best to provide `NodeId`s back to the caller for child nodes. In the end, I landed on taking inspiration from the `NodeRef` solution mentioned in #275. The main difference is that I'm using a `Cell<_>` instead of a `RefCell<_>` to hold the `NodeId`, since `NodeId` implement `copy`. I'm looking for feedback here regarding how this is implemented and also if another pattern for result feedback would be desired over this.
* I'm a fairly new rust programmer  and this is my first time implementing a declarative macro. Feedback would be appreciated on that aspect, and on the rust programming language at large as well.
