### PR TITLE
Fix serde feature on 32bit targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,28 @@ jobs:
       - run: cargo build
       - run: cargo test --tests
 
+  test-features-all:
+    name: "Test Suite [all features]"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build --all-features
+      - run: cargo test --tests --all-features
+
+  # The main reason for this target is to test compilation on 32bit targets
+  test-features-android-32bit:
+    name: "Test Suite [all features (i686-linux-android)]"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: i686-linux-android
+      - run: cargo build --all-features --target i686-linux-android
+      # TODO: enable tests (currently running into linking errors)
+      # - run: cargo test --tests --all-features --target i686-linux-android
+
   test-features-default-with-serde:
     name: "Test Suite [default + serde]"
     runs-on: ubuntu-latest

--- a/src/style/compact_length.rs
+++ b/src/style/compact_length.rs
@@ -197,7 +197,7 @@ mod inner {
         #[inline(always)]
         #[cfg(feature = "serde")]
         pub(super) fn from_serialized(value: u64) -> Self {
-            Self { tag: value >> 32 as usize, ptr: value & 0xFFFFFFFF as usize as *const () }
+            Self { tag: (value >> 32) as usize, ptr: (value & 0xFFFFFFFF) as usize as *const () }
         }
     }
 }


### PR DESCRIPTION
# Objective

- Fix compilation on 32bit targets with the `serde` feature enabled
- Add CI check to prevent future regressions on 32bit targets

## Context

Failed Servo CI build:
- https://github.com/servo/servo/actions/runs/15518902310/job/43689449782
