### PR TITLE
fix: removed wrong addition, causing items to be misplaced.

### DIFF
--- a/src/compute/grid/placement.rs
+++ b/src/compute/grid/placement.rs
@@ -247,7 +247,7 @@ fn place_indefinitely_positioned_item(
         // Compute starting position for search
         if defined_primary_idx < primary_idx && secondary_idx != secondary_axis_grid_start_line {
             secondary_idx = secondary_axis_grid_start_line;
-            primary_idx = defined_primary_idx + 1;
+            primary_idx = defined_primary_idx;
         } else {
             primary_idx = defined_primary_idx;
         }

--- a/test_fixtures/grid/grid_placement_definite_primary.html
+++ b/test_fixtures/grid/grid_placement_definite_primary.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="height: 200px; width: 200px; display: grid; grid-template-columns: 33% 74%;">
+  <div style="grid-column-start: 1;"></div>
+  <div style="grid-column-start: 2;"></div>
+  <div style="grid-column-start: 1;"></div>
+  <div style="grid-column-start: 2;"></div>
+  <div style="grid-column-start: 1;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/generated/grid/grid_placement_definite_primary.rs
+++ b/tests/generated/grid/grid_placement_definite_primary.rs
@@ -1,0 +1,189 @@
+#[test]
+#[allow(non_snake_case)]
+fn grid_placement_definite_primary__border_box() {
+    #[allow(unused_imports)]
+    use taffy::{prelude::*, Layout};
+    let mut taffy = crate::new_test_tree();
+    let node0 = taffy
+        .new_leaf(taffy::style::Style {
+            grid_column: taffy::geometry::Line { start: line(1i16), end: taffy::style::GridPlacement::Auto },
+            ..Default::default()
+        })
+        .unwrap();
+    let node1 = taffy
+        .new_leaf(taffy::style::Style {
+            grid_column: taffy::geometry::Line { start: line(2i16), end: taffy::style::GridPlacement::Auto },
+            ..Default::default()
+        })
+        .unwrap();
+    let node2 = taffy
+        .new_leaf(taffy::style::Style {
+            grid_column: taffy::geometry::Line { start: line(1i16), end: taffy::style::GridPlacement::Auto },
+            ..Default::default()
+        })
+        .unwrap();
+    let node3 = taffy
+        .new_leaf(taffy::style::Style {
+            grid_column: taffy::geometry::Line { start: line(2i16), end: taffy::style::GridPlacement::Auto },
+            ..Default::default()
+        })
+        .unwrap();
+    let node4 = taffy
+        .new_leaf(taffy::style::Style {
+            grid_column: taffy::geometry::Line { start: line(1i16), end: taffy::style::GridPlacement::Auto },
+            ..Default::default()
+        })
+        .unwrap();
+    let node = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Grid,
+                grid_template_columns: vec![percent(0.33f32), percent(0.74f32)],
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::from_length(200f32),
+                    height: taffy::style::Dimension::from_length(200f32),
+                },
+                ..Default::default()
+            },
+            &[node0, node1, node2, node3, node4],
+        )
+        .unwrap();
+    taffy.compute_layout_with_measure(node, taffy::geometry::Size::MAX_CONTENT, crate::test_measure_function).unwrap();
+    println!("\nComputed tree:");
+    taffy.print_tree(node);
+    println!();
+    let layout = taffy.layout(node).unwrap();
+    let Layout { size, location, .. } = layout;
+    assert_eq!(size.width, 200f32, "width of node {:?}. Expected {}. Actual {}", node, 200f32, size.width);
+    assert_eq!(size.height, 200f32, "height of node {:?}. Expected {}. Actual {}", node, 200f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node, 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node, 0f32, location.y);
+    let layout = taffy.layout(node0).unwrap();
+    let Layout { size, location, .. } = layout;
+    assert_eq!(size.width, 66f32, "width of node {:?}. Expected {}. Actual {}", node0, 66f32, size.width);
+    assert_eq!(size.height, 67f32, "height of node {:?}. Expected {}. Actual {}", node0, 67f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node0, 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node0, 0f32, location.y);
+    let layout = taffy.layout(node1).unwrap();
+    let Layout { size, location, .. } = layout;
+    assert_eq!(size.width, 148f32, "width of node {:?}. Expected {}. Actual {}", node1, 148f32, size.width);
+    assert_eq!(size.height, 67f32, "height of node {:?}. Expected {}. Actual {}", node1, 67f32, size.height);
+    assert_eq!(location.x, 66f32, "x of node {:?}. Expected {}. Actual {}", node1, 66f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node1, 0f32, location.y);
+    let layout = taffy.layout(node2).unwrap();
+    let Layout { size, location, .. } = layout;
+    assert_eq!(size.width, 66f32, "width of node {:?}. Expected {}. Actual {}", node2, 66f32, size.width);
+    assert_eq!(size.height, 66f32, "height of node {:?}. Expected {}. Actual {}", node2, 66f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node2, 0f32, location.x);
+    assert_eq!(location.y, 67f32, "y of node {:?}. Expected {}. Actual {}", node2, 67f32, location.y);
+    let layout = taffy.layout(node3).unwrap();
+    let Layout { size, location, .. } = layout;
+    assert_eq!(size.width, 148f32, "width of node {:?}. Expected {}. Actual {}", node3, 148f32, size.width);
+    assert_eq!(size.height, 66f32, "height of node {:?}. Expected {}. Actual {}", node3, 66f32, size.height);
+    assert_eq!(location.x, 66f32, "x of node {:?}. Expected {}. Actual {}", node3, 66f32, location.x);
+    assert_eq!(location.y, 67f32, "y of node {:?}. Expected {}. Actual {}", node3, 67f32, location.y);
+    let layout = taffy.layout(node4).unwrap();
+    let Layout { size, location, .. } = layout;
+    assert_eq!(size.width, 66f32, "width of node {:?}. Expected {}. Actual {}", node4, 66f32, size.width);
+    assert_eq!(size.height, 67f32, "height of node {:?}. Expected {}. Actual {}", node4, 67f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node4, 0f32, location.x);
+    assert_eq!(location.y, 133f32, "y of node {:?}. Expected {}. Actual {}", node4, 133f32, location.y);
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn grid_placement_definite_primary__content_box() {
+    #[allow(unused_imports)]
+    use taffy::{prelude::*, Layout};
+    let mut taffy = crate::new_test_tree();
+    let node0 = taffy
+        .new_leaf(taffy::style::Style {
+            box_sizing: taffy::style::BoxSizing::ContentBox,
+            grid_column: taffy::geometry::Line { start: line(1i16), end: taffy::style::GridPlacement::Auto },
+            ..Default::default()
+        })
+        .unwrap();
+    let node1 = taffy
+        .new_leaf(taffy::style::Style {
+            box_sizing: taffy::style::BoxSizing::ContentBox,
+            grid_column: taffy::geometry::Line { start: line(2i16), end: taffy::style::GridPlacement::Auto },
+            ..Default::default()
+        })
+        .unwrap();
+    let node2 = taffy
+        .new_leaf(taffy::style::Style {
+            box_sizing: taffy::style::BoxSizing::ContentBox,
+            grid_column: taffy::geometry::Line { start: line(1i16), end: taffy::style::GridPlacement::Auto },
+            ..Default::default()
+        })
+        .unwrap();
+    let node3 = taffy
+        .new_leaf(taffy::style::Style {
+            box_sizing: taffy::style::BoxSizing::ContentBox,
+            grid_column: taffy::geometry::Line { start: line(2i16), end: taffy::style::GridPlacement::Auto },
+            ..Default::default()
+        })
+        .unwrap();
+    let node4 = taffy
+        .new_leaf(taffy::style::Style {
+            box_sizing: taffy::style::BoxSizing::ContentBox,
+            grid_column: taffy::geometry::Line { start: line(1i16), end: taffy::style::GridPlacement::Auto },
+            ..Default::default()
+        })
+        .unwrap();
+    let node = taffy
+        .new_with_children(
+            taffy::style::Style {
+                display: taffy::style::Display::Grid,
+                box_sizing: taffy::style::BoxSizing::ContentBox,
+                grid_template_columns: vec![percent(0.33f32), percent(0.74f32)],
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::from_length(200f32),
+                    height: taffy::style::Dimension::from_length(200f32),
+                },
+                ..Default::default()
+            },
+            &[node0, node1, node2, node3, node4],
+        )
+        .unwrap();
+    taffy.compute_layout_with_measure(node, taffy::geometry::Size::MAX_CONTENT, crate::test_measure_function).unwrap();
+    println!("\nComputed tree:");
+    taffy.print_tree(node);
+    println!();
+    let layout = taffy.layout(node).unwrap();
+    let Layout { size, location, .. } = layout;
+    assert_eq!(size.width, 200f32, "width of node {:?}. Expected {}. Actual {}", node, 200f32, size.width);
+    assert_eq!(size.height, 200f32, "height of node {:?}. Expected {}. Actual {}", node, 200f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node, 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node, 0f32, location.y);
+    let layout = taffy.layout(node0).unwrap();
+    let Layout { size, location, .. } = layout;
+    assert_eq!(size.width, 66f32, "width of node {:?}. Expected {}. Actual {}", node0, 66f32, size.width);
+    assert_eq!(size.height, 67f32, "height of node {:?}. Expected {}. Actual {}", node0, 67f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node0, 0f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node0, 0f32, location.y);
+    let layout = taffy.layout(node1).unwrap();
+    let Layout { size, location, .. } = layout;
+    assert_eq!(size.width, 148f32, "width of node {:?}. Expected {}. Actual {}", node1, 148f32, size.width);
+    assert_eq!(size.height, 67f32, "height of node {:?}. Expected {}. Actual {}", node1, 67f32, size.height);
+    assert_eq!(location.x, 66f32, "x of node {:?}. Expected {}. Actual {}", node1, 66f32, location.x);
+    assert_eq!(location.y, 0f32, "y of node {:?}. Expected {}. Actual {}", node1, 0f32, location.y);
+    let layout = taffy.layout(node2).unwrap();
+    let Layout { size, location, .. } = layout;
+    assert_eq!(size.width, 66f32, "width of node {:?}. Expected {}. Actual {}", node2, 66f32, size.width);
+    assert_eq!(size.height, 66f32, "height of node {:?}. Expected {}. Actual {}", node2, 66f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node2, 0f32, location.x);
+    assert_eq!(location.y, 67f32, "y of node {:?}. Expected {}. Actual {}", node2, 67f32, location.y);
+    let layout = taffy.layout(node3).unwrap();
+    let Layout { size, location, .. } = layout;
+    assert_eq!(size.width, 148f32, "width of node {:?}. Expected {}. Actual {}", node3, 148f32, size.width);
+    assert_eq!(size.height, 66f32, "height of node {:?}. Expected {}. Actual {}", node3, 66f32, size.height);
+    assert_eq!(location.x, 66f32, "x of node {:?}. Expected {}. Actual {}", node3, 66f32, location.x);
+    assert_eq!(location.y, 67f32, "y of node {:?}. Expected {}. Actual {}", node3, 67f32, location.y);
+    let layout = taffy.layout(node4).unwrap();
+    let Layout { size, location, .. } = layout;
+    assert_eq!(size.width, 66f32, "width of node {:?}. Expected {}. Actual {}", node4, 66f32, size.width);
+    assert_eq!(size.height, 67f32, "height of node {:?}. Expected {}. Actual {}", node4, 67f32, size.height);
+    assert_eq!(location.x, 0f32, "x of node {:?}. Expected {}. Actual {}", node4, 0f32, location.x);
+    assert_eq!(location.y, 133f32, "y of node {:?}. Expected {}. Actual {}", node4, 133f32, location.y);
+}

--- a/tests/generated/grid/mod.rs
+++ b/tests/generated/grid/mod.rs
@@ -450,6 +450,8 @@ mod grid_placement_auto_negative;
 #[cfg(feature = "grid")]
 mod grid_placement_definite_in_secondary_axis_with_fully_definite_negative;
 #[cfg(feature = "grid")]
+mod grid_placement_definite_primary;
+#[cfg(feature = "grid")]
 mod grid_relative_all_sides;
 #[cfg(feature = "grid")]
 mod grid_relayout_vertical_text;


### PR DESCRIPTION
# Objective

This fixes a case where a grid item on the primary axis would get put into a wrong track.

## Context
This came up in this issue https://github.com/DioxusLabs/blitz/issues/187
Where a gird looked like this
![taffy_one](https://github.com/user-attachments/assets/a59c1eec-0f81-41d6-acec-b9b7eed55edf)

(with commit)
![taffy_two](https://github.com/user-attachments/assets/30a1e0e3-730e-46e9-a900-04213f387fe1)
