### PR TITLE
More correct caching logic

### DIFF
--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -303,6 +303,13 @@ pub fn compute_block_layout(
         if let Size { width: Some(width), height: Some(height) } = styled_based_known_dimensions {
             return LayoutOutput::from_outer_size(Size { width, height });
         }
+
+        // We can also short-circuit if the width is known and only the width has been requested.
+        if inputs.axis == RequestedAxis::Horizontal {
+            if let Some(width) = styled_based_known_dimensions.width {
+                return LayoutOutput::from_outer_size(Size { width, height: 0.0 });
+            }
+        }
     }
 
     // Unwrap the block formatting context if one was passed, or else create a new one
@@ -445,6 +452,11 @@ fn compute_inner(
     // Short-circuit if computing size and both dimensions known
     if let (RunMode::ComputeSize, Some(container_outer_height)) = (run_mode, known_dimensions.height) {
         return LayoutOutput::from_outer_size(Size { width: container_outer_width, height: container_outer_height });
+    }
+
+    // We can also short-circuit if the width is known and only the width has been requested.
+    if run_mode == RunMode::ComputeSize && inputs.axis == RequestedAxis::Horizontal {
+        return LayoutOutput::from_outer_size(Size { width: container_outer_width, height: 0.0 });
     }
 
     let container_percentage_resolution_height =
@@ -695,16 +707,15 @@ fn determine_content_based_container_width(
             .resolve_or_zero(available_space.width.into_option(), |val, basis| tree.calc(val, basis))
             .horizontal_axis_sum();
         let width = known_dimensions.width.unwrap_or_else(|| {
-            let size_and_baselines = tree.perform_child_layout(
+            tree.measure_child_size(
                 item.node_id,
                 known_dimensions,
                 Size::NONE,
                 available_space.map_width(|w| w.maybe_sub(item_x_margin_sum)),
                 SizingMode::InherentSize,
+                crate::AbsoluteAxis::Horizontal,
                 Line::TRUE,
-            );
-
-            size_and_baselines.size.width
+            )
         });
 
         let width = f32_max(width, item.padding_border_sum.width) + item_x_margin_sum;

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -13,7 +13,7 @@ use crate::util::debug::debug_log;
 use crate::util::sys::{f32_max, new_vec_with_capacity, Vec};
 use crate::util::MaybeMath;
 use crate::util::{MaybeResolve, ResolveOrZero};
-use crate::{BoxGenerationMode, BoxSizing, Direction};
+use crate::{BoxGenerationMode, BoxSizing, Direction, RequestedAxis};
 
 use super::common::alignment::apply_alignment_fallback;
 #[cfg(feature = "content_size")]
@@ -209,6 +209,21 @@ pub fn compute_flexbox_layout(
     // The size of the container should be floored by the padding and border
     let styled_based_known_dimensions =
         known_dimensions.or(min_max_definite_size.or(clamped_style_size).maybe_max(padding_border_sum));
+
+    // Short-circuit layout if the container's size is fully determined by the container's size and the run mode
+    // is ComputeSize (and thus the container's size is all that we're interested in)
+    if run_mode == RunMode::ComputeSize {
+        if let Size { width: Some(width), height: Some(height) } = styled_based_known_dimensions {
+            return LayoutOutput::from_outer_size(Size { width, height });
+        }
+
+        // We can also short-circuit if the width is known and only the width has been requested.
+        if inputs.axis == RequestedAxis::Horizontal {
+            if let Some(width) = styled_based_known_dimensions.width {
+                return LayoutOutput::from_outer_size(Size { width, height: 0.0 });
+            }
+        }
+    }
 
     // Short-circuit layout if the container's size is fully determined by the container's size and the run mode
     // is ComputeSize (and thus the container's size is all that we're interested in)

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -10,7 +10,7 @@ use crate::util::MaybeMath;
 use crate::util::{MaybeResolve, ResolveOrZero};
 use crate::{
     style_helpers::*, AlignContent, BoxGenerationMode, BoxSizing, CoreStyle, Direction, GridContainerStyle,
-    GridItemStyle, JustifyContent, LayoutGridContainer,
+    GridItemStyle, JustifyContent, LayoutGridContainer, RequestedAxis,
 };
 use alignment::{align_and_position_item, align_tracks};
 use explicit_grid::{compute_explicit_grid_size_in_axis, initialize_grid_tracks, AutoRepeatStrategy};
@@ -134,9 +134,19 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
     debug_log!("outer_node_size", dbg:outer_node_size);
     debug_log!("inner_node_size", dbg:inner_node_size);
 
-    if let (RunMode::ComputeSize, Some(width), Some(height)) = (run_mode, outer_node_size.width, outer_node_size.height)
-    {
-        return LayoutOutput::from_outer_size(Size { width, height });
+    // Short-circuit layout if the container's size is fully determined by the container's size and the run mode
+    // is ComputeSize (and thus the container's size is all that we're interested in)
+    if run_mode == RunMode::ComputeSize {
+        if let Size { width: Some(width), height: Some(height) } = outer_node_size {
+            return LayoutOutput::from_outer_size(Size { width, height });
+        }
+
+        // We can also short-circuit if the width is known and only the width has been requested.
+        if inputs.axis == RequestedAxis::Horizontal {
+            if let Some(width) = outer_node_size.width {
+                return LayoutOutput::from_outer_size(Size { width, height: 0.0 });
+            }
+        }
     }
 
     let get_child_styles_iter =

--- a/src/tree/cache.rs
+++ b/src/tree/cache.rs
@@ -15,8 +15,15 @@ const CACHE_SIZE: usize = 9;
 
 /// `f32::INFINITY` as a u32
 const INFINITY_BITS: u32 = 0b_0_11111111_00000000000000000000000_u32;
+/// `f32::INFINITY` as a u32
+const NEG_INFINITY_BITS: u32 = 0b_1_11111111_00000000000000000000000_u32;
 /// A positive NaN f32 values as a u32
 const SPECIFIC_NAN_BITS: u32 = 0b0_11111111_10000000000000000000001_u32;
+
+const A_ONE: u64 = 1u64 << 63;
+const B_ONE: u64 = 1u64 << 31;
+const CHECK_MASK: u64 = A_ONE | B_ONE;
+const SET_MASK: u64 = !CHECK_MASK;
 
 /// Pack `Option<f32>` into `u32`
 #[inline(always)]
@@ -37,8 +44,8 @@ fn size_option_cache_key(input: Size<Option<f32>>) -> u64 {
 #[inline(always)]
 fn available_space_cache_key(input: AvailableSpace) -> u32 {
     match input {
-        AvailableSpace::Definite(value) => value.to_bits(),
-        AvailableSpace::MinContent => SPECIFIC_NAN_BITS,
+        AvailableSpace::Definite(value) => (-value).to_bits(),
+        AvailableSpace::MinContent => NEG_INFINITY_BITS,
         AvailableSpace::MaxContent => INFINITY_BITS,
     }
 }
@@ -49,14 +56,22 @@ fn size_available_space_cache_key(input: Size<AvailableSpace>) -> u64 {
     (available_space_cache_key(input.width) as u64) << 32 | available_space_cache_key(input.height) as u64
 }
 
+#[inline(always)]
+fn mixed_cache_key(kd: Option<f32>, avs: AvailableSpace) -> u32 {
+    kd.map(|kd| kd.to_bits()).unwrap_or_else(|| available_space_cache_key(avs))
+}
+
+#[inline(always)]
+fn size_mixed_cache_key(kd: Size<Option<f32>>, avs: Size<AvailableSpace>) -> u64 {
+    (mixed_cache_key(kd.width, avs.width) as u64) << 32 | mixed_cache_key(kd.height, avs.height) as u64
+}
+
 /// Space-optimised cache key that packs bits into as small a size as possible
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 struct CacheKey {
     /// The initial cached size of the node itself
-    known_dimensions: u64,
-    /// The initial cached size of the parent's node
-    available_space: u64,
+    kd_available_space: u64,
     /// The initial cached size of the parent's node
     parent_size: u64,
 }
@@ -64,19 +79,15 @@ struct CacheKey {
 impl From<&LayoutInput> for CacheKey {
     fn from(input: &LayoutInput) -> Self {
         // Pack axis enum into spare bits in the known_dimensions and available_space values
-        const ONE: u64 = 1u64 << 63;
-        const ZERO: u64 = 0;
-        const MASK: u64 = !ONE;
-        let (kd_mask, as_mask) = match input.axis {
-            RequestedAxis::Horizontal => (ONE, ZERO),
-            RequestedAxis::Vertical => (ZERO, ONE),
-            RequestedAxis::Both => (ONE, ONE),
+        let extra_bits = match input.axis {
+            RequestedAxis::Horizontal => A_ONE,
+            RequestedAxis::Vertical => B_ONE,
+            RequestedAxis::Both => A_ONE | B_ONE,
         };
 
         Self {
-            known_dimensions: (size_option_cache_key(input.known_dimensions) & MASK) | kd_mask,
-            available_space: (size_available_space_cache_key(input.available_space) & MASK) | as_mask,
-            parent_size: size_option_cache_key(input.parent_size),
+            kd_available_space: size_mixed_cache_key(input.known_dimensions, input.available_space),
+            parent_size: (size_option_cache_key(input.parent_size) & SET_MASK) | extra_bits,
         }
     }
 }
@@ -187,8 +198,8 @@ impl Cache {
             RunMode::PerformLayout => self.final_layout_entry.filter(|entry| entry.key == key).map(|e| e.content),
             RunMode::ComputeSize => {
                 for entry in self.measure_entries.iter().flatten() {
-                    if entry.key.known_dimensions == key.known_dimensions
-                        && entry.key.available_space == key.available_space
+                    if entry.key.kd_available_space == key.kd_available_space
+                        && (entry.key.parent_size & CHECK_MASK == key.parent_size & CHECK_MASK)
                     {
                         return Some(LayoutOutput::from_outer_size(entry.content));
                     }

--- a/src/tree/cache.rs
+++ b/src/tree/cache.rs
@@ -3,6 +3,8 @@ use crate::geometry::Size;
 use crate::style::AvailableSpace;
 use crate::tree::{LayoutInput, LayoutOutput, RunMode};
 
+use crate::RequestedAxis;
+
 /// The number of cache entries for each node in the tree
 const CACHE_SIZE: usize = 9;
 
@@ -14,6 +16,8 @@ pub(crate) struct CacheEntry<T> {
     known_dimensions: Size<Option<f32>>,
     /// The initial cached size of the parent's node
     available_space: Size<AvailableSpace>,
+    /// The initial cached size of the parent's node
+    axis: RequestedAxis,
     /// The cached size and baselines of the item
     content: T,
 }
@@ -125,6 +129,7 @@ impl Cache {
                             || entry.available_space.width.is_roughly_equal(available_space.width))
                         && (known_dimensions.height.is_some()
                             || entry.available_space.height.is_roughly_equal(available_space.height))
+                        && input.axis == entry.axis
                 })
                 .map(|e| e.content),
             RunMode::ComputeSize => {
@@ -139,6 +144,7 @@ impl Cache {
                             || entry.available_space.width.is_roughly_equal(available_space.width))
                         && (known_dimensions.height.is_some()
                             || entry.available_space.height.is_roughly_equal(available_space.height))
+                        && input.axis == entry.axis
                     {
                         return Some(LayoutOutput::from_outer_size(cached_size));
                     }
@@ -154,17 +160,19 @@ impl Cache {
     pub fn store(&mut self, input: &LayoutInput, layout_output: LayoutOutput) {
         let known_dimensions = input.known_dimensions;
         let available_space = input.available_space;
+        let axis = input.axis;
 
         match input.run_mode {
             RunMode::PerformLayout => {
                 self.is_empty = false;
-                self.final_layout_entry = Some(CacheEntry { known_dimensions, available_space, content: layout_output })
+                self.final_layout_entry =
+                    Some(CacheEntry { axis, known_dimensions, available_space, content: layout_output })
             }
             RunMode::ComputeSize => {
                 self.is_empty = false;
                 let cache_slot = Self::compute_cache_slot(known_dimensions, available_space);
                 self.measure_entries[cache_slot] =
-                    Some(CacheEntry { known_dimensions, available_space, content: layout_output.size });
+                    Some(CacheEntry { axis, known_dimensions, available_space, content: layout_output.size });
             }
             RunMode::PerformHiddenLayout => {}
         }

--- a/src/tree/cache.rs
+++ b/src/tree/cache.rs
@@ -1,25 +1,92 @@
 //! A cache for storing the results of layout computation
+
+#![allow(clippy::unusual_byte_groupings)]
+
 use crate::geometry::Size;
 use crate::style::AvailableSpace;
 use crate::tree::{LayoutInput, LayoutOutput, RunMode};
-
 use crate::RequestedAxis;
 
 /// The number of cache entries for each node in the tree
 const CACHE_SIZE: usize = 9;
 
+// Manually written-out results of float to u32 bit casts because
+// `f32::to_bits` is not yet const at our MSRV.
+
+/// `f32::INFINITY` as a u32
+const INFINITY_BITS: u32 = 0b_0_11111111_00000000000000000000000_u32;
+/// A positive NaN f32 values as a u32
+const SPECIFIC_NAN_BITS: u32 = 0b0_11111111_10000000000000000000001_u32;
+
+/// Pack `Option<f32>` into `u32`
+#[inline(always)]
+fn option_cache_key(input: Option<f32>) -> u32 {
+    match input {
+        Some(value) => value.to_bits(),
+        None => INFINITY_BITS,
+    }
+}
+
+/// Pack `Size<Option<f32>>` into `u64`
+#[inline(always)]
+fn size_option_cache_key(input: Size<Option<f32>>) -> u64 {
+    (option_cache_key(input.width) as u64) << 32 | option_cache_key(input.height) as u64
+}
+
+/// Pack `AvailableSpace` into `u32`
+#[inline(always)]
+fn available_space_cache_key(input: AvailableSpace) -> u32 {
+    match input {
+        AvailableSpace::Definite(value) => value.to_bits(),
+        AvailableSpace::MinContent => SPECIFIC_NAN_BITS,
+        AvailableSpace::MaxContent => INFINITY_BITS,
+    }
+}
+
+/// Pack `Size<AvailableSpace>` into `u64`
+#[inline(always)]
+fn size_available_space_cache_key(input: Size<AvailableSpace>) -> u64 {
+    (available_space_cache_key(input.width) as u64) << 32 | available_space_cache_key(input.height) as u64
+}
+
+/// Space-optimised cache key that packs bits into as small a size as possible
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+struct CacheKey {
+    /// The initial cached size of the node itself
+    known_dimensions: u64,
+    /// The initial cached size of the parent's node
+    available_space: u64,
+    /// The initial cached size of the parent's node
+    parent_size: u64,
+}
+
+impl From<&LayoutInput> for CacheKey {
+    fn from(input: &LayoutInput) -> Self {
+        // Pack axis enum into spare bits in the known_dimensions and available_space values
+        const ONE: u64 = 1u64 << 63;
+        const ZERO: u64 = 0;
+        const MASK: u64 = !ONE;
+        let (kd_mask, as_mask) = match input.axis {
+            RequestedAxis::Horizontal => (ONE, ZERO),
+            RequestedAxis::Vertical => (ZERO, ONE),
+            RequestedAxis::Both => (ONE, ONE),
+        };
+
+        Self {
+            known_dimensions: (size_option_cache_key(input.known_dimensions) & MASK) | kd_mask,
+            available_space: (size_available_space_cache_key(input.available_space) & MASK) | as_mask,
+            parent_size: size_option_cache_key(input.parent_size),
+        }
+    }
+}
+
 /// Cached intermediate layout results
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 pub(crate) struct CacheEntry<T> {
-    /// The initial cached size of the node itself
-    known_dimensions: Size<Option<f32>>,
-    /// The initial cached size of the parent's node
-    available_space: Size<AvailableSpace>,
-    /// The initial cached size of the parent's node
-    axis: RequestedAxis,
-    /// The initial cached size of the parent's node
-    parent_size: Size<Option<f32>>,
+    /// The key for the cache entry
+    key: CacheKey,
     /// The cached size and baselines of the item
     content: T,
 }
@@ -115,41 +182,15 @@ impl Cache {
     /// Try to retrieve a cached result from the cache
     #[inline]
     pub fn get(&self, input: &LayoutInput) -> Option<LayoutOutput> {
-        let known_dimensions = input.known_dimensions;
-        let available_space = input.available_space;
-
+        let key = CacheKey::from(input);
         match input.run_mode {
-            RunMode::PerformLayout => self
-                .final_layout_entry
-                .filter(|entry| {
-                    let cached_size = entry.content.size;
-                    (known_dimensions.width == entry.known_dimensions.width
-                        || known_dimensions.width == Some(cached_size.width))
-                        && (known_dimensions.height == entry.known_dimensions.height
-                            || known_dimensions.height == Some(cached_size.height))
-                        && (known_dimensions.width.is_some()
-                            || entry.available_space.width.is_roughly_equal(available_space.width))
-                        && (known_dimensions.height.is_some()
-                            || entry.available_space.height.is_roughly_equal(available_space.height))
-                        && input.axis == entry.axis
-                        && input.parent_size == entry.parent_size
-                })
-                .map(|e| e.content),
+            RunMode::PerformLayout => self.final_layout_entry.filter(|entry| entry.key == key).map(|e| e.content),
             RunMode::ComputeSize => {
                 for entry in self.measure_entries.iter().flatten() {
-                    let cached_size = entry.content;
-
-                    if (known_dimensions.width == entry.known_dimensions.width
-                        || known_dimensions.width == Some(cached_size.width))
-                        && (known_dimensions.height == entry.known_dimensions.height
-                            || known_dimensions.height == Some(cached_size.height))
-                        && (known_dimensions.width.is_some()
-                            || entry.available_space.width.is_roughly_equal(available_space.width))
-                        && (known_dimensions.height.is_some()
-                            || entry.available_space.height.is_roughly_equal(available_space.height))
-                        && input.axis == entry.axis
+                    if entry.key.known_dimensions == key.known_dimensions
+                        && entry.key.available_space == key.available_space
                     {
-                        return Some(LayoutOutput::from_outer_size(cached_size));
+                        return Some(LayoutOutput::from_outer_size(entry.content));
                     }
                 }
 
@@ -161,27 +202,16 @@ impl Cache {
 
     /// Store a computed size in the cache
     pub fn store(&mut self, input: &LayoutInput, layout_output: LayoutOutput) {
-        let known_dimensions = input.known_dimensions;
-        let available_space = input.available_space;
-        let axis = input.axis;
-        let parent_size = input.parent_size;
-
+        let key = CacheKey::from(input);
         match input.run_mode {
             RunMode::PerformLayout => {
                 self.is_empty = false;
-                self.final_layout_entry =
-                    Some(CacheEntry { axis, parent_size, known_dimensions, available_space, content: layout_output })
+                self.final_layout_entry = Some(CacheEntry { key, content: layout_output })
             }
             RunMode::ComputeSize => {
                 self.is_empty = false;
-                let cache_slot = Self::compute_cache_slot(known_dimensions, available_space);
-                self.measure_entries[cache_slot] = Some(CacheEntry {
-                    axis,
-                    parent_size,
-                    known_dimensions,
-                    available_space,
-                    content: layout_output.size,
-                });
+                let cache_slot = Self::compute_cache_slot(input.known_dimensions, input.available_space);
+                self.measure_entries[cache_slot] = Some(CacheEntry { key, content: layout_output.size });
             }
             RunMode::PerformHiddenLayout => {}
         }

--- a/src/tree/cache.rs
+++ b/src/tree/cache.rs
@@ -18,6 +18,8 @@ pub(crate) struct CacheEntry<T> {
     available_space: Size<AvailableSpace>,
     /// The initial cached size of the parent's node
     axis: RequestedAxis,
+    /// The initial cached size of the parent's node
+    parent_size: Size<Option<f32>>,
     /// The cached size and baselines of the item
     content: T,
 }
@@ -130,6 +132,7 @@ impl Cache {
                         && (known_dimensions.height.is_some()
                             || entry.available_space.height.is_roughly_equal(available_space.height))
                         && input.axis == entry.axis
+                        && input.parent_size == entry.parent_size
                 })
                 .map(|e| e.content),
             RunMode::ComputeSize => {
@@ -161,18 +164,24 @@ impl Cache {
         let known_dimensions = input.known_dimensions;
         let available_space = input.available_space;
         let axis = input.axis;
+        let parent_size = input.parent_size;
 
         match input.run_mode {
             RunMode::PerformLayout => {
                 self.is_empty = false;
                 self.final_layout_entry =
-                    Some(CacheEntry { axis, known_dimensions, available_space, content: layout_output })
+                    Some(CacheEntry { axis, parent_size, known_dimensions, available_space, content: layout_output })
             }
             RunMode::ComputeSize => {
                 self.is_empty = false;
                 let cache_slot = Self::compute_cache_slot(known_dimensions, available_space);
-                self.measure_entries[cache_slot] =
-                    Some(CacheEntry { axis, known_dimensions, available_space, content: layout_output.size });
+                self.measure_entries[cache_slot] = Some(CacheEntry {
+                    axis,
+                    parent_size,
+                    known_dimensions,
+                    available_space,
+                    content: layout_output.size,
+                });
             }
             RunMode::PerformHiddenLayout => {}
         }

--- a/src/tree/cache.rs
+++ b/src/tree/cache.rs
@@ -20,10 +20,18 @@ const NEG_INFINITY_BITS: u32 = 0b_1_11111111_00000000000000000000000_u32;
 // /// A positive NaN f32 values as a u32
 // const SPECIFIC_NAN_BITS: u32 = 0b0_11111111_10000000000000000000001_u32;
 
-const A_ONE: u64 = 1u64 << 63;
-const B_ONE: u64 = 1u64 << 31;
-const CHECK_MASK: u64 = A_ONE | B_ONE;
-const SET_MASK: u64 = !CHECK_MASK;
+// The `CacheKey` encodes two f32s as a u64. We know that the f32s will always be
+// non-negative, so we pack two extra bits encoding the `RequestedAxis` into the
+// sign bits of the f32s. These constants help to encode and decode those bits.
+
+/// The sign bit of the first f32
+const SIGN_BIT_1: u64 = 1u64 << 63;
+/// The sign bit of the second f32
+const SIGN_BIT_2: u64 = 1u64 << 31;
+/// Mask of both sign bits (used to compute NON_SIGN_BITS_MASK)
+const BOTH_SIGN_BITS_MASK: u64 = SIGN_BIT_1 | SIGN_BIT_2;
+/// Mask of excluding the sign bits (used when setting/getting the size excluding the packed bits)
+const NON_SIGN_BITS_MASK: u64 = !BOTH_SIGN_BITS_MASK;
 
 /// Pack `Option<f32>` into `u32`
 #[inline(always)]
@@ -57,11 +65,15 @@ fn size_available_space_cache_key(input: Size<AvailableSpace>) -> u64 {
     (available_space_cache_key(input.width) as u64) << 32 | available_space_cache_key(input.height) as u64
 }
 
+/// Encodes combination of a `known_dimension` (Option<f32>) and `AvailableSpace` in
+/// a single dimension into a cache key in a single dimension.
 #[inline(always)]
 fn mixed_cache_key(kd: Option<f32>, avs: AvailableSpace) -> u32 {
     kd.map(|kd| kd.to_bits()).unwrap_or_else(|| available_space_cache_key(avs))
 }
 
+/// Encodes combination of a `known_dimension` (Option<f32>) and `AvailableSpace` in
+/// two dimensions into a cache key in a single dimension.
 #[inline(always)]
 fn size_mixed_cache_key(kd: Size<Option<f32>>, avs: Size<AvailableSpace>) -> u64 {
     (mixed_cache_key(kd.width, avs.width) as u64) << 32 | mixed_cache_key(kd.height, avs.height) as u64
@@ -77,18 +89,26 @@ struct CacheKey {
     parent_size: u64,
 }
 
+impl CacheKey {
+    #[inline(always)]
+    /// Return the parent size with the extra bits that encode the requested axis masked out
+    fn parent_size(&self) -> u64 {
+        self.parent_size & NON_SIGN_BITS_MASK
+    }
+}
+
 impl From<&LayoutInput> for CacheKey {
     fn from(input: &LayoutInput) -> Self {
         // Pack axis enum into spare bits in the known_dimensions and available_space values
         let extra_bits = match input.axis {
-            RequestedAxis::Horizontal => A_ONE,
-            RequestedAxis::Vertical => B_ONE,
-            RequestedAxis::Both => A_ONE | B_ONE,
+            RequestedAxis::Horizontal => SIGN_BIT_1,
+            RequestedAxis::Vertical => SIGN_BIT_2,
+            RequestedAxis::Both => SIGN_BIT_1 | SIGN_BIT_2,
         };
 
         Self {
             kd_available_space: size_mixed_cache_key(input.known_dimensions, input.available_space),
-            parent_size: (size_option_cache_key(input.parent_size) & SET_MASK) | extra_bits,
+            parent_size: (size_option_cache_key(input.parent_size) & NON_SIGN_BITS_MASK) | extra_bits,
         }
     }
 }
@@ -200,7 +220,7 @@ impl Cache {
             RunMode::ComputeSize => {
                 for entry in self.measure_entries.iter().flatten() {
                     if entry.key.kd_available_space == key.kd_available_space
-                        && (entry.key.parent_size & CHECK_MASK == key.parent_size & CHECK_MASK)
+                        && (entry.key.parent_size() == key.parent_size())
                     {
                         return Some(LayoutOutput::from_outer_size(entry.content));
                     }

--- a/src/tree/cache.rs
+++ b/src/tree/cache.rs
@@ -31,7 +31,9 @@ const BOTH_SIGN_BITS_MASK: u64 = SIGN_BIT_1 | SIGN_BIT_2;
 /// Mask of excluding the sign bits (used when setting/getting the size excluding the packed bits)
 const NON_SIGN_BITS_MASK: u64 = !BOTH_SIGN_BITS_MASK;
 
-const X_AXIS_VALUE_MASK : u64 = (u32::MAX as u64) << 32;
+/// Mask which includes only the bits which encode the x-axis value that we can use to ignore the
+/// y-axis value when comparing a cache key.
+const X_AXIS_VALUE_MASK: u64 = (u32::MAX as u64) << 32;
 
 /// Pack `Option<f32>` into `u32`
 #[inline(always)]
@@ -102,8 +104,6 @@ impl CacheKey {
     fn x_axis_parent_size(&self) -> u64 {
         self.parent_size & (X_AXIS_VALUE_MASK & NON_SIGN_BITS_MASK)
     }
-
-    
 }
 
 impl From<&LayoutInput> for CacheKey {

--- a/src/tree/cache.rs
+++ b/src/tree/cache.rs
@@ -17,8 +17,8 @@ const CACHE_SIZE: usize = 9;
 const INFINITY_BITS: u32 = 0b_0_11111111_00000000000000000000000_u32;
 /// `f32::INFINITY` as a u32
 const NEG_INFINITY_BITS: u32 = 0b_1_11111111_00000000000000000000000_u32;
-/// A positive NaN f32 values as a u32
-const SPECIFIC_NAN_BITS: u32 = 0b0_11111111_10000000000000000000001_u32;
+// /// A positive NaN f32 values as a u32
+// const SPECIFIC_NAN_BITS: u32 = 0b0_11111111_10000000000000000000001_u32;
 
 const A_ONE: u64 = 1u64 << 63;
 const B_ONE: u64 = 1u64 << 31;
@@ -52,6 +52,7 @@ fn available_space_cache_key(input: AvailableSpace) -> u32 {
 
 /// Pack `Size<AvailableSpace>` into `u64`
 #[inline(always)]
+#[allow(dead_code)]
 fn size_available_space_cache_key(input: Size<AvailableSpace>) -> u64 {
     (available_space_cache_key(input.width) as u64) << 32 | available_space_cache_key(input.height) as u64
 }

--- a/src/tree/cache.rs
+++ b/src/tree/cache.rs
@@ -31,6 +31,8 @@ const BOTH_SIGN_BITS_MASK: u64 = SIGN_BIT_1 | SIGN_BIT_2;
 /// Mask of excluding the sign bits (used when setting/getting the size excluding the packed bits)
 const NON_SIGN_BITS_MASK: u64 = !BOTH_SIGN_BITS_MASK;
 
+const X_AXIS_VALUE_MASK : u64 = (u32::MAX as u64) << 32;
+
 /// Pack `Option<f32>` into `u32`
 #[inline(always)]
 fn option_cache_key(input: Option<f32>) -> u32 {
@@ -89,10 +91,19 @@ struct CacheKey {
 
 impl CacheKey {
     #[inline(always)]
+    #[allow(dead_code)]
     /// Return the parent size with the extra bits that encode the requested axis masked out
     fn parent_size(&self) -> u64 {
         self.parent_size & NON_SIGN_BITS_MASK
     }
+
+    /// Return the parent size with the extra bits that encode the requested axis masked out
+    /// And the y-axis value masked out
+    fn x_axis_parent_size(&self) -> u64 {
+        self.parent_size & (X_AXIS_VALUE_MASK & NON_SIGN_BITS_MASK)
+    }
+
+    
 }
 
 impl From<&LayoutInput> for CacheKey {
@@ -218,7 +229,7 @@ impl Cache {
             RunMode::ComputeSize => {
                 for entry in self.measure_entries.iter().flatten() {
                     if entry.key.kd_available_space == key.kd_available_space
-                        && (entry.key.parent_size() == key.parent_size())
+                        && (entry.key.x_axis_parent_size() == key.x_axis_parent_size())
                     {
                         return Some(LayoutOutput::from_outer_size(entry.content));
                     }

--- a/src/tree/cache.rs
+++ b/src/tree/cache.rs
@@ -15,10 +15,8 @@ const CACHE_SIZE: usize = 9;
 
 /// `f32::INFINITY` as a u32
 const INFINITY_BITS: u32 = 0b_0_11111111_00000000000000000000000_u32;
-/// `f32::INFINITY` as a u32
+/// `f32::NEG_INFINITY` as a u32
 const NEG_INFINITY_BITS: u32 = 0b_1_11111111_00000000000000000000000_u32;
-// /// A positive NaN f32 values as a u32
-// const SPECIFIC_NAN_BITS: u32 = 0b0_11111111_10000000000000000000001_u32;
 
 // The `CacheKey` encodes two f32s as a u64. We know that the f32s will always be
 // non-negative, so we pack two extra bits encoding the `RequestedAxis` into the

--- a/tests/hand_written/caching.rs
+++ b/tests/hand_written/caching.rs
@@ -18,7 +18,7 @@ mod caching {
 
         taffy.compute_layout_with_measure(node, Size::MAX_CONTENT, test_measure_function).unwrap();
 
-        assert_eq!(taffy.get_node_context_mut(leaf).unwrap().count, 5);
+        assert_eq!(taffy.get_node_context_mut(leaf).unwrap().count, 7);
     }
 
     #[test]
@@ -35,6 +35,6 @@ mod caching {
         }
 
         taffy.compute_layout_with_measure(node, Size::MAX_CONTENT, test_measure_function).unwrap();
-        assert_eq!(taffy.get_node_context_mut(leaf).unwrap().count, 5);
+        assert_eq!(taffy.get_node_context_mut(leaf).unwrap().count, 7);
     }
 }

--- a/tests/hand_written/caching.rs
+++ b/tests/hand_written/caching.rs
@@ -18,7 +18,7 @@ mod caching {
 
         taffy.compute_layout_with_measure(node, Size::MAX_CONTENT, test_measure_function).unwrap();
 
-        assert_eq!(taffy.get_node_context_mut(leaf).unwrap().count, 4);
+        assert_eq!(taffy.get_node_context_mut(leaf).unwrap().count, 5);
     }
 
     #[test]
@@ -35,6 +35,6 @@ mod caching {
         }
 
         taffy.compute_layout_with_measure(node, Size::MAX_CONTENT, test_measure_function).unwrap();
-        assert_eq!(taffy.get_node_context_mut(leaf).unwrap().count, 4);
+        assert_eq!(taffy.get_node_context_mut(leaf).unwrap().count, 5);
     }
 }


### PR DESCRIPTION
# Objective

Ensure that Taffy correctly computes layouts when re-layouting with a warm/populated cache.

## Context

Blitz is seeing bugs in the layout that only occur when incremental mode  is enabled (which corresponds to having a Taffy cache populated from a previous frame). There are reports of similar bugs from Floem.

In the screenshots below, note how in incremental mode the text in the top-right ("Create Account" and "Log In") wraps, whereas in non-incremental mode it does. It is not supposed to wrap and does not do so in other browsers.


<table>
<tr><th>NON-incremental mode</th><th>Incremental mode</th></tr>
<tr>
<td>

<img width="912" height="740" alt="Screenshot 2026-01-31 at 16 56 46" src="https://github.com/user-attachments/assets/0ef5900f-ebec-4fd5-b231-7c4af17c0e56" />


</td>
<td>

<img width="912" height="740" alt="Screenshot 2026-01-31 at 16 56 29" src="https://github.com/user-attachments/assets/bab95496-2b23-4402-93d8-ddbd6c0a40ef" />

</td>
</tr>
</table>

## Benchmarks

This appears to have little effect on some benchmarks. But it is a 40-50% regression on the Flexbox "Deep tree (auto size)" benchmarks and the "mixed tree" benchmarks and a 15-25% regression on the CSS Grid "deep tree" benchmarks.

I'm also seeing perf regressions around the 50-80% mark when doing a full (non-incremental) re-layouts of some websites in Blitz. https://en.wikipedia.org/wiki/Barack_Obama is ~36ms -> ~46ms. https://www.bbc.co.uk/news is ~9ms -> 16ms. Layouts with populated cache are very fast ~100 microseconds. I don't have good numbers for the "partial cache" case.

The good news is that it doesn't seem to affect scaling behaviour. It's a ~flat perf regression regardless of tree size.

```
yoga 'huge nested'/Taffy 0.7 /10000
                        time:   [5.5657 ms 5.6373 ms 5.7209 ms]
                        change: [+0.1505% +1.5011% +3.1079%] (p = 0.04 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

Wide tree/Taffy 0.7 (2-level hierarchy)/10000
                        time:   [7.0300 ms 7.0637 ms 7.1339 ms]
                        change: [−2.2727% +0.1393% +2.4889%] (p = 0.92 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe

Deep tree (auto size)/Taffy 0.7 (12-level hierarchy)/4000
                        time:   [4.9999 ms 5.0195 ms 5.0477 ms]
                        change: [+54.452% +56.722% +59.103%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Deep tree (auto size)/Taffy 0.7 (14-level hierarchy)/10000
                        time:   [12.688 ms 12.755 ms 12.842 ms]
                        change: [+49.213% +51.115% +53.081%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

Deep tree (random size)/Taffy 0.7 (12-level hierarchy)/4000
                        time:   [2.4592 ms 2.4673 ms 2.4777 ms]
                        change: [−1.7941% +0.2944% +2.6305%] (p = 0.82 > 0.05)
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high severe
Deep tree (random size)/Taffy 0.7 (14-level hierarchy)/10000
                        time:   [6.5680 ms 6.6522 ms 6.7420 ms]
                        change: [−5.8214% −3.8350% −1.9587%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) low mild
  1 (10.00%) high mild

super deep/Taffy 0.7 /100
                        time:   [417.47 µs 420.16 µs 422.45 µs]
                        change: [+32.857% +35.339% +37.782%] (p = 0.00 < 0.05)
                        Performance has regressed.

     Running benches/grid.rs (target/release/deps/grid-bfd8fc1f29505f53)
Gnuplot not found, using plotters backend
grid/wide/31x31/961     time:   [1.0561 ms 1.0774 ms 1.0982 ms]
                        change: [−12.797% −9.4303% −5.8275%] (p = 0.00 < 0.05)
                        Performance has improved.
grid/wide/100x100/10000 time:   [16.047 ms 16.166 ms 16.283 ms]
                        change: [−2.4088% −0.3128% +1.8773%] (p = 0.80 > 0.05)
                        No change in performance detected.
grid/wide/316x316/99856 time:   [188.39 ms 189.61 ms 191.00 ms]
                        change: [−10.135% −8.7799% −7.4959%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

grid/deep/2x2/1024      time:   [3.4978 ms 3.5074 ms 3.5258 ms]
                        change: [+6.7821% +10.784% +14.950%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
grid/deep/3x3/6561      time:   [18.016 ms 18.068 ms 18.146 ms]
                        change: [+4.8730% +6.8613% +8.6593%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 10 measurements (40.00%)
  2 (20.00%) low mild
  1 (10.00%) high mild
  1 (10.00%) high severe
grid/deep/2x2/16384     time:   [64.379 ms 64.568 ms 64.938 ms]
                        change: [+6.7077% +8.0594% +9.4394%] (p = 0.00 < 0.05)
                        Performance has regressed.

grid/superdeep/1x1/100  time:   [429.75 µs 432.07 µs 434.36 µs]
                        change: [+51.145% +54.094% +56.499%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
grid/superdeep/1x1/1000 time:   [4.3362 ms 4.3747 ms 4.4062 ms]
                        change: [+41.140% +43.256% +45.505%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

     Running benches/mixed.rs (target/release/deps/mixed-f23556c822b53402)
Gnuplot not found, using plotters backend
mixed_flex_grid/mixed/depth_2_width_4
                        time:   [606.29 µs 607.85 µs 609.92 µs]
                        change: [+23.449% +24.091% +24.719%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 40 measurements (7.50%)
  3 (7.50%) high mild
mixed_flex_grid/mixed/depth_2_width_8
                        time:   [1.5473 ms 1.5525 ms 1.5572 ms]
                        change: [+5.7597% +6.1488% +6.5374%] (p = 0.00 < 0.05)
                        Performance has regressed.
mixed_flex_grid/mixed/depth_4_width_4
                        time:   [13.953 ms 13.979 ms 14.007 ms]
                        change: [+34.589% +35.594% +36.516%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking mixed_flex_grid/mixed/depth_4_width_8: Warming up for 3.0000 s
Warning: Unable to complete 40 samples in 5.0s. You may wish to increase target time to 19.0s, or reduce sample count to 10.
mixed_flex_grid/mixed/depth_4_width_8
                        time:   [200.69 ms 201.10 ms 201.52 ms]
                        change: [+20.151% +21.647% +22.723%] (p = 0.00 < 0.05)
                        Performance has regressed.
```
