### PR TITLE
Prepare for v0.8.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.8.3
+
+### Fixed
+
+- Fix `serde` feature on 32bit targets (#845)
+
 ## 0.8.2
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taffy"
-version = "0.8.2"
+version = "0.8.3"
 authors = [
     "Alice Cecile <alice.i.cecile@gmail.com>",
     "Johnathan Kelley <jkelleyrtp@gmail.com>",


### PR DESCRIPTION
# Objective

Update version and changelog for `v0.8.3` release
