### PR TITLE
Fix clippy::large_enum_variant lint in cosmic-text example

### DIFF
--- a/examples/cosmic_text/src/main.rs
+++ b/examples/cosmic_text/src/main.rs
@@ -45,6 +45,7 @@ impl CosmicTextContext {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 enum NodeContext {
     Text(CosmicTextContext),
     Image(ImageContext),


### PR DESCRIPTION
# Objective

Fix clippy on `main`