### PR TITLE
Block layout: only "measure" children (don't run full layout) in the measure phase of a block container

### DIFF
--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -330,7 +330,13 @@ fn compute_inner(
     #[allow(unused_mut)] mut block_ctx: &mut BlockContext<'_>,
 ) -> LayoutOutput {
     let LayoutInput {
-        known_dimensions, parent_size, available_space, run_mode, vertical_margins_are_collapsible, ..
+        axis,
+        known_dimensions,
+        parent_size,
+        available_space,
+        run_mode,
+        vertical_margins_are_collapsible,
+        ..
     } = inputs;
 
     let style = tree.get_block_container_style(node_id);
@@ -425,8 +431,11 @@ fn compute_inner(
     });
 
     // Short-circuit if computing size and both dimensions known
-    if let (RunMode::ComputeSize, Some(container_outer_height)) = (run_mode, known_dimensions.height) {
-        return LayoutOutput::from_outer_size(Size { width: container_outer_width, height: container_outer_height });
+    if run_mode == RunMode::ComputeSize && (axis == RequestedAxis::Horizontal || known_dimensions.height.is_some()) {
+        return LayoutOutput::from_outer_size(Size {
+            width: container_outer_width,
+            height: known_dimensions.height.unwrap_or(0.0),
+        });
     }
 
     let container_percentage_resolution_height =
@@ -628,16 +637,15 @@ fn determine_content_based_container_width(
             .resolve_or_zero(available_space.width.into_option(), |val, basis| tree.calc(val, basis))
             .horizontal_axis_sum();
         let width = known_dimensions.width.unwrap_or_else(|| {
-            let size_and_baselines = tree.perform_child_layout(
+            tree.measure_child_size(
                 item.node_id,
                 known_dimensions,
                 Size::NONE,
                 available_space.map_width(|w| w.maybe_sub(item_x_margin_sum)),
                 SizingMode::InherentSize,
+                crate::AbsoluteAxis::Horizontal,
                 Line::TRUE,
-            );
-
-            size_and_baselines.size.width
+            )
         });
 
         let width = f32_max(width, item.padding_border_sum.width) + item_x_margin_sum;

--- a/src/tree/cache.rs
+++ b/src/tree/cache.rs
@@ -3,6 +3,8 @@ use crate::geometry::Size;
 use crate::style::AvailableSpace;
 use crate::tree::{LayoutInput, LayoutOutput, RunMode};
 
+use crate::RequestedAxis;
+
 /// The number of cache entries for each node in the tree
 const CACHE_SIZE: usize = 9;
 
@@ -14,6 +16,8 @@ pub(crate) struct CacheEntry<T> {
     known_dimensions: Size<Option<f32>>,
     /// The initial cached size of the parent's node
     available_space: Size<AvailableSpace>,
+    /// The initial cached size of the parent's node
+    axis: RequestedAxis,
     /// The cached size and baselines of the item
     content: T,
 }
@@ -125,6 +129,7 @@ impl Cache {
                             || entry.available_space.width.is_roughly_equal(available_space.width))
                         && (known_dimensions.height.is_some()
                             || entry.available_space.height.is_roughly_equal(available_space.height))
+                        && input.axis == entry.axis
                 })
                 .map(|e| e.content),
             RunMode::ComputeSize => {
@@ -139,6 +144,7 @@ impl Cache {
                             || entry.available_space.width.is_roughly_equal(available_space.width))
                         && (known_dimensions.height.is_some()
                             || entry.available_space.height.is_roughly_equal(available_space.height))
+                        && input.axis == entry.axis
                     {
                         return Some(LayoutOutput::from_outer_size(cached_size));
                     }
@@ -154,17 +160,19 @@ impl Cache {
     pub fn store(&mut self, input: &LayoutInput, layout_output: LayoutOutput) {
         let known_dimensions = input.known_dimensions;
         let available_space = input.available_space;
+        let axis = input.axis;
 
         match input.run_mode {
             RunMode::PerformLayout => {
                 self.is_empty = false;
-                self.final_layout_entry = Some(CacheEntry { known_dimensions, available_space, content: layout_output })
+                self.final_layout_entry =
+                    Some(CacheEntry { axis, known_dimensions, available_space, content: layout_output })
             }
             RunMode::ComputeSize => {
                 self.is_empty = false;
                 let cache_slot = Self::compute_cache_slot(known_dimensions, available_space);
                 self.measure_entries[cache_slot] =
-                    Some(CacheEntry { known_dimensions, available_space, content: layout_output.size });
+                    Some(CacheEntry { axis, known_dimensions, available_space, content: layout_output.size });
             }
             RunMode::PerformHiddenLayout => {}
         }

--- a/src/tree/cache.rs
+++ b/src/tree/cache.rs
@@ -1,25 +1,92 @@
 //! A cache for storing the results of layout computation
+
+#![allow(clippy::unusual_byte_groupings)]
+
 use crate::geometry::Size;
 use crate::style::AvailableSpace;
 use crate::tree::{LayoutInput, LayoutOutput, RunMode};
-
 use crate::RequestedAxis;
 
 /// The number of cache entries for each node in the tree
 const CACHE_SIZE: usize = 9;
 
+// Manually written-out results of float to u32 bit casts because
+// `f32::to_bits` is not yet const at our MSRV.
+
+/// `f32::INFINITY` as a u32
+const INFINITY_BITS: u32 = 0b_0_11111111_00000000000000000000000_u32;
+/// A positive NaN f32 values as a u32
+const SPECIFIC_NAN_BITS: u32 = 0b0_11111111_10000000000000000000001_u32;
+
+/// Pack `Option<f32>` into `u32`
+#[inline(always)]
+fn option_cache_key(input: Option<f32>) -> u32 {
+    match input {
+        Some(value) => value.to_bits(),
+        None => INFINITY_BITS,
+    }
+}
+
+/// Pack `Size<Option<f32>>` into `u64`
+#[inline(always)]
+fn size_option_cache_key(input: Size<Option<f32>>) -> u64 {
+    (option_cache_key(input.width) as u64) << 32 | option_cache_key(input.height) as u64
+}
+
+/// Pack `AvailableSpace` into `u32`
+#[inline(always)]
+fn available_space_cache_key(input: AvailableSpace) -> u32 {
+    match input {
+        AvailableSpace::Definite(value) => value.to_bits(),
+        AvailableSpace::MinContent => SPECIFIC_NAN_BITS,
+        AvailableSpace::MaxContent => INFINITY_BITS,
+    }
+}
+
+/// Pack `Size<AvailableSpace>` into `u64`
+#[inline(always)]
+fn size_available_space_cache_key(input: Size<AvailableSpace>) -> u64 {
+    (available_space_cache_key(input.width) as u64) << 32 | available_space_cache_key(input.height) as u64
+}
+
+/// Space-optimised cache key that packs bits into as small a size as possible
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+struct CacheKey {
+    /// The initial cached size of the node itself
+    known_dimensions: u64,
+    /// The initial cached size of the parent's node
+    available_space: u64,
+    /// The initial cached size of the parent's node
+    parent_size: u64,
+}
+
+impl From<&LayoutInput> for CacheKey {
+    fn from(input: &LayoutInput) -> Self {
+        // Pack axis enum into spare bits in the known_dimensions and available_space values
+        const ONE: u64 = 1u64 << 63;
+        const ZERO: u64 = 0;
+        const MASK: u64 = !ONE;
+        let (kd_mask, as_mask) = match input.axis {
+            RequestedAxis::Horizontal => (ONE, ZERO),
+            RequestedAxis::Vertical => (ZERO, ONE),
+            RequestedAxis::Both => (ONE, ONE),
+        };
+
+        Self {
+            known_dimensions: (size_option_cache_key(input.known_dimensions) & MASK) | kd_mask,
+            available_space: (size_available_space_cache_key(input.available_space) & MASK) | as_mask,
+            parent_size: size_option_cache_key(input.parent_size),
+        }
+    }
+}
+
 /// Cached intermediate layout results
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 pub(crate) struct CacheEntry<T> {
-    /// The initial cached size of the node itself
-    known_dimensions: Size<Option<f32>>,
-    /// The initial cached size of the parent's node
-    available_space: Size<AvailableSpace>,
-    /// The initial cached size of the parent's node
-    axis: RequestedAxis,
-    /// The initial cached size of the parent's node
-    parent_size: Size<Option<f32>>,
+    /// The key for the cache entry
+    key: CacheKey,
     /// The cached size and baselines of the item
     content: T,
 }
@@ -115,41 +182,15 @@ impl Cache {
     /// Try to retrieve a cached result from the cache
     #[inline]
     pub fn get(&self, input: &LayoutInput) -> Option<LayoutOutput> {
-        let known_dimensions = input.known_dimensions;
-        let available_space = input.available_space;
-
+        let key = CacheKey::from(input);
         match input.run_mode {
-            RunMode::PerformLayout => self
-                .final_layout_entry
-                .filter(|entry| {
-                    let cached_size = entry.content.size;
-                    (known_dimensions.width == entry.known_dimensions.width
-                        || known_dimensions.width == Some(cached_size.width))
-                        && (known_dimensions.height == entry.known_dimensions.height
-                            || known_dimensions.height == Some(cached_size.height))
-                        && (known_dimensions.width.is_some()
-                            || entry.available_space.width.is_roughly_equal(available_space.width))
-                        && (known_dimensions.height.is_some()
-                            || entry.available_space.height.is_roughly_equal(available_space.height))
-                        && input.axis == entry.axis
-                        && input.parent_size == entry.parent_size
-                })
-                .map(|e| e.content),
+            RunMode::PerformLayout => self.final_layout_entry.filter(|entry| entry.key == key).map(|e| e.content),
             RunMode::ComputeSize => {
                 for entry in self.measure_entries.iter().flatten() {
-                    let cached_size = entry.content;
-
-                    if (known_dimensions.width == entry.known_dimensions.width
-                        || known_dimensions.width == Some(cached_size.width))
-                        && (known_dimensions.height == entry.known_dimensions.height
-                            || known_dimensions.height == Some(cached_size.height))
-                        && (known_dimensions.width.is_some()
-                            || entry.available_space.width.is_roughly_equal(available_space.width))
-                        && (known_dimensions.height.is_some()
-                            || entry.available_space.height.is_roughly_equal(available_space.height))
-                        && input.axis == entry.axis
+                    if entry.key.known_dimensions == key.known_dimensions
+                        && entry.key.available_space == key.available_space
                     {
-                        return Some(LayoutOutput::from_outer_size(cached_size));
+                        return Some(LayoutOutput::from_outer_size(entry.content));
                     }
                 }
 
@@ -161,27 +202,16 @@ impl Cache {
 
     /// Store a computed size in the cache
     pub fn store(&mut self, input: &LayoutInput, layout_output: LayoutOutput) {
-        let known_dimensions = input.known_dimensions;
-        let available_space = input.available_space;
-        let axis = input.axis;
-        let parent_size = input.parent_size;
-
+        let key = CacheKey::from(input);
         match input.run_mode {
             RunMode::PerformLayout => {
                 self.is_empty = false;
-                self.final_layout_entry =
-                    Some(CacheEntry { axis, parent_size, known_dimensions, available_space, content: layout_output })
+                self.final_layout_entry = Some(CacheEntry { key, content: layout_output })
             }
             RunMode::ComputeSize => {
                 self.is_empty = false;
-                let cache_slot = Self::compute_cache_slot(known_dimensions, available_space);
-                self.measure_entries[cache_slot] = Some(CacheEntry {
-                    axis,
-                    parent_size,
-                    known_dimensions,
-                    available_space,
-                    content: layout_output.size,
-                });
+                let cache_slot = Self::compute_cache_slot(input.known_dimensions, input.available_space);
+                self.measure_entries[cache_slot] = Some(CacheEntry { key, content: layout_output.size });
             }
             RunMode::PerformHiddenLayout => {}
         }

--- a/src/tree/cache.rs
+++ b/src/tree/cache.rs
@@ -18,6 +18,8 @@ pub(crate) struct CacheEntry<T> {
     available_space: Size<AvailableSpace>,
     /// The initial cached size of the parent's node
     axis: RequestedAxis,
+    /// The initial cached size of the parent's node
+    parent_size: Size<Option<f32>>,
     /// The cached size and baselines of the item
     content: T,
 }
@@ -130,6 +132,7 @@ impl Cache {
                         && (known_dimensions.height.is_some()
                             || entry.available_space.height.is_roughly_equal(available_space.height))
                         && input.axis == entry.axis
+                        && input.parent_size == entry.parent_size
                 })
                 .map(|e| e.content),
             RunMode::ComputeSize => {
@@ -161,18 +164,24 @@ impl Cache {
         let known_dimensions = input.known_dimensions;
         let available_space = input.available_space;
         let axis = input.axis;
+        let parent_size = input.parent_size;
 
         match input.run_mode {
             RunMode::PerformLayout => {
                 self.is_empty = false;
                 self.final_layout_entry =
-                    Some(CacheEntry { axis, known_dimensions, available_space, content: layout_output })
+                    Some(CacheEntry { axis, parent_size, known_dimensions, available_space, content: layout_output })
             }
             RunMode::ComputeSize => {
                 self.is_empty = false;
                 let cache_slot = Self::compute_cache_slot(known_dimensions, available_space);
-                self.measure_entries[cache_slot] =
-                    Some(CacheEntry { axis, known_dimensions, available_space, content: layout_output.size });
+                self.measure_entries[cache_slot] = Some(CacheEntry {
+                    axis,
+                    parent_size,
+                    known_dimensions,
+                    available_space,
+                    content: layout_output.size,
+                });
             }
             RunMode::PerformHiddenLayout => {}
         }

--- a/tests/caching.rs
+++ b/tests/caching.rs
@@ -18,7 +18,7 @@ mod caching {
 
         taffy.compute_layout_with_measure(node, Size::MAX_CONTENT, test_measure_function).unwrap();
 
-        assert_eq!(taffy.get_node_context_mut(leaf).unwrap().count, 5);
+        assert_eq!(taffy.get_node_context_mut(leaf).unwrap().count, 7);
     }
 
     #[test]
@@ -35,6 +35,6 @@ mod caching {
         }
 
         taffy.compute_layout_with_measure(node, Size::MAX_CONTENT, test_measure_function).unwrap();
-        assert_eq!(taffy.get_node_context_mut(leaf).unwrap().count, 5);
+        assert_eq!(taffy.get_node_context_mut(leaf).unwrap().count, 7);
     }
 }

--- a/tests/caching.rs
+++ b/tests/caching.rs
@@ -18,7 +18,7 @@ mod caching {
 
         taffy.compute_layout_with_measure(node, Size::MAX_CONTENT, test_measure_function).unwrap();
 
-        assert_eq!(taffy.get_node_context_mut(leaf).unwrap().count, 4);
+        assert_eq!(taffy.get_node_context_mut(leaf).unwrap().count, 5);
     }
 
     #[test]
@@ -35,6 +35,6 @@ mod caching {
         }
 
         taffy.compute_layout_with_measure(node, Size::MAX_CONTENT, test_measure_function).unwrap();
-        assert_eq!(taffy.get_node_context_mut(leaf).unwrap().count, 4);
+        assert_eq!(taffy.get_node_context_mut(leaf).unwrap().count, 5);
     }
 }


### PR DESCRIPTION
Optimise the "measure" phase of block layout.

- Depends on https://github.com/DioxusLabs/taffy/pull/911