### PR TITLE
feat: implement CSS order property for flex and grid items

### DIFF
--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -499,7 +499,8 @@ fn generate_anonymous_flex_items(
     node: NodeId,
     constants: &AlgoConstants,
 ) -> Vec<FlexItem> {
-    tree.child_ids(node)
+    let mut flex_items: Vec<FlexItem> = tree
+        .child_ids(node)
         .enumerate()
         .map(|(index, child)| (index, child, tree.get_flexbox_child_style(child)))
         .filter(|(_, _, style)| style.position() != Position::Absolute)
@@ -570,7 +571,20 @@ fn generate_anonymous_flex_items(
                 offset_cross: 0.0,
             }
         })
-        .collect()
+        .collect();
+
+    // CSS Flexbox §5.4: Reorder flex items by the CSS `order` property.
+    // Stable sort preserves source order for items with equal `order` values.
+    flex_items.sort_by(|a, b| {
+        tree.get_flexbox_child_style(a.node).order().cmp(&tree.get_flexbox_child_style(b.node).order())
+    });
+
+    // Reassign rendering order to reflect the new visual sequence.
+    for (i, item) in flex_items.iter_mut().enumerate() {
+        item.order = i as u32;
+    }
+
+    flex_items
 }
 
 /// Determine the available main and cross space for the flex items.

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -197,13 +197,20 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
     // Match items (children) to a definite grid position (row start/end and column start/end position)
     let mut items = Vec::with_capacity(tree.child_count(node));
     let mut cell_occupancy_matrix = CellOccupancyMatrix::with_track_counts(est_col_counts, est_row_counts);
+    // CSS Grid §6.3: Items are placed in order-modified document order.
+    // Collect child indices sorted by (CSS order, source order).
+    let mut sorted_children: Vec<(usize, NodeId)> = tree
+        .child_ids(node)
+        .enumerate()
+        .filter(|(_, child_node)| {
+            let style = tree.get_grid_child_style(*child_node);
+            style.box_generation_mode() != BoxGenerationMode::None && style.position() != Position::Absolute
+        })
+        .collect();
+    sorted_children.sort_by_key(|(_, child_node)| tree.get_grid_child_style(*child_node).order());
+
     let in_flow_children_iter = || {
-        tree.child_ids(node)
-            .enumerate()
-            .map(|(index, child_node)| (index, child_node, tree.get_grid_child_style(child_node)))
-            .filter(|(_, _, style)| {
-                style.box_generation_mode() != BoxGenerationMode::None && style.position() != Position::Absolute
-            })
+        sorted_children.iter().map(|&(index, child_node)| (index, child_node, tree.get_grid_child_style(child_node)))
     };
     place_grid_items(
         &mut cell_occupancy_matrix,
@@ -214,6 +221,13 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
         justify_items.unwrap_or(AlignItems::Stretch),
         &name_resolver,
     );
+
+    // Assign visual order reflecting CSS `order`-modified document order.
+    // Items are currently in placement order (which respects CSS `order`).
+    // We assign before track sizing, which re-sorts items by other criteria.
+    for (i, item) in items.iter_mut().enumerate() {
+        item.order = i as u32;
+    }
 
     // Extract track counts from previous step (auto-placement can expand the number of tracks)
     let final_col_counts = *cell_occupancy_matrix.track_counts(AbsoluteAxis::Horizontal);
@@ -500,7 +514,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
     let container_alignment_styles = InBothAbsAxis { horizontal: justify_items, vertical: align_items };
 
     // Position in-flow children (stored in items vector)
-    for (index, item) in items.iter_mut().enumerate() {
+    for item in items.iter_mut() {
         let grid_area = Rect {
             top: rows[item.row_indexes.start as usize + 1].offset,
             bottom: rows[item.row_indexes.end as usize].offset,
@@ -511,7 +525,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
         let (content_size_contribution, y_position, height) = align_and_position_item(
             tree,
             item.node,
-            index as u32,
+            item.order,
             grid_area,
             container_alignment_styles,
             item.baseline_shim,

--- a/src/compute/grid/types/grid_item.rs
+++ b/src/compute/grid/types/grid_item.rs
@@ -21,6 +21,10 @@ pub(in super::super) struct GridItem {
     /// for final positioning
     pub source_order: u16,
 
+    /// The visual order of the item, reflecting CSS `order`-modified document order.
+    /// Used for `Layout.order` to inform painting/z-order.
+    pub order: u32,
+
     /// The item's definite row-start and row-end, as resolved by the placement algorithm
     /// (in origin-zero coordinates)
     pub row: Line<OriginZeroLine>,
@@ -105,6 +109,7 @@ impl GridItem {
         GridItem {
             node,
             source_order,
+            order: 0, // Assigned after placement, before final positioning
             row: row_span,
             column: col_span,
             is_compressible_replaced: style.is_compressible_replaced(),

--- a/src/style/flex.rs
+++ b/src/style/flex.rs
@@ -64,6 +64,20 @@ pub trait FlexboxItemStyle: CoreStyle {
     fn align_self(&self) -> Option<AlignSelf> {
         Style::<Self::CustomIdent>::DEFAULT.align_self
     }
+
+    /// The CSS `order` property. Controls the order in which flex items appear
+    /// within their flex container.
+    ///
+    /// Items with lower order values are laid out first. Items with the same
+    /// order value are laid out in source order.
+    ///
+    /// Defaults to `0`.
+    ///
+    /// [Specification](https://www.w3.org/TR/css-display-3/#order-property)
+    #[inline(always)]
+    fn order(&self) -> i32 {
+        0
+    }
 }
 
 use crate::geometry::AbsoluteAxis;

--- a/src/style/grid.rs
+++ b/src/style/grid.rs
@@ -256,6 +256,20 @@ pub trait GridItemStyle: CoreStyle {
         Style::<Self::CustomIdent>::DEFAULT.justify_self
     }
 
+    /// The CSS `order` property. Controls order-modified document order
+    /// for grid item placement.
+    ///
+    /// Items with lower order values are placed first. Items with the same
+    /// order value are placed in source order.
+    ///
+    /// Defaults to `0`.
+    ///
+    /// [Specification](https://www.w3.org/TR/css-display-3/#order-property)
+    #[inline(always)]
+    fn order(&self) -> i32 {
+        0
+    }
+
     /// Get a grid item's row or column placement depending on the axis passed
     #[inline(always)]
     fn grid_placement(&self, axis: AbsoluteAxis) -> Line<GridPlacement<Self::CustomIdent>> {

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -479,6 +479,16 @@ pub struct Style<S: CheapCloneStr = DefaultCheapStr> {
     #[cfg(feature = "flexbox")]
     pub flex_shrink: f32,
 
+    // Order property (applies to both flex and grid items)
+    /// The CSS `order` property. Controls the visual order of flex and grid items.
+    ///
+    /// Items with lower values are laid out first. Items with the same value
+    /// maintain their source order. Defaults to `0`.
+    ///
+    /// [Specification](https://www.w3.org/TR/css-display-3/#order-property)
+    #[cfg(any(feature = "flexbox", feature = "grid"))]
+    pub order: i32,
+
     // Grid container properies
     /// Defines the track sizing functions (heights) of the grid rows
     #[cfg(feature = "grid")]
@@ -568,6 +578,9 @@ impl<S: CheapCloneStr> Style<S> {
         flex_shrink: 1.0,
         #[cfg(feature = "flexbox")]
         flex_basis: Dimension::AUTO,
+        // Order
+        #[cfg(any(feature = "flexbox", feature = "grid"))]
+        order: 0,
         // Grid
         #[cfg(feature = "grid")]
         grid_template_rows: GridTrackVec::new(),
@@ -862,6 +875,10 @@ impl<S: CheapCloneStr> FlexboxItemStyle for Style<S> {
     fn align_self(&self) -> Option<AlignSelf> {
         self.align_self
     }
+    #[inline(always)]
+    fn order(&self) -> i32 {
+        self.order
+    }
 }
 
 #[cfg(feature = "flexbox")]
@@ -881,6 +898,10 @@ impl<T: FlexboxItemStyle> FlexboxItemStyle for &'_ T {
     #[inline(always)]
     fn align_self(&self) -> Option<AlignSelf> {
         (*self).align_self()
+    }
+    #[inline(always)]
+    fn order(&self) -> i32 {
+        (*self).order()
     }
 }
 
@@ -1081,6 +1102,10 @@ impl<S: CheapCloneStr> GridItemStyle for Style<S> {
     fn justify_self(&self) -> Option<AlignSelf> {
         self.justify_self
     }
+    #[inline(always)]
+    fn order(&self) -> i32 {
+        self.order
+    }
 }
 
 #[cfg(feature = "grid")]
@@ -1100,6 +1125,10 @@ impl<T: GridItemStyle> GridItemStyle for &'_ T {
     #[inline(always)]
     fn justify_self(&self) -> Option<AlignSelf> {
         (*self).justify_self()
+    }
+    #[inline(always)]
+    fn order(&self) -> i32 {
+        (*self).order()
     }
 }
 
@@ -1158,6 +1187,8 @@ mod tests {
             flex_shrink: 1.0,
             #[cfg(feature = "flexbox")]
             flex_basis: super::Dimension::AUTO,
+            #[cfg(any(feature = "flexbox", feature = "grid"))]
+            order: 0,
             size: Size::auto(),
             min_size: Size::auto(),
             max_size: Size::auto(),
@@ -1252,12 +1283,12 @@ mod tests {
         assert_type_size::<GridTemplateComponent<String>>(56);
         assert_type_size::<GridPlacement<String>>(32);
         assert_type_size::<Line<GridPlacement<String>>>(64);
-        assert_type_size::<Style<String>>(536);
+        assert_type_size::<Style<String>>(544);
 
         // String-type dependent (Arc<str>)
         assert_type_size::<GridTemplateComponent<Arc<str>>>(56);
         assert_type_size::<GridPlacement<Arc<str>>>(24);
         assert_type_size::<Line<GridPlacement<Arc<str>>>>(48);
-        assert_type_size::<Style<Arc<str>>>(504);
+        assert_type_size::<Style<Arc<str>>>(512);
     }
 }

--- a/tests/order.rs
+++ b/tests/order.rs
@@ -1,0 +1,348 @@
+#[cfg(test)]
+mod order {
+    use taffy::prelude::*;
+    use taffy_test_helpers::new_test_tree;
+
+    #[cfg(feature = "flexbox")]
+    mod flex {
+        use super::*;
+
+        #[test]
+        fn flex_order_reorders_items() {
+            let mut taffy = new_test_tree();
+
+            // Three children with order: 2, 0, 1
+            // Visual order should be: child_b (0), child_c (1), child_a (2)
+            let child_a = taffy
+                .new_leaf(Style {
+                    size: Size { width: Dimension::from_length(50.0), height: Dimension::from_length(50.0) },
+                    order: 2,
+                    ..Default::default()
+                })
+                .unwrap();
+
+            let child_b = taffy
+                .new_leaf(Style {
+                    size: Size { width: Dimension::from_length(50.0), height: Dimension::from_length(50.0) },
+                    order: 0,
+                    ..Default::default()
+                })
+                .unwrap();
+
+            let child_c = taffy
+                .new_leaf(Style {
+                    size: Size { width: Dimension::from_length(50.0), height: Dimension::from_length(50.0) },
+                    order: 1,
+                    ..Default::default()
+                })
+                .unwrap();
+
+            let container = taffy
+                .new_with_children(
+                    Style {
+                        display: Display::Flex,
+                        flex_direction: FlexDirection::Row,
+                        size: Size { width: Dimension::from_length(300.0), height: Dimension::from_length(100.0) },
+                        ..Default::default()
+                    },
+                    &[child_a, child_b, child_c],
+                )
+                .unwrap();
+
+            taffy
+                .compute_layout(
+                    container,
+                    Size { width: AvailableSpace::Definite(300.0), height: AvailableSpace::Definite(100.0) },
+                )
+                .unwrap();
+
+            // child_b (order: 0) should be first (x=0)
+            // child_c (order: 1) should be second (x=50)
+            // child_a (order: 2) should be third (x=100)
+            let layout_a = taffy.layout(child_a).unwrap();
+            let layout_b = taffy.layout(child_b).unwrap();
+            let layout_c = taffy.layout(child_c).unwrap();
+
+            assert_eq!(layout_b.location.x, 0.0, "child_b (order: 0) should be at x=0");
+            assert_eq!(layout_c.location.x, 50.0, "child_c (order: 1) should be at x=50");
+            assert_eq!(layout_a.location.x, 100.0, "child_a (order: 2) should be at x=100");
+
+            // Layout.order reflects visual position
+            assert_eq!(layout_b.order, 0, "child_b should have visual order 0");
+            assert_eq!(layout_c.order, 1, "child_c should have visual order 1");
+            assert_eq!(layout_a.order, 2, "child_a should have visual order 2");
+        }
+
+        #[test]
+        fn flex_order_preserves_source_order_for_equal_values() {
+            let mut taffy = new_test_tree();
+
+            // All children have default order (0) — should maintain source order
+            let child_a = taffy
+                .new_leaf(Style {
+                    size: Size { width: Dimension::from_length(50.0), height: Dimension::from_length(50.0) },
+                    ..Default::default()
+                })
+                .unwrap();
+
+            let child_b = taffy
+                .new_leaf(Style {
+                    size: Size { width: Dimension::from_length(50.0), height: Dimension::from_length(50.0) },
+                    ..Default::default()
+                })
+                .unwrap();
+
+            let child_c = taffy
+                .new_leaf(Style {
+                    size: Size { width: Dimension::from_length(50.0), height: Dimension::from_length(50.0) },
+                    ..Default::default()
+                })
+                .unwrap();
+
+            let container = taffy
+                .new_with_children(
+                    Style {
+                        display: Display::Flex,
+                        flex_direction: FlexDirection::Row,
+                        size: Size { width: Dimension::from_length(300.0), height: Dimension::from_length(100.0) },
+                        ..Default::default()
+                    },
+                    &[child_a, child_b, child_c],
+                )
+                .unwrap();
+
+            taffy
+                .compute_layout(
+                    container,
+                    Size { width: AvailableSpace::Definite(300.0), height: AvailableSpace::Definite(100.0) },
+                )
+                .unwrap();
+
+            // Source order preserved: a=0, b=50, c=100
+            assert_eq!(taffy.layout(child_a).unwrap().location.x, 0.0);
+            assert_eq!(taffy.layout(child_b).unwrap().location.x, 50.0);
+            assert_eq!(taffy.layout(child_c).unwrap().location.x, 100.0);
+        }
+
+        #[test]
+        fn flex_order_mixed_positive_negative() {
+            let mut taffy = new_test_tree();
+
+            // Items with order: 1, -2, 0, -1, 3
+            // Expected visual order: -2, -1, 0, 1, 3
+            let children: Vec<_> = [1, -2, 0, -1, 3]
+                .iter()
+                .map(|&ord| {
+                    taffy
+                        .new_leaf(Style {
+                            size: Size { width: Dimension::from_length(20.0), height: Dimension::from_length(20.0) },
+                            order: ord,
+                            ..Default::default()
+                        })
+                        .unwrap()
+                })
+                .collect();
+
+            let container = taffy
+                .new_with_children(
+                    Style {
+                        display: Display::Flex,
+                        flex_direction: FlexDirection::Row,
+                        size: Size { width: Dimension::from_length(200.0), height: Dimension::from_length(50.0) },
+                        ..Default::default()
+                    },
+                    &children,
+                )
+                .unwrap();
+
+            taffy
+                .compute_layout(
+                    container,
+                    Size { width: AvailableSpace::Definite(200.0), height: AvailableSpace::Definite(50.0) },
+                )
+                .unwrap();
+
+            // Visual order: children[1](-2), children[3](-1), children[2](0), children[0](1), children[4](3)
+            assert_eq!(taffy.layout(children[1]).unwrap().location.x, 0.0, "order -2 at x=0");
+            assert_eq!(taffy.layout(children[3]).unwrap().location.x, 20.0, "order -1 at x=20");
+            assert_eq!(taffy.layout(children[2]).unwrap().location.x, 40.0, "order 0 at x=40");
+            assert_eq!(taffy.layout(children[0]).unwrap().location.x, 60.0, "order 1 at x=60");
+            assert_eq!(taffy.layout(children[4]).unwrap().location.x, 80.0, "order 3 at x=80");
+        }
+
+        #[test]
+        fn flex_order_negative_values() {
+            let mut taffy = new_test_tree();
+
+            let child_a = taffy
+                .new_leaf(Style {
+                    size: Size { width: Dimension::from_length(50.0), height: Dimension::from_length(50.0) },
+                    order: 0,
+                    ..Default::default()
+                })
+                .unwrap();
+
+            let child_b = taffy
+                .new_leaf(Style {
+                    size: Size { width: Dimension::from_length(50.0), height: Dimension::from_length(50.0) },
+                    order: -1,
+                    ..Default::default()
+                })
+                .unwrap();
+
+            let container = taffy
+                .new_with_children(
+                    Style {
+                        display: Display::Flex,
+                        flex_direction: FlexDirection::Row,
+                        size: Size { width: Dimension::from_length(300.0), height: Dimension::from_length(100.0) },
+                        ..Default::default()
+                    },
+                    &[child_a, child_b],
+                )
+                .unwrap();
+
+            taffy
+                .compute_layout(
+                    container,
+                    Size { width: AvailableSpace::Definite(300.0), height: AvailableSpace::Definite(100.0) },
+                )
+                .unwrap();
+
+            // child_b (order: -1) comes before child_a (order: 0)
+            assert_eq!(taffy.layout(child_b).unwrap().location.x, 0.0, "child_b (order: -1) should be first");
+            assert_eq!(taffy.layout(child_a).unwrap().location.x, 50.0, "child_a (order: 0) should be second");
+        }
+    }
+
+    #[cfg(feature = "grid")]
+    mod grid {
+        use super::*;
+
+        #[test]
+        fn grid_order_reorders_auto_placed_items() {
+            let mut taffy = new_test_tree();
+
+            // Three auto-placed children with order: 2, 0, 1
+            // Grid auto-placement should place them in order-modified document order
+            let child_a = taffy
+                .new_leaf(Style {
+                    size: Size { width: Dimension::from_length(50.0), height: Dimension::from_length(50.0) },
+                    order: 2,
+                    ..Default::default()
+                })
+                .unwrap();
+
+            let child_b = taffy
+                .new_leaf(Style {
+                    size: Size { width: Dimension::from_length(50.0), height: Dimension::from_length(50.0) },
+                    order: 0,
+                    ..Default::default()
+                })
+                .unwrap();
+
+            let child_c = taffy
+                .new_leaf(Style {
+                    size: Size { width: Dimension::from_length(50.0), height: Dimension::from_length(50.0) },
+                    order: 1,
+                    ..Default::default()
+                })
+                .unwrap();
+
+            let container = taffy
+                .new_with_children(
+                    Style {
+                        display: Display::Grid,
+                        grid_template_columns: vec![
+                            GridTemplateComponent::from_length(50.0),
+                            GridTemplateComponent::from_length(50.0),
+                            GridTemplateComponent::from_length(50.0),
+                        ],
+                        size: Size { width: Dimension::from_length(150.0), height: Dimension::AUTO },
+                        ..Default::default()
+                    },
+                    &[child_a, child_b, child_c],
+                )
+                .unwrap();
+
+            taffy
+                .compute_layout(
+                    container,
+                    Size { width: AvailableSpace::Definite(150.0), height: AvailableSpace::Definite(200.0) },
+                )
+                .unwrap();
+
+            // Auto-placement in order-modified document order:
+            // child_b (order: 0) -> column 1 (x=0)
+            // child_c (order: 1) -> column 2 (x=50)
+            // child_a (order: 2) -> column 3 (x=100)
+            let layout_a = taffy.layout(child_a).unwrap();
+            let layout_b = taffy.layout(child_b).unwrap();
+            let layout_c = taffy.layout(child_c).unwrap();
+
+            assert_eq!(layout_b.location.x, 0.0, "child_b (order: 0) should be in column 1");
+            assert_eq!(layout_c.location.x, 50.0, "child_c (order: 1) should be in column 2");
+            assert_eq!(layout_a.location.x, 100.0, "child_a (order: 2) should be in column 3");
+
+            // Layout.order reflects CSS order-modified visual position
+            assert_eq!(layout_b.order, 0, "child_b should have visual order 0");
+            assert_eq!(layout_c.order, 1, "child_c should have visual order 1");
+            assert_eq!(layout_a.order, 2, "child_a should have visual order 2");
+        }
+
+        #[test]
+        fn grid_order_preserves_source_order_for_equal_values() {
+            let mut taffy = new_test_tree();
+
+            // Three auto-placed children with same order (0) — source order must be preserved
+            let child_a = taffy
+                .new_leaf(Style {
+                    size: Size { width: Dimension::from_length(50.0), height: Dimension::from_length(50.0) },
+                    ..Default::default()
+                })
+                .unwrap();
+
+            let child_b = taffy
+                .new_leaf(Style {
+                    size: Size { width: Dimension::from_length(50.0), height: Dimension::from_length(50.0) },
+                    ..Default::default()
+                })
+                .unwrap();
+
+            let child_c = taffy
+                .new_leaf(Style {
+                    size: Size { width: Dimension::from_length(50.0), height: Dimension::from_length(50.0) },
+                    ..Default::default()
+                })
+                .unwrap();
+
+            let container = taffy
+                .new_with_children(
+                    Style {
+                        display: Display::Grid,
+                        grid_template_columns: vec![
+                            GridTemplateComponent::from_length(50.0),
+                            GridTemplateComponent::from_length(50.0),
+                            GridTemplateComponent::from_length(50.0),
+                        ],
+                        size: Size { width: Dimension::from_length(150.0), height: Dimension::AUTO },
+                        ..Default::default()
+                    },
+                    &[child_a, child_b, child_c],
+                )
+                .unwrap();
+
+            taffy
+                .compute_layout(
+                    container,
+                    Size { width: AvailableSpace::Definite(150.0), height: AvailableSpace::Definite(200.0) },
+                )
+                .unwrap();
+
+            // Source order preserved: a=col1, b=col2, c=col3
+            assert_eq!(taffy.layout(child_a).unwrap().location.x, 0.0);
+            assert_eq!(taffy.layout(child_b).unwrap().location.x, 50.0);
+            assert_eq!(taffy.layout(child_c).unwrap().location.x, 100.0);
+        }
+    }
+}


### PR DESCRIPTION
# Objective                                                                                                                                                                                   
                                                                                                                                                                                                
  Implement the CSS `order` property for flex and grid items, as defined in [CSS Display Module Level 3 §3](https://www.w3.org/TR/css-display-3/#order-property).                               
                  
  This allows users to control the visual ordering of flex and grid children independently of their source (DOM) order, which is a commonly expected CSS feature that taffy was missing.        

  ## Context

  The CSS `order` property is an integer (default `0`) that controls:
  - **Flexbox** (§5.4): The order in which flex items appear within their flex container during layout.
  - **CSS Grid** (§6.3): The order-modified document order used during auto-placement.

  Items with lower `order` values are laid out first. Items with equal `order` values preserve their source order (stable sort).

  ### Changes

  - Added `order: i32` field to `Style` (gated behind `flexbox` or `grid` features)
  - Added `order()` method to both `FlexboxItemStyle` and `GridItemStyle` traits (defaults to `0` for backwards compatibility)
  - **Flexbox**: After generating flex items, stable-sort them by `order` and reassign visual indices
  - **Grid**: Sort children by `order` before auto-placement, assign visual order before track sizing
  - Added `order` field to `GridItem` to carry visual order through to final positioning
  - Comprehensive tests covering reordering, source-order stability, and negative values for both flex and grid

  ## Feedback wanted

  The `order` property is defined once in CSS Display Level 3 but applies to both flex and grid contexts. I added `order()` to both `FlexboxItemStyle` and `GridItemStyle` traits separately
  (each defaulting to `0`) rather than pulling it into `CoreStyle`. This avoids a larger trait refactor while keeping backwards compatibility for custom style implementations. Open to feedback on whether a shared trait approach would be preferred.