### PR TITLE
grid: resolve intrinsic item percentages against the grid area

### DIFF
--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -323,27 +323,27 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
 
     // 6. Compute container size
     let resolved_style_size = known_dimensions.or(preferred_size);
-    let container_border_box = Size {
-        width: resolved_style_size
-            .get(AbstractAxis::Inline)
-            .unwrap_or_else(|| initial_column_sum + content_box_inset.horizontal_axis_sum())
-            .maybe_clamp(min_size.width, max_size.width)
-            .max(padding_border_size.width),
-        height: resolved_style_size
-            .get(AbstractAxis::Block)
-            .unwrap_or_else(|| initial_row_sum + content_box_inset.vertical_axis_sum())
-            .maybe_clamp(min_size.height, max_size.height)
-            .max(padding_border_size.height),
+    let compute_container_boxes = |column_sum: f32, row_sum: f32| {
+        let container_border_box = Size {
+            width: resolved_style_size
+                .get(AbstractAxis::Inline)
+                .unwrap_or_else(|| column_sum + content_box_inset.horizontal_axis_sum())
+                .maybe_clamp(min_size.width, max_size.width)
+                .max(padding_border_size.width),
+            height: resolved_style_size
+                .get(AbstractAxis::Block)
+                .unwrap_or_else(|| row_sum + content_box_inset.vertical_axis_sum())
+                .maybe_clamp(min_size.height, max_size.height)
+                .max(padding_border_size.height),
+        };
+        let container_content_box = Size {
+            width: f32_max(0.0, container_border_box.width - content_box_inset.horizontal_axis_sum()),
+            height: f32_max(0.0, container_border_box.height - content_box_inset.vertical_axis_sum()),
+        };
+        (container_border_box, container_content_box)
     };
-    let container_content_box = Size {
-        width: f32_max(0.0, container_border_box.width - content_box_inset.horizontal_axis_sum()),
-        height: f32_max(0.0, container_border_box.height - content_box_inset.vertical_axis_sum()),
-    };
-
-    // If only the container's size has been requested
-    if run_mode == RunMode::ComputeSize {
-        return LayoutOutput::from_outer_size(container_border_box);
-    }
+    let (mut container_border_box, mut container_content_box) =
+        compute_container_boxes(initial_column_sum, initial_row_sum);
 
     // 7. Resolve percentage track base sizes
     // In the case of an indefinitely sized container these resolve to zero during the "Initialise Tracks" step
@@ -376,13 +376,15 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
     //   - Any grid item crossing an intrinsically sized track's min content contribution width has changed
     // TODO: Only rerun sizing for tracks that actually require it rather than for all tracks if any need it.
     let mut rerun_column_sizing;
+    let mut intrinsic_column_contribution_changed = false;
 
     let has_percentage_column = columns.iter().any(|track| track.uses_percentage());
+    let has_percentage_row = rows.iter().any(|track| track.uses_percentage());
     let parent_width_indefinite = !available_space.width.is_definite();
     rerun_column_sizing = parent_width_indefinite && has_percentage_column;
 
     if !rerun_column_sizing {
-        let min_content_contribution_changed =
+        intrinsic_column_contribution_changed =
             items.iter_mut().filter(|item| item.crosses_intrinsic_column).any(|item| {
                 let available_space = item.available_space(
                     AbstractAxis::Inline,
@@ -411,7 +413,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
 
                 has_changed
             });
-        rerun_column_sizing = min_content_contribution_changed;
+        rerun_column_sizing = intrinsic_column_contribution_changed;
     } else {
         // Clear intrinsic width caches
         items.iter_mut().for_each(|item| {
@@ -421,6 +423,8 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
             item.minimum_contribution_cache.width = None;
         });
     }
+
+    let mut intrinsic_row_contribution_changed = false;
 
     if rerun_column_sizing {
         // Re-run track sizing algorithm for Inline axis
@@ -446,12 +450,11 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
         // TODO: Only rerun sizing for tracks that actually require it rather than for all tracks if any need it.
         let mut rerun_row_sizing;
 
-        let has_percentage_row = rows.iter().any(|track| track.uses_percentage());
         let parent_height_indefinite = !available_space.height.is_definite();
         rerun_row_sizing = parent_height_indefinite && has_percentage_row;
 
         if !rerun_row_sizing {
-            let min_content_contribution_changed =
+            intrinsic_row_contribution_changed =
                 items.iter_mut().filter(|item| item.crosses_intrinsic_column).any(|item| {
                     let available_space = item.available_space(
                         AbstractAxis::Block,
@@ -480,7 +483,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
 
                     has_changed
                 });
-            rerun_row_sizing = min_content_contribution_changed;
+            rerun_row_sizing = intrinsic_row_contribution_changed;
         } else {
             items.iter_mut().for_each(|item| {
                 // Clear intrinsic height caches
@@ -509,6 +512,38 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
                 false, // TODO: Support baseline alignment in the vertical axis
             );
         }
+    }
+
+    if (intrinsic_column_contribution_changed && !has_percentage_column)
+        || (intrinsic_row_contribution_changed && !has_percentage_row)
+    {
+        let final_column_sum = columns.iter().map(|track| track.base_size).sum::<f32>();
+        let final_row_sum = rows.iter().map(|track| track.base_size).sum::<f32>();
+
+        if intrinsic_column_contribution_changed && !has_percentage_column {
+            container_border_box.width = resolved_style_size
+                .get(AbstractAxis::Inline)
+                .unwrap_or_else(|| final_column_sum + content_box_inset.horizontal_axis_sum())
+                .maybe_clamp(min_size.width, max_size.width)
+                .max(padding_border_size.width);
+            container_content_box.width =
+                f32_max(0.0, container_border_box.width - content_box_inset.horizontal_axis_sum());
+        }
+
+        if intrinsic_row_contribution_changed && !has_percentage_row {
+            container_border_box.height = resolved_style_size
+                .get(AbstractAxis::Block)
+                .unwrap_or_else(|| final_row_sum + content_box_inset.vertical_axis_sum())
+                .maybe_clamp(min_size.height, max_size.height)
+                .max(padding_border_size.height);
+            container_content_box.height =
+                f32_max(0.0, container_border_box.height - content_box_inset.vertical_axis_sum());
+        }
+    }
+
+    // If only the container's size has been requested
+    if run_mode == RunMode::ComputeSize {
+        return LayoutOutput::from_outer_size(container_border_box);
     }
 
     // 8. Track Alignment

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -390,8 +390,17 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
                     inner_node_size.height,
                     |track: &GridTrack, _| Some(track.base_size),
                 );
+                let grid_area_size = Size {
+                    width: item.definite_grid_area_size_in_axis(
+                        AbstractAxis::Inline,
+                        &columns,
+                        inner_node_size.width,
+                        &|val, basis| tree.calc(val, basis),
+                    ),
+                    height: available_space.height,
+                };
                 let new_min_content_contribution =
-                    item.min_content_contribution(AbstractAxis::Inline, tree, available_space, inner_node_size);
+                    item.min_content_contribution(AbstractAxis::Inline, tree, grid_area_size, available_space);
 
                 let has_changed = Some(new_min_content_contribution) != item.min_content_contribution_cache.width;
 
@@ -450,8 +459,17 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
                         inner_node_size.width,
                         |track: &GridTrack, _| Some(track.base_size),
                     );
+                    let grid_area_size = Size {
+                        width: available_space.width,
+                        height: item.definite_grid_area_size_in_axis(
+                            AbstractAxis::Block,
+                            &rows,
+                            inner_node_size.height,
+                            &|val, basis| tree.calc(val, basis),
+                        ),
+                    };
                     let new_min_content_contribution =
-                        item.min_content_contribution(AbstractAxis::Block, tree, available_space, inner_node_size);
+                        item.min_content_contribution(AbstractAxis::Block, tree, grid_area_size, available_space);
 
                     let has_changed = Some(new_min_content_contribution) != item.min_content_contribution_cache.height;
 

--- a/src/compute/grid/track_sizing.rs
+++ b/src/compute/grid/track_sizing.rs
@@ -101,11 +101,33 @@ where
         )
     }
 
+    /// Combines the opposite-axis estimate with the current axis's definite grid-area size, if known.
+    #[inline(always)]
+    fn grid_area_size(&self, item: &mut GridItem, axis_tracks: &[GridTrack]) -> Size<Option<f32>> {
+        let mut grid_area_size = self.available_space(item);
+        grid_area_size.set(
+            self.axis,
+            item.definite_grid_area_size_in_axis(
+                self.axis,
+                axis_tracks,
+                self.inner_node_size.get(self.axis),
+                &|val, basis| self.tree.calc(val, basis),
+            ),
+        );
+        grid_area_size
+    }
+
     /// Compute the item's resolved margins for size contributions. Horizontal percentage margins always resolve
     /// to zero if the container size is indefinite as otherwise this would introduce a cyclic dependency.
     #[inline(always)]
-    fn margins_axis_sums_with_baseline_shims(&self, item: &GridItem) -> Size<f32> {
-        item.margins_axis_sums_with_baseline_shims(self.inner_node_size.width, self.tree)
+    fn margins_axis_sums_with_baseline_shims(&self, item: &GridItem, axis_tracks: &[GridTrack]) -> Size<f32> {
+        let percentage_basis = item.definite_grid_area_size_in_axis(
+            AbstractAxis::Inline,
+            if self.axis == AbstractAxis::Inline { axis_tracks } else { self.other_axis_tracks },
+            self.inner_node_size.width,
+            &|val, basis| self.tree.calc(val, basis),
+        );
+        item.margins_axis_sums_with_baseline_shims(percentage_basis, self.tree)
     }
 
     /// Simple pass-through function to `LayoutPartialTreeExt::calc`
@@ -116,21 +138,21 @@ where
 
     /// Retrieve the item's min content contribution from the cache or compute it using the provided parameters
     #[inline(always)]
-    fn min_content_contribution(&mut self, item: &mut GridItem) -> f32 {
+    fn min_content_contribution(&mut self, item: &mut GridItem, axis_tracks: &[GridTrack]) -> f32 {
+        let grid_area_size = self.grid_area_size(item, axis_tracks);
         let available_space = self.available_space(item);
-        let margin_axis_sums = self.margins_axis_sums_with_baseline_shims(item);
-        let contribution =
-            item.min_content_contribution_cached(self.axis, self.tree, available_space, self.inner_node_size);
+        let margin_axis_sums = self.margins_axis_sums_with_baseline_shims(item, axis_tracks);
+        let contribution = item.min_content_contribution_cached(self.axis, self.tree, grid_area_size, available_space);
         contribution + margin_axis_sums.get(self.axis)
     }
 
     /// Retrieve the item's max content contribution from the cache or compute it using the provided parameters
     #[inline(always)]
-    fn max_content_contribution(&mut self, item: &mut GridItem) -> f32 {
+    fn max_content_contribution(&mut self, item: &mut GridItem, axis_tracks: &[GridTrack]) -> f32 {
+        let grid_area_size = self.grid_area_size(item, axis_tracks);
         let available_space = self.available_space(item);
-        let margin_axis_sums = self.margins_axis_sums_with_baseline_shims(item);
-        let contribution =
-            item.max_content_contribution_cached(self.axis, self.tree, available_space, self.inner_node_size);
+        let margin_axis_sums = self.margins_axis_sums_with_baseline_shims(item, axis_tracks);
+        let contribution = item.max_content_contribution_cached(self.axis, self.tree, grid_area_size, available_space);
         contribution + margin_axis_sums.get(self.axis)
     }
 
@@ -143,10 +165,10 @@ where
     /// Because the minimum contribution often depends on the size of the item’s content, it is considered a type of intrinsic size contribution.
     #[inline(always)]
     fn minimum_contribution(&mut self, item: &mut GridItem, axis_tracks: &[GridTrack]) -> f32 {
-        let available_space = self.available_space(item);
-        let margin_axis_sums = self.margins_axis_sums_with_baseline_shims(item);
+        let grid_area_size = self.grid_area_size(item, axis_tracks);
+        let margin_axis_sums = self.margins_axis_sums_with_baseline_shims(item, axis_tracks);
         let contribution =
-            item.minimum_contribution_cached(self.tree, self.axis, axis_tracks, available_space, self.inner_node_size);
+            item.minimum_contribution_cached(self.tree, self.axis, axis_tracks, grid_area_size, self.inner_node_size);
         contribution + margin_axis_sums.get(self.axis)
     }
 }
@@ -354,7 +376,6 @@ pub(super) fn track_sizing_algorithm<Tree: LayoutPartialTree>(
         axis_min_size,
         axis_max_size,
         axis_available_space_for_expansion,
-        inner_node_size,
     );
 
     // 11.8. Stretch auto Tracks
@@ -570,19 +591,19 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                 // Handle base sizes
                 let new_base_size = match track.min_track_sizing_function.0.tag() {
                     CompactLength::MIN_CONTENT_TAG => {
-                        f32_max(track.base_size, item_sizer.min_content_contribution(item))
+                        f32_max(track.base_size, item_sizer.min_content_contribution(item, axis_tracks))
                     }
                     // If the container size is indefinite and has not yet been resolved then percentage sized
                     // tracks should be treated as min-content (this matches Chrome's behaviour and seems sensible)
                     CompactLength::PERCENT_TAG => {
                         if axis_inner_node_size.is_none() {
-                            f32_max(track.base_size, item_sizer.min_content_contribution(item))
+                            f32_max(track.base_size, item_sizer.min_content_contribution(item, axis_tracks))
                         } else {
                             track.base_size
                         }
                     }
                     CompactLength::MAX_CONTENT_TAG => {
-                        f32_max(track.base_size, item_sizer.max_content_contribution(item))
+                        f32_max(track.base_size, item_sizer.max_content_contribution(item, axis_tracks))
                     }
                     CompactLength::AUTO_TAG => {
                         let space = match axis_available_grid_space {
@@ -598,7 +619,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                                 if !item.overflow.get(axis).is_scroll_container() =>
                             {
                                 let axis_minimum_size = item_sizer.minimum_contribution(item, axis_tracks);
-                                let axis_min_content_size = item_sizer.min_content_contribution(item);
+                                let axis_min_content_size = item_sizer.min_content_contribution(item, axis_tracks);
                                 let limit = track
                                     .max_track_sizing_function
                                     .definite_limit(axis_inner_node_size, |val, basis| item_sizer.calc(val, basis));
@@ -616,13 +637,21 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                     #[cfg(feature = "calc")]
                     _ if track.min_track_sizing_function.0.is_calc() => {
                         if axis_inner_node_size.is_none() {
-                            f32_max(track.base_size, item_sizer.min_content_contribution(item))
+                            f32_max(track.base_size, item_sizer.min_content_contribution(item, axis_tracks))
                         } else {
                             track.base_size
                         }
                     }
                     _ => unreachable!(),
                 };
+                let growth_limit_min_content_contribution = if !item.overflow.get(axis).is_scroll_container() {
+                    Some(item_sizer.min_content_contribution(item, axis_tracks))
+                } else {
+                    None
+                };
+                let growth_limit_max_content_contribution = item_sizer.max_content_contribution(item, axis_tracks);
+                let growth_limit_intrinsic_min_content_contribution =
+                    item_sizer.min_content_contribution(item, axis_tracks);
                 let track = &mut axis_tracks[track_index as usize];
                 track.base_size = new_base_size;
 
@@ -630,8 +659,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                 if track.max_track_sizing_function.is_fit_content() {
                     // If item is not a scroll container, then increase the growth limit to at least the
                     // size of the min-content contribution
-                    if !item.overflow.get(axis).is_scroll_container() {
-                        let min_content_contribution = item_sizer.min_content_contribution(item);
+                    if let Some(min_content_contribution) = growth_limit_min_content_contribution {
                         track.growth_limit_planned_increase =
                             f32_max(track.growth_limit_planned_increase, min_content_contribution);
                     }
@@ -639,8 +667,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                     // Always increase the growth limit to at least the size of the *fit-content limited*
                     // max-content contribution
                     let fit_content_limit = track.fit_content_limit(axis_inner_node_size);
-                    let max_content_contribution =
-                        f32_min(item_sizer.max_content_contribution(item), fit_content_limit);
+                    let max_content_contribution = f32_min(growth_limit_max_content_contribution, fit_content_limit);
                     track.growth_limit_planned_increase =
                         f32_max(track.growth_limit_planned_increase, max_content_contribution);
                 } else if track.max_track_sizing_function.is_max_content_alike()
@@ -649,10 +676,10 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                     // If the container size is indefinite and has not yet been resolved then percentage sized
                     // tracks should be treated as auto (this matches Chrome's behaviour and seems sensible)
                     track.growth_limit_planned_increase =
-                        f32_max(track.growth_limit_planned_increase, item_sizer.max_content_contribution(item));
+                        f32_max(track.growth_limit_planned_increase, growth_limit_max_content_contribution);
                 } else if track.max_track_sizing_function.is_intrinsic() {
                     track.growth_limit_planned_increase =
-                        f32_max(track.growth_limit_planned_increase, item_sizer.min_content_contribution(item));
+                        f32_max(track.growth_limit_planned_increase, growth_limit_intrinsic_min_content_contribution);
                 }
             }
 
@@ -693,7 +720,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                     if !item.overflow.get(axis).is_scroll_container() =>
                 {
                     let axis_minimum_size = item_sizer.minimum_contribution(item, axis_tracks);
-                    let axis_min_content_size = item_sizer.min_content_contribution(item);
+                    let axis_min_content_size = item_sizer.min_content_contribution(item, axis_tracks);
                     let limit = item.spanned_track_limit(axis, axis_tracks, axis_inner_node_size, &|val, basis| {
                         item_sizer.calc(val, basis)
                     });
@@ -742,7 +769,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
         let has_min_or_max_content_min_track_sizing_function =
             move |track: &GridTrack| track.min_track_sizing_function.is_min_or_max_content();
         for item in batch.iter_mut() {
-            let space = item_sizer.min_content_contribution(item);
+            let space = item_sizer.min_content_contribution(item, axis_tracks);
             let tracks = &mut axis_tracks[item.track_range_excluding_lines(axis)];
             if space > 0.0 {
                 if item.overflow.get(axis).is_scroll_container() {
@@ -802,7 +829,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
             }
 
             for item in batch.iter_mut() {
-                let axis_max_content_size = item_sizer.max_content_contribution(item);
+                let axis_max_content_size = item_sizer.max_content_contribution(item, axis_tracks);
                 let limit = item.spanned_track_limit(axis, axis_tracks, axis_inner_node_size, &|val, basis| {
                     item_sizer.calc(val, basis)
                 });
@@ -852,7 +879,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
         let has_max_content_min_track_sizing_function =
             move |track: &GridTrack| track.min_track_sizing_function.is_max_content();
         for item in batch.iter_mut() {
-            let axis_max_content_size = item_sizer.max_content_contribution(item);
+            let axis_max_content_size = item_sizer.max_content_contribution(item, axis_tracks);
             let space = axis_max_content_size;
             let tracks = &mut axis_tracks[item.track_range_excluding_lines(axis)];
             if space > 0.0 {
@@ -884,7 +911,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
             let has_intrinsic_max_track_sizing_function =
                 move |track: &GridTrack| !track.max_track_sizing_function.has_definite_value(axis_inner_node_size);
             for item in batch.iter_mut() {
-                let axis_min_content_size = item_sizer.min_content_contribution(item);
+                let axis_min_content_size = item_sizer.min_content_contribution(item, axis_tracks);
                 let space = axis_min_content_size;
                 let tracks = &mut axis_tracks[item.track_range_excluding_lines(axis)];
                 if space > 0.0 {
@@ -907,7 +934,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                     || (track.max_track_sizing_function.uses_percentage() && axis_inner_node_size.is_none())
             };
             for item in batch.iter_mut() {
-                let axis_max_content_size = item_sizer.max_content_contribution(item);
+                let axis_max_content_size = item_sizer.max_content_contribution(item, axis_tracks);
                 let space = axis_max_content_size;
                 let tracks = &mut axis_tracks[item.track_range_excluding_lines(axis)];
                 if space > 0.0 {
@@ -1175,7 +1202,6 @@ fn expand_flexible_tracks(
     axis_min_size: Option<f32>,
     axis_max_size: Option<f32>,
     axis_available_space_for_expansion: AvailableSpace,
-    inner_node_size: Size<Option<f32>>,
 ) {
     // First, find the grid’s used flex fraction:
     let flex_fraction = match axis_available_space_for_expansion {
@@ -1223,7 +1249,7 @@ fn expand_flexible_tracks(
                         let tracks = &axis_tracks[item.track_range_excluding_lines(axis)];
                         // TODO: plumb estimate of other axis size (known_dimensions) in here rather than just passing Size::NONE?
                         let max_content_contribution =
-                            item.max_content_contribution_cached(axis, tree, Size::NONE, inner_node_size);
+                            item.max_content_contribution_cached(axis, tree, Size::NONE, Size::NONE);
                         find_size_of_fr(tracks, max_content_contribution)
                     })
                     .max_by(|a, b| a.total_cmp(b))

--- a/src/compute/grid/track_sizing.rs
+++ b/src/compute/grid/track_sizing.rs
@@ -120,13 +120,17 @@ where
     /// Compute the item's resolved margins for size contributions. Horizontal percentage margins always resolve
     /// to zero if the container size is indefinite as otherwise this would introduce a cyclic dependency.
     #[inline(always)]
-    fn margins_axis_sums_with_baseline_shims(&self, item: &GridItem, axis_tracks: &[GridTrack]) -> Size<f32> {
-        let percentage_basis = item.definite_grid_area_size_in_axis(
-            AbstractAxis::Inline,
-            if self.axis == AbstractAxis::Inline { axis_tracks } else { self.other_axis_tracks },
-            self.inner_node_size.width,
-            &|val, basis| self.tree.calc(val, basis),
-        );
+    fn margins_axis_sums_with_baseline_shims(&self, item: &mut GridItem, axis_tracks: &[GridTrack]) -> Size<f32> {
+        let percentage_basis = if self.axis == AbstractAxis::Block {
+            self.available_space(item).width
+        } else {
+            item.definite_grid_area_size_in_axis(
+                AbstractAxis::Inline,
+                axis_tracks,
+                self.inner_node_size.width,
+                &|val, basis| self.tree.calc(val, basis),
+            )
+        };
         item.margins_axis_sums_with_baseline_shims(percentage_basis, self.tree)
     }
 

--- a/src/compute/grid/track_sizing.rs
+++ b/src/compute/grid/track_sizing.rs
@@ -101,11 +101,33 @@ where
         )
     }
 
+    /// Combines the opposite-axis estimate with the current axis's definite grid-area size, if known.
+    #[inline(always)]
+    fn grid_area_size(&self, item: &mut GridItem, axis_tracks: &[GridTrack]) -> Size<Option<f32>> {
+        let mut grid_area_size = self.available_space(item);
+        grid_area_size.set(
+            self.axis,
+            item.definite_grid_area_size_in_axis(
+                self.axis,
+                axis_tracks,
+                self.inner_node_size.get(self.axis),
+                &|val, basis| self.tree.calc(val, basis),
+            ),
+        );
+        grid_area_size
+    }
+
     /// Compute the item's resolved margins for size contributions. Horizontal percentage margins always resolve
     /// to zero if the container size is indefinite as otherwise this would introduce a cyclic dependency.
     #[inline(always)]
-    fn margins_axis_sums_with_baseline_shims(&self, item: &GridItem) -> Size<f32> {
-        item.margins_axis_sums_with_baseline_shims(self.inner_node_size.width, self.tree)
+    fn margins_axis_sums_with_baseline_shims(&self, item: &GridItem, axis_tracks: &[GridTrack]) -> Size<f32> {
+        let percentage_basis = item.definite_grid_area_size_in_axis(
+            AbstractAxis::Inline,
+            if self.axis == AbstractAxis::Inline { axis_tracks } else { self.other_axis_tracks },
+            self.inner_node_size.width,
+            &|val, basis| self.tree.calc(val, basis),
+        );
+        item.margins_axis_sums_with_baseline_shims(percentage_basis, self.tree)
     }
 
     /// Simple pass-through function to `LayoutPartialTreeExt::calc`
@@ -116,21 +138,21 @@ where
 
     /// Retrieve the item's min content contribution from the cache or compute it using the provided parameters
     #[inline(always)]
-    fn min_content_contribution(&mut self, item: &mut GridItem) -> f32 {
+    fn min_content_contribution(&mut self, item: &mut GridItem, axis_tracks: &[GridTrack]) -> f32 {
+        let grid_area_size = self.grid_area_size(item, axis_tracks);
         let available_space = self.available_space(item);
-        let margin_axis_sums = self.margins_axis_sums_with_baseline_shims(item);
-        let contribution =
-            item.min_content_contribution_cached(self.axis, self.tree, available_space, self.inner_node_size);
+        let margin_axis_sums = self.margins_axis_sums_with_baseline_shims(item, axis_tracks);
+        let contribution = item.min_content_contribution_cached(self.axis, self.tree, grid_area_size, available_space);
         contribution + margin_axis_sums.get(self.axis)
     }
 
     /// Retrieve the item's max content contribution from the cache or compute it using the provided parameters
     #[inline(always)]
-    fn max_content_contribution(&mut self, item: &mut GridItem) -> f32 {
+    fn max_content_contribution(&mut self, item: &mut GridItem, axis_tracks: &[GridTrack]) -> f32 {
+        let grid_area_size = self.grid_area_size(item, axis_tracks);
         let available_space = self.available_space(item);
-        let margin_axis_sums = self.margins_axis_sums_with_baseline_shims(item);
-        let contribution =
-            item.max_content_contribution_cached(self.axis, self.tree, available_space, self.inner_node_size);
+        let margin_axis_sums = self.margins_axis_sums_with_baseline_shims(item, axis_tracks);
+        let contribution = item.max_content_contribution_cached(self.axis, self.tree, grid_area_size, available_space);
         contribution + margin_axis_sums.get(self.axis)
     }
 
@@ -143,10 +165,10 @@ where
     /// Because the minimum contribution often depends on the size of the item’s content, it is considered a type of intrinsic size contribution.
     #[inline(always)]
     fn minimum_contribution(&mut self, item: &mut GridItem, axis_tracks: &[GridTrack]) -> f32 {
-        let available_space = self.available_space(item);
-        let margin_axis_sums = self.margins_axis_sums_with_baseline_shims(item);
+        let grid_area_size = self.grid_area_size(item, axis_tracks);
+        let margin_axis_sums = self.margins_axis_sums_with_baseline_shims(item, axis_tracks);
         let contribution =
-            item.minimum_contribution_cached(self.tree, self.axis, axis_tracks, available_space, self.inner_node_size);
+            item.minimum_contribution_cached(self.tree, self.axis, axis_tracks, grid_area_size, self.inner_node_size);
         contribution + margin_axis_sums.get(self.axis)
     }
 }
@@ -355,7 +377,6 @@ pub(super) fn track_sizing_algorithm<Tree: LayoutPartialTree>(
         axis_min_size,
         axis_max_size,
         axis_available_space_for_expansion,
-        inner_node_size,
     );
 
     // 11.8. Stretch auto Tracks
@@ -571,19 +592,19 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                 // Handle base sizes
                 let new_base_size = match track.min_track_sizing_function.0.tag() {
                     CompactLength::MIN_CONTENT_TAG => {
-                        f32_max(track.base_size, item_sizer.min_content_contribution(item))
+                        f32_max(track.base_size, item_sizer.min_content_contribution(item, axis_tracks))
                     }
                     // If the container size is indefinite and has not yet been resolved then percentage sized
                     // tracks should be treated as min-content (this matches Chrome's behaviour and seems sensible)
                     CompactLength::PERCENT_TAG => {
                         if axis_inner_node_size.is_none() {
-                            f32_max(track.base_size, item_sizer.min_content_contribution(item))
+                            f32_max(track.base_size, item_sizer.min_content_contribution(item, axis_tracks))
                         } else {
                             track.base_size
                         }
                     }
                     CompactLength::MAX_CONTENT_TAG => {
-                        f32_max(track.base_size, item_sizer.max_content_contribution(item))
+                        f32_max(track.base_size, item_sizer.max_content_contribution(item, axis_tracks))
                     }
                     CompactLength::AUTO_TAG => {
                         let space = match axis_available_grid_space {
@@ -599,7 +620,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                                 if !item.overflow.get(axis).is_scroll_container() =>
                             {
                                 let axis_minimum_size = item_sizer.minimum_contribution(item, axis_tracks);
-                                let axis_min_content_size = item_sizer.min_content_contribution(item);
+                                let axis_min_content_size = item_sizer.min_content_contribution(item, axis_tracks);
                                 let limit = track
                                     .max_track_sizing_function
                                     .definite_limit(axis_inner_node_size, |val, basis| item_sizer.calc(val, basis));
@@ -617,13 +638,21 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                     #[cfg(feature = "calc")]
                     _ if track.min_track_sizing_function.0.is_calc() => {
                         if axis_inner_node_size.is_none() {
-                            f32_max(track.base_size, item_sizer.min_content_contribution(item))
+                            f32_max(track.base_size, item_sizer.min_content_contribution(item, axis_tracks))
                         } else {
                             track.base_size
                         }
                     }
                     _ => unreachable!(),
                 };
+                let growth_limit_min_content_contribution = if !item.overflow.get(axis).is_scroll_container() {
+                    Some(item_sizer.min_content_contribution(item, axis_tracks))
+                } else {
+                    None
+                };
+                let growth_limit_max_content_contribution = item_sizer.max_content_contribution(item, axis_tracks);
+                let growth_limit_intrinsic_min_content_contribution =
+                    item_sizer.min_content_contribution(item, axis_tracks);
                 let track = &mut axis_tracks[track_index as usize];
                 track.base_size = new_base_size;
 
@@ -631,8 +660,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                 if track.max_track_sizing_function.is_fit_content() {
                     // If item is not a scroll container, then increase the growth limit to at least the
                     // size of the min-content contribution
-                    if !item.overflow.get(axis).is_scroll_container() {
-                        let min_content_contribution = item_sizer.min_content_contribution(item);
+                    if let Some(min_content_contribution) = growth_limit_min_content_contribution {
                         track.growth_limit_planned_increase =
                             f32_max(track.growth_limit_planned_increase, min_content_contribution);
                     }
@@ -640,8 +668,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                     // Always increase the growth limit to at least the size of the *fit-content limited*
                     // max-content contribution
                     let fit_content_limit = track.fit_content_limit(axis_inner_node_size);
-                    let max_content_contribution =
-                        f32_min(item_sizer.max_content_contribution(item), fit_content_limit);
+                    let max_content_contribution = f32_min(growth_limit_max_content_contribution, fit_content_limit);
                     track.growth_limit_planned_increase =
                         f32_max(track.growth_limit_planned_increase, max_content_contribution);
                 } else if track.max_track_sizing_function.is_max_content_alike()
@@ -650,10 +677,10 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                     // If the container size is indefinite and has not yet been resolved then percentage sized
                     // tracks should be treated as auto (this matches Chrome's behaviour and seems sensible)
                     track.growth_limit_planned_increase =
-                        f32_max(track.growth_limit_planned_increase, item_sizer.max_content_contribution(item));
+                        f32_max(track.growth_limit_planned_increase, growth_limit_max_content_contribution);
                 } else if track.max_track_sizing_function.is_intrinsic() {
                     track.growth_limit_planned_increase =
-                        f32_max(track.growth_limit_planned_increase, item_sizer.min_content_contribution(item));
+                        f32_max(track.growth_limit_planned_increase, growth_limit_intrinsic_min_content_contribution);
                 }
             }
 
@@ -694,7 +721,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                     if !item.overflow.get(axis).is_scroll_container() =>
                 {
                     let axis_minimum_size = item_sizer.minimum_contribution(item, axis_tracks);
-                    let axis_min_content_size = item_sizer.min_content_contribution(item);
+                    let axis_min_content_size = item_sizer.min_content_contribution(item, axis_tracks);
                     let limit = item.spanned_track_limit(axis, axis_tracks, axis_inner_node_size, &|val, basis| {
                         item_sizer.calc(val, basis)
                     });
@@ -743,7 +770,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
         let has_min_or_max_content_min_track_sizing_function =
             move |track: &GridTrack| track.min_track_sizing_function.is_min_or_max_content();
         for item in batch.iter_mut() {
-            let space = item_sizer.min_content_contribution(item);
+            let space = item_sizer.min_content_contribution(item, axis_tracks);
             let tracks = &mut axis_tracks[item.track_range_excluding_lines(axis)];
             if space > 0.0 {
                 if item.overflow.get(axis).is_scroll_container() {
@@ -803,7 +830,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
             }
 
             for item in batch.iter_mut() {
-                let axis_max_content_size = item_sizer.max_content_contribution(item);
+                let axis_max_content_size = item_sizer.max_content_contribution(item, axis_tracks);
                 let limit = item.spanned_track_limit(axis, axis_tracks, axis_inner_node_size, &|val, basis| {
                     item_sizer.calc(val, basis)
                 });
@@ -853,7 +880,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
         let has_max_content_min_track_sizing_function =
             move |track: &GridTrack| track.min_track_sizing_function.is_max_content();
         for item in batch.iter_mut() {
-            let axis_max_content_size = item_sizer.max_content_contribution(item);
+            let axis_max_content_size = item_sizer.max_content_contribution(item, axis_tracks);
             let space = axis_max_content_size;
             let tracks = &mut axis_tracks[item.track_range_excluding_lines(axis)];
             if space > 0.0 {
@@ -885,7 +912,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
             let has_intrinsic_max_track_sizing_function =
                 move |track: &GridTrack| !track.max_track_sizing_function.has_definite_value(axis_inner_node_size);
             for item in batch.iter_mut() {
-                let axis_min_content_size = item_sizer.min_content_contribution(item);
+                let axis_min_content_size = item_sizer.min_content_contribution(item, axis_tracks);
                 let space = axis_min_content_size;
                 let tracks = &mut axis_tracks[item.track_range_excluding_lines(axis)];
                 if space > 0.0 {
@@ -908,7 +935,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                     || (track.max_track_sizing_function.uses_percentage() && axis_inner_node_size.is_none())
             };
             for item in batch.iter_mut() {
-                let axis_max_content_size = item_sizer.max_content_contribution(item);
+                let axis_max_content_size = item_sizer.max_content_contribution(item, axis_tracks);
                 let space = axis_max_content_size;
                 let tracks = &mut axis_tracks[item.track_range_excluding_lines(axis)];
                 if space > 0.0 {
@@ -1176,7 +1203,6 @@ fn expand_flexible_tracks(
     axis_min_size: Option<f32>,
     axis_max_size: Option<f32>,
     axis_available_space_for_expansion: AvailableSpace,
-    inner_node_size: Size<Option<f32>>,
 ) {
     // First, find the grid’s used flex fraction:
     let flex_fraction = match axis_available_space_for_expansion {
@@ -1224,7 +1250,7 @@ fn expand_flexible_tracks(
                         let tracks = &axis_tracks[item.track_range_excluding_lines(axis)];
                         // TODO: plumb estimate of other axis size (known_dimensions) in here rather than just passing Size::NONE?
                         let max_content_contribution =
-                            item.max_content_contribution_cached(axis, tree, Size::NONE, inner_node_size);
+                            item.max_content_contribution_cached(axis, tree, Size::NONE, Size::NONE);
                         find_size_of_fr(tracks, max_content_contribution)
                     })
                     .max_by(|a, b| a.total_cmp(b))

--- a/src/compute/grid/types/grid_item.rs
+++ b/src/compute/grid/types/grid_item.rs
@@ -92,6 +92,20 @@ pub(in super::super) struct GridItem {
 }
 
 impl GridItem {
+    /// Resolves each side of a padding or border rect against a shared percentage basis.
+    fn resolved_axis_side_lengths(
+        rect: Rect<LengthPercentage>,
+        percentage_basis: Option<f32>,
+        calc: impl Fn(*const (), f32) -> f32,
+    ) -> Rect<f32> {
+        Rect {
+            left: rect.left.resolve_or_zero(percentage_basis, &calc),
+            right: rect.right.resolve_or_zero(percentage_basis, &calc),
+            top: rect.top.resolve_or_zero(percentage_basis, &calc),
+            bottom: rect.bottom.resolve_or_zero(percentage_basis, &calc),
+        }
+    }
+
     /// Create a new item given a concrete placement in both axes
     pub fn new_with_placement_style_and_order<S: GridItemStyle>(
         node: NodeId,
@@ -238,20 +252,58 @@ impl GridItem {
         }
     }
 
+    /// Returns the grid area's size in the specified axis when every spanned track has a definite fixed size.
+    ///
+    /// During intrinsic sizing, percentages on grid items resolve against the size of the grid area,
+    /// not the grid container. If the spanned tracks in an axis are not all definite yet, the grid
+    /// area is still indefinite in that axis and percentage-dependent values must stay unresolved here.
+    ///
+    /// Spec:
+    /// https://www.w3.org/TR/css-grid-1/#grid-item-sizing
+    /// https://www.w3.org/TR/css-grid-1/#algo-overview
+    pub fn definite_grid_area_size_in_axis(
+        &self,
+        axis: AbstractAxis,
+        axis_tracks: &[GridTrack],
+        axis_parent_size: Option<f32>,
+        resolve_calc_value: &dyn Fn(*const (), f32) -> f32,
+    ) -> Option<f32> {
+        axis_tracks[self.track_range_excluding_lines(axis)]
+            .iter()
+            .map(|track| {
+                let min_size = track.min_track_sizing_function.definite_value(axis_parent_size, resolve_calc_value)?;
+                let max_size = track.max_track_sizing_function.definite_value(axis_parent_size, resolve_calc_value)?;
+
+                if min_size.total_cmp(&max_size).is_eq() {
+                    Some(track.base_size)
+                } else {
+                    None
+                }
+            })
+            .sum::<Option<f32>>()
+    }
+
     /// Compute the known_dimensions to be passed to the child sizing functions
     /// The key thing that is being done here is applying stretch alignment, which is necessary to
     /// allow percentage sizes further down the tree to resolve properly in some cases
     fn known_dimensions(
         &self,
         tree: &mut impl LayoutPartialTree,
-        inner_node_size: Size<Option<f32>>,
         grid_area_size: Size<Option<f32>>,
     ) -> Size<Option<f32>> {
-        let margins = self.margins_axis_sums_with_baseline_shims(inner_node_size.width, tree);
+        let margins = self.margins_axis_sums_with_baseline_shims(grid_area_size.width, tree);
 
         let aspect_ratio = self.aspect_ratio;
-        let padding = self.padding.resolve_or_zero(grid_area_size, |val, basis| tree.calc(val, basis));
-        let border = self.border.resolve_or_zero(grid_area_size, |val, basis| tree.calc(val, basis));
+        // CSS resolves percentage padding and border against the inline size of the containing
+        // block. For a grid item under intrinsic measurement, that inline-size basis is the grid
+        // area's width when it is definite.
+        // Spec:
+        // https://www.w3.org/TR/css-grid-1/#item-margins
+        // https://www.w3.org/TR/CSS22/box.html#padding-properties
+        let padding =
+            Self::resolved_axis_side_lengths(self.padding, grid_area_size.width, |val, basis| tree.calc(val, basis));
+        let border =
+            Self::resolved_axis_side_lengths(self.border, grid_area_size.width, |val, basis| tree.calc(val, basis));
         let padding_border_size = (padding + border).sum_axes();
         let box_sizing_adjustment =
             if self.box_sizing == BoxSizing::ContentBox { padding_border_size } else { Size::ZERO };
@@ -375,14 +427,19 @@ impl GridItem {
         &self,
         axis: AbstractAxis,
         tree: &mut impl LayoutPartialTree,
+        grid_area_size: Size<Option<f32>>,
         available_space: Size<Option<f32>>,
-        inner_node_size: Size<Option<f32>>,
     ) -> f32 {
-        let known_dimensions = self.known_dimensions(tree, inner_node_size, available_space);
+        let known_dimensions = self.known_dimensions(tree, grid_area_size);
+        // The child sees the grid area as its containing block during intrinsic measurement, so
+        // percentage box properties resolve against the grid area when that size is definite.
+        // Spec:
+        // https://www.w3.org/TR/css-grid-1/#grid-item-sizing
+        // https://www.w3.org/TR/css-grid-1/#algo-overview
         tree.measure_child_size(
             self.node,
             known_dimensions,
-            inner_node_size,
+            grid_area_size,
             available_space.map(|opt| match opt {
                 Some(size) => AvailableSpace::Definite(size),
                 None => AvailableSpace::MinContent,
@@ -399,11 +456,11 @@ impl GridItem {
         &mut self,
         axis: AbstractAxis,
         tree: &mut impl LayoutPartialTree,
+        grid_area_size: Size<Option<f32>>,
         available_space: Size<Option<f32>>,
-        inner_node_size: Size<Option<f32>>,
     ) -> f32 {
         self.min_content_contribution_cache.get(axis).unwrap_or_else(|| {
-            let size = self.min_content_contribution(axis, tree, available_space, inner_node_size);
+            let size = self.min_content_contribution(axis, tree, grid_area_size, available_space);
             self.min_content_contribution_cache.set(axis, Some(size));
             size
         })
@@ -414,14 +471,17 @@ impl GridItem {
         &self,
         axis: AbstractAxis,
         tree: &mut impl LayoutPartialTree,
+        grid_area_size: Size<Option<f32>>,
         available_space: Size<Option<f32>>,
-        inner_node_size: Size<Option<f32>>,
     ) -> f32 {
-        let known_dimensions = self.known_dimensions(tree, inner_node_size, available_space);
+        let known_dimensions = self.known_dimensions(tree, grid_area_size);
+        // See the min-content path above. Max-content measurement uses the same containing-block
+        // basis so percentage-dependent item geometry is measured from the grid area rather than
+        // from the container.
         tree.measure_child_size(
             self.node,
             known_dimensions,
-            inner_node_size,
+            grid_area_size,
             available_space.map(|opt| match opt {
                 Some(size) => AvailableSpace::Definite(size),
                 None => AvailableSpace::MaxContent,
@@ -438,11 +498,11 @@ impl GridItem {
         &mut self,
         axis: AbstractAxis,
         tree: &mut impl LayoutPartialTree,
+        grid_area_size: Size<Option<f32>>,
         available_space: Size<Option<f32>>,
-        inner_node_size: Size<Option<f32>>,
     ) -> f32 {
         self.max_content_contribution_cache.get(axis).unwrap_or_else(|| {
-            let size = self.max_content_contribution(axis, tree, available_space, inner_node_size);
+            let size = self.max_content_contribution(axis, tree, grid_area_size, available_space);
             self.max_content_contribution_cache.set(axis, Some(size));
             size
         })
@@ -461,23 +521,25 @@ impl GridItem {
         tree: &mut impl LayoutPartialTree,
         axis: AbstractAxis,
         axis_tracks: &[GridTrack],
-        known_dimensions: Size<Option<f32>>,
+        grid_area_size: Size<Option<f32>>,
         inner_node_size: Size<Option<f32>>,
     ) -> f32 {
-        let padding = self.padding.resolve_or_zero(inner_node_size, |val, basis| tree.calc(val, basis));
-        let border = self.border.resolve_or_zero(inner_node_size, |val, basis| tree.calc(val, basis));
+        let padding =
+            Self::resolved_axis_side_lengths(self.padding, grid_area_size.width, |val, basis| tree.calc(val, basis));
+        let border =
+            Self::resolved_axis_side_lengths(self.border, grid_area_size.width, |val, basis| tree.calc(val, basis));
         let padding_border_size = (padding + border).sum_axes();
         let box_sizing_adjustment =
             if self.box_sizing == BoxSizing::ContentBox { padding_border_size } else { Size::ZERO };
         let size = self
             .size
-            .maybe_resolve(inner_node_size, |val, basis| tree.calc(val, basis))
+            .maybe_resolve(grid_area_size, |val, basis| tree.calc(val, basis))
             .maybe_apply_aspect_ratio(self.aspect_ratio)
             .maybe_add(box_sizing_adjustment)
             .get(axis)
             .or_else(|| {
                 self.min_size
-                    .maybe_resolve(inner_node_size, |val, basis| tree.calc(val, basis))
+                    .maybe_resolve(grid_area_size, |val, basis| tree.calc(val, basis))
                     .maybe_apply_aspect_ratio(self.aspect_ratio)
                     .maybe_add(box_sizing_adjustment)
                     .get(axis)
@@ -509,7 +571,7 @@ impl GridItem {
                 // Otherwise, the automatic minimum size is zero, as usual.
                 if use_content_based_minimum {
                     let mut minimum_contribution =
-                        self.min_content_contribution_cached(axis, tree, known_dimensions, inner_node_size);
+                        self.min_content_contribution_cached(axis, tree, grid_area_size, grid_area_size);
 
                     // If the item is a compressible replaced element, and has a definite preferred size or maximum size in the
                     // relevant axis, the size suggestion is capped by those sizes; for this purpose, any indefinite percentages
@@ -543,11 +605,11 @@ impl GridItem {
         tree: &mut impl LayoutPartialTree,
         axis: AbstractAxis,
         axis_tracks: &[GridTrack],
-        known_dimensions: Size<Option<f32>>,
+        grid_area_size: Size<Option<f32>>,
         inner_node_size: Size<Option<f32>>,
     ) -> f32 {
         self.minimum_contribution_cache.get(axis).unwrap_or_else(|| {
-            let size = self.minimum_contribution(tree, axis, axis_tracks, known_dimensions, inner_node_size);
+            let size = self.minimum_contribution(tree, axis, axis_tracks, grid_area_size, inner_node_size);
             self.minimum_contribution_cache.set(axis, Some(size));
             size
         })

--- a/tests/grid_percentage_paddings.rs
+++ b/tests/grid_percentage_paddings.rs
@@ -1,0 +1,61 @@
+use taffy::prelude::*;
+use taffy::Direction;
+use taffy_test_helpers::{new_test_tree, test_measure_function, TestNodeContext};
+
+const TEXT_10X10: TestNodeContext = TestNodeContext::fixed(10.0, 10.0);
+
+#[test]
+fn grid_item_percentage_padding_top_uses_grid_area_width_in_rtl() {
+    let mut taffy = new_test_tree();
+
+    let padded_item = taffy
+        .new_leaf_with_context(
+            Style {
+                direction: Direction::Rtl,
+                padding: Rect { left: zero(), right: zero(), top: percent(0.5), bottom: zero() },
+                ..Default::default()
+            },
+            TEXT_10X10,
+        )
+        .unwrap();
+
+    let second_row_item = taffy
+        .new_leaf(Style {
+            direction: Direction::Rtl,
+            size: Size { width: percent(1.0), height: length(10.0) },
+            ..Default::default()
+        })
+        .unwrap();
+
+    let grid = taffy
+        .new_with_children(
+            Style {
+                display: Display::Grid,
+                direction: Direction::Rtl,
+                size: Size { width: length(500.0), height: auto() },
+                justify_items: Some(AlignItems::Start),
+                grid_template_columns: vec![length(100.0)],
+                ..Default::default()
+            },
+            &[padded_item, second_row_item],
+        )
+        .unwrap();
+
+    taffy.compute_layout_with_measure(grid, Size::MAX_CONTENT, test_measure_function).unwrap();
+
+    let grid_layout = taffy.layout(grid).unwrap();
+    assert_eq!(grid_layout.size.width, 500.0);
+    assert_eq!(grid_layout.size.height, 70.0);
+
+    let padded_item_layout = taffy.layout(padded_item).unwrap();
+    assert_eq!(padded_item_layout.location.x, 490.0);
+    assert_eq!(padded_item_layout.location.y, 0.0);
+    assert_eq!(padded_item_layout.size.width, 10.0);
+    assert_eq!(padded_item_layout.size.height, 60.0);
+
+    let second_row_item_layout = taffy.layout(second_row_item).unwrap();
+    assert_eq!(second_row_item_layout.location.x, 400.0);
+    assert_eq!(second_row_item_layout.location.y, 60.0);
+    assert_eq!(second_row_item_layout.size.width, 100.0);
+    assert_eq!(second_row_item_layout.size.height, 10.0);
+}


### PR DESCRIPTION
# Objective

Fixes #920 

## Fixes the following WPT tests

Fail => Pass css/css-grid/alignment/grid-item-aspect-ratio-justify-self-001.html
Fail => Pass css/css-grid/alignment/grid-item-aspect-ratio-justify-self-002.html
Fail => Pass css/css-grid/grid-definition/flex-content-resolution-columns-001.html
Fail => Pass css/css-grid/grid-definition/flex-content-resolution-columns-002.html
Fail => Pass css/css-grid/grid-items/grid-item-containing-block-003.html
Fail => Pass css/css-grid/grid-items/grid-item-containing-block-004.html
Fail => Pass css/css-grid/grid-items/grid-items-percentage-margins-001.html
Fail => Pass css/css-grid/grid-items/grid-items-percentage-margins-002.html

## Context

To make the WPT test pass in Servo required some [changes there](https://github.com/rustnn/servo-ml/commit/0f57de8f25b08f89db7298f6035afd3d9f8bea91).

The screenshot still looks different from FF, but the WPT test is passing; I'm guessing because it's only the padding that matters. 

Servo:
<img width="558" height="626" alt="Screenshot 2026-04-03 at 12 53 32 AM" src="https://github.com/user-attachments/assets/77d8b912-6916-4971-be10-74a46cd58631" />

FF:
<img width="541" height="622" alt="Screenshot 2026-04-03 at 12 54 30 AM" src="https://github.com/user-attachments/assets/a0a52685-cda3-48f3-ab9b-a78a10695424" />
