### PR TITLE
Doc: ensure detailed grid info types are public / documented

### DIFF
--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -279,7 +279,7 @@ pub fn compute_hidden_layout(tree: &mut (impl LayoutPartialTree + CacheTree), no
 #[cfg(feature = "detailed_layout_info")]
 pub mod detailed_info {
     #[cfg(feature = "grid")]
-    pub use super::grid::DetailedGridInfo;
+    pub use super::grid::{DetailedGridInfo, DetailedGridTracksInfo};
 }
 
 #[cfg(test)]

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -55,7 +55,7 @@ pub trait CoreStyle {
         false
     }
     /// Is it a compressible replaced element?
-    /// https://drafts.csswg.org/css-sizing-3/#min-content-zero
+    /// <https://drafts.csswg.org/css-sizing-3/#min-content-zero>
     #[inline(always)]
     fn is_compressible_replaced(&self) -> bool {
         false
@@ -345,7 +345,7 @@ pub struct Style {
     /// This should really be part of `Display`, but it is currently seperate because table layout isn't implemented
     pub item_is_table: bool,
     /// Is it a replaced element like an image or form field?
-    /// https://drafts.csswg.org/css-sizing-3/#min-content-zero
+    /// <https://drafts.csswg.org/css-sizing-3/#min-content-zero>
     pub item_is_replaced: bool,
     /// Should size styles apply to the content box or the border box of the node
     pub box_sizing: BoxSizing,


### PR DESCRIPTION
# Objective

The `DetailedGridTracksInfo` struct was previously public but not exported from a public module which makes it difficult to access and means that it wasn't properly documented.
