### PR TITLE
Make `DetailedGridTracksInfo` accessible from a public module

### DIFF
--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -281,7 +281,7 @@ pub fn compute_hidden_layout(tree: &mut (impl LayoutPartialTree + CacheTree), no
 #[cfg(feature = "detailed_layout_info")]
 pub mod detailed_info {
     #[cfg(feature = "grid")]
-    pub use super::grid::{DetailedGridInfo, DetailedGridTracksInfo};
+    pub use super::grid::{DetailedGridInfo, DetailedGridItemsInfo, DetailedGridTracksInfo};
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Objective

Previously the `DetailedGridTracksInfo` type was public but not exported from a public module. Meaning that it wasn't documented and couldn't be explicitly named.

<img width="1027" height="622" alt="Screenshot 2025-11-30 at 14 04 30" src="https://github.com/user-attachments/assets/42a52ba8-8f6e-493a-8eb5-e388d8e811ba" />
