### PR TITLE
Upgrade cosmic-text to 0.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,16 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo build --examples
-      - run: cargo build -p cosmic-text-example
+
+  # cosmic_text example is excluded from the workspace as it breaks compilation of all crates
+  # in the workspace with our MSRV compiler
+  build-cosmic-text-example:
+    name: "Build cosmic-text example"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cd examples/cosmic_text && cargo build
 
   # No features
   test-features-none:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 /scripts/gentest/target
+/examples/cosmic_text/target
 /yoga_test_fixtures
 /yoga_test_fixtures_grouped
 /test_fixtures/_scratch

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,5 +107,9 @@ members = [
     "scripts/gentest",
     "scripts/format-fixtures",
     "scripts/import-yoga-tests",
-    "benches", "examples/cosmic_text", "tests/common",
+    "benches",
+    "tests/common",
 ]
+# The cosmic_text example is excluded from the workspace as including it breaks compilation
+# of all crates in the workspace with our MSRV compiler
+exclude = ["examples/cosmic_text"]

--- a/examples/cosmic_text/Cargo.toml
+++ b/examples/cosmic_text/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 
 [dependencies]
 taffy = { path = "../.." }
-cosmic-text = "0.12"
+cosmic-text = "0.13"


### PR DESCRIPTION
# Objective

Upgrade cosmic-text dependency used in our cosmic-text example to the latest version

## Notes

I had the remove the example's crate from the main workspace as otherwise it breaks the MSRV compile for the main `taffy` crate.
