### PR TITLE
fix: typo

### DIFF
--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -98,9 +98,9 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
 
     // Note: we avoid accessing the grid rows/columns methods more than once as this can
     // cause an expensive-ish computation
-    let grid_template_columms = style.grid_template_columns();
+    let grid_template_columns = style.grid_template_columns();
     let grid_template_rows = style.grid_template_rows();
-    let grid_auto_columms = style.grid_auto_columns();
+    let grid_auto_columns = style.grid_auto_columns();
     let grid_auto_rows = style.grid_auto_rows();
 
     let constrained_available_space = known_dimensions
@@ -232,9 +232,9 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
     });
 
     drop(grid_template_rows);
-    drop(grid_template_columms);
+    drop(grid_template_columns);
     drop(grid_auto_rows);
-    drop(grid_auto_columms);
+    drop(grid_auto_columns);
     drop(style);
 
     // 6. Track Sizing
@@ -381,7 +381,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
             });
         rerun_column_sizing = min_content_contribution_changed;
     } else {
-        // Clear intrisic width caches
+        // Clear intrinsic width caches
         items.iter_mut().for_each(|item| {
             item.available_space_cache = None;
             item.min_content_contribution_cache.width = None;
@@ -442,7 +442,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
             rerun_row_sizing = min_content_contribution_changed;
         } else {
             items.iter_mut().for_each(|item| {
-                // Clear intrisic height caches
+                // Clear intrinsic height caches
                 item.available_space_cache = None;
                 item.min_content_contribution_cache.height = None;
                 item.max_content_contribution_cache.height = None;
@@ -582,7 +582,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
             };
             drop(child_style);
 
-            // TODO: Baseline alignment support for absolutely positioned items (should check if is actuallty specified)
+            // TODO: Baseline alignment support for absolutely positioned items (should check if is actually specified)
             #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
             let (content_size_contribution, _, _) =
                 align_and_position_item(tree, child, order, grid_area, container_alignment_styles, 0.0);

--- a/src/compute/grid/track_sizing.rs
+++ b/src/compute/grid/track_sizing.rs
@@ -64,7 +64,7 @@ impl ItemBatcher {
 
 /// This struct captures a bunch of variables which are used to compute the intrinsic sizes of children so that those variables
 /// don't have to be passed around all over the place below. It then has methods that implement the intrinsic sizing computations
-struct IntrisicSizeMeasurer<'tree, 'oat, Tree, EstimateFunction>
+struct IntrinsicSizeMeasurer<'tree, 'oat, Tree, EstimateFunction>
 where
     Tree: LayoutPartialTree,
     EstimateFunction: Fn(&GridTrack, Option<f32>, &Tree) -> Option<f32>,
@@ -82,7 +82,7 @@ where
     inner_node_size: Size<Option<f32>>,
 }
 
-impl<Tree, EstimateFunction> IntrisicSizeMeasurer<'_, '_, Tree, EstimateFunction>
+impl<Tree, EstimateFunction> IntrinsicSizeMeasurer<'_, '_, Tree, EstimateFunction>
 where
     Tree: LayoutPartialTree,
     EstimateFunction: Fn(&GridTrack, Option<f32>, &Tree) -> Option<f32>,
@@ -536,7 +536,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
 
     // Step 2.
 
-    // The track sizing algorithm requires us to iterate through the items in ascendeding order of the number of
+    // The track sizing algorithm requires us to iterate through the items in ascending order of the number of
     // tracks they span (first items that span 1 track, then items that span 2 tracks, etc).
     // To avoid having to do multiple iterations of the items, we pre-sort them into this order.
     items.sort_by(cmp_by_cross_flex_then_span_then_start(axis));
@@ -555,7 +555,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
     let axis_inner_node_size = inner_node_size.get(axis);
     let flex_factor_sum = axis_tracks.iter().map(|track| track.flex_factor()).sum::<f32>();
     let mut item_sizer =
-        IntrisicSizeMeasurer { tree, other_axis_tracks, axis, inner_node_size, get_track_size_estimate };
+        IntrinsicSizeMeasurer { tree, other_axis_tracks, axis, inner_node_size, get_track_size_estimate };
 
     let mut batched_item_iterator = ItemBatcher::new(axis);
     while let Some((batch, is_flex)) = batched_item_iterator.next(items) {
@@ -637,7 +637,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                     }
 
                     // Always increase the growth limit to at least the size of the *fit-content limited*
-                    // max-cotent contribution
+                    // max-content contribution
                     let fit_content_limit = track.fit_content_limit(axis_inner_node_size);
                     let max_content_contribution =
                         f32_min(item_sizer.max_content_contribution(item), fit_content_limit);


### PR DESCRIPTION
Fixes some typos in variable names and comments