### PR TITLE
feat: Add stacksafe feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ categories = ["gui"]
 license = "MIT"
 
 [dependencies]
+## Enable use of stacksafe in recursive callsites, preventing stack overflows at the cost of performance penalties
+stacksafe = { version = "0.1", default-features = false, optional = true }
 arrayvec = { version = "0.7", default-features = false }
 document-features = { version = "0.2.7", optional = true }
 serde = { version = "1.0", default-features = false, optional = true, features = ["serde_derive"] }

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -61,6 +61,7 @@ struct BlockItem {
 }
 
 /// Computes the layout of [`LayoutPartialTree`] according to the block layout algorithm
+#[cfg_attr(feature = "stacksafe", stacksafe::stacksafe)]
 pub fn compute_block_layout(
     tree: &mut impl LayoutBlockContainer,
     node_id: NodeId,
@@ -122,6 +123,7 @@ pub fn compute_block_layout(
 }
 
 /// Computes the layout of [`LayoutBlockContainer`] according to the block layout algorithm
+#[cfg_attr(feature = "stacksafe", stacksafe::stacksafe)]
 fn compute_inner(tree: &mut impl LayoutBlockContainer, node_id: NodeId, inputs: LayoutInput) -> LayoutOutput {
     let LayoutInput {
         known_dimensions, parent_size, available_space, run_mode, vertical_margins_are_collapsible, ..
@@ -390,6 +392,7 @@ fn determine_content_based_container_width(
 
 /// Compute each child's final size and position
 #[inline]
+#[cfg_attr(feature = "stacksafe", stacksafe::stacksafe)]
 fn perform_final_layout_on_in_flow_children(
     tree: &mut impl LayoutPartialTree,
     items: &mut [BlockItem],

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -161,6 +161,7 @@ struct AlgoConstants {
 }
 
 /// Computes the layout of a box according to the flexbox algorithm
+#[cfg_attr(feature = "stacksafe", stacksafe::stacksafe)]
 pub fn compute_flexbox_layout(
     tree: &mut impl LayoutFlexboxContainer,
     node: NodeId,

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -40,6 +40,7 @@ mod util;
 ///   - Placing items (which also resolves the implicit grid)
 ///   - Track (row/column) sizing
 ///   - Alignment & Final item placement
+#[cfg_attr(feature = "stacksafe", stacksafe::stacksafe)]
 pub fn compute_grid_layout<Tree: LayoutGridContainer>(
     tree: &mut Tree,
     node: NodeId,

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -157,6 +157,7 @@ pub fn compute_root_layout(tree: &mut impl LayoutPartialTree, root: NodeId, avai
 /// Attempts to find a cached layout for the specified node and layout inputs.
 ///
 /// Uses the provided closure to compute the layout (and then stores the result in the cache) if no cached layout is found.
+#[cfg_attr(feature = "stacksafe", stacksafe::stacksafe)]
 #[inline(always)]
 pub fn compute_cached_layout<Tree: CacheTree + ?Sized, ComputeFunction>(
     tree: &mut Tree,

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -209,6 +209,7 @@ pub fn round_layout(tree: &mut impl RoundTree, node_id: NodeId) {
     return round_layout_inner(tree, node_id, 0.0, 0.0);
 
     /// Recursive function to apply rounding to all descendents
+    #[cfg_attr(feature = "stacksafe", stacksafe::stacksafe)]
     fn round_layout_inner(tree: &mut impl RoundTree, node_id: NodeId, cumulative_x: f32, cumulative_y: f32) {
         let unrounded_layout = tree.get_unrounded_layout(node_id);
         let mut layout = unrounded_layout;

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -346,6 +346,7 @@ where
     }
 
     #[inline(always)]
+    #[cfg_attr(feature = "stacksafe", stacksafe::stacksafe)]
     fn compute_child_layout(&mut self, node: NodeId, inputs: LayoutInput) -> LayoutOutput {
         // If RunMode is PerformHiddenLayout then this indicates that an ancestor node is `Display::None`
         // and thus that we should lay out this node using hidden layout regardless of it's own display style.


### PR DESCRIPTION
# Objective

This PR adds `stacksafe` feature. We ran taffy `super_deep` benchmark with different display kinds and annotated all stack overflow-inducing call-sites with stacksafe::stacksafe.

**Changes that will affect external library users must update RELEASES.md before they will be merged.**

## Context

There was a prior discussion about `stacksafe` use in #853.

