### PR TITLE
Introduce a `Units` trait

### DIFF
--- a/examples/custom_tree_owned_partial.rs
+++ b/examples/custom_tree_owned_partial.rs
@@ -13,7 +13,7 @@ use common::image::{image_measure_function, ImageContext};
 use common::text::{text_measure_function, FontMetrics, TextContext, WritingMode, LOREM_IPSUM};
 use taffy::{
     compute_cached_layout, compute_flexbox_layout, compute_grid_layout, compute_leaf_layout, compute_root_layout,
-    prelude::*, Cache, CacheTree, Layout, Style,
+    prelude::*, Cache, CacheTree, DefaultUnits, Layout, Style,
 };
 
 #[derive(Debug, Copy, Clone)]
@@ -138,7 +138,7 @@ impl taffy::LayoutPartialTree for Node {
     where
         Self: 'a;
 
-    type CustomIdent = String;
+    type Units = DefaultUnits;
 
     fn get_core_container_style(&self, node_id: NodeId) -> Self::CoreContainerStyle<'_> {
         &self.node_from_id(node_id).style

--- a/examples/custom_tree_owned_unsafe.rs
+++ b/examples/custom_tree_owned_unsafe.rs
@@ -9,7 +9,7 @@ use taffy::tree::Cache;
 use taffy::util::print_tree;
 use taffy::{
     compute_cached_layout, compute_flexbox_layout, compute_grid_layout, compute_leaf_layout, compute_root_layout,
-    prelude::*, round_layout, CacheTree,
+    prelude::*, round_layout, CacheTree, DefaultUnits,
 };
 
 #[derive(Debug, Copy, Clone)]
@@ -136,7 +136,7 @@ impl LayoutPartialTree for StatelessLayoutTree {
     where
         Self: 'a;
 
-    type CustomIdent = String;
+    type Units = DefaultUnits;
 
     fn get_core_container_style(&self, node_id: NodeId) -> Self::CoreContainerStyle<'_> {
         unsafe { &node_from_id(node_id).style }

--- a/examples/custom_tree_vec.rs
+++ b/examples/custom_tree_vec.rs
@@ -7,7 +7,7 @@ use common::text::{text_measure_function, FontMetrics, TextContext, WritingMode,
 use taffy::util::print_tree;
 use taffy::{
     compute_cached_layout, compute_flexbox_layout, compute_grid_layout, compute_leaf_layout, compute_root_layout,
-    prelude::*, round_layout, Cache, CacheTree,
+    prelude::*, round_layout, Cache, CacheTree, DefaultUnits,
 };
 
 #[derive(Debug, Copy, Clone)]
@@ -139,7 +139,7 @@ impl taffy::TraversePartialTree for Tree {
 impl taffy::TraverseTree for Tree {}
 
 impl taffy::LayoutPartialTree for Tree {
-    type CustomIdent = String;
+    type Units = DefaultUnits;
 
     type CoreContainerStyle<'a>
         = &'a Style

--- a/src/compute/grid/explicit_grid.rs
+++ b/src/compute/grid/explicit_grid.rs
@@ -323,7 +323,7 @@ mod test {
     use crate::compute::grid::util::*;
     use crate::geometry::AbsoluteAxis;
     use crate::prelude::*;
-    use crate::sys::DefaultCheapStr;
+    use crate::DefaultUnits;
 
     #[test]
     fn explicit_grid_sizing_no_repeats() {
@@ -352,7 +352,7 @@ mod test {
     #[test]
     fn explicit_grid_sizing_auto_fill_exact_fit() {
         use RepetitionCount::AutoFill;
-        let grid_style: Style<DefaultCheapStr> = Style {
+        let grid_style: Style<DefaultUnits> = Style {
             display: Display::Grid,
             size: Size { width: length(120.0), height: length(80.0) },
             grid_template_columns: vec![repeat(AutoFill, vec![length(40.0)])],
@@ -383,7 +383,7 @@ mod test {
     #[test]
     fn explicit_grid_sizing_auto_fill_non_exact_fit() {
         use RepetitionCount::AutoFill;
-        let grid_style: Style<DefaultCheapStr> = Style {
+        let grid_style: Style<DefaultUnits> = Style {
             display: Display::Grid,
             size: Size { width: length(140.0), height: length(90.0) },
             grid_template_columns: vec![repeat(AutoFill, vec![length(40.0)])],
@@ -414,7 +414,7 @@ mod test {
     #[test]
     fn explicit_grid_sizing_auto_fill_min_size_exact_fit() {
         use RepetitionCount::AutoFill;
-        let grid_style: Style<DefaultCheapStr> = Style {
+        let grid_style: Style<DefaultUnits> = Style {
             display: Display::Grid,
             min_size: Size { width: length(120.0), height: length(80.0) },
             grid_template_columns: vec![repeat(AutoFill, vec![length(40.0)])],
@@ -445,7 +445,7 @@ mod test {
     #[test]
     fn explicit_grid_sizing_auto_fill_min_size_non_exact_fit() {
         use RepetitionCount::AutoFill;
-        let grid_style: Style<DefaultCheapStr> = Style {
+        let grid_style: Style<DefaultUnits> = Style {
             display: Display::Grid,
             min_size: Size { width: length(140.0), height: length(90.0) },
             grid_template_columns: vec![repeat(AutoFill, vec![length(40.0)])],
@@ -476,7 +476,7 @@ mod test {
     #[test]
     fn explicit_grid_sizing_auto_fill_multiple_repeated_tracks() {
         use RepetitionCount::AutoFill;
-        let grid_style: Style<DefaultCheapStr> = Style {
+        let grid_style: Style<DefaultUnits> = Style {
             display: Display::Grid,
             size: Size { width: length(140.0), height: length(100.0) },
             grid_template_columns: vec![repeat(AutoFill, vec![length(40.0), length(20.0)])],
@@ -507,7 +507,7 @@ mod test {
     #[test]
     fn explicit_grid_sizing_auto_fill_gap() {
         use RepetitionCount::AutoFill;
-        let grid_style: Style<DefaultCheapStr> = Style {
+        let grid_style: Style<DefaultUnits> = Style {
             display: Display::Grid,
             size: Size { width: length(140.0), height: length(100.0) },
             grid_template_columns: vec![repeat(AutoFill, vec![length(40.0)])],
@@ -539,7 +539,7 @@ mod test {
     #[test]
     fn explicit_grid_sizing_no_defined_size() {
         use RepetitionCount::AutoFill;
-        let grid_style: Style<DefaultCheapStr> = Style {
+        let grid_style: Style<DefaultUnits> = Style {
             display: Display::Grid,
             grid_template_columns: vec![repeat(AutoFill, vec![length(40.0), percent(0.5), length(20.0)])],
             grid_template_rows: vec![repeat(AutoFill, vec![length(20.0)])],
@@ -570,7 +570,7 @@ mod test {
     #[test]
     fn explicit_grid_sizing_mix_repeated_and_non_repeated() {
         use RepetitionCount::AutoFill;
-        let grid_style: Style<DefaultCheapStr> = Style {
+        let grid_style: Style<DefaultUnits> = Style {
             display: Display::Grid,
             size: Size { width: length(140.0), height: length(100.0) },
             grid_template_columns: vec![length(20.0), repeat(AutoFill, vec![length(40.0)])],
@@ -602,7 +602,7 @@ mod test {
     #[test]
     fn explicit_grid_sizing_mix_with_padding() {
         use RepetitionCount::AutoFill;
-        let grid_style: Style<DefaultCheapStr> = Style {
+        let grid_style: Style<DefaultUnits> = Style {
             display: Display::Grid,
             size: Size { width: length(120.0), height: length(120.0) },
             padding: Rect { left: length(10.0), right: length(10.0), top: length(20.0), bottom: length(20.0) },
@@ -642,7 +642,7 @@ mod test {
         let maxpx100 = MaxTrackSizingFunction::from_length(100.0);
 
         // Setup test
-        let grid_style: Style<DefaultCheapStr> = Style {
+        let grid_style: Style<DefaultUnits> = Style {
             display: Display::Grid,
             gap: length(20.0),
             grid_template_columns: vec![length(100.0), minmax(length(100.0), fr(2.0)), fr(1.0)],

--- a/src/compute/grid/implicit_grid.rs
+++ b/src/compute/grid/implicit_grid.rs
@@ -2,7 +2,7 @@
 //! to reduce the number of allocations required when creating a grid.
 use crate::geometry::Line;
 use crate::style::{GenericGridPlacement, GridPlacement};
-use crate::{CheapCloneStr, Direction, GridItemStyle};
+use crate::{CheapCloneStr, Direction, GridItemStyle, Units};
 use core::cmp::{max, min};
 
 use super::types::TrackCounts;
@@ -77,9 +77,9 @@ fn get_known_child_positions<'a, S: GridItemStyle + 'a>(
         // Note: that the children reference the lines in between (and around) the tracks not tracks themselves,
         // and thus we must subtract 1 to get an accurate estimate of the number of tracks
         let (mut child_col_min, mut child_col_max, child_col_span) =
-            child_min_line_max_line_span::<S::CustomIdent>(col_line, explicit_col_count);
+            child_min_line_max_line_span::<<S::Units as Units>::Str>(col_line, explicit_col_count);
         let (child_row_min, child_row_max, child_row_span) =
-            child_min_line_max_line_span::<S::CustomIdent>(row_line, explicit_row_count);
+            child_min_line_max_line_span::<<S::Units as Units>::Str>(row_line, explicit_row_count);
 
         // Placement mirrors horizontal spans in RTL, so mirror known column line bounds here
         // to keep implicit-grid pre-sizing consistent with actual placement.

--- a/src/compute/grid/placement.rs
+++ b/src/compute/grid/placement.rs
@@ -4,10 +4,10 @@ use super::types::{CellOccupancyMatrix, CellOccupancyState, GridItem};
 use super::{NamedLineResolver, OriginZeroLine};
 use crate::geometry::Line;
 use crate::geometry::{AbsoluteAxis, InBothAbsAxis};
-use crate::style::{AlignItems, GridAutoFlow, OriginZeroGridPlacement, Units};
+use crate::style::{AlignItems, GridAutoFlow, OriginZeroGridPlacement};
 use crate::tree::NodeId;
 use crate::util::sys::Vec;
-use crate::{CoreStyle, Direction, GridItemStyle};
+use crate::{Direction, GridItemStyle};
 
 #[inline]
 /// Returns whether placement/search should run in reverse for this axis.
@@ -87,7 +87,7 @@ pub(super) fn place_grid_items<'a, S, ChildIter>(
     grid_auto_flow: GridAutoFlow,
     align_items: AlignItems,
     justify_items: AlignItems,
-    named_line_resolver: &NamedLineResolver<<S::Units as Units>::Str>,
+    named_line_resolver: &NamedLineResolver<S::Units>,
 ) where
     S: GridItemStyle + 'a,
     ChildIter: Iterator<Item = (usize, NodeId, S)>,

--- a/src/compute/grid/placement.rs
+++ b/src/compute/grid/placement.rs
@@ -4,7 +4,7 @@ use super::types::{CellOccupancyMatrix, CellOccupancyState, GridItem};
 use super::{NamedLineResolver, OriginZeroLine};
 use crate::geometry::Line;
 use crate::geometry::{AbsoluteAxis, InBothAbsAxis};
-use crate::style::{AlignItems, GridAutoFlow, OriginZeroGridPlacement};
+use crate::style::{AlignItems, GridAutoFlow, OriginZeroGridPlacement, Units};
 use crate::tree::NodeId;
 use crate::util::sys::Vec;
 use crate::{CoreStyle, Direction, GridItemStyle};
@@ -87,7 +87,7 @@ pub(super) fn place_grid_items<'a, S, ChildIter>(
     grid_auto_flow: GridAutoFlow,
     align_items: AlignItems,
     justify_items: AlignItems,
-    named_line_resolver: &NamedLineResolver<<S as CoreStyle>::CustomIdent>,
+    named_line_resolver: &NamedLineResolver<<S::Units as Units>::Str>,
 ) where
     S: GridItemStyle + 'a,
     ChildIter: Iterator<Item = (usize, NodeId, S)>,

--- a/src/compute/grid/util/test_helpers.rs
+++ b/src/compute/grid/util/test_helpers.rs
@@ -1,7 +1,7 @@
 //! Helpers for use in unit tests within the grid module
 use super::super::OriginZeroLine;
-use crate::prelude::*;
 use crate::style::{Dimension, GridPlacement, Style};
+use crate::{prelude::*, DefaultUnits};
 
 pub(crate) trait CreateParentTestNode {
     fn into_grid(self) -> Style;
@@ -23,7 +23,7 @@ pub(crate) trait CreateChildTestNode {
 impl CreateChildTestNode
     for (GridPlacement<String>, GridPlacement<String>, GridPlacement<String>, GridPlacement<String>)
 {
-    fn into_grid_child(self) -> Style<String> {
+    fn into_grid_child(self) -> Style<DefaultUnits> {
         Style {
             display: Display::Grid,
             grid_column: Line { start: self.0, end: self.1 },

--- a/src/style/block.rs
+++ b/src/style/block.rs
@@ -6,7 +6,7 @@ pub trait BlockContainerStyle: CoreStyle {
     /// Defines which row in the grid the item should start and end at
     #[inline(always)]
     fn text_align(&self) -> TextAlign {
-        Style::<Self::CustomIdent>::DEFAULT.text_align
+        Style::<Self::Units>::DEFAULT.text_align
     }
 }
 

--- a/src/style/flex.rs
+++ b/src/style/flex.rs
@@ -1,5 +1,7 @@
 //! Style types for Flexbox layout
-use super::{AlignContent, AlignItems, AlignSelf, CoreStyle, Dimension, JustifyContent, LengthPercentage, Style};
+use super::{
+    AlignContent, AlignItems, AlignSelf, CoreStyle, Dimension, JustifyContent, LengthPercentage, Style, Units,
+};
 use crate::geometry::Size;
 
 /// The set of styles required for a Flexbox container
@@ -7,18 +9,18 @@ pub trait FlexboxContainerStyle: CoreStyle {
     /// Which direction does the main axis flow in?
     #[inline(always)]
     fn flex_direction(&self) -> FlexDirection {
-        Style::<Self::CustomIdent>::DEFAULT.flex_direction
+        Style::<Self::Units>::DEFAULT.flex_direction
     }
     /// Should elements wrap, or stay in a single line?
     #[inline(always)]
     fn flex_wrap(&self) -> FlexWrap {
-        Style::<Self::CustomIdent>::DEFAULT.flex_wrap
+        Style::<Self::Units>::DEFAULT.flex_wrap
     }
 
     /// How large should the gaps between items in a grid or flex container be?
     #[inline(always)]
     fn gap(&self) -> Size<LengthPercentage> {
-        Style::<Self::CustomIdent>::DEFAULT.gap
+        Style::<Self::Units>::DEFAULT.gap
     }
 
     // Alignment properties
@@ -26,17 +28,17 @@ pub trait FlexboxContainerStyle: CoreStyle {
     /// How should content contained within this item be aligned in the cross/block axis
     #[inline(always)]
     fn align_content(&self) -> Option<AlignContent> {
-        Style::<Self::CustomIdent>::DEFAULT.align_content
+        Style::<Self::Units>::DEFAULT.align_content
     }
     /// How this node's children aligned in the cross/block axis?
     #[inline(always)]
     fn align_items(&self) -> Option<AlignItems> {
-        Style::<Self::CustomIdent>::DEFAULT.align_items
+        Style::<Self::Units>::DEFAULT.align_items
     }
     /// How this node's children should be aligned in the inline axis
     #[inline(always)]
     fn justify_content(&self) -> Option<JustifyContent> {
-        Style::<Self::CustomIdent>::DEFAULT.justify_content
+        Style::<Self::Units>::DEFAULT.justify_content
     }
 }
 
@@ -45,24 +47,24 @@ pub trait FlexboxItemStyle: CoreStyle {
     /// Sets the initial main axis size of the item
     #[inline(always)]
     fn flex_basis(&self) -> Dimension {
-        Style::<Self::CustomIdent>::DEFAULT.flex_basis
+        Style::<Self::Units>::DEFAULT.flex_basis
     }
     /// The relative rate at which this item grows when it is expanding to fill space
     #[inline(always)]
     fn flex_grow(&self) -> f32 {
-        Style::<Self::CustomIdent>::DEFAULT.flex_grow
+        Style::<Self::Units>::DEFAULT.flex_grow
     }
     /// The relative rate at which this item shrinks when it is contracting to fit into space
     #[inline(always)]
     fn flex_shrink(&self) -> f32 {
-        Style::<Self::CustomIdent>::DEFAULT.flex_shrink
+        Style::<Self::Units>::DEFAULT.flex_shrink
     }
 
     /// How this node should be aligned in the cross/block axis
     /// Falls back to the parents [`AlignItems`] if not set
     #[inline(always)]
     fn align_self(&self) -> Option<AlignSelf> {
-        Style::<Self::CustomIdent>::DEFAULT.align_self
+        Style::<Self::Units>::DEFAULT.align_self
     }
 }
 

--- a/src/style/flex.rs
+++ b/src/style/flex.rs
@@ -1,7 +1,5 @@
 //! Style types for Flexbox layout
-use super::{
-    AlignContent, AlignItems, AlignSelf, CoreStyle, Dimension, JustifyContent, LengthPercentage, Style, Units,
-};
+use super::{AlignContent, AlignItems, AlignSelf, CoreStyle, Dimension, JustifyContent, LengthPercentage, Style};
 use crate::geometry::Size;
 
 /// The set of styles required for a Flexbox container

--- a/src/style/grid.rs
+++ b/src/style/grid.rs
@@ -1,7 +1,7 @@
 //! Style types for CSS Grid layout
 use super::{
     AlignContent, AlignItems, AlignSelf, CheapCloneStr, CompactLength, CoreStyle, Dimension, JustifyContent,
-    LengthPercentage, LengthPercentageAuto, Style,
+    LengthPercentage, LengthPercentageAuto, Style, Units,
 };
 use crate::compute::grid::{GridCoordinate, GridLine, OriginZeroLine};
 use crate::geometry::{AbsoluteAxis, AbstractAxis, Line, MinMax, Size};
@@ -135,12 +135,12 @@ where
 /// The set of styles required for a CSS Grid container
 pub trait GridContainerStyle: CoreStyle {
     /// The type for a `repeat()` within a grid_template_rows or grid_template_columns
-    type Repetition<'a>: GenericRepetition<CustomIdent = Self::CustomIdent>
+    type Repetition<'a>: GenericRepetition<CustomIdent = <Self::Units as Units>::Str>
     where
         Self: 'a;
 
     /// The type returned by grid_template_rows and grid_template_columns
-    type TemplateTrackList<'a>: Iterator<Item = GenericGridTemplateComponent<Self::CustomIdent, Self::Repetition<'a>>>
+    type TemplateTrackList<'a>: Iterator<Item = GenericGridTemplateComponent<<Self::Units as Units>::Str, Self::Repetition<'a>>>
         + ExactSizeIterator
         + Clone
     where
@@ -153,12 +153,12 @@ pub trait GridContainerStyle: CoreStyle {
 
     /// The type returned by grid_template_row_names and grid_template_column_names
     //IntoIterator<Item = &'a Self::LineNameSet<'a>>
-    type TemplateLineNames<'a>: TemplateLineNames<'a, Self::CustomIdent>
+    type TemplateLineNames<'a>: TemplateLineNames<'a, <Self::Units as Units>::Str>
     where
         Self: 'a;
 
     /// The type of custom identifiers used to identify named grid lines and areas
-    type GridTemplateAreas<'a>: IntoIterator<Item = GridTemplateArea<Self::CustomIdent>>
+    type GridTemplateAreas<'a>: IntoIterator<Item = GridTemplateArea<<Self::Units as Units>::Str>>
     where
         Self: 'a;
 
@@ -184,13 +184,13 @@ pub trait GridContainerStyle: CoreStyle {
     /// Controls how items get placed into the grid for auto-placed items
     #[inline(always)]
     fn grid_auto_flow(&self) -> GridAutoFlow {
-        Style::<Self::CustomIdent>::DEFAULT.grid_auto_flow
+        Style::<Self::Units>::DEFAULT.grid_auto_flow
     }
 
     /// How large should the gaps between items in a grid or flex container be?
     #[inline(always)]
     fn gap(&self) -> Size<LengthPercentage> {
-        Style::<Self::CustomIdent>::DEFAULT.gap
+        Style::<Self::Units>::DEFAULT.gap
     }
 
     // Alignment properties
@@ -198,22 +198,22 @@ pub trait GridContainerStyle: CoreStyle {
     /// How should content contained within this item be aligned in the cross/block axis
     #[inline(always)]
     fn align_content(&self) -> Option<AlignContent> {
-        Style::<Self::CustomIdent>::DEFAULT.align_content
+        Style::<Self::Units>::DEFAULT.align_content
     }
     /// How should contained within this item be aligned in the main/inline axis
     #[inline(always)]
     fn justify_content(&self) -> Option<JustifyContent> {
-        Style::<Self::CustomIdent>::DEFAULT.justify_content
+        Style::<Self::Units>::DEFAULT.justify_content
     }
     /// How this node's children aligned in the cross/block axis?
     #[inline(always)]
     fn align_items(&self) -> Option<AlignItems> {
-        Style::<Self::CustomIdent>::DEFAULT.align_items
+        Style::<Self::Units>::DEFAULT.align_items
     }
     /// How this node's children should be aligned in the inline axis
     #[inline(always)]
     fn justify_items(&self) -> Option<AlignItems> {
-        Style::<Self::CustomIdent>::DEFAULT.justify_items
+        Style::<Self::Units>::DEFAULT.justify_items
     }
 
     /// Get a grid item's row or column placement depending on the axis passed
@@ -239,12 +239,12 @@ pub trait GridContainerStyle: CoreStyle {
 pub trait GridItemStyle: CoreStyle {
     /// Defines which row in the grid the item should start and end at
     #[inline(always)]
-    fn grid_row(&self) -> Line<GridPlacement<Self::CustomIdent>> {
+    fn grid_row(&self) -> Line<GridPlacement<<Self::Units as Units>::Str>> {
         Default::default()
     }
     /// Defines which column in the grid the item should start and end at
     #[inline(always)]
-    fn grid_column(&self) -> Line<GridPlacement<Self::CustomIdent>> {
+    fn grid_column(&self) -> Line<GridPlacement<<Self::Units as Units>::Str>> {
         Default::default()
     }
 
@@ -252,18 +252,18 @@ pub trait GridItemStyle: CoreStyle {
     /// Falls back to the parents [`AlignItems`] if not set
     #[inline(always)]
     fn align_self(&self) -> Option<AlignSelf> {
-        Style::<Self::CustomIdent>::DEFAULT.align_self
+        Style::<Self::Units>::DEFAULT.align_self
     }
     /// How this node should be aligned in the inline axis
     /// Falls back to the parents [`super::JustifyItems`] if not set
     #[inline(always)]
     fn justify_self(&self) -> Option<AlignSelf> {
-        Style::<Self::CustomIdent>::DEFAULT.justify_self
+        Style::<Self::Units>::DEFAULT.justify_self
     }
 
     /// Get a grid item's row or column placement depending on the axis passed
     #[inline(always)]
-    fn grid_placement(&self, axis: AbsoluteAxis) -> Line<GridPlacement<Self::CustomIdent>> {
+    fn grid_placement(&self, axis: AbsoluteAxis) -> Line<GridPlacement<<Self::Units as Units>::Str>> {
         match axis {
             AbsoluteAxis::Horizontal => self.grid_column(),
             AbsoluteAxis::Vertical => self.grid_row(),

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -64,6 +64,25 @@ impl<T> CheapCloneStr for T where
 {
 }
 
+/// Allows Taffy to abstract of the types it uses to represent strings and calc expressions.
+/// In future it may be extended to abstract the scalar number type (currently f32)
+pub trait Units {
+    /// Trait that represents a cheaply clonable string. If you're unsure what to use here
+    /// consider `Arc<str>` or `string_cache::Atom`.
+    type Str: CheapCloneStr;
+
+    /// Type representing a calc expression.
+    /// If you're not using Calc then you can just use `()`
+    type Calc: 'static;
+}
+
+pub struct DefaultUnits;
+
+impl Units for DefaultUnits {
+    type Str = String;
+    type Calc = ();
+}
+
 /// Trait that represents a cheaply clonable string. If you're unsure what to use here
 /// consider `Arc<str>` or `string_cache::Atom`.
 #[cfg(not(any(feature = "alloc", feature = "std")))]
@@ -78,7 +97,7 @@ impl<T> CheapCloneStr for T {}
 /// to override the default implementation for each style property that your style type actually supports.
 pub trait CoreStyle {
     /// The type of custom identifiers used to identify named grid lines and areas
-    type CustomIdent: CheapCloneStr;
+    type Units: Units;
 
     /// Which box generation mode should be used
     #[inline(always)]
@@ -112,7 +131,7 @@ pub trait CoreStyle {
     /// How children overflowing their container should affect layout
     #[inline(always)]
     fn overflow(&self) -> Point<Overflow> {
-        Style::<Self::CustomIdent>::DEFAULT.overflow
+        Style::<Self::Units>::DEFAULT.overflow
     }
     /// How much space (in points) should be reserved for the scrollbars of `Overflow::Scroll` and `Overflow::Auto` nodes.
     #[inline(always)]
@@ -124,52 +143,52 @@ pub trait CoreStyle {
     /// What should the `position` value of this struct use as a base offset?
     #[inline(always)]
     fn position(&self) -> Position {
-        Style::<Self::CustomIdent>::DEFAULT.position
+        Style::<Self::Units>::DEFAULT.position
     }
     /// How should the position of this element be tweaked relative to the layout defined?
     #[inline(always)]
     fn inset(&self) -> Rect<LengthPercentageAuto> {
-        Style::<Self::CustomIdent>::DEFAULT.inset
+        Style::<Self::Units>::DEFAULT.inset
     }
 
     // Size properies
     /// Sets the initial size of the item
     #[inline(always)]
     fn size(&self) -> Size<Dimension> {
-        Style::<Self::CustomIdent>::DEFAULT.size
+        Style::<Self::Units>::DEFAULT.size
     }
     /// Controls the minimum size of the item
     #[inline(always)]
     fn min_size(&self) -> Size<Dimension> {
-        Style::<Self::CustomIdent>::DEFAULT.min_size
+        Style::<Self::Units>::DEFAULT.min_size
     }
     /// Controls the maximum size of the item
     #[inline(always)]
     fn max_size(&self) -> Size<Dimension> {
-        Style::<Self::CustomIdent>::DEFAULT.max_size
+        Style::<Self::Units>::DEFAULT.max_size
     }
     /// Sets the preferred aspect ratio for the item
     /// The ratio is calculated as width divided by height.
     #[inline(always)]
     fn aspect_ratio(&self) -> Option<f32> {
-        Style::<Self::CustomIdent>::DEFAULT.aspect_ratio
+        Style::<Self::Units>::DEFAULT.aspect_ratio
     }
 
     // Spacing Properties
     /// How large should the margin be on each side?
     #[inline(always)]
     fn margin(&self) -> Rect<LengthPercentageAuto> {
-        Style::<Self::CustomIdent>::DEFAULT.margin
+        Style::<Self::Units>::DEFAULT.margin
     }
     /// How large should the padding be on each side?
     #[inline(always)]
     fn padding(&self) -> Rect<LengthPercentage> {
-        Style::<Self::CustomIdent>::DEFAULT.padding
+        Style::<Self::Units>::DEFAULT.padding
     }
     /// How large should the border be on each side?
     #[inline(always)]
     fn border(&self) -> Rect<LengthPercentage> {
-        Style::<Self::CustomIdent>::DEFAULT.border
+        Style::<Self::Units>::DEFAULT.border
     }
 }
 
@@ -427,10 +446,10 @@ crate::util::parse::impl_parse_for_keyword_enum!(Direction,
 #[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(default))]
-pub struct Style<S: CheapCloneStr = DefaultCheapStr> {
+pub struct Style<U: Units = DefaultCheapStr> {
     /// This is a dummy field which is necessary to make Taffy compile with the `grid` feature disabled
     /// It should always be set to `core::marker::PhantomData`.
-    pub dummy: core::marker::PhantomData<S>,
+    pub dummy: core::marker::PhantomData<U>,
     /// What layout strategy should be used?
     pub display: Display,
     /// Whether a child is display:table or not. This affects children of block layouts.
@@ -547,10 +566,10 @@ pub struct Style<S: CheapCloneStr = DefaultCheapStr> {
     // Grid container properies
     /// Defines the track sizing functions (heights) of the grid rows
     #[cfg(feature = "grid")]
-    pub grid_template_rows: GridTrackVec<GridTemplateComponent<S>>,
+    pub grid_template_rows: GridTrackVec<GridTemplateComponent<U::Str>>,
     /// Defines the track sizing functions (widths) of the grid columns
     #[cfg(feature = "grid")]
-    pub grid_template_columns: GridTrackVec<GridTemplateComponent<S>>,
+    pub grid_template_columns: GridTrackVec<GridTemplateComponent<U::Str>>,
     /// Defines the size of implicitly created rows
     #[cfg(feature = "grid")]
     pub grid_auto_rows: GridTrackVec<TrackSizingFunction>,
@@ -564,26 +583,26 @@ pub struct Style<S: CheapCloneStr = DefaultCheapStr> {
     // Grid container named properties
     /// Defines the rectangular grid areas
     #[cfg(feature = "grid")]
-    pub grid_template_areas: GridTrackVec<GridTemplateArea<S>>,
+    pub grid_template_areas: GridTrackVec<GridTemplateArea<U::Str>>,
     /// The named lines between the columns
     #[cfg(feature = "grid")]
-    pub grid_template_column_names: GridTrackVec<GridTrackVec<S>>,
+    pub grid_template_column_names: GridTrackVec<GridTrackVec<U>>,
     /// The named lines between the rows
     #[cfg(feature = "grid")]
-    pub grid_template_row_names: GridTrackVec<GridTrackVec<S>>,
+    pub grid_template_row_names: GridTrackVec<GridTrackVec<U>>,
 
     // Grid child properties
     /// Defines which row in the grid the item should start and end at
     #[cfg(feature = "grid")]
-    pub grid_row: Line<GridPlacement<S>>,
+    pub grid_row: Line<GridPlacement<U::Str>>,
     /// Defines which column in the grid the item should start and end at
     #[cfg(feature = "grid")]
-    pub grid_column: Line<GridPlacement<S>>,
+    pub grid_column: Line<GridPlacement<U::Str>>,
 }
 
-impl<S: CheapCloneStr> Style<S> {
+impl<U: Units> Style<U> {
     /// The [`Default`] layout, in a form that can be used in const functions
-    pub const DEFAULT: Style<S> = Style {
+    pub const DEFAULT: Style<U> = Style {
         dummy: core::marker::PhantomData,
         display: Display::DEFAULT,
         item_is_table: false,
@@ -652,20 +671,20 @@ impl<S: CheapCloneStr> Style<S> {
         #[cfg(feature = "grid")]
         grid_auto_flow: GridAutoFlow::Row,
         #[cfg(feature = "grid")]
-        grid_row: Line { start: GridPlacement::<S>::Auto, end: GridPlacement::<S>::Auto },
+        grid_row: Line { start: GridPlacement::<U>::Auto, end: GridPlacement::<U>::Auto },
         #[cfg(feature = "grid")]
-        grid_column: Line { start: GridPlacement::<S>::Auto, end: GridPlacement::<S>::Auto },
+        grid_column: Line { start: GridPlacement::<U>::Auto, end: GridPlacement::<U>::Auto },
     };
 }
 
-impl<S: CheapCloneStr> Default for Style<S> {
+impl<U: Units> Default for Style<U> {
     fn default() -> Self {
         Style::DEFAULT
     }
 }
 
-impl<S: CheapCloneStr> CoreStyle for Style<S> {
-    type CustomIdent = S;
+impl<U: Units> CoreStyle for Style<U> {
+    type Units = U;
 
     #[inline(always)]
     fn box_generation_mode(&self) -> BoxGenerationMode {
@@ -738,7 +757,7 @@ impl<S: CheapCloneStr> CoreStyle for Style<S> {
 }
 
 impl<T: CoreStyle> CoreStyle for &'_ T {
-    type CustomIdent = T::CustomIdent;
+    type Units = T::Units;
 
     #[inline(always)]
     fn box_generation_mode(&self) -> BoxGenerationMode {
@@ -807,7 +826,7 @@ impl<T: CoreStyle> CoreStyle for &'_ T {
 }
 
 #[cfg(feature = "block_layout")]
-impl<S: CheapCloneStr> BlockContainerStyle for Style<S> {
+impl<U: Units> BlockContainerStyle for Style<U> {
     #[inline(always)]
     fn text_align(&self) -> TextAlign {
         self.text_align
@@ -823,7 +842,7 @@ impl<T: BlockContainerStyle> BlockContainerStyle for &'_ T {
 }
 
 #[cfg(feature = "block_layout")]
-impl<S: CheapCloneStr> BlockItemStyle for Style<S> {
+impl<U: Units> BlockItemStyle for Style<U> {
     #[inline(always)]
     fn is_table(&self) -> bool {
         self.item_is_table
@@ -863,7 +882,7 @@ impl<T: BlockItemStyle> BlockItemStyle for &'_ T {
 }
 
 #[cfg(feature = "flexbox")]
-impl<S: CheapCloneStr> FlexboxContainerStyle for Style<S> {
+impl<U: Units> FlexboxContainerStyle for Style<U> {
     #[inline(always)]
     fn flex_direction(&self) -> FlexDirection {
         self.flex_direction
@@ -919,7 +938,7 @@ impl<T: FlexboxContainerStyle> FlexboxContainerStyle for &'_ T {
 }
 
 #[cfg(feature = "flexbox")]
-impl<S: CheapCloneStr> FlexboxItemStyle for Style<S> {
+impl<U: Units> FlexboxItemStyle for Style<U> {
     #[inline(always)]
     fn flex_basis(&self) -> Dimension {
         self.flex_basis
@@ -959,16 +978,18 @@ impl<T: FlexboxItemStyle> FlexboxItemStyle for &'_ T {
 }
 
 #[cfg(feature = "grid")]
-impl<S: CheapCloneStr> GridContainerStyle for Style<S> {
+impl<U: Units> GridContainerStyle for Style<U> {
     type Repetition<'a>
-        = &'a GridTemplateRepetition<S>
+        = &'a GridTemplateRepetition<U::Str>
     where
         Self: 'a;
 
     type TemplateTrackList<'a>
         = core::iter::Map<
-        core::slice::Iter<'a, GridTemplateComponent<S>>,
-        fn(&'a GridTemplateComponent<S>) -> GenericGridTemplateComponent<S, &'a GridTemplateRepetition<S>>,
+        core::slice::Iter<'a, GridTemplateComponent<U::Str>>,
+        fn(
+            &'a GridTemplateComponent<U::Str>,
+        ) -> GenericGridTemplateComponent<U::Str, &'a GridTemplateRepetition<U::Str>>,
     >
     where
         Self: 'a;
@@ -980,12 +1001,15 @@ impl<S: CheapCloneStr> GridContainerStyle for Style<S> {
 
     #[cfg(feature = "grid")]
     type TemplateLineNames<'a>
-        = core::iter::Map<core::slice::Iter<'a, GridTrackVec<S>>, fn(&GridTrackVec<S>) -> core::slice::Iter<'_, S>>
+        = core::iter::Map<
+        core::slice::Iter<'a, GridTrackVec<U::Str>>,
+        fn(&GridTrackVec<U::Str>) -> core::slice::Iter<'_, U::Str>,
+    >
     where
         Self: 'a;
     #[cfg(feature = "grid")]
     type GridTemplateAreas<'a>
-        = core::iter::Cloned<core::slice::Iter<'a, GridTemplateArea<S>>>
+        = core::iter::Cloned<core::slice::Iter<'a, GridTemplateArea<U::Str>>>
     where
         Self: 'a;
 
@@ -1136,14 +1160,14 @@ impl<T: GridContainerStyle> GridContainerStyle for &'_ T {
 }
 
 #[cfg(feature = "grid")]
-impl<S: CheapCloneStr> GridItemStyle for Style<S> {
+impl<U: Units> GridItemStyle for Style<U> {
     #[inline(always)]
-    fn grid_row(&self) -> Line<GridPlacement<S>> {
+    fn grid_row(&self) -> Line<GridPlacement<U::Str>> {
         // TODO: Investigate eliminating clone
         self.grid_row.clone()
     }
     #[inline(always)]
-    fn grid_column(&self) -> Line<GridPlacement<S>> {
+    fn grid_column(&self) -> Line<GridPlacement<U::Str>> {
         // TODO: Investigate eliminating clone
         self.grid_column.clone()
     }
@@ -1160,11 +1184,11 @@ impl<S: CheapCloneStr> GridItemStyle for Style<S> {
 #[cfg(feature = "grid")]
 impl<T: GridItemStyle> GridItemStyle for &'_ T {
     #[inline(always)]
-    fn grid_row(&self) -> Line<GridPlacement<Self::CustomIdent>> {
+    fn grid_row(&self) -> Line<GridPlacement<<T::Units as Units>::Str>> {
         (*self).grid_row()
     }
     #[inline(always)]
-    fn grid_column(&self) -> Line<GridPlacement<Self::CustomIdent>> {
+    fn grid_column(&self) -> Line<GridPlacement<<T::Units as Units>::Str>> {
         (*self).grid_column()
     }
     #[inline(always)]
@@ -1321,7 +1345,7 @@ mod tests {
         assert_type_size::<MaxTrackSizingFunction>(8);
         assert_type_size::<TrackSizingFunction>(16);
         assert_type_size::<Vec<TrackSizingFunction>>(24);
-        assert_type_size::<Vec<GridTemplateComponent<S>>>(24);
+        assert_type_size::<Vec<GridTemplateComponent<U>>>(24);
 
         // String-type dependent (String)
         assert_type_size::<GridTemplateComponent<String>>(56);

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -17,7 +17,6 @@ pub use self::alignment::{AlignContent, AlignItems, AlignSelf, JustifyContent, J
 pub use self::available_space::AvailableSpace;
 pub use self::compact_length::CompactLength;
 pub use self::dimension::{Dimension, LengthPercentage, LengthPercentageAuto};
-use crate::sys::DefaultCheapStr;
 
 #[cfg(feature = "block_layout")]
 pub use self::block::{BlockContainerStyle, BlockItemStyle, TextAlign};
@@ -64,6 +63,10 @@ impl<T> CheapCloneStr for T where
 {
 }
 
+/// Trait that represent a `calc()` expression
+pub trait Calc: Clone + Debug + 'static {}
+impl<T> Calc for T where T: Clone + Debug + 'static {}
+
 /// Allows Taffy to abstract of the types it uses to represent strings and calc expressions.
 /// In future it may be extended to abstract the scalar number type (currently f32)
 pub trait Units {
@@ -73,9 +76,11 @@ pub trait Units {
 
     /// Type representing a calc expression.
     /// If you're not using Calc then you can just use `()`
-    type Calc: 'static;
+    type Calc: Calc;
 }
 
+/// A default implementation of the [`Units`] trait
+#[derive(Debug, Copy, Clone, Default, Eq, PartialEq)]
 pub struct DefaultUnits;
 
 impl Units for DefaultUnits {
@@ -446,7 +451,7 @@ crate::util::parse::impl_parse_for_keyword_enum!(Direction,
 #[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(default))]
-pub struct Style<U: Units = DefaultCheapStr> {
+pub struct Style<U: Units = DefaultUnits> {
     /// This is a dummy field which is necessary to make Taffy compile with the `grid` feature disabled
     /// It should always be set to `core::marker::PhantomData`.
     pub dummy: core::marker::PhantomData<U>,
@@ -586,10 +591,10 @@ pub struct Style<U: Units = DefaultCheapStr> {
     pub grid_template_areas: GridTrackVec<GridTemplateArea<U::Str>>,
     /// The named lines between the columns
     #[cfg(feature = "grid")]
-    pub grid_template_column_names: GridTrackVec<GridTrackVec<U>>,
+    pub grid_template_column_names: GridTrackVec<GridTrackVec<U::Str>>,
     /// The named lines between the rows
     #[cfg(feature = "grid")]
-    pub grid_template_row_names: GridTrackVec<GridTrackVec<U>>,
+    pub grid_template_row_names: GridTrackVec<GridTrackVec<U::Str>>,
 
     // Grid child properties
     /// Defines which row in the grid the item should start and end at
@@ -671,9 +676,9 @@ impl<U: Units> Style<U> {
         #[cfg(feature = "grid")]
         grid_auto_flow: GridAutoFlow::Row,
         #[cfg(feature = "grid")]
-        grid_row: Line { start: GridPlacement::<U>::Auto, end: GridPlacement::<U>::Auto },
+        grid_row: Line { start: GridPlacement::<U::Str>::Auto, end: GridPlacement::<U::Str>::Auto },
         #[cfg(feature = "grid")]
-        grid_column: Line { start: GridPlacement::<U>::Auto, end: GridPlacement::<U>::Auto },
+        grid_column: Line { start: GridPlacement::<U::Str>::Auto, end: GridPlacement::<U::Str>::Auto },
     };
 }
 
@@ -1206,7 +1211,7 @@ mod tests {
     use std::sync::Arc;
 
     use super::Style;
-    use crate::sys::DefaultCheapStr;
+    use crate::DefaultUnits;
     use crate::{geometry::*, style_helpers::TaffyAuto as _};
 
     #[test]
@@ -1214,7 +1219,7 @@ mod tests {
         #[cfg(feature = "grid")]
         use super::GridPlacement;
 
-        let old_defaults: Style<DefaultCheapStr> = Style {
+        let old_defaults: Style<DefaultUnits> = Style {
             dummy: core::marker::PhantomData,
             display: Default::default(),
             item_is_table: false,
@@ -1283,7 +1288,7 @@ mod tests {
             grid_column: Line { start: GridPlacement::Auto, end: GridPlacement::Auto },
         };
 
-        assert_eq!(Style::DEFAULT, Style::<DefaultCheapStr>::default());
+        assert_eq!(Style::DEFAULT, Style::<DefaultUnits>::default());
         assert_eq!(Style::DEFAULT, old_defaults);
     }
 
@@ -1345,18 +1350,19 @@ mod tests {
         assert_type_size::<MaxTrackSizingFunction>(8);
         assert_type_size::<TrackSizingFunction>(16);
         assert_type_size::<Vec<TrackSizingFunction>>(24);
-        assert_type_size::<Vec<GridTemplateComponent<U>>>(24);
+        assert_type_size::<Vec<GridTemplateComponent<S>>>(24);
 
         // String-type dependent (String)
         assert_type_size::<GridTemplateComponent<String>>(56);
         assert_type_size::<GridPlacement<String>>(32);
         assert_type_size::<Line<GridPlacement<String>>>(64);
-        assert_type_size::<Style<String>>(536);
 
         // String-type dependent (Arc<str>)
         assert_type_size::<GridTemplateComponent<Arc<str>>>(56);
         assert_type_size::<GridPlacement<Arc<str>>>(24);
         assert_type_size::<Line<GridPlacement<Arc<str>>>>(48);
-        assert_type_size::<Style<Arc<str>>>(504);
+
+        // Overall size (default units)
+        assert_type_size::<Style<DefaultUnits>>(536);
     }
 }

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -72,7 +72,12 @@ impl<T> Calc for T where T: Clone + Debug + 'static {}
 pub trait Units {
     /// Trait that represents a cheaply clonable string. If you're unsure what to use here
     /// consider `Arc<str>` or `string_cache::Atom`.
+    #[cfg(not(feature = "serde"))]
     type Str: CheapCloneStr;
+    /// Trait that represents a cheaply clonable string. If you're unsure what to use here
+    /// consider `Arc<str>` or `string_cache::Atom`.
+    #[cfg(feature = "serde")]
+    type Str: CheapCloneStr + serde::Serialize + for<'a> serde::Deserialize<'a>;
 
     /// Type representing a calc expression.
     /// If you're not using Calc then you can just use `()`

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -9,7 +9,6 @@ use slotmap::{DefaultKey, SlotMap};
 use crate::block::BlockContext;
 use crate::geometry::Size;
 use crate::style::{AvailableSpace, Display, Style};
-use crate::sys::DefaultCheapStr;
 use crate::tree::{
     Cache, ClearState, Layout, LayoutInput, LayoutOutput, LayoutPartialTree, NodeId, PrintTree, RoundTree, RunMode,
     TraversePartialTree, TraverseTree,
@@ -20,14 +19,13 @@ use crate::util::sys::{new_vec_with_capacity, ChildrenVec, Vec};
 use crate::compute::{
     compute_cached_layout, compute_hidden_layout, compute_leaf_layout, compute_root_layout, round_layout,
 };
-use crate::CacheTree;
-
 #[cfg(feature = "block_layout")]
 use crate::{compute::compute_block_layout, LayoutBlockContainer};
 #[cfg(feature = "flexbox")]
 use crate::{compute::compute_flexbox_layout, LayoutFlexboxContainer};
 #[cfg(feature = "grid")]
 use crate::{compute::compute_grid_layout, LayoutGridContainer};
+use crate::{CacheTree, DefaultUnits};
 
 #[cfg(all(feature = "detailed_layout_info", feature = "grid"))]
 use crate::compute::grid::DetailedGridInfo;
@@ -375,7 +373,7 @@ where
     where
         Self: 'a;
 
-    type CustomIdent = DefaultCheapStr;
+    type Units = DefaultUnits;
 
     #[inline(always)]
     fn get_core_container_style(&self, node_id: NodeId) -> Self::CoreContainerStyle<'_> {

--- a/src/tree/traits.rs
+++ b/src/tree/traits.rs
@@ -130,12 +130,11 @@ use super::{Layout, LayoutInput, LayoutOutput, NodeId, RequestedAxis, RunMode, S
 #[cfg(feature = "detailed_layout_info")]
 use crate::debug::debug_log;
 use crate::geometry::{AbsoluteAxis, Line, Size};
-use crate::style::{AvailableSpace, CoreStyle};
+use crate::style::{AvailableSpace, CoreStyle, Units};
 #[cfg(feature = "flexbox")]
 use crate::style::{FlexboxContainerStyle, FlexboxItemStyle};
 #[cfg(feature = "grid")]
 use crate::style::{GridContainerStyle, GridItemStyle};
-use crate::CheapCloneStr;
 #[cfg(feature = "block_layout")]
 use crate::{BlockContainerStyle, BlockContext, BlockItemStyle};
 
@@ -174,13 +173,13 @@ pub trait TraverseTree: TraversePartialTree {}
 pub trait LayoutPartialTree: TraversePartialTree {
     /// The style type representing the core container styles that all containers should have
     /// Used when laying out the root node of a tree
-    type CoreContainerStyle<'a>: CoreStyle<CustomIdent = Self::CustomIdent>
+    type CoreContainerStyle<'a>: CoreStyle<Units = Self::Units>
     where
         Self: 'a;
 
     /// String type for representing "custom identifiers" (for example, named grid lines or areas)
     /// If you are unsure what to use here then consider `Arc<str>`.
-    type CustomIdent: CheapCloneStr;
+    type Units: Units;
 
     /// Get core style
     fn get_core_container_style(&self, node_id: NodeId) -> Self::CoreContainerStyle<'_>;
@@ -258,12 +257,12 @@ pub trait LayoutFlexboxContainer: LayoutPartialTree {
 /// Extends [`LayoutPartialTree`] with getters for the styles required for CSS Grid layout
 pub trait LayoutGridContainer: LayoutPartialTree {
     /// The style type representing the CSS Grid container's styles
-    type GridContainerStyle<'a>: GridContainerStyle<CustomIdent = Self::CustomIdent>
+    type GridContainerStyle<'a>: GridContainerStyle<Units = Self::Units>
     where
         Self: 'a;
 
     /// The style type representing each CSS Grid item's styles
-    type GridItemStyle<'a>: GridItemStyle<CustomIdent = Self::CustomIdent>
+    type GridItemStyle<'a>: GridItemStyle<Units = Self::Units>
     where
         Self: 'a;
 

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -2,11 +2,11 @@
 #[cfg(feature = "serde")]
 mod serde {
     use serde_json::{self, Value};
-    use taffy::style::Style;
+    use taffy::{DefaultUnits, Style};
 
     #[test]
     fn serde_can_serialize() {
-        let style: Style<String> = Style::DEFAULT;
+        let style: Style<DefaultUnits> = Style::DEFAULT;
         let _ = serde_json::to_string(&style).unwrap();
     }
 


### PR DESCRIPTION
# Objective

Introduce an abstraction that allows "the whole of Taffy" to be generic over multiple types with only one generic parameter.

The core of this change is the introduction of:

```rust
/// Allows Taffy to abstract of the types it uses to represent strings and calc expressions.
/// In future it may be extended to abstract the scalar number type (currently f32)
pub trait Units {
    /// Trait that represents a cheaply clonable string. If you're unsure what to use here
    /// consider `Arc<str>` or `string_cache::Atom`.
    type Str: CheapCloneStr;

    /// Type representing a calc expression.
    /// If you're not using Calc then you can just use `()`
    type Calc: 'static;
}

pub struct DefaultUnits;
impl Units for DefaultUnits {
    type Str = String;
    type Calc = ();
}
```

## Context

- https://github.com/DioxusLabs/taffy/pull/840 made lots of Taffy (including the `Style` struct) generic over a string type
- The most obvious fix for https://github.com/DioxusLabs/taffy/issues/823 is to be generic over the `Calc` type.
- In future, we may want to be generic over the scalar numeric type (https://github.com/DioxusLabs/taffy/issues/332)

## Feedback wanted

Is this a sensible change or am I going overboard with the generic types?
