### PR TITLE
Use `&LayoutInput` in cache APIs

### DIFF
--- a/examples/custom_tree_owned_partial.rs
+++ b/examples/custom_tree_owned_partial.rs
@@ -187,25 +187,12 @@ impl taffy::LayoutPartialTree for Node {
 }
 
 impl CacheTree for Node {
-    fn cache_get(
-        &self,
-        node_id: NodeId,
-        known_dimensions: Size<Option<f32>>,
-        available_space: Size<AvailableSpace>,
-        run_mode: taffy::RunMode,
-    ) -> Option<taffy::LayoutOutput> {
-        self.node_from_id(node_id).cache.get(known_dimensions, available_space, run_mode)
+    fn cache_get(&self, node_id: NodeId, inputs: &taffy::LayoutInput) -> Option<taffy::LayoutOutput> {
+        self.node_from_id(node_id).cache.get(inputs)
     }
 
-    fn cache_store(
-        &mut self,
-        node_id: NodeId,
-        known_dimensions: Size<Option<f32>>,
-        available_space: Size<AvailableSpace>,
-        run_mode: taffy::RunMode,
-        layout_output: taffy::LayoutOutput,
-    ) {
-        self.node_from_id_mut(node_id).cache.store(known_dimensions, available_space, run_mode, layout_output)
+    fn cache_store(&mut self, node_id: NodeId, inputs: &taffy::LayoutInput, layout_output: taffy::LayoutOutput) {
+        self.node_from_id_mut(node_id).cache.store(inputs, layout_output)
     }
 
     fn cache_clear(&mut self, node_id: NodeId) {

--- a/examples/custom_tree_owned_unsafe.rs
+++ b/examples/custom_tree_owned_unsafe.rs
@@ -185,25 +185,12 @@ impl LayoutPartialTree for StatelessLayoutTree {
 }
 
 impl CacheTree for StatelessLayoutTree {
-    fn cache_get(
-        &self,
-        node_id: NodeId,
-        known_dimensions: Size<Option<f32>>,
-        available_space: Size<AvailableSpace>,
-        run_mode: taffy::RunMode,
-    ) -> Option<taffy::LayoutOutput> {
-        unsafe { node_from_id(node_id) }.cache.get(known_dimensions, available_space, run_mode)
+    fn cache_get(&self, node_id: NodeId, inputs: &taffy::LayoutInput) -> Option<taffy::LayoutOutput> {
+        unsafe { node_from_id(node_id) }.cache.get(inputs)
     }
 
-    fn cache_store(
-        &mut self,
-        node_id: NodeId,
-        known_dimensions: Size<Option<f32>>,
-        available_space: Size<AvailableSpace>,
-        run_mode: taffy::RunMode,
-        layout_output: taffy::LayoutOutput,
-    ) {
-        unsafe { node_from_id_mut(node_id) }.cache.store(known_dimensions, available_space, run_mode, layout_output)
+    fn cache_store(&mut self, node_id: NodeId, inputs: &taffy::LayoutInput, layout_output: taffy::LayoutOutput) {
+        unsafe { node_from_id_mut(node_id) }.cache.store(inputs, layout_output)
     }
 
     fn cache_clear(&mut self, node_id: NodeId) {

--- a/examples/custom_tree_vec.rs
+++ b/examples/custom_tree_vec.rs
@@ -193,25 +193,12 @@ impl taffy::LayoutPartialTree for Tree {
 }
 
 impl CacheTree for Tree {
-    fn cache_get(
-        &self,
-        node_id: NodeId,
-        known_dimensions: Size<Option<f32>>,
-        available_space: Size<AvailableSpace>,
-        run_mode: taffy::RunMode,
-    ) -> Option<taffy::LayoutOutput> {
-        self.node_from_id(node_id).cache.get(known_dimensions, available_space, run_mode)
+    fn cache_get(&self, node_id: NodeId, inputs: &taffy::LayoutInput) -> Option<taffy::LayoutOutput> {
+        self.node_from_id(node_id).cache.get(inputs)
     }
 
-    fn cache_store(
-        &mut self,
-        node_id: NodeId,
-        known_dimensions: Size<Option<f32>>,
-        available_space: Size<AvailableSpace>,
-        run_mode: taffy::RunMode,
-        layout_output: taffy::LayoutOutput,
-    ) {
-        self.node_from_id_mut(node_id).cache.store(known_dimensions, available_space, run_mode, layout_output)
+    fn cache_store(&mut self, node_id: NodeId, inputs: &taffy::LayoutInput, layout_output: taffy::LayoutOutput) {
+        self.node_from_id_mut(node_id).cache.store(inputs, layout_output)
     }
 
     fn cache_clear(&mut self, node_id: NodeId) {

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -181,23 +181,22 @@ where
     ComputeFunction: FnOnce(&mut Tree, NodeId, LayoutInput) -> LayoutOutput,
 {
     debug_push_node!(node);
-    let LayoutInput { known_dimensions, available_space, run_mode, .. } = inputs;
 
     // First we check if we have a cached result for the given input
-    let cache_entry = tree.cache_get(node, known_dimensions, available_space, run_mode);
+    let cache_entry = tree.cache_get(node, &inputs);
     if let Some(cached_size_and_baselines) = cache_entry {
-        debug_log_node!(known_dimensions, inputs.parent_size, available_space, run_mode, inputs.sizing_mode);
+        debug_log_node!(inputs);
         debug_log!("RESULT (CACHED)", dbg:cached_size_and_baselines.size);
         debug_pop_node!();
         return cached_size_and_baselines;
     }
 
-    debug_log_node!(known_dimensions, inputs.parent_size, available_space, run_mode, inputs.sizing_mode);
+    debug_log_node!(inputs);
 
     let computed_size_and_baselines = compute_uncached(tree, node, inputs);
 
     // Cache result
-    tree.cache_store(node, known_dimensions, available_space, run_mode, computed_size_and_baselines);
+    tree.cache_store(node, &inputs, computed_size_and_baselines);
 
     debug_log!("RESULT", dbg:computed_size_and_baselines.size);
     debug_pop_node!();

--- a/src/tree/cache.rs
+++ b/src/tree/cache.rs
@@ -1,7 +1,7 @@
 //! A cache for storing the results of layout computation
 use crate::geometry::Size;
 use crate::style::AvailableSpace;
-use crate::tree::{LayoutOutput, RunMode};
+use crate::tree::{LayoutInput, LayoutOutput, RunMode};
 
 /// The number of cache entries for each node in the tree
 const CACHE_SIZE: usize = 9;
@@ -108,13 +108,11 @@ impl Cache {
 
     /// Try to retrieve a cached result from the cache
     #[inline]
-    pub fn get(
-        &self,
-        known_dimensions: Size<Option<f32>>,
-        available_space: Size<AvailableSpace>,
-        run_mode: RunMode,
-    ) -> Option<LayoutOutput> {
-        match run_mode {
+    pub fn get(&self, input: &LayoutInput) -> Option<LayoutOutput> {
+        let known_dimensions = input.known_dimensions;
+        let available_space = input.available_space;
+
+        match input.run_mode {
             RunMode::PerformLayout => self
                 .final_layout_entry
                 .filter(|entry| {
@@ -153,14 +151,11 @@ impl Cache {
     }
 
     /// Store a computed size in the cache
-    pub fn store(
-        &mut self,
-        known_dimensions: Size<Option<f32>>,
-        available_space: Size<AvailableSpace>,
-        run_mode: RunMode,
-        layout_output: LayoutOutput,
-    ) {
-        match run_mode {
+    pub fn store(&mut self, input: &LayoutInput, layout_output: LayoutOutput) {
+        let known_dimensions = input.known_dimensions;
+        let available_space = input.available_space;
+
+        match input.run_mode {
             RunMode::PerformLayout => {
                 self.is_empty = false;
                 self.final_layout_entry = Some(CacheEntry { known_dimensions, available_space, content: layout_output })

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -210,25 +210,12 @@ impl<NodeContext> TraverseTree for TaffyTree<NodeContext> {}
 
 // CacheTree impl for TaffyTree
 impl<NodeContext> CacheTree for TaffyTree<NodeContext> {
-    fn cache_get(
-        &self,
-        node_id: NodeId,
-        known_dimensions: Size<Option<f32>>,
-        available_space: Size<AvailableSpace>,
-        run_mode: RunMode,
-    ) -> Option<LayoutOutput> {
-        self.nodes[node_id.into()].cache.get(known_dimensions, available_space, run_mode)
+    fn cache_get(&self, node_id: NodeId, input: &LayoutInput) -> Option<LayoutOutput> {
+        self.nodes[node_id.into()].cache.get(input)
     }
 
-    fn cache_store(
-        &mut self,
-        node_id: NodeId,
-        known_dimensions: Size<Option<f32>>,
-        available_space: Size<AvailableSpace>,
-        run_mode: RunMode,
-        layout_output: LayoutOutput,
-    ) {
-        self.nodes[node_id.into()].cache.store(known_dimensions, available_space, run_mode, layout_output)
+    fn cache_store(&mut self, node_id: NodeId, input: &LayoutInput, layout_output: LayoutOutput) {
+        self.nodes[node_id.into()].cache.store(input, layout_output)
     }
 
     fn cache_clear(&mut self, node_id: NodeId) {
@@ -317,13 +304,7 @@ where
             let has_children = tree.child_count(node_id) > 0;
 
             debug_log!(display_mode);
-            debug_log_node!(
-                inputs.known_dimensions,
-                inputs.parent_size,
-                inputs.available_space,
-                inputs.run_mode,
-                inputs.sizing_mode
-            );
+            debug_log_node!(inputs);
 
             // Dispatch to a layout algorithm based on the node's display style and whether the node has children or not.
             match (display_mode, has_children) {
@@ -427,25 +408,12 @@ where
     MeasureFunction:
         FnMut(Size<Option<f32>>, Size<AvailableSpace>, NodeId, Option<&mut NodeContext>, &Style) -> Size<f32>,
 {
-    fn cache_get(
-        &self,
-        node_id: NodeId,
-        known_dimensions: Size<Option<f32>>,
-        available_space: Size<AvailableSpace>,
-        run_mode: RunMode,
-    ) -> Option<LayoutOutput> {
-        self.taffy.nodes[node_id.into()].cache.get(known_dimensions, available_space, run_mode)
+    fn cache_get(&self, node_id: NodeId, input: &LayoutInput) -> Option<LayoutOutput> {
+        self.taffy.nodes[node_id.into()].cache.get(input)
     }
 
-    fn cache_store(
-        &mut self,
-        node_id: NodeId,
-        known_dimensions: Size<Option<f32>>,
-        available_space: Size<AvailableSpace>,
-        run_mode: RunMode,
-        layout_output: LayoutOutput,
-    ) {
-        self.taffy.nodes[node_id.into()].cache.store(known_dimensions, available_space, run_mode, layout_output)
+    fn cache_store(&mut self, node_id: NodeId, input: &LayoutInput, layout_output: LayoutOutput) {
+        self.taffy.nodes[node_id.into()].cache.store(input, layout_output)
     }
 
     fn cache_clear(&mut self, node_id: NodeId) {

--- a/src/tree/traits.rs
+++ b/src/tree/traits.rs
@@ -205,23 +205,10 @@ pub trait LayoutPartialTree: TraversePartialTree {
 /// The `Cache` struct implements a per-node cache that is compatible with this trait.
 pub trait CacheTree {
     /// Try to retrieve a cached result from the cache
-    fn cache_get(
-        &self,
-        node_id: NodeId,
-        known_dimensions: Size<Option<f32>>,
-        available_space: Size<AvailableSpace>,
-        run_mode: RunMode,
-    ) -> Option<LayoutOutput>;
+    fn cache_get(&self, node_id: NodeId, input: &LayoutInput) -> Option<LayoutOutput>;
 
     /// Store a computed size in the cache
-    fn cache_store(
-        &mut self,
-        node_id: NodeId,
-        known_dimensions: Size<Option<f32>>,
-        available_space: Size<AvailableSpace>,
-        run_mode: RunMode,
-        layout_output: LayoutOutput,
-    );
+    fn cache_store(&mut self, node_id: NodeId, input: &LayoutInput, layout_output: LayoutOutput);
 
     /// Clear all cache entries for the node
     fn cache_clear(&mut self, node_id: NodeId);

--- a/src/util/debug.rs
+++ b/src/util/debug.rs
@@ -96,12 +96,12 @@ macro_rules! debug_log {
 }
 
 macro_rules! debug_log_node {
-    ($known_dimensions: expr, $parent_size: expr, $available_space: expr, $run_mode: expr, $sizing_mode: expr) => {
-        debug_log!(dbg:$run_mode);
-        debug_log!("sizing_mode", dbg:$sizing_mode);
-        debug_log!("known_dimensions", dbg:$known_dimensions);
-        debug_log!("parent_size", dbg:$parent_size);
-        debug_log!("available_space", dbg:$available_space);
+    ($inputs: expr) => {
+        debug_log!(dbg:$inputs.run_mode);
+        debug_log!("sizing_mode", dbg:$inputs.sizing_mode);
+        debug_log!("known_dimensions", dbg:$inputs.known_dimensions);
+        debug_log!("parent_size", dbg:$inputs.parent_size);
+        debug_log!("available_space", dbg:$inputs.available_space);
     };
 }
 


### PR DESCRIPTION
# Objective

- Simplify the API signature
- Allow the caching logic to experiment with different cache keys without breaking the API.

## Context

We have some issues with cache invalidation (we're not invalidating aggressively enough and this is leading to incremental layout bugs), and will likely need to add more parts of `LayoutInput` to the cache key. This PR passes the entire `&LayoutInput` into the cache `get` and `set` methods, which will allow those functions to internally manage which parts of the key they need.
