### PR TITLE
Impl GridItemStyle and BlockContainerStyle for Style

### DIFF
--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -671,7 +671,7 @@ impl<T: CoreStyle> CoreStyle for &'_ T {
 }
 
 #[cfg(feature = "block_layout")]
-impl BlockContainerStyle for &Style {
+impl BlockContainerStyle for Style {
     #[inline(always)]
     fn text_align(&self) -> TextAlign {
         self.text_align
@@ -905,7 +905,7 @@ impl<T: GridContainerStyle> GridContainerStyle for &'_ T {
 }
 
 #[cfg(feature = "grid")]
-impl GridItemStyle for &'_ Style {
+impl GridItemStyle for Style {
     #[inline(always)]
     fn grid_row(&self) -> Line<GridPlacement> {
         self.grid_row


### PR DESCRIPTION
# Objective

Make trait implementations on `Style` more flexible.

- Fixes https://github.com/DioxusLabs/taffy/issues/827

Previously these were only implemented for &Style. There is a blanket impl that implements these traits for &T where they are implemented for T, so implementing them for `Style` is more general than implementing them for `&Style`.
