### PR TITLE
Implement `safe` and `unsafe` overflow-position alignment keywords

### DIFF
--- a/benches/src/taffy_03_helpers.rs
+++ b/benches/src/taffy_03_helpers.rs
@@ -14,7 +14,7 @@ pub struct Taffy03TreeBuilder<R: Rng, G: GenStyle<TaffyStyle>> {
 
 // Implement the BuildTree trait
 impl<R: Rng, G: GenStyle<TaffyStyle>> BuildTree<R, G> for Taffy03TreeBuilder<R, G> {
-    const NAME: &'static str = "Taffy 0.3_f32";
+    const NAME: &'static str = "Taffy 0.3";
     type Tree = taffy_03::Taffy;
     type Node = taffy_03::prelude::Node;
 
@@ -153,7 +153,7 @@ fn convert_display(input: taffy::style::Display) -> taffy_03::style::Display {
         taffy::style::Display::None => taffy_03::style::Display::None,
         taffy::style::Display::Flex => taffy_03::style::Display::Flex,
         taffy::style::Display::Grid => taffy_03::style::Display::Grid,
-        taffy::style::Display::Block => panic!("Block layout not implemented in taffy 0.3_f32"),
+        taffy::style::Display::Block => panic!("Block layout not implemented in taffy 0.3"),
     }
 }
 

--- a/benches/src/taffy_03_helpers.rs
+++ b/benches/src/taffy_03_helpers.rs
@@ -1,4 +1,4 @@
-use rand::distributions::uniform::SampleRange;
+use rand::distr::uniform::SampleRange;
 use rand::Rng;
 use rand_chacha::ChaCha8Rng;
 use taffy::style::Style as TaffyStyle;
@@ -14,7 +14,7 @@ pub struct Taffy03TreeBuilder<R: Rng, G: GenStyle<TaffyStyle>> {
 
 // Implement the BuildTree trait
 impl<R: Rng, G: GenStyle<TaffyStyle>> BuildTree<R, G> for Taffy03TreeBuilder<R, G> {
-    const NAME: &'static str = "Taffy 0.3";
+    const NAME: &'static str = "Taffy 0.3_f32";
     type Tree = taffy_03::Taffy;
     type Node = taffy_03::prelude::Node;
 
@@ -120,25 +120,31 @@ fn convert_point<T, U, F: Fn(T) -> U>(input: taffy::geometry::Point<T>, map: F) 
 }
 
 fn convert_dimension(input: taffy::style::Dimension) -> taffy_03::style::Dimension {
-    match input {
-        taffy::style::Dimension::Length(val) => taffy_03::style::Dimension::Points(val),
-        taffy::style::Dimension::Percent(val) => taffy_03::style::Dimension::Percent(val),
-        taffy::style::Dimension::Auto => taffy_03::style::Dimension::Auto,
+    let raw = input.into_raw();
+    match raw.tag() {
+        taffy::style::CompactLength::LENGTH_TAG => taffy_03::style::Dimension::Points(raw.value()),
+        taffy::style::CompactLength::PERCENT_TAG => taffy_03::style::Dimension::Percent(raw.value()),
+        taffy::style::CompactLength::AUTO_TAG => taffy_03::style::Dimension::Auto,
+        _ => panic!("unsupported Dimension variant"),
     }
 }
 
 fn convert_length_percentage_auto(input: taffy::style::LengthPercentageAuto) -> taffy_03::style::LengthPercentageAuto {
-    match input {
-        taffy::style::LengthPercentageAuto::Length(val) => taffy_03::style::LengthPercentageAuto::Points(val),
-        taffy::style::LengthPercentageAuto::Percent(val) => taffy_03::style::LengthPercentageAuto::Percent(val),
-        taffy::style::LengthPercentageAuto::Auto => taffy_03::style::LengthPercentageAuto::Auto,
+    let raw = input.into_raw();
+    match raw.tag() {
+        taffy::style::CompactLength::LENGTH_TAG => taffy_03::style::LengthPercentageAuto::Points(raw.value()),
+        taffy::style::CompactLength::PERCENT_TAG => taffy_03::style::LengthPercentageAuto::Percent(raw.value()),
+        taffy::style::CompactLength::AUTO_TAG => taffy_03::style::LengthPercentageAuto::Auto,
+        _ => panic!("unsupported LengthPercentageAuto variant"),
     }
 }
 
 fn convert_length_percentage(input: taffy::style::LengthPercentage) -> taffy_03::style::LengthPercentage {
-    match input {
-        taffy::style::LengthPercentage::Length(val) => taffy_03::style::LengthPercentage::Points(val),
-        taffy::style::LengthPercentage::Percent(val) => taffy_03::style::LengthPercentage::Percent(val),
+    let raw = input.into_raw();
+    match raw.tag() {
+        taffy::style::CompactLength::LENGTH_TAG => taffy_03::style::LengthPercentage::Points(raw.value()),
+        taffy::style::CompactLength::PERCENT_TAG => taffy_03::style::LengthPercentage::Percent(raw.value()),
+        _ => panic!("unsupported LengthPercentage variant"),
     }
 }
 
@@ -147,7 +153,7 @@ fn convert_display(input: taffy::style::Display) -> taffy_03::style::Display {
         taffy::style::Display::None => taffy_03::style::Display::None,
         taffy::style::Display::Flex => taffy_03::style::Display::Flex,
         taffy::style::Display::Grid => taffy_03::style::Display::Grid,
-        taffy::style::Display::Block => panic!("Block layout not implemented in taffy 0.3"),
+        taffy::style::Display::Block => panic!("Block layout not implemented in taffy 0.3_f32"),
     }
 }
 

--- a/benches/src/yoga_helpers.rs
+++ b/benches/src/yoga_helpers.rs
@@ -139,70 +139,45 @@ fn into_yg_units(dim: impl Into<tf::Dimension>) -> yg::StyleUnit {
 }
 
 fn into_pixels(dim: impl Into<tf::Dimension>) -> f32 {
-    dim.into().into_option().unwrap_or(0.0)
+    dim.into().into_option().unwrap_or(0.0_f32)
 }
 
 fn items_into_align(align: Option<tf::AlignSelf>) -> yg::Align {
-    match align {
-        None => yg::Align::Auto,
-        Some(tf::AlignSelf::FlexStart) => yg::Align::FlexStart,
-        Some(tf::AlignSelf::FlexEnd) => yg::Align::FlexEnd,
-        Some(tf::AlignSelf::Center) => yg::Align::Center,
-        Some(tf::AlignSelf::Baseline) => yg::Align::Baseline,
-        Some(tf::AlignSelf::Stretch) => yg::Align::Stretch,
-        Some(tf::AlignSelf::Start) => unimplemented!(),
-        Some(tf::AlignSelf::End) => unimplemented!(),
-        Some(
-            tf::AlignSelf::SafeStart
-            | tf::AlignSelf::SafeEnd
-            | tf::AlignSelf::SafeFlexStart
-            | tf::AlignSelf::SafeFlexEnd
-            | tf::AlignSelf::SafeCenter,
-        ) => unimplemented!(),
+    // Yoga has no safe/unsafe overflow-position concept — drop the safety field and dispatch
+    // on the bare keyword. Safe and unsafe alike fold to the same yoga keyword.
+    let Some(align) = align else { return yg::Align::Auto };
+    match align.keyword {
+        tf::AlignItemsKeyword::FlexStart => yg::Align::FlexStart,
+        tf::AlignItemsKeyword::FlexEnd => yg::Align::FlexEnd,
+        tf::AlignItemsKeyword::Center => yg::Align::Center,
+        tf::AlignItemsKeyword::Baseline => yg::Align::Baseline,
+        tf::AlignItemsKeyword::Stretch => yg::Align::Stretch,
+        tf::AlignItemsKeyword::Start | tf::AlignItemsKeyword::End => unimplemented!(),
     }
 }
 
 fn content_into_align(align: Option<tf::AlignContent>) -> yg::Align {
-    match align {
-        None => yg::Align::Auto,
-        Some(tf::AlignContent::FlexStart) => yg::Align::FlexStart,
-        Some(tf::AlignContent::Start) => yg::Align::FlexStart,
-        Some(tf::AlignContent::FlexEnd) => yg::Align::FlexEnd,
-        Some(tf::AlignContent::End) => yg::Align::FlexEnd,
-        Some(tf::AlignContent::Center) => yg::Align::Center,
-        Some(tf::AlignContent::Stretch) => yg::Align::Stretch,
-        Some(tf::AlignContent::SpaceBetween) => yg::Align::SpaceBetween,
-        Some(tf::AlignContent::SpaceAround) => yg::Align::SpaceAround,
-        Some(tf::AlignContent::SpaceEvenly) => unimplemented!(),
-        Some(
-            tf::AlignContent::SafeStart
-            | tf::AlignContent::SafeEnd
-            | tf::AlignContent::SafeFlexStart
-            | tf::AlignContent::SafeFlexEnd
-            | tf::AlignContent::SafeCenter,
-        ) => unimplemented!(),
+    let Some(align) = align else { return yg::Align::Auto };
+    match align.keyword {
+        tf::AlignContentKeyword::FlexStart | tf::AlignContentKeyword::Start => yg::Align::FlexStart,
+        tf::AlignContentKeyword::FlexEnd | tf::AlignContentKeyword::End => yg::Align::FlexEnd,
+        tf::AlignContentKeyword::Center => yg::Align::Center,
+        tf::AlignContentKeyword::Stretch => yg::Align::Stretch,
+        tf::AlignContentKeyword::SpaceBetween => yg::Align::SpaceBetween,
+        tf::AlignContentKeyword::SpaceAround => yg::Align::SpaceAround,
+        tf::AlignContentKeyword::SpaceEvenly => unimplemented!(),
     }
 }
 
 fn content_into_justify(align: Option<tf::JustifyContent>) -> yg::Justify {
-    match align {
-        None => yg::Justify::FlexStart,
-        Some(tf::JustifyContent::FlexStart) => yg::Justify::FlexStart,
-        Some(tf::JustifyContent::Start) => yg::Justify::FlexStart,
-        Some(tf::JustifyContent::FlexEnd) => yg::Justify::FlexEnd,
-        Some(tf::JustifyContent::End) => yg::Justify::FlexEnd,
-        Some(tf::JustifyContent::Center) => yg::Justify::Center,
-        Some(tf::JustifyContent::SpaceBetween) => yg::Justify::SpaceBetween,
-        Some(tf::JustifyContent::SpaceAround) => yg::Justify::SpaceAround,
-        Some(tf::JustifyContent::Stretch) => unimplemented!(),
-        Some(tf::JustifyContent::SpaceEvenly) => unimplemented!(),
-        Some(
-            tf::JustifyContent::SafeStart
-            | tf::JustifyContent::SafeEnd
-            | tf::JustifyContent::SafeFlexStart
-            | tf::JustifyContent::SafeFlexEnd
-            | tf::JustifyContent::SafeCenter,
-        ) => unimplemented!(),
+    let Some(align) = align else { return yg::Justify::FlexStart };
+    match align.keyword {
+        tf::AlignContentKeyword::FlexStart | tf::AlignContentKeyword::Start => yg::Justify::FlexStart,
+        tf::AlignContentKeyword::FlexEnd | tf::AlignContentKeyword::End => yg::Justify::FlexEnd,
+        tf::AlignContentKeyword::Center => yg::Justify::Center,
+        tf::AlignContentKeyword::SpaceBetween => yg::Justify::SpaceBetween,
+        tf::AlignContentKeyword::SpaceAround => yg::Justify::SpaceAround,
+        tf::AlignContentKeyword::Stretch | tf::AlignContentKeyword::SpaceEvenly => unimplemented!(),
     }
 }
 

--- a/benches/src/yoga_helpers.rs
+++ b/benches/src/yoga_helpers.rs
@@ -139,7 +139,7 @@ fn into_yg_units(dim: impl Into<tf::Dimension>) -> yg::StyleUnit {
 }
 
 fn into_pixels(dim: impl Into<tf::Dimension>) -> f32 {
-    dim.into().into_option().unwrap_or(0.0_f32)
+    dim.into().into_option().unwrap_or(0.0)
 }
 
 fn items_into_align(align: Option<tf::AlignSelf>) -> yg::Align {

--- a/benches/src/yoga_helpers.rs
+++ b/benches/src/yoga_helpers.rs
@@ -152,6 +152,13 @@ fn items_into_align(align: Option<tf::AlignSelf>) -> yg::Align {
         Some(tf::AlignSelf::Stretch) => yg::Align::Stretch,
         Some(tf::AlignSelf::Start) => unimplemented!(),
         Some(tf::AlignSelf::End) => unimplemented!(),
+        Some(
+            tf::AlignSelf::SafeStart
+            | tf::AlignSelf::SafeEnd
+            | tf::AlignSelf::SafeFlexStart
+            | tf::AlignSelf::SafeFlexEnd
+            | tf::AlignSelf::SafeCenter,
+        ) => unimplemented!(),
     }
 }
 
@@ -167,6 +174,13 @@ fn content_into_align(align: Option<tf::AlignContent>) -> yg::Align {
         Some(tf::AlignContent::SpaceBetween) => yg::Align::SpaceBetween,
         Some(tf::AlignContent::SpaceAround) => yg::Align::SpaceAround,
         Some(tf::AlignContent::SpaceEvenly) => unimplemented!(),
+        Some(
+            tf::AlignContent::SafeStart
+            | tf::AlignContent::SafeEnd
+            | tf::AlignContent::SafeFlexStart
+            | tf::AlignContent::SafeFlexEnd
+            | tf::AlignContent::SafeCenter,
+        ) => unimplemented!(),
     }
 }
 
@@ -182,6 +196,13 @@ fn content_into_justify(align: Option<tf::JustifyContent>) -> yg::Justify {
         Some(tf::JustifyContent::SpaceAround) => yg::Justify::SpaceAround,
         Some(tf::JustifyContent::Stretch) => unimplemented!(),
         Some(tf::JustifyContent::SpaceEvenly) => unimplemented!(),
+        Some(
+            tf::JustifyContent::SafeStart
+            | tf::JustifyContent::SafeEnd
+            | tf::JustifyContent::SafeFlexStart
+            | tf::JustifyContent::SafeFlexEnd
+            | tf::JustifyContent::SafeCenter,
+        ) => unimplemented!(),
     }
 }
 

--- a/docs/style-properties.md
+++ b/docs/style-properties.md
@@ -47,3 +47,26 @@ N = Supported in spec but not implemented in Taffy
 | `grid_row`               | -    | Y    | `Line<GridPlacement>`                 | 8     | -      | The vertical (row) placement of a grid item                                                 |
 | `grid_column`            | -    | Y    | `Line<GridPlacement>`                 | 8     | -      | The horizontal (row) placement of a grid item                                               |
 | `grid_area`              | -    | 5    | -                                     | -     | -      | Accepts either shorthand row/column-start/end or a named grid area                          |
+
+## Safe and unsafe overflow alignment
+
+The `AlignItems` and `AlignContent` enums (and their `AlignSelf`, `JustifyItems`, `JustifySelf`,
+and `JustifyContent` aliases) carry a set of `Safe*` variants that pair the spec's
+[overflow-position keyword](https://www.w3.org/TR/css-align-3/#overflow-values) `safe` with the
+underlying position keyword. The variants are:
+
+- `SafeStart`, `SafeEnd`, `SafeFlexStart`, `SafeFlexEnd`, `SafeCenter`
+
+When the alignment subject would overflow its alignment container, a `Safe*` value falls back
+to logical `Start` so the start edge of the content stays visible. When the subject fits, the
+`Safe*` variant behaves identically to its underlying position keyword. The plain (non-`Safe*`)
+variants are equivalent to the spec's `unsafe` keyword and keep their requested position even
+when that causes overflow at the start edge.
+
+The CSS modifier is only valid against the position keywords listed above. Combinations such
+as `safe stretch`, `safe baseline`, and `safe space-between` are not representable and are
+rejected by the parser when the `parse` feature is enabled.
+
+The `safe`/`unsafe` overflow-position keyword is supported by both the Flexbox and CSS Grid
+layout algorithms for both content-level (`align-content`, `justify-content`) and self-level
+(`align-self`, `justify-self`) alignment.

--- a/docs/style-properties.md
+++ b/docs/style-properties.md
@@ -24,12 +24,12 @@ N = Supported in spec but not implemented in Taffy
 | `margin`                 | Y    | ~Y   | `Rect<LengthPercentageAuto>`          | 32    | -      | How large should the margin be on each side?                                                |
 | `gap`                    | Y    | Y    | `Size<LengthPercentage>`              | 16    | -      | The size of the vertical and horizontal gaps between flex items / grid rows                 |
 | **Alignment**            |      |      |                                       |       |        |                                                                                             |
-| `align_content`          | Y    | Y    | `AlignContent`                        | 1     | -      | How should content contained within this item be aligned relative to the cross axis?        |
-| `justify_content`        | Y    | Y    | `AlignContent`                        | 1     | -      | How should content contained within this item be aligned relative to the main axis?         |
-| `align_items`            | Y    | Y    | `AlignItems`                          | 1     | -      | How should items be aligned relative to the cross axis?                                     |
-| `align_self`             | Y    | Y    | `Option<AlignItems>`                  | 1     | -      | Should this item violate the cross axis alignment specified by its parent's [`AlignItems`]? |
-| `justify_items`          | -    | Y    | `AlignItems`                          | 1     | -      | How should items be aligned relative to the main axis?                                      |
-| `justify_self`           | -    | Y    | `Option<AlignItems>`                  | 1     | -      | Should this item violate the main axis alignment specified by its parent's [`AlignItems`]?  |
+| `align_content`          | Y    | Y    | `AlignContent`                        | 2     | -      | How should content contained within this item be aligned relative to the cross axis?        |
+| `justify_content`        | Y    | Y    | `AlignContent`                        | 2     | -      | How should content contained within this item be aligned relative to the main axis?         |
+| `align_items`            | Y    | Y    | `AlignItems`                          | 2     | -      | How should items be aligned relative to the cross axis?                                     |
+| `align_self`             | Y    | Y    | `Option<AlignItems>`                  | 2     | -      | Should this item violate the cross axis alignment specified by its parent's [`AlignItems`]? |
+| `justify_items`          | -    | Y    | `AlignItems`                          | 2     | -      | How should items be aligned relative to the main axis?                                      |
+| `justify_self`           | -    | Y    | `Option<AlignItems>`                  | 2     | -      | Should this item violate the main axis alignment specified by its parent's [`AlignItems`]?  |
 | **Flexbox**              |      |      |                                       |       |        |                                                                                             |
 | `flex_direction`         | Y    | -    | `FlexDirection`                       | 1     | -      | Which direction does the main axis flow in?                                                 |
 | `flex_wrap`              | Y    | -    | `FlexWrap`                            | 1     | -      | Should elements wrap, or stay in a single line?                                             |
@@ -50,23 +50,34 @@ N = Supported in spec but not implemented in Taffy
 
 ## Safe and unsafe overflow alignment
 
-The `AlignItems` and `AlignContent` enums (and their `AlignSelf`, `JustifyItems`, `JustifySelf`,
-and `JustifyContent` aliases) carry a set of `Safe*` variants that pair the spec's
-[overflow-position keyword](https://www.w3.org/TR/css-align-3/#overflow-values) `safe` with the
-underlying position keyword. The variants are:
+`AlignItems` and `AlignContent` (and their aliases `AlignSelf`, `JustifyItems`, `JustifySelf`,
+`JustifyContent`) are structs with two orthogonal fields:
 
-- `SafeStart`, `SafeEnd`, `SafeFlexStart`, `SafeFlexEnd`, `SafeCenter`
+```rust
+pub struct AlignContent {
+    pub keyword: AlignContentKeyword,   // Start, End, FlexStart, FlexEnd, Center,
+                                        // Stretch, SpaceBetween, SpaceEvenly, SpaceAround
+    pub safety: AlignmentSafety,        // Safe | Unsafe
+}
+```
 
-When the alignment subject would overflow its alignment container, a `Safe*` value falls back
-to logical `Start` so the start edge of the content stays visible. When the subject fits, the
-`Safe*` variant behaves identically to its underlying position keyword. The plain (non-`Safe*`)
-variants are equivalent to the spec's `unsafe` keyword and keep their requested position even
-when that causes overflow at the start edge.
+For ergonomics every CSS spelling is exposed as an associated constant — `AlignContent::Start`,
+`AlignContent::SafeStart`, `AlignItems::SafeFlexEnd`, etc. — so call sites read identically to
+the previous enum form.
 
-The CSS modifier is only valid against the position keywords listed above. Combinations such
-as `safe stretch`, `safe baseline`, and `safe space-between` are not representable and are
-rejected by the parser when the `parse` feature is enabled.
+The `safety` field corresponds to the spec's
+[overflow-position keyword](https://www.w3.org/TR/css-align-3/#overflow-values). When the
+alignment subject would overflow its alignment container, `AlignmentSafety::Safe` falls back
+to logical `Start` so the start edge of the content stays visible. `AlignmentSafety::Unsafe`
+(the default) keeps the requested alignment even when that causes overflow at the start edge.
 
-The `safe`/`unsafe` overflow-position keyword is supported by both the Flexbox and CSS Grid
-layout algorithms for both content-level (`align-content`, `justify-content`) and self-level
-(`align-self`, `justify-self`) alignment.
+The spec only defines `safe`/`unsafe` against the position keywords `start`, `end`,
+`flex-start`, `flex-end`, `center`. Combinations such as `safe stretch`, `safe baseline`, and
+`safe space-between` are rejected by the parser when the `parse` feature is enabled, and the
+compute pass treats them as `Unsafe` if a value somehow reaches it via manual struct
+construction.
+
+Use the `is_safe()` method to check the safety modifier and `keyword()` to retrieve the bare
+position keyword. The `safe`/`unsafe` overflow-position keyword is supported by both the
+Flexbox and CSS Grid layout algorithms for both content-level (`align-content`,
+`justify-content`) and self-level (`align-self`, `justify-self`) alignment.

--- a/src/compute/common/alignment.rs
+++ b/src/compute/common/alignment.rs
@@ -18,7 +18,7 @@ pub(crate) fn apply_alignment_fallback(
     //    distributed alignment keywords (`stretch`, `space-*`) fall back to a positional keyword
     //    and gain implicit `safe` semantics so step 2 can flip them to `Start` on overflow.
     //    https://www.w3.org/TR/css-align-3/#distribution-values
-    if num_items <= 1 || free_space <= 0.0_f32 {
+    if num_items <= 1 || free_space <= 0.0 {
         (keyword, is_safe) = match keyword {
             AlignContentKeyword::Stretch | AlignContentKeyword::SpaceBetween => (AlignContentKeyword::FlexStart, true),
             AlignContentKeyword::SpaceAround | AlignContentKeyword::SpaceEvenly => (AlignContentKeyword::Center, true),
@@ -28,7 +28,7 @@ pub(crate) fn apply_alignment_fallback(
 
     // 2. Safe alignment falls back to `Start` whenever the alignment subject would overflow the
     //    alignment container.
-    if free_space <= 0.0_f32 && is_safe {
+    if free_space <= 0.0 && is_safe {
         keyword = AlignContentKeyword::Start;
     }
 
@@ -51,7 +51,7 @@ pub(crate) fn compute_alignment_offset(
 ) -> f32 {
     if is_first {
         match alignment_mode {
-            AlignContentKeyword::Start => 0.0_f32,
+            AlignContentKeyword::Start => 0.0,
             AlignContentKeyword::FlexStart => {
                 if layout_is_flex_reversed {
                     free_space
@@ -67,18 +67,18 @@ pub(crate) fn compute_alignment_offset(
                     free_space
                 }
             }
-            AlignContentKeyword::Center => free_space / 2.0_f32,
-            AlignContentKeyword::Stretch => 0.0_f32,
-            AlignContentKeyword::SpaceBetween => 0.0_f32,
+            AlignContentKeyword::Center => free_space / 2.0,
+            AlignContentKeyword::Stretch => 0.0,
+            AlignContentKeyword::SpaceBetween => 0.0,
             AlignContentKeyword::SpaceAround => {
-                if free_space >= 0.0_f32 {
+                if free_space >= 0.0 {
                     (free_space / num_items as f32) / 2.0
                 } else {
                     free_space / 2.0
                 }
             }
             AlignContentKeyword::SpaceEvenly => {
-                if free_space >= 0.0_f32 {
+                if free_space >= 0.0 {
                     free_space / (num_items + 1) as f32
                 } else {
                     free_space / 2.0
@@ -86,14 +86,14 @@ pub(crate) fn compute_alignment_offset(
             }
         }
     } else {
-        let free_space = free_space.max(0.0_f32);
+        let free_space = free_space.max(0.0);
         gap + match alignment_mode {
             AlignContentKeyword::Start
             | AlignContentKeyword::FlexStart
             | AlignContentKeyword::End
             | AlignContentKeyword::FlexEnd
             | AlignContentKeyword::Center
-            | AlignContentKeyword::Stretch => 0.0_f32,
+            | AlignContentKeyword::Stretch => 0.0,
             AlignContentKeyword::SpaceBetween => free_space / (num_items - 1) as f32,
             AlignContentKeyword::SpaceAround => free_space / num_items as f32,
             AlignContentKeyword::SpaceEvenly => free_space / (num_items + 1) as f32,

--- a/src/compute/common/alignment.rs
+++ b/src/compute/common/alignment.rs
@@ -1,42 +1,38 @@
 //! Generic CSS alignment code that is shared between both the Flexbox and CSS Grid algorithms.
-use crate::style::AlignContent;
+use crate::style::{AlignContent, AlignContentKeyword, AlignmentSafety};
 
-/// Implement fallback alignment.
+/// Resolve any spec-defined fallbacks for the given [`AlignContent`] value, returning the
+/// bare position keyword the alignment math should use.
 ///
-/// In addition to the spec at https://www.w3.org/TR/css-align-3/ this implementation follows
-/// the resolution of https://github.com/w3c/csswg-drafts/issues/10154
+/// In addition to the spec at <https://www.w3.org/TR/css-align-3/> this implementation follows
+/// the resolution of <https://github.com/w3c/csswg-drafts/issues/10154>.
 pub(crate) fn apply_alignment_fallback(
     free_space: f32,
     num_items: usize,
-    mut alignment_mode: AlignContent,
-) -> AlignContent {
-    // Pick up the overflow-position modifier from the alignment style itself, then continue
-    // with the underlying position keyword.
-    let mut is_safe = alignment_mode.is_safe();
-    if is_safe {
-        alignment_mode = alignment_mode.position();
-    }
+    alignment_mode: AlignContent,
+) -> AlignContentKeyword {
+    let mut keyword = alignment_mode.keyword;
+    let mut is_safe = matches!(alignment_mode.safety, AlignmentSafety::Safe);
 
-    // Fallback occurs in two cases:
-
-    // 1. If there is only a single item being aligned and alignment is a distributed alignment keyword
+    // 1. If there is only a single item being aligned or the items overflow the container, the
+    //    distributed alignment keywords (`stretch`, `space-*`) fall back to a positional keyword
+    //    and gain implicit `safe` semantics so step 2 can flip them to `Start` on overflow.
     //    https://www.w3.org/TR/css-align-3/#distribution-values
-    if num_items <= 1 || free_space <= 0.0 {
-        (alignment_mode, is_safe) = match alignment_mode {
-            AlignContent::Stretch => (AlignContent::FlexStart, true),
-            AlignContent::SpaceBetween => (AlignContent::FlexStart, true),
-            AlignContent::SpaceAround => (AlignContent::Center, true),
-            AlignContent::SpaceEvenly => (AlignContent::Center, true),
-            _ => (alignment_mode, is_safe),
-        }
-    };
-
-    // 2. If free space is negative the "safe" alignment variants all fallback to Start alignment
-    if free_space <= 0.0 && is_safe {
-        alignment_mode = AlignContent::Start;
+    if num_items <= 1 || free_space <= 0.0_f32 {
+        (keyword, is_safe) = match keyword {
+            AlignContentKeyword::Stretch | AlignContentKeyword::SpaceBetween => (AlignContentKeyword::FlexStart, true),
+            AlignContentKeyword::SpaceAround | AlignContentKeyword::SpaceEvenly => (AlignContentKeyword::Center, true),
+            other => (other, is_safe),
+        };
     }
 
-    alignment_mode
+    // 2. Safe alignment falls back to `Start` whenever the alignment subject would overflow the
+    //    alignment container.
+    if free_space <= 0.0_f32 && is_safe {
+        keyword = AlignContentKeyword::Start;
+    }
+
+    keyword
 }
 
 /// Generic alignment function that is used:
@@ -49,42 +45,40 @@ pub(crate) fn compute_alignment_offset(
     free_space: f32,
     num_items: usize,
     gap: f32,
-    alignment_mode: AlignContent,
+    alignment_mode: AlignContentKeyword,
     layout_is_flex_reversed: bool,
     is_first: bool,
 ) -> f32 {
-    // Safe* variants share the offset math of their underlying position keyword. The
-    // overflow-aware fallback to Start is applied upstream by `apply_alignment_fallback`.
     if is_first {
         match alignment_mode {
-            AlignContent::Start | AlignContent::SafeStart => 0.0,
-            AlignContent::FlexStart | AlignContent::SafeFlexStart => {
+            AlignContentKeyword::Start => 0.0_f32,
+            AlignContentKeyword::FlexStart => {
                 if layout_is_flex_reversed {
                     free_space
                 } else {
                     0.0
                 }
             }
-            AlignContent::End | AlignContent::SafeEnd => free_space,
-            AlignContent::FlexEnd | AlignContent::SafeFlexEnd => {
+            AlignContentKeyword::End => free_space,
+            AlignContentKeyword::FlexEnd => {
                 if layout_is_flex_reversed {
                     0.0
                 } else {
                     free_space
                 }
             }
-            AlignContent::Center | AlignContent::SafeCenter => free_space / 2.0,
-            AlignContent::Stretch => 0.0,
-            AlignContent::SpaceBetween => 0.0,
-            AlignContent::SpaceAround => {
-                if free_space >= 0.0 {
+            AlignContentKeyword::Center => free_space / 2.0_f32,
+            AlignContentKeyword::Stretch => 0.0_f32,
+            AlignContentKeyword::SpaceBetween => 0.0_f32,
+            AlignContentKeyword::SpaceAround => {
+                if free_space >= 0.0_f32 {
                     (free_space / num_items as f32) / 2.0
                 } else {
                     free_space / 2.0
                 }
             }
-            AlignContent::SpaceEvenly => {
-                if free_space >= 0.0 {
+            AlignContentKeyword::SpaceEvenly => {
+                if free_space >= 0.0_f32 {
                     free_space / (num_items + 1) as f32
                 } else {
                     free_space / 2.0
@@ -92,17 +86,17 @@ pub(crate) fn compute_alignment_offset(
             }
         }
     } else {
-        let free_space = free_space.max(0.0);
+        let free_space = free_space.max(0.0_f32);
         gap + match alignment_mode {
-            AlignContent::Start | AlignContent::SafeStart => 0.0,
-            AlignContent::FlexStart | AlignContent::SafeFlexStart => 0.0,
-            AlignContent::End | AlignContent::SafeEnd => 0.0,
-            AlignContent::FlexEnd | AlignContent::SafeFlexEnd => 0.0,
-            AlignContent::Center | AlignContent::SafeCenter => 0.0,
-            AlignContent::Stretch => 0.0,
-            AlignContent::SpaceBetween => free_space / (num_items - 1) as f32,
-            AlignContent::SpaceAround => free_space / num_items as f32,
-            AlignContent::SpaceEvenly => free_space / (num_items + 1) as f32,
+            AlignContentKeyword::Start
+            | AlignContentKeyword::FlexStart
+            | AlignContentKeyword::End
+            | AlignContentKeyword::FlexEnd
+            | AlignContentKeyword::Center
+            | AlignContentKeyword::Stretch => 0.0_f32,
+            AlignContentKeyword::SpaceBetween => free_space / (num_items - 1) as f32,
+            AlignContentKeyword::SpaceAround => free_space / num_items as f32,
+            AlignContentKeyword::SpaceEvenly => free_space / (num_items + 1) as f32,
         }
     }
 }

--- a/src/compute/common/alignment.rs
+++ b/src/compute/common/alignment.rs
@@ -11,6 +11,13 @@ pub(crate) fn apply_alignment_fallback(
     mut alignment_mode: AlignContent,
     mut is_safe: bool,
 ) -> AlignContent {
+    // If a Safe* variant was passed in, fold its overflow-position modifier into the
+    // is_safe flag and continue with the underlying position keyword.
+    if alignment_mode.is_safe() {
+        is_safe = true;
+        alignment_mode = alignment_mode.position();
+    }
+
     // Fallback occurs in two cases:
 
     // 1. If there is only a single item being aligned and alignment is a distributed alignment keyword
@@ -47,25 +54,27 @@ pub(crate) fn compute_alignment_offset(
     layout_is_flex_reversed: bool,
     is_first: bool,
 ) -> f32 {
+    // Safe* variants share the offset math of their underlying position keyword. The
+    // overflow-aware fallback to Start is applied upstream by `apply_alignment_fallback`.
     if is_first {
         match alignment_mode {
-            AlignContent::Start => 0.0,
-            AlignContent::FlexStart => {
+            AlignContent::Start | AlignContent::SafeStart => 0.0,
+            AlignContent::FlexStart | AlignContent::SafeFlexStart => {
                 if layout_is_flex_reversed {
                     free_space
                 } else {
                     0.0
                 }
             }
-            AlignContent::End => free_space,
-            AlignContent::FlexEnd => {
+            AlignContent::End | AlignContent::SafeEnd => free_space,
+            AlignContent::FlexEnd | AlignContent::SafeFlexEnd => {
                 if layout_is_flex_reversed {
                     0.0
                 } else {
                     free_space
                 }
             }
-            AlignContent::Center => free_space / 2.0,
+            AlignContent::Center | AlignContent::SafeCenter => free_space / 2.0,
             AlignContent::Stretch => 0.0,
             AlignContent::SpaceBetween => 0.0,
             AlignContent::SpaceAround => {
@@ -86,11 +95,11 @@ pub(crate) fn compute_alignment_offset(
     } else {
         let free_space = free_space.max(0.0);
         gap + match alignment_mode {
-            AlignContent::Start => 0.0,
-            AlignContent::FlexStart => 0.0,
-            AlignContent::End => 0.0,
-            AlignContent::FlexEnd => 0.0,
-            AlignContent::Center => 0.0,
+            AlignContent::Start | AlignContent::SafeStart => 0.0,
+            AlignContent::FlexStart | AlignContent::SafeFlexStart => 0.0,
+            AlignContent::End | AlignContent::SafeEnd => 0.0,
+            AlignContent::FlexEnd | AlignContent::SafeFlexEnd => 0.0,
+            AlignContent::Center | AlignContent::SafeCenter => 0.0,
             AlignContent::Stretch => 0.0,
             AlignContent::SpaceBetween => free_space / (num_items - 1) as f32,
             AlignContent::SpaceAround => free_space / num_items as f32,

--- a/src/compute/common/alignment.rs
+++ b/src/compute/common/alignment.rs
@@ -9,12 +9,11 @@ pub(crate) fn apply_alignment_fallback(
     free_space: f32,
     num_items: usize,
     mut alignment_mode: AlignContent,
-    mut is_safe: bool,
 ) -> AlignContent {
-    // If a Safe* variant was passed in, fold its overflow-position modifier into the
-    // is_safe flag and continue with the underlying position keyword.
-    if alignment_mode.is_safe() {
-        is_safe = true;
+    // Pick up the overflow-position modifier from the alignment style itself, then continue
+    // with the underlying position keyword.
+    let mut is_safe = alignment_mode.is_safe();
+    if is_safe {
         alignment_mode = alignment_mode.position();
     }
 

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -233,13 +233,13 @@ fn compute_preliminary(tree: &mut impl LayoutFlexboxContainer, node: NodeId, inp
 
     // 9. Flex Layout Algorithm
 
-    // 9.1_f32. Initial Setup
+    // 9.1. Initial Setup
 
     // 1. Generate anonymous flex items as described in §4 Flex Items.
     debug_log!("generate_anonymous_flex_items");
     let mut flex_items = generate_anonymous_flex_items(tree, node, &constants);
 
-    // 9.2_f32. Line Length Determination
+    // 9.2. Line Length Determination
 
     // 2. Determine the available main and cross space for the flex items
     debug_log!("determine_available_space");
@@ -261,7 +261,7 @@ fn compute_preliminary(tree: &mut impl LayoutFlexboxContainer, node: NodeId, inp
     // 4. Determine the main size of the flex container
     // This has already been done as part of compute_constants. The inner size is exposed as constants.node_inner_size.
 
-    // 9.3_f32. Main Size Determination
+    // 9.3. Main Size Determination
 
     // 5. Collect flex items into flex lines.
     debug_log!("collect_flex_lines");
@@ -290,7 +290,7 @@ fn compute_preliminary(tree: &mut impl LayoutFlexboxContainer, node: NodeId, inp
             .gap()
             .main(constants.dir)
             .maybe_resolve(inner_container_size, |val, basis| tree.calc(val, basis))
-            .unwrap_or(0.0_f32);
+            .unwrap_or(0.0);
         constants.gap.set_main(constants.dir, new_gap);
     }
 
@@ -300,7 +300,7 @@ fn compute_preliminary(tree: &mut impl LayoutFlexboxContainer, node: NodeId, inp
         resolve_flexible_lengths(line, &constants);
     }
 
-    // 9.4_f32. Cross Size Determination
+    // 9.4. Cross Size Determination
 
     // 7. Determine the hypothetical cross size of each item.
     debug_log!("determine_hypothetical_cross_size");
@@ -340,13 +340,13 @@ fn compute_preliminary(tree: &mut impl LayoutFlexboxContainer, node: NodeId, inp
     debug_log!("determine_used_cross_size");
     determine_used_cross_size(tree, &mut flex_lines, &constants);
 
-    // 9.5_f32. Main-Axis Alignment
+    // 9.5. Main-Axis Alignment
 
     // 12. Distribute any remaining free space.
     debug_log!("distribute_remaining_free_space");
     distribute_remaining_free_space(&mut flex_lines, &constants);
 
-    // 9.6_f32. Cross-Axis Alignment
+    // 9.6. Cross-Axis Alignment
 
     // 13. Resolve cross-axis auto margins (also includes 14).
     debug_log!("resolve_cross_axis_auto_margins");
@@ -391,7 +391,7 @@ fn compute_preliminary(tree: &mut impl LayoutFlexboxContainer, node: NodeId, inp
         }
     }
 
-    // 8.5_f32. Flex Container Baselines: calculate the flex container's first baseline
+    // 8.5. Flex Container Baselines: calculate the flex container's first baseline
     // See https://www.w3.org/TR/css-flexbox-1/#flex-baselines
     let first_vertical_baseline = if flex_lines.is_empty() {
         None
@@ -446,7 +446,7 @@ fn compute_constants(
     // *horizontal* space to be reserved for a scrollbar
     let scrollbar_gutter = style.overflow().transpose().map(|overflow| match overflow {
         Overflow::Scroll => style.scrollbar_width(),
-        _ => 0.0_f32,
+        _ => 0.0,
     });
     let mut content_box_inset = padding + border;
     content_box_inset.bottom += scrollbar_gutter.y;
@@ -497,7 +497,7 @@ fn compute_constants(
 
 /// Generate anonymous flex items.
 ///
-/// # [9.1_f32. Initial Setup](https://www.w3.org/TR/css-flexbox-1/#box-manip)
+/// # [9.1. Initial Setup](https://www.w3.org/TR/css-flexbox-1/#box-manip)
 ///
 /// - [**Generate anonymous flex items**](https://www.w3.org/TR/css-flexbox-1/#algo-anon-box) as described in [§4 Flex Items](https://www.w3.org/TR/css-flexbox-1/#flex-items).
 #[inline]
@@ -559,22 +559,22 @@ fn generate_anonymous_flex_items(
                 scrollbar_width: child_style.scrollbar_width(),
                 flex_grow: child_style.flex_grow(),
                 flex_shrink: child_style.flex_shrink(),
-                flex_basis: 0.0_f32,
-                inner_flex_basis: 0.0_f32,
-                violation: 0.0_f32,
+                flex_basis: 0.0,
+                inner_flex_basis: 0.0,
+                violation: 0.0,
                 frozen: false,
 
-                resolved_minimum_main_size: 0.0_f32,
+                resolved_minimum_main_size: 0.0,
                 hypothetical_inner_size: Size::zero(),
                 hypothetical_outer_size: Size::zero(),
                 target_size: Size::zero(),
                 outer_target_size: Size::zero(),
-                content_flex_fraction: 0.0_f32,
+                content_flex_fraction: 0.0,
 
-                baseline: 0.0_f32,
+                baseline: 0.0,
 
-                offset_main: 0.0_f32,
-                offset_cross: 0.0_f32,
+                offset_main: 0.0,
+                offset_cross: 0.0,
             }
         })
         .collect()
@@ -582,7 +582,7 @@ fn generate_anonymous_flex_items(
 
 /// Determine the available main and cross space for the flex items.
 ///
-/// # [9.2_f32. Line Length Determination](https://www.w3.org/TR/css-flexbox-1/#line-sizing)
+/// # [9.2. Line Length Determination](https://www.w3.org/TR/css-flexbox-1/#line-sizing)
 ///
 /// - [**Determine the available main and cross space for the flex items**](https://www.w3.org/TR/css-flexbox-1/#algo-available).
 ///
@@ -619,7 +619,7 @@ fn determine_available_space(
 
 /// Determine the flex base size and hypothetical main size of each item.
 ///
-/// # [9.2_f32. Line Length Determination](https://www.w3.org/TR/css-flexbox-1/#line-sizing)
+/// # [9.2. Line Length Determination](https://www.w3.org/TR/css-flexbox-1/#line-sizing)
 ///
 /// - [**Determine the flex base size and hypothetical main size of each item:**](https://www.w3.org/TR/css-flexbox-1/#algo-main-item)
 ///
@@ -818,7 +818,7 @@ fn determine_flex_base_size(
                 )
             };
 
-            // 4.5_f32. Automatic Minimum Size of Flex Items
+            // 4.5. Automatic Minimum Size of Flex Items
             // https://www.w3.org/TR/css-flexbox-1/#min-size-auto
             let clamped_min_content_size =
                 min_content_main_size.maybe_min(child.size.main(dir)).maybe_min(child.max_size.main(dir));
@@ -838,7 +838,7 @@ fn determine_flex_base_size(
 
 /// Collect flex items into flex lines.
 ///
-/// # [9.3_f32. Main Size Determination](https://www.w3.org/TR/css-flexbox-1/#main-sizing)
+/// # [9.3. Main Size Determination](https://www.w3.org/TR/css-flexbox-1/#main-sizing)
 ///
 /// - [**Collect flex items into flex lines**](https://www.w3.org/TR/css-flexbox-1/#algo-line-break):
 ///
@@ -861,7 +861,7 @@ fn collect_flex_lines<'a>(
 ) -> Vec<FlexLine<'a>> {
     if !constants.is_wrap {
         let mut lines = new_vec_with_capacity(1);
-        lines.push(FlexLine { items: flex_items.as_mut_slice(), cross_size: 0.0_f32, offset_cross: 0.0_f32 });
+        lines.push(FlexLine { items: flex_items.as_mut_slice(), cross_size: 0.0, offset_cross: 0.0 });
         lines
     } else {
         let main_axis_available_space = match constants.max_size.main(constants.dir) {
@@ -880,7 +880,7 @@ fn collect_flex_lines<'a>(
             // (at least for now - future extensions to the CSS spec may add provisions for forced wrap points)
             AvailableSpace::MaxContent => {
                 let mut lines = new_vec_with_capacity(1);
-                lines.push(FlexLine { items: flex_items.as_mut_slice(), cross_size: 0.0_f32, offset_cross: 0.0_f32 });
+                lines.push(FlexLine { items: flex_items.as_mut_slice(), cross_size: 0.0, offset_cross: 0.0 });
                 lines
             }
             // If flex-wrap is Wrap and we're sizing under a min-content constraint, then we take every possible wrapping opportunity
@@ -890,7 +890,7 @@ fn collect_flex_lines<'a>(
                 let mut items = &mut flex_items[..];
                 while !items.is_empty() {
                     let (line_items, rest) = items.split_at_mut(1);
-                    lines.push(FlexLine { items: line_items, cross_size: 0.0_f32, offset_cross: 0.0_f32 });
+                    lines.push(FlexLine { items: line_items, cross_size: 0.0, offset_cross: 0.0 });
                     items = rest;
                 }
                 lines
@@ -903,14 +903,14 @@ fn collect_flex_lines<'a>(
                 while !flex_items.is_empty() {
                     // Find index of the first item in the next line
                     // (or the last item if all remaining items are in the current line)
-                    let mut line_length = 0.0_f32;
+                    let mut line_length = 0.0;
                     let index = flex_items
                         .iter()
                         .enumerate()
                         .find(|&(idx, child)| {
                             // Gaps only occur between items (not before the first one or after the last one)
                             // So first item in the line does not contribute a gap to the line length
-                            let gap_contribution = if idx == 0 { 0.0_f32 } else { main_axis_gap };
+                            let gap_contribution = if idx == 0 { 0.0 } else { main_axis_gap };
                             line_length += child.hypothetical_outer_size.main(constants.dir) + gap_contribution;
                             line_length > main_axis_available_space && idx != 0
                         })
@@ -918,7 +918,7 @@ fn collect_flex_lines<'a>(
                         .unwrap_or(flex_items.len());
 
                     let (items, rest) = flex_items.split_at_mut(index);
-                    lines.push(FlexLine { items, cross_size: 0.0_f32, offset_cross: 0.0_f32 });
+                    lines.push(FlexLine { items, cross_size: 0.0, offset_cross: 0.0 });
                     flex_items = rest;
                 }
                 lines
@@ -957,7 +957,7 @@ fn determine_container_main_size(
                         total_target_size + line_main_axis_gap
                     })
                     .max_by(|a, b| a.total_cmp(b))
-                    .unwrap_or(0.0_f32);
+                    .unwrap_or(0.0);
                 let size = longest_line_length + main_content_box_inset;
                 if lines.len() > 1 {
                     f32_max(size, main_axis_available_space)
@@ -983,14 +983,14 @@ fn determine_container_main_size(
                         total_target_size + line_main_axis_gap
                     })
                     .max_by(|a, b| a.total_cmp(b))
-                    .unwrap_or(0.0_f32);
+                    .unwrap_or(0.0);
                 longest_line_length + main_content_box_inset
             }
             AvailableSpace::MinContent | AvailableSpace::MaxContent => {
                 // Define a base main_size variable. This is mutated once for iteration over the outer
                 // loop over the flex lines as:
                 //   "The flex container’s max-content size is the largest sum of the afore-calculated sizes of all items within a single line."
-                let mut main_size = 0.0_f32;
+                let mut main_size = 0.0;
 
                 for line in lines.iter_mut() {
                     for item in line.items.iter_mut() {
@@ -1006,8 +1006,8 @@ fn determine_container_main_size(
                         // Issue: https://github.com/w3c/csswg-drafts/issues/1435
                         // Gentest: padding_border_overrides_size_flex_basis_0.html
                         let clamping_basis = Some(item.flex_basis).maybe_max(style_preferred);
-                        let flex_basis_min = clamping_basis.filter(|_| item.flex_shrink == 0.0_f32);
-                        let flex_basis_max = clamping_basis.filter(|_| item.flex_grow == 0.0_f32);
+                        let flex_basis_min = clamping_basis.filter(|_| item.flex_shrink == 0.0);
+                        let flex_basis_max = clamping_basis.filter(|_| item.flex_grow == 0.0);
 
                         let min_main_size = style_min
                             .maybe_max(flex_basis_min)
@@ -1096,13 +1096,13 @@ fn determine_container_main_size(
                         };
                         item.content_flex_fraction = {
                             let diff = content_contribution - item.flex_basis;
-                            if diff > 0.0_f32 {
-                                diff / f32_max(1.0_f32, item.flex_grow)
-                            } else if diff < 0.0_f32 {
-                                let scaled_shrink_factor = f32_max(1.0_f32, item.flex_shrink * item.inner_flex_basis);
+                            if diff > 0.0 {
+                                diff / f32_max(1.0, item.flex_grow)
+                            } else if diff < 0.0 {
+                                let scaled_shrink_factor = f32_max(1.0, item.flex_shrink * item.inner_flex_basis);
                                 diff / scaled_shrink_factor
                             } else {
-                                // We are assuming that diff is 0.0_f32 here and that we haven't accidentally introduced a NaN
+                                // We are assuming that diff is 0.0 here and that we haven't accidentally introduced a NaN
                                 0.0
                             }
                         };
@@ -1117,7 +1117,7 @@ fn determine_container_main_size(
                     //     .iter()
                     //     .map(|item| item.content_flex_fraction)
                     //     .max_by(|a, b| a.total_cmp(b))
-                    //     .unwrap_or(0.0_f32); // Unwrap case never gets hit because there is always at least one item a line
+                    //     .unwrap_or(0.0); // Unwrap case never gets hit because there is always at least one item a line
 
                     // Add each item’s flex base size to the product of:
                     //   - its flex grow factor (or scaled flex shrink factor,if the chosen max-content flex fraction was negative)
@@ -1132,10 +1132,10 @@ fn determine_container_main_size(
                             let flex_fraction = item.content_flex_fraction;
                             // let flex_fraction = line_flex_fraction;
 
-                            let flex_contribution = if item.content_flex_fraction > 0.0_f32 {
-                                f32_max(1.0_f32, item.flex_grow) * flex_fraction
-                            } else if item.content_flex_fraction < 0.0_f32 {
-                                let scaled_shrink_factor = f32_max(1.0_f32, item.flex_shrink) * item.inner_flex_basis;
+                            let flex_contribution = if item.content_flex_fraction > 0.0 {
+                                f32_max(1.0, item.flex_grow) * flex_fraction
+                            } else if item.content_flex_fraction < 0.0 {
+                                let scaled_shrink_factor = f32_max(1.0, item.flex_shrink) * item.inner_flex_basis;
                                 scaled_shrink_factor * flex_fraction
                             } else {
                                 0.0
@@ -1161,7 +1161,7 @@ fn determine_container_main_size(
         .max(main_content_box_inset - constants.scrollbar_gutter.main(constants.dir));
 
     // let outer_main_size = inner_main_size + constants.padding_border.main_axis_sum(constants.dir);
-    let inner_main_size = f32_max(outer_main_size - main_content_box_inset, 0.0_f32);
+    let inner_main_size = f32_max(outer_main_size - main_content_box_inset, 0.0);
     constants.container_size.set_main(constants.dir, outer_main_size);
     constants.inner_container_size.set_main(constants.dir, inner_main_size);
     constants.node_inner_size.set_main(constants.dir, Some(inner_main_size));
@@ -1170,7 +1170,7 @@ fn determine_container_main_size(
 /// Resolve the flexible lengths of the items within a flex line.
 /// Sets the `main` component of each item's `target_size` and `outer_target_size`
 ///
-/// # [9.7_f32. Resolving Flexible Lengths](https://www.w3.org/TR/css-flexbox-1/#resolve-flexible-lengths)
+/// # [9.7. Resolving Flexible Lengths](https://www.w3.org/TR/css-flexbox-1/#resolve-flexible-lengths)
 #[inline]
 fn resolve_flexible_lengths(line: &mut FlexLine, constants: &AlgoConstants) {
     let total_main_axis_gap = sum_axis_gaps(constants.gap.main(constants.dir), line.items.len());
@@ -1183,8 +1183,8 @@ fn resolve_flexible_lengths(line: &mut FlexLine, constants: &AlgoConstants) {
     let total_hypothetical_outer_main_size =
         line.items.iter().map(|child| child.hypothetical_outer_size.main(constants.dir)).sum::<f32>();
     let used_flex_factor: f32 = total_main_axis_gap + total_hypothetical_outer_main_size;
-    let growing = used_flex_factor < constants.node_inner_size.main(constants.dir).unwrap_or(0.0_f32);
-    let shrinking = used_flex_factor > constants.node_inner_size.main(constants.dir).unwrap_or(0.0_f32);
+    let growing = used_flex_factor < constants.node_inner_size.main(constants.dir).unwrap_or(0.0);
+    let shrinking = used_flex_factor > constants.node_inner_size.main(constants.dir).unwrap_or(0.0);
     let exactly_sized = !growing & !shrinking;
 
     // 2. Size inflexible items. Freeze, setting its target main size to its hypothetical main size
@@ -1199,7 +1199,7 @@ fn resolve_flexible_lengths(line: &mut FlexLine, constants: &AlgoConstants) {
         child.target_size.set_main(constants.dir, inner_target_size);
 
         if exactly_sized
-            || (child.flex_grow == 0.0_f32 && child.flex_shrink == 0.0_f32)
+            || (child.flex_grow == 0.0 && child.flex_shrink == 0.0)
             || (growing && child.flex_basis > child.hypothetical_inner_size.main(constants.dir))
             || (shrinking && child.flex_basis < child.hypothetical_inner_size.main(constants.dir))
         {
@@ -1230,7 +1230,7 @@ fn resolve_flexible_lengths(line: &mut FlexLine, constants: &AlgoConstants) {
             })
             .sum::<f32>();
 
-    let initial_free_space = constants.node_inner_size.main(constants.dir).maybe_sub(used_space).unwrap_or(0.0_f32);
+    let initial_free_space = constants.node_inner_size.main(constants.dir).maybe_sub(used_space).unwrap_or(0.0);
 
     // 4. Loop
 
@@ -1264,14 +1264,14 @@ fn resolve_flexible_lengths(line: &mut FlexLine, constants: &AlgoConstants) {
         let mut unfrozen: Vec<&mut FlexItem> = line.items.iter_mut().filter(|child| !child.frozen).collect();
 
         let (sum_flex_grow, sum_flex_shrink): (f32, f32) =
-            unfrozen.iter().fold((0.0_f32, 0.0_f32), |(flex_grow, flex_shrink), item| {
+            unfrozen.iter().fold((0.0, 0.0), |(flex_grow, flex_shrink), item| {
                 (flex_grow + item.flex_grow, flex_shrink + item.flex_shrink)
             });
 
-        let free_space = if growing && sum_flex_grow < 1.0_f32 {
+        let free_space = if growing && sum_flex_grow < 1.0 {
             (initial_free_space * sum_flex_grow - total_main_axis_gap)
                 .maybe_min(constants.node_inner_size.main(constants.dir).maybe_sub(used_space))
-        } else if shrinking && sum_flex_shrink < 1.0_f32 {
+        } else if shrinking && sum_flex_shrink < 1.0 {
             (initial_free_space * sum_flex_shrink - total_main_axis_gap)
                 .maybe_max(constants.node_inner_size.main(constants.dir).maybe_sub(used_space))
         } else {
@@ -1299,17 +1299,17 @@ fn resolve_flexible_lengths(line: &mut FlexLine, constants: &AlgoConstants) {
         //        Do Nothing
 
         if free_space.is_normal() {
-            if growing && sum_flex_grow > 0.0_f32 {
+            if growing && sum_flex_grow > 0.0 {
                 for child in &mut unfrozen {
                     child
                         .target_size
                         .set_main(constants.dir, child.flex_basis + free_space * (child.flex_grow / sum_flex_grow));
                 }
-            } else if shrinking && sum_flex_shrink > 0.0_f32 {
+            } else if shrinking && sum_flex_shrink > 0.0 {
                 let sum_scaled_shrink_factor: f32 =
                     unfrozen.iter().map(|child| child.inner_flex_basis * child.flex_shrink).sum();
 
-                if sum_scaled_shrink_factor > 0.0_f32 {
+                if sum_scaled_shrink_factor > 0.0 {
                     for child in &mut unfrozen {
                         let scaled_shrink_factor = child.inner_flex_basis * child.flex_shrink;
                         child.target_size.set_main(
@@ -1326,10 +1326,10 @@ fn resolve_flexible_lengths(line: &mut FlexLine, constants: &AlgoConstants) {
         //    item’s target main size was made smaller by this, it’s a max violation.
         //    If the item’s target main size was made larger by this, it’s a min violation.
 
-        let total_violation = unfrozen.iter_mut().fold(0.0_f32, |acc, child| -> f32 {
+        let total_violation = unfrozen.iter_mut().fold(0.0, |acc, child| -> f32 {
             let resolved_min_main: Option<f32> = child.resolved_minimum_main_size.into();
             let max_main = child.max_size.main(constants.dir);
-            let clamped = child.target_size.main(constants.dir).maybe_clamp(resolved_min_main, max_main).max(0.0_f32);
+            let clamped = child.target_size.main(constants.dir).maybe_clamp(resolved_min_main, max_main).max(0.0);
             child.violation = clamped - child.target_size.main(constants.dir);
             child.target_size.set_main(constants.dir, clamped);
             child.outer_target_size.set_main(
@@ -1351,8 +1351,8 @@ fn resolve_flexible_lengths(line: &mut FlexLine, constants: &AlgoConstants) {
 
         for child in &mut unfrozen {
             match total_violation {
-                v if v > 0.0_f32 => child.frozen = child.violation > 0.0_f32,
-                v if v < 0.0_f32 => child.frozen = child.violation < 0.0_f32,
+                v if v > 0.0 => child.frozen = child.violation > 0.0,
+                v if v < 0.0 => child.frozen = child.violation < 0.0,
                 _ => child.frozen = true,
             }
         }
@@ -1363,7 +1363,7 @@ fn resolve_flexible_lengths(line: &mut FlexLine, constants: &AlgoConstants) {
 
 /// Determine the hypothetical cross size of each item.
 ///
-/// # [9.4_f32. Cross Size Determination](https://www.w3.org/TR/css-flexbox-1/#cross-sizing)
+/// # [9.4. Cross Size Determination](https://www.w3.org/TR/css-flexbox-1/#cross-sizing)
 ///
 /// - [**Determine the hypothetical cross size of each item**](https://www.w3.org/TR/css-flexbox-1/#algo-cross-item)
 ///   by performing layout with the used main size and the available space, treating auto as fit-content.
@@ -1487,7 +1487,7 @@ fn calculate_children_base_lines(
 
 /// Calculate the cross size of each flex line.
 ///
-/// # [9.4_f32. Cross Size Determination](https://www.w3.org/TR/css-flexbox-1/#cross-sizing)
+/// # [9.4. Cross Size Determination](https://www.w3.org/TR/css-flexbox-1/#cross-sizing)
 ///
 /// - [**Calculate the cross size of each flex line**](https://www.w3.org/TR/css-flexbox-1/#algo-cross-line).
 #[inline]
@@ -1502,8 +1502,8 @@ fn calculate_cross_size(flex_lines: &mut [FlexLine], node_size: Size<Option<f32>
             .cross(constants.dir)
             .maybe_clamp(cross_min_size, cross_max_size)
             .maybe_sub(cross_axis_padding_border)
-            .maybe_max(0.0_f32)
-            .unwrap_or(0.0_f32);
+            .maybe_max(0.0)
+            .unwrap_or(0.0);
     } else {
         // Otherwise, for each flex line:
         //
@@ -1519,7 +1519,7 @@ fn calculate_cross_size(flex_lines: &mut [FlexLine], node_size: Size<Option<f32>
         //    3. The used cross-size of the flex line is the largest of the numbers found in the
         //       previous two steps and zero.
         for line in flex_lines.iter_mut() {
-            let max_baseline: f32 = line.items.iter().map(|child| child.baseline).fold(0.0_f32, |acc, x| acc.max(x));
+            let max_baseline: f32 = line.items.iter().map(|child| child.baseline).fold(0.0, |acc, x| acc.max(x));
             line.cross_size = line
                 .items
                 .iter()
@@ -1533,11 +1533,11 @@ fn calculate_cross_size(flex_lines: &mut [FlexLine], node_size: Size<Option<f32>
                         child.hypothetical_outer_size.cross(constants.dir)
                     }
                 })
-                .fold(0.0_f32, |acc, x| acc.max(x));
+                .fold(0.0, |acc, x| acc.max(x));
         }
 
         // If the flex container is single-line, then clamp the line’s cross-size to be within the container’s computed min and max cross sizes.
-        // Note that if CSS 2.1_f32’s definition of min/max-width/height applied more generally, this behavior would fall out automatically.
+        // Note that if CSS 2.1’s definition of min/max-width/height applied more generally, this behavior would fall out automatically.
         if !constants.is_wrap {
             let cross_axis_padding_border = constants.content_box_inset.cross_axis_sum(constants.dir);
             let cross_min_size = constants.min_size.cross(constants.dir);
@@ -1552,7 +1552,7 @@ fn calculate_cross_size(flex_lines: &mut [FlexLine], node_size: Size<Option<f32>
 
 /// Handle 'align-content: stretch'.
 ///
-/// # [9.4_f32. Cross Size Determination](https://www.w3.org/TR/css-flexbox-1/#cross-sizing)
+/// # [9.4. Cross Size Determination](https://www.w3.org/TR/css-flexbox-1/#cross-sizing)
 ///
 /// - [**Handle 'align-content: stretch'**](https://www.w3.org/TR/css-flexbox-1/#algo-line-stretch). If the flex container has a definite cross size, align-content is stretch,
 ///   and the sum of the flex lines' cross sizes is less than the flex container’s inner cross size,
@@ -1568,8 +1568,8 @@ fn handle_align_content_stretch(flex_lines: &mut [FlexLine], node_size: Size<Opt
             .or(cross_min_size)
             .maybe_clamp(cross_min_size, cross_max_size)
             .maybe_sub(cross_axis_padding_border)
-            .maybe_max(0.0_f32)
-            .unwrap_or(0.0_f32);
+            .maybe_max(0.0)
+            .unwrap_or(0.0);
 
         let total_cross_axis_gap = sum_axis_gaps(constants.gap.cross(constants.dir), flex_lines.len());
         let lines_total_cross: f32 = flex_lines.iter().map(|line| line.cross_size).sum::<f32>() + total_cross_axis_gap;
@@ -1584,7 +1584,7 @@ fn handle_align_content_stretch(flex_lines: &mut [FlexLine], node_size: Size<Opt
 
 /// Determine the used cross size of each flex item.
 ///
-/// # [9.4_f32. Cross Size Determination](https://www.w3.org/TR/css-flexbox-1/#cross-sizing)
+/// # [9.4. Cross Size Determination](https://www.w3.org/TR/css-flexbox-1/#cross-sizing)
 ///
 /// - [**Determine the used cross size of each flex item**](https://www.w3.org/TR/css-flexbox-1/#algo-stretch). If a flex item has align-self: stretch, its computed cross size property is auto,
 ///   and neither of its cross-axis margins are auto, the used outer cross size is the used cross size of its flex line, clamped according to the item’s used min and max cross sizes.
@@ -1648,7 +1648,7 @@ fn determine_used_cross_size(
 
 /// Distribute any remaining free space.
 ///
-/// # [9.5_f32. Main-Axis Alignment](https://www.w3.org/TR/css-flexbox-1/#main-alignment)
+/// # [9.5. Main-Axis Alignment](https://www.w3.org/TR/css-flexbox-1/#main-alignment)
 ///
 /// - [**Distribute any remaining free space**](https://www.w3.org/TR/css-flexbox-1/#algo-main-align). For each flex line:
 ///
@@ -1674,7 +1674,7 @@ fn distribute_remaining_free_space(flex_lines: &mut [FlexLine], constants: &Algo
             }
         }
 
-        if free_space > 0.0_f32 && num_auto_margins > 0 {
+        if free_space > 0.0 && num_auto_margins > 0 {
             let margin = free_space / num_auto_margins as f32;
 
             for child in line.items.iter_mut() {
@@ -1716,7 +1716,7 @@ fn distribute_remaining_free_space(flex_lines: &mut [FlexLine], constants: &Algo
 
 /// Resolve cross-axis `auto` margins.
 ///
-/// # [9.6_f32. Cross-Axis Alignment](https://www.w3.org/TR/css-flexbox-1/#cross-alignment)
+/// # [9.6. Cross-Axis Alignment](https://www.w3.org/TR/css-flexbox-1/#cross-alignment)
 ///
 /// - [**Resolve cross-axis `auto` margins**](https://www.w3.org/TR/css-flexbox-1/#algo-cross-margins).
 ///   If a flex item has auto cross-axis margins:
@@ -1730,18 +1730,18 @@ fn distribute_remaining_free_space(flex_lines: &mut [FlexLine], constants: &Algo
 fn resolve_cross_axis_auto_margins(flex_lines: &mut [FlexLine], constants: &AlgoConstants) {
     for line in flex_lines {
         let line_cross_size = line.cross_size;
-        let max_baseline: f32 = line.items.iter_mut().map(|child| child.baseline).fold(0.0_f32, |acc, x| acc.max(x));
+        let max_baseline: f32 = line.items.iter_mut().map(|child| child.baseline).fold(0.0, |acc, x| acc.max(x));
 
         for child in line.items.iter_mut() {
             let free_space = line_cross_size - child.outer_target_size.cross(constants.dir);
 
             if child.margin_is_auto.cross_start(constants.dir) && child.margin_is_auto.cross_end(constants.dir) {
                 if constants.is_row {
-                    child.margin.top = free_space / 2.0_f32;
-                    child.margin.bottom = free_space / 2.0_f32;
+                    child.margin.top = free_space / 2.0;
+                    child.margin.bottom = free_space / 2.0;
                 } else {
-                    child.margin.left = free_space / 2.0_f32;
-                    child.margin.right = free_space / 2.0_f32;
+                    child.margin.left = free_space / 2.0;
+                    child.margin.right = free_space / 2.0;
                 }
             } else if child.margin_is_auto.cross_start(constants.dir) {
                 if constants.is_row {
@@ -1765,7 +1765,7 @@ fn resolve_cross_axis_auto_margins(flex_lines: &mut [FlexLine], constants: &Algo
 
 /// Align all flex items along the cross-axis.
 ///
-/// # [9.6_f32. Cross-Axis Alignment](https://www.w3.org/TR/css-flexbox-1/#cross-alignment)
+/// # [9.6. Cross-Axis Alignment](https://www.w3.org/TR/css-flexbox-1/#cross-alignment)
 ///
 /// - [**Align all flex items along the cross-axis**](https://www.w3.org/TR/css-flexbox-1/#algo-cross-align) per `align-self`,
 ///   if neither of the item's cross-axis margins are `auto`.
@@ -1780,9 +1780,9 @@ fn align_flex_items_along_cross_axis(
 
     // If align-self uses a "safe" overflow-position keyword and the item would overflow its
     // line cross size, fall back to logical Start to avoid data loss. See CSS Box Alignment 3
-    // §4.3_f32 <https://www.w3.org/TR/css-align-3/#overflow-values>. Otherwise, drop the safety
+    // §4.3 <https://www.w3.org/TR/css-align-3/#overflow-values>. Otherwise, drop the safety
     // field so the match below operates on a bare keyword and stays exhaustive.
-    let align_keyword = if child.align_self.is_safe() && free_space < 0.0_f32 {
+    let align_keyword = if child.align_self.is_safe() && free_space < 0.0 {
         AlignItemsKeyword::Start
     } else {
         child.align_self.keyword
@@ -1817,7 +1817,7 @@ fn align_flex_items_along_cross_axis(
                 free_space
             }
         }
-        AlignItemsKeyword::Center => free_space / 2.0_f32,
+        AlignItemsKeyword::Center => free_space / 2.0,
         AlignItemsKeyword::Baseline => {
             if constants.is_row {
                 max_baseline - child.baseline
@@ -1844,7 +1844,7 @@ fn align_flex_items_along_cross_axis(
 
 /// Determine the flex container’s used cross size.
 ///
-/// # [9.6_f32. Cross-Axis Alignment](https://www.w3.org/TR/css-flexbox-1/#cross-alignment)
+/// # [9.6. Cross-Axis Alignment](https://www.w3.org/TR/css-flexbox-1/#cross-alignment)
 ///
 /// - [**Determine the flex container’s used cross size**](https://www.w3.org/TR/css-flexbox-1/#algo-cross-container):
 ///
@@ -1870,7 +1870,7 @@ fn determine_container_cross_size(
         .unwrap_or(total_line_cross_size + total_cross_axis_gap + padding_border_sum)
         .maybe_clamp(min_cross_size, max_cross_size)
         .max(padding_border_sum - cross_scrollbar_gutter);
-    let inner_container_size = f32_max(outer_container_size - padding_border_sum, 0.0_f32);
+    let inner_container_size = f32_max(outer_container_size - padding_border_sum, 0.0);
 
     constants.container_size.set_cross(constants.dir, outer_container_size);
     constants.inner_container_size.set_cross(constants.dir, inner_container_size);
@@ -1880,7 +1880,7 @@ fn determine_container_cross_size(
 
 /// Align all flex lines per `align-content`.
 ///
-/// # [9.6_f32. Cross-Axis Alignment](https://www.w3.org/TR/css-flexbox-1/#cross-alignment)
+/// # [9.6. Cross-Axis Alignment](https://www.w3.org/TR/css-flexbox-1/#cross-alignment)
 ///
 /// - [**Align all flex lines**](https://www.w3.org/TR/css-flexbox-1/#algo-line-align) per `align-content`.
 #[inline]
@@ -1936,16 +1936,16 @@ fn calculate_flex_item(
     let is_rtl_row = direction.is_row() && layout_direction.is_rtl();
     let is_rtl_column = direction.is_column() && layout_direction.is_rtl();
     let main_relative_inset = if is_rtl_row {
-        item.inset.main_end(direction).or(item.inset.main_start(direction).map(|pos| -pos)).unwrap_or(0.0_f32)
+        item.inset.main_end(direction).or(item.inset.main_start(direction).map(|pos| -pos)).unwrap_or(0.0)
     } else {
-        item.inset.main_start(direction).or(item.inset.main_end(direction).map(|pos| -pos)).unwrap_or(0.0_f32)
+        item.inset.main_start(direction).or(item.inset.main_end(direction).map(|pos| -pos)).unwrap_or(0.0)
     };
     let cross_relative_inset = if is_rtl_column {
-        item.inset.cross_end(direction).map(|pos| -pos).or(item.inset.cross_start(direction)).unwrap_or(0.0_f32)
+        item.inset.cross_end(direction).map(|pos| -pos).or(item.inset.cross_start(direction)).unwrap_or(0.0)
     } else {
-        item.inset.cross_start(direction).or(item.inset.cross_end(direction).map(|pos| -pos)).unwrap_or(0.0_f32)
+        item.inset.cross_start(direction).or(item.inset.cross_end(direction).map(|pos| -pos)).unwrap_or(0.0)
     };
-    let effective_line_offset_cross = if is_rtl_column { 0.0_f32 } else { line_offset_cross };
+    let effective_line_offset_cross = if is_rtl_column { 0.0 } else { line_offset_cross };
 
     let offset_main = if is_rtl_row {
         *total_offset_main - item.offset_main - item.margin.main_end(direction) - main_relative_inset - size.width
@@ -1976,8 +1976,8 @@ fn calculate_flex_item(
         Point { x: offset_cross, y: offset_main }
     };
     let scrollbar_size = Size {
-        width: if item.overflow.y == Overflow::Scroll { item.scrollbar_width } else { 0.0_f32 },
-        height: if item.overflow.x == Overflow::Scroll { item.scrollbar_width } else { 0.0_f32 },
+        width: if item.overflow.y == Overflow::Scroll { item.scrollbar_width } else { 0.0 },
+        height: if item.overflow.x == Overflow::Scroll { item.scrollbar_width } else { 0.0 },
     };
 
     tree.set_unrounded_layout(
@@ -2216,7 +2216,7 @@ fn perform_absolute_layout_on_absolute_children(
         //   - Item has both left and right inset properties set
         if let (None, Some(left), Some(right)) = (known_dimensions.width, left, right) {
             let new_width_raw = inset_relative_size.width.maybe_sub(margin.left).maybe_sub(margin.right) - left - right;
-            known_dimensions.width = Some(f32_max(new_width_raw, 0.0_f32));
+            known_dimensions.width = Some(f32_max(new_width_raw, 0.0));
             known_dimensions = known_dimensions.maybe_apply_aspect_ratio(aspect_ratio).maybe_clamp(min_size, max_size);
         }
 
@@ -2226,7 +2226,7 @@ fn perform_absolute_layout_on_absolute_children(
         if let (None, Some(top), Some(bottom)) = (known_dimensions.height, top, bottom) {
             let new_height_raw =
                 inset_relative_size.height.maybe_sub(margin.top).maybe_sub(margin.bottom) - top - bottom;
-            known_dimensions.height = Some(f32_max(new_height_raw, 0.0_f32));
+            known_dimensions.height = Some(f32_max(new_height_raw, 0.0));
             known_dimensions = known_dimensions.maybe_apply_aspect_ratio(aspect_ratio).maybe_clamp(min_size, max_size);
         }
         let measured_size = tree.measure_child_size_both(
@@ -2254,7 +2254,7 @@ fn perform_absolute_layout_on_absolute_children(
             Line::FALSE,
         );
 
-        let non_auto_margin = margin.map(|m| m.unwrap_or(0.0_f32));
+        let non_auto_margin = margin.map(|m| m.unwrap_or(0.0));
 
         let free_space = Size {
             width: constants.container_size.width - final_size.width - non_auto_margin.horizontal_axis_sum(),
@@ -2301,12 +2301,12 @@ fn perform_absolute_layout_on_absolute_children(
         let main_axis_flex_start_reversed = constants.dir.is_reverse() ^ main_is_rtl;
         let cross_axis_flex_start_reversed = constants.is_wrap_reverse ^ cross_is_rtl;
         let main_start_scrollbar_offset =
-            if main_is_rtl { constants.scrollbar_gutter.main(constants.dir) } else { 0.0_f32 };
+            if main_is_rtl { constants.scrollbar_gutter.main(constants.dir) } else { 0.0 };
         let cross_start_scrollbar_offset =
-            if cross_is_rtl { constants.scrollbar_gutter.cross(constants.dir) } else { 0.0_f32 };
-        let main_end_scrollbar_offset = if main_is_rtl { 0.0_f32 } else { constants.scrollbar_gutter.main(constants.dir) };
+            if cross_is_rtl { constants.scrollbar_gutter.cross(constants.dir) } else { 0.0 };
+        let main_end_scrollbar_offset = if main_is_rtl { 0.0 } else { constants.scrollbar_gutter.main(constants.dir) };
         let cross_end_scrollbar_offset =
-            if cross_is_rtl { 0.0_f32 } else { constants.scrollbar_gutter.cross(constants.dir) };
+            if cross_is_rtl { 0.0 } else { constants.scrollbar_gutter.cross(constants.dir) };
 
         // Apply main-axis alignment
         // let free_main_space = free_space.main(constants.dir) - resolved_margin.main_axis_sum(constants.dir);
@@ -2316,7 +2316,7 @@ fn perform_absolute_layout_on_absolute_children(
                     - constants.border.main_end(constants.dir)
                     - main_end_scrollbar_offset
                     - final_size.main(constants.dir)
-                    - end_main.unwrap_or(0.0_f32)
+                    - end_main.unwrap_or(0.0)
                     - resolved_margin.main_end(constants.dir)
             } else if let Some(start) = start_main {
                 start
@@ -2328,7 +2328,7 @@ fn perform_absolute_layout_on_absolute_children(
                     - constants.border.main_end(constants.dir)
                     - main_end_scrollbar_offset
                     - final_size.main(constants.dir)
-                    - end_main.unwrap_or(0.0_f32)
+                    - end_main.unwrap_or(0.0)
                     - resolved_margin.main_end(constants.dir)
             }
         } else {
@@ -2392,7 +2392,7 @@ fn perform_absolute_layout_on_absolute_children(
                     - constants.border.cross_end(constants.dir)
                     - cross_end_scrollbar_offset
                     - final_size.cross(constants.dir)
-                    - end_cross.unwrap_or(0.0_f32)
+                    - end_cross.unwrap_or(0.0)
                     - resolved_margin.cross_end(constants.dir)
             } else if let Some(start) = start_cross {
                 start
@@ -2404,7 +2404,7 @@ fn perform_absolute_layout_on_absolute_children(
                     - constants.border.cross_end(constants.dir)
                     - cross_end_scrollbar_offset
                     - final_size.cross(constants.dir)
-                    - end_cross.unwrap_or(0.0_f32)
+                    - end_cross.unwrap_or(0.0)
                     - resolved_margin.cross_end(constants.dir)
             }
         } else {
@@ -2460,8 +2460,8 @@ fn perform_absolute_layout_on_absolute_children(
             false => Point { x: offset_cross, y: offset_main },
         };
         let scrollbar_size = Size {
-            width: if overflow.y == Overflow::Scroll { scrollbar_width } else { 0.0_f32 },
-            height: if overflow.x == Overflow::Scroll { scrollbar_width } else { 0.0_f32 },
+            width: if overflow.y == Overflow::Scroll { scrollbar_width } else { 0.0 },
+            height: if overflow.x == Overflow::Scroll { scrollbar_width } else { 0.0 },
         };
         tree.set_unrounded_layout(
             child,
@@ -2493,7 +2493,7 @@ fn perform_absolute_layout_on_absolute_children(
             if size_content_size_contribution.has_non_zero_area() {
                 let absolute_area_offset = Point {
                     x: constants.border.left
-                        + if constants.layout_direction.is_rtl() { constants.scrollbar_gutter.x } else { 0.0_f32 },
+                        + if constants.layout_direction.is_rtl() { constants.scrollbar_gutter.x } else { 0.0 },
                     y: constants.border.top,
                 };
                 let relative_location =
@@ -2501,8 +2501,8 @@ fn perform_absolute_layout_on_absolute_children(
                 let content_size_contribution = Size {
                     width: if constants.layout_direction.is_rtl() {
                         let overflow_extra_width =
-                            f32_max(size_content_size_contribution.width - final_size.width, 0.0_f32);
-                        f32_max(inset_relative_size.width - relative_location.x, 0.0_f32) + overflow_extra_width
+                            f32_max(size_content_size_contribution.width - final_size.width, 0.0);
+                        f32_max(inset_relative_size.width - relative_location.x, 0.0) + overflow_extra_width
                     } else {
                         relative_location.x + size_content_size_contribution.width
                     },

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -2,8 +2,8 @@
 use crate::compute::common::alignment::compute_alignment_offset;
 use crate::geometry::{Line, Point, Rect, Size};
 use crate::style::{
-    AlignContent, AlignItems, AlignSelf, AvailableSpace, FlexWrap, JustifyContent, LengthPercentageAuto, Overflow,
-    Position,
+    AlignContent, AlignContentKeyword, AlignItems, AlignItemsKeyword, AlignSelf, AvailableSpace, FlexWrap,
+    JustifyContent, LengthPercentageAuto, Overflow, Position,
 };
 use crate::style::{CoreStyle, FlexDirection, FlexboxContainerStyle, FlexboxItemStyle};
 use crate::style_helpers::{TaffyMaxContent, TaffyMinContent};
@@ -233,13 +233,13 @@ fn compute_preliminary(tree: &mut impl LayoutFlexboxContainer, node: NodeId, inp
 
     // 9. Flex Layout Algorithm
 
-    // 9.1. Initial Setup
+    // 9.1_f32. Initial Setup
 
     // 1. Generate anonymous flex items as described in §4 Flex Items.
     debug_log!("generate_anonymous_flex_items");
     let mut flex_items = generate_anonymous_flex_items(tree, node, &constants);
 
-    // 9.2. Line Length Determination
+    // 9.2_f32. Line Length Determination
 
     // 2. Determine the available main and cross space for the flex items
     debug_log!("determine_available_space");
@@ -261,7 +261,7 @@ fn compute_preliminary(tree: &mut impl LayoutFlexboxContainer, node: NodeId, inp
     // 4. Determine the main size of the flex container
     // This has already been done as part of compute_constants. The inner size is exposed as constants.node_inner_size.
 
-    // 9.3. Main Size Determination
+    // 9.3_f32. Main Size Determination
 
     // 5. Collect flex items into flex lines.
     debug_log!("collect_flex_lines");
@@ -290,7 +290,7 @@ fn compute_preliminary(tree: &mut impl LayoutFlexboxContainer, node: NodeId, inp
             .gap()
             .main(constants.dir)
             .maybe_resolve(inner_container_size, |val, basis| tree.calc(val, basis))
-            .unwrap_or(0.0);
+            .unwrap_or(0.0_f32);
         constants.gap.set_main(constants.dir, new_gap);
     }
 
@@ -300,7 +300,7 @@ fn compute_preliminary(tree: &mut impl LayoutFlexboxContainer, node: NodeId, inp
         resolve_flexible_lengths(line, &constants);
     }
 
-    // 9.4. Cross Size Determination
+    // 9.4_f32. Cross Size Determination
 
     // 7. Determine the hypothetical cross size of each item.
     debug_log!("determine_hypothetical_cross_size");
@@ -340,13 +340,13 @@ fn compute_preliminary(tree: &mut impl LayoutFlexboxContainer, node: NodeId, inp
     debug_log!("determine_used_cross_size");
     determine_used_cross_size(tree, &mut flex_lines, &constants);
 
-    // 9.5. Main-Axis Alignment
+    // 9.5_f32. Main-Axis Alignment
 
     // 12. Distribute any remaining free space.
     debug_log!("distribute_remaining_free_space");
     distribute_remaining_free_space(&mut flex_lines, &constants);
 
-    // 9.6. Cross-Axis Alignment
+    // 9.6_f32. Cross-Axis Alignment
 
     // 13. Resolve cross-axis auto margins (also includes 14).
     debug_log!("resolve_cross_axis_auto_margins");
@@ -391,7 +391,7 @@ fn compute_preliminary(tree: &mut impl LayoutFlexboxContainer, node: NodeId, inp
         }
     }
 
-    // 8.5. Flex Container Baselines: calculate the flex container's first baseline
+    // 8.5_f32. Flex Container Baselines: calculate the flex container's first baseline
     // See https://www.w3.org/TR/css-flexbox-1/#flex-baselines
     let first_vertical_baseline = if flex_lines.is_empty() {
         None
@@ -446,7 +446,7 @@ fn compute_constants(
     // *horizontal* space to be reserved for a scrollbar
     let scrollbar_gutter = style.overflow().transpose().map(|overflow| match overflow {
         Overflow::Scroll => style.scrollbar_width(),
-        _ => 0.0,
+        _ => 0.0_f32,
     });
     let mut content_box_inset = padding + border;
     content_box_inset.bottom += scrollbar_gutter.y;
@@ -497,7 +497,7 @@ fn compute_constants(
 
 /// Generate anonymous flex items.
 ///
-/// # [9.1. Initial Setup](https://www.w3.org/TR/css-flexbox-1/#box-manip)
+/// # [9.1_f32. Initial Setup](https://www.w3.org/TR/css-flexbox-1/#box-manip)
 ///
 /// - [**Generate anonymous flex items**](https://www.w3.org/TR/css-flexbox-1/#algo-anon-box) as described in [§4 Flex Items](https://www.w3.org/TR/css-flexbox-1/#flex-items).
 #[inline]
@@ -559,22 +559,22 @@ fn generate_anonymous_flex_items(
                 scrollbar_width: child_style.scrollbar_width(),
                 flex_grow: child_style.flex_grow(),
                 flex_shrink: child_style.flex_shrink(),
-                flex_basis: 0.0,
-                inner_flex_basis: 0.0,
-                violation: 0.0,
+                flex_basis: 0.0_f32,
+                inner_flex_basis: 0.0_f32,
+                violation: 0.0_f32,
                 frozen: false,
 
-                resolved_minimum_main_size: 0.0,
+                resolved_minimum_main_size: 0.0_f32,
                 hypothetical_inner_size: Size::zero(),
                 hypothetical_outer_size: Size::zero(),
                 target_size: Size::zero(),
                 outer_target_size: Size::zero(),
-                content_flex_fraction: 0.0,
+                content_flex_fraction: 0.0_f32,
 
-                baseline: 0.0,
+                baseline: 0.0_f32,
 
-                offset_main: 0.0,
-                offset_cross: 0.0,
+                offset_main: 0.0_f32,
+                offset_cross: 0.0_f32,
             }
         })
         .collect()
@@ -582,7 +582,7 @@ fn generate_anonymous_flex_items(
 
 /// Determine the available main and cross space for the flex items.
 ///
-/// # [9.2. Line Length Determination](https://www.w3.org/TR/css-flexbox-1/#line-sizing)
+/// # [9.2_f32. Line Length Determination](https://www.w3.org/TR/css-flexbox-1/#line-sizing)
 ///
 /// - [**Determine the available main and cross space for the flex items**](https://www.w3.org/TR/css-flexbox-1/#algo-available).
 ///
@@ -619,7 +619,7 @@ fn determine_available_space(
 
 /// Determine the flex base size and hypothetical main size of each item.
 ///
-/// # [9.2. Line Length Determination](https://www.w3.org/TR/css-flexbox-1/#line-sizing)
+/// # [9.2_f32. Line Length Determination](https://www.w3.org/TR/css-flexbox-1/#line-sizing)
 ///
 /// - [**Determine the flex base size and hypothetical main size of each item:**](https://www.w3.org/TR/css-flexbox-1/#algo-main-item)
 ///
@@ -818,7 +818,7 @@ fn determine_flex_base_size(
                 )
             };
 
-            // 4.5. Automatic Minimum Size of Flex Items
+            // 4.5_f32. Automatic Minimum Size of Flex Items
             // https://www.w3.org/TR/css-flexbox-1/#min-size-auto
             let clamped_min_content_size =
                 min_content_main_size.maybe_min(child.size.main(dir)).maybe_min(child.max_size.main(dir));
@@ -838,7 +838,7 @@ fn determine_flex_base_size(
 
 /// Collect flex items into flex lines.
 ///
-/// # [9.3. Main Size Determination](https://www.w3.org/TR/css-flexbox-1/#main-sizing)
+/// # [9.3_f32. Main Size Determination](https://www.w3.org/TR/css-flexbox-1/#main-sizing)
 ///
 /// - [**Collect flex items into flex lines**](https://www.w3.org/TR/css-flexbox-1/#algo-line-break):
 ///
@@ -861,7 +861,7 @@ fn collect_flex_lines<'a>(
 ) -> Vec<FlexLine<'a>> {
     if !constants.is_wrap {
         let mut lines = new_vec_with_capacity(1);
-        lines.push(FlexLine { items: flex_items.as_mut_slice(), cross_size: 0.0, offset_cross: 0.0 });
+        lines.push(FlexLine { items: flex_items.as_mut_slice(), cross_size: 0.0_f32, offset_cross: 0.0_f32 });
         lines
     } else {
         let main_axis_available_space = match constants.max_size.main(constants.dir) {
@@ -880,7 +880,7 @@ fn collect_flex_lines<'a>(
             // (at least for now - future extensions to the CSS spec may add provisions for forced wrap points)
             AvailableSpace::MaxContent => {
                 let mut lines = new_vec_with_capacity(1);
-                lines.push(FlexLine { items: flex_items.as_mut_slice(), cross_size: 0.0, offset_cross: 0.0 });
+                lines.push(FlexLine { items: flex_items.as_mut_slice(), cross_size: 0.0_f32, offset_cross: 0.0_f32 });
                 lines
             }
             // If flex-wrap is Wrap and we're sizing under a min-content constraint, then we take every possible wrapping opportunity
@@ -890,7 +890,7 @@ fn collect_flex_lines<'a>(
                 let mut items = &mut flex_items[..];
                 while !items.is_empty() {
                     let (line_items, rest) = items.split_at_mut(1);
-                    lines.push(FlexLine { items: line_items, cross_size: 0.0, offset_cross: 0.0 });
+                    lines.push(FlexLine { items: line_items, cross_size: 0.0_f32, offset_cross: 0.0_f32 });
                     items = rest;
                 }
                 lines
@@ -903,14 +903,14 @@ fn collect_flex_lines<'a>(
                 while !flex_items.is_empty() {
                     // Find index of the first item in the next line
                     // (or the last item if all remaining items are in the current line)
-                    let mut line_length = 0.0;
+                    let mut line_length = 0.0_f32;
                     let index = flex_items
                         .iter()
                         .enumerate()
                         .find(|&(idx, child)| {
                             // Gaps only occur between items (not before the first one or after the last one)
                             // So first item in the line does not contribute a gap to the line length
-                            let gap_contribution = if idx == 0 { 0.0 } else { main_axis_gap };
+                            let gap_contribution = if idx == 0 { 0.0_f32 } else { main_axis_gap };
                             line_length += child.hypothetical_outer_size.main(constants.dir) + gap_contribution;
                             line_length > main_axis_available_space && idx != 0
                         })
@@ -918,7 +918,7 @@ fn collect_flex_lines<'a>(
                         .unwrap_or(flex_items.len());
 
                     let (items, rest) = flex_items.split_at_mut(index);
-                    lines.push(FlexLine { items, cross_size: 0.0, offset_cross: 0.0 });
+                    lines.push(FlexLine { items, cross_size: 0.0_f32, offset_cross: 0.0_f32 });
                     flex_items = rest;
                 }
                 lines
@@ -957,7 +957,7 @@ fn determine_container_main_size(
                         total_target_size + line_main_axis_gap
                     })
                     .max_by(|a, b| a.total_cmp(b))
-                    .unwrap_or(0.0);
+                    .unwrap_or(0.0_f32);
                 let size = longest_line_length + main_content_box_inset;
                 if lines.len() > 1 {
                     f32_max(size, main_axis_available_space)
@@ -983,14 +983,14 @@ fn determine_container_main_size(
                         total_target_size + line_main_axis_gap
                     })
                     .max_by(|a, b| a.total_cmp(b))
-                    .unwrap_or(0.0);
+                    .unwrap_or(0.0_f32);
                 longest_line_length + main_content_box_inset
             }
             AvailableSpace::MinContent | AvailableSpace::MaxContent => {
                 // Define a base main_size variable. This is mutated once for iteration over the outer
                 // loop over the flex lines as:
                 //   "The flex container’s max-content size is the largest sum of the afore-calculated sizes of all items within a single line."
-                let mut main_size = 0.0;
+                let mut main_size = 0.0_f32;
 
                 for line in lines.iter_mut() {
                     for item in line.items.iter_mut() {
@@ -1006,8 +1006,8 @@ fn determine_container_main_size(
                         // Issue: https://github.com/w3c/csswg-drafts/issues/1435
                         // Gentest: padding_border_overrides_size_flex_basis_0.html
                         let clamping_basis = Some(item.flex_basis).maybe_max(style_preferred);
-                        let flex_basis_min = clamping_basis.filter(|_| item.flex_shrink == 0.0);
-                        let flex_basis_max = clamping_basis.filter(|_| item.flex_grow == 0.0);
+                        let flex_basis_min = clamping_basis.filter(|_| item.flex_shrink == 0.0_f32);
+                        let flex_basis_max = clamping_basis.filter(|_| item.flex_grow == 0.0_f32);
 
                         let min_main_size = style_min
                             .maybe_max(flex_basis_min)
@@ -1096,13 +1096,13 @@ fn determine_container_main_size(
                         };
                         item.content_flex_fraction = {
                             let diff = content_contribution - item.flex_basis;
-                            if diff > 0.0 {
-                                diff / f32_max(1.0, item.flex_grow)
-                            } else if diff < 0.0 {
-                                let scaled_shrink_factor = f32_max(1.0, item.flex_shrink * item.inner_flex_basis);
+                            if diff > 0.0_f32 {
+                                diff / f32_max(1.0_f32, item.flex_grow)
+                            } else if diff < 0.0_f32 {
+                                let scaled_shrink_factor = f32_max(1.0_f32, item.flex_shrink * item.inner_flex_basis);
                                 diff / scaled_shrink_factor
                             } else {
-                                // We are assuming that diff is 0.0 here and that we haven't accidentally introduced a NaN
+                                // We are assuming that diff is 0.0_f32 here and that we haven't accidentally introduced a NaN
                                 0.0
                             }
                         };
@@ -1117,7 +1117,7 @@ fn determine_container_main_size(
                     //     .iter()
                     //     .map(|item| item.content_flex_fraction)
                     //     .max_by(|a, b| a.total_cmp(b))
-                    //     .unwrap_or(0.0); // Unwrap case never gets hit because there is always at least one item a line
+                    //     .unwrap_or(0.0_f32); // Unwrap case never gets hit because there is always at least one item a line
 
                     // Add each item’s flex base size to the product of:
                     //   - its flex grow factor (or scaled flex shrink factor,if the chosen max-content flex fraction was negative)
@@ -1132,10 +1132,10 @@ fn determine_container_main_size(
                             let flex_fraction = item.content_flex_fraction;
                             // let flex_fraction = line_flex_fraction;
 
-                            let flex_contribution = if item.content_flex_fraction > 0.0 {
-                                f32_max(1.0, item.flex_grow) * flex_fraction
-                            } else if item.content_flex_fraction < 0.0 {
-                                let scaled_shrink_factor = f32_max(1.0, item.flex_shrink) * item.inner_flex_basis;
+                            let flex_contribution = if item.content_flex_fraction > 0.0_f32 {
+                                f32_max(1.0_f32, item.flex_grow) * flex_fraction
+                            } else if item.content_flex_fraction < 0.0_f32 {
+                                let scaled_shrink_factor = f32_max(1.0_f32, item.flex_shrink) * item.inner_flex_basis;
                                 scaled_shrink_factor * flex_fraction
                             } else {
                                 0.0
@@ -1161,7 +1161,7 @@ fn determine_container_main_size(
         .max(main_content_box_inset - constants.scrollbar_gutter.main(constants.dir));
 
     // let outer_main_size = inner_main_size + constants.padding_border.main_axis_sum(constants.dir);
-    let inner_main_size = f32_max(outer_main_size - main_content_box_inset, 0.0);
+    let inner_main_size = f32_max(outer_main_size - main_content_box_inset, 0.0_f32);
     constants.container_size.set_main(constants.dir, outer_main_size);
     constants.inner_container_size.set_main(constants.dir, inner_main_size);
     constants.node_inner_size.set_main(constants.dir, Some(inner_main_size));
@@ -1170,7 +1170,7 @@ fn determine_container_main_size(
 /// Resolve the flexible lengths of the items within a flex line.
 /// Sets the `main` component of each item's `target_size` and `outer_target_size`
 ///
-/// # [9.7. Resolving Flexible Lengths](https://www.w3.org/TR/css-flexbox-1/#resolve-flexible-lengths)
+/// # [9.7_f32. Resolving Flexible Lengths](https://www.w3.org/TR/css-flexbox-1/#resolve-flexible-lengths)
 #[inline]
 fn resolve_flexible_lengths(line: &mut FlexLine, constants: &AlgoConstants) {
     let total_main_axis_gap = sum_axis_gaps(constants.gap.main(constants.dir), line.items.len());
@@ -1183,8 +1183,8 @@ fn resolve_flexible_lengths(line: &mut FlexLine, constants: &AlgoConstants) {
     let total_hypothetical_outer_main_size =
         line.items.iter().map(|child| child.hypothetical_outer_size.main(constants.dir)).sum::<f32>();
     let used_flex_factor: f32 = total_main_axis_gap + total_hypothetical_outer_main_size;
-    let growing = used_flex_factor < constants.node_inner_size.main(constants.dir).unwrap_or(0.0);
-    let shrinking = used_flex_factor > constants.node_inner_size.main(constants.dir).unwrap_or(0.0);
+    let growing = used_flex_factor < constants.node_inner_size.main(constants.dir).unwrap_or(0.0_f32);
+    let shrinking = used_flex_factor > constants.node_inner_size.main(constants.dir).unwrap_or(0.0_f32);
     let exactly_sized = !growing & !shrinking;
 
     // 2. Size inflexible items. Freeze, setting its target main size to its hypothetical main size
@@ -1199,7 +1199,7 @@ fn resolve_flexible_lengths(line: &mut FlexLine, constants: &AlgoConstants) {
         child.target_size.set_main(constants.dir, inner_target_size);
 
         if exactly_sized
-            || (child.flex_grow == 0.0 && child.flex_shrink == 0.0)
+            || (child.flex_grow == 0.0_f32 && child.flex_shrink == 0.0_f32)
             || (growing && child.flex_basis > child.hypothetical_inner_size.main(constants.dir))
             || (shrinking && child.flex_basis < child.hypothetical_inner_size.main(constants.dir))
         {
@@ -1230,7 +1230,7 @@ fn resolve_flexible_lengths(line: &mut FlexLine, constants: &AlgoConstants) {
             })
             .sum::<f32>();
 
-    let initial_free_space = constants.node_inner_size.main(constants.dir).maybe_sub(used_space).unwrap_or(0.0);
+    let initial_free_space = constants.node_inner_size.main(constants.dir).maybe_sub(used_space).unwrap_or(0.0_f32);
 
     // 4. Loop
 
@@ -1264,14 +1264,14 @@ fn resolve_flexible_lengths(line: &mut FlexLine, constants: &AlgoConstants) {
         let mut unfrozen: Vec<&mut FlexItem> = line.items.iter_mut().filter(|child| !child.frozen).collect();
 
         let (sum_flex_grow, sum_flex_shrink): (f32, f32) =
-            unfrozen.iter().fold((0.0, 0.0), |(flex_grow, flex_shrink), item| {
+            unfrozen.iter().fold((0.0_f32, 0.0_f32), |(flex_grow, flex_shrink), item| {
                 (flex_grow + item.flex_grow, flex_shrink + item.flex_shrink)
             });
 
-        let free_space = if growing && sum_flex_grow < 1.0 {
+        let free_space = if growing && sum_flex_grow < 1.0_f32 {
             (initial_free_space * sum_flex_grow - total_main_axis_gap)
                 .maybe_min(constants.node_inner_size.main(constants.dir).maybe_sub(used_space))
-        } else if shrinking && sum_flex_shrink < 1.0 {
+        } else if shrinking && sum_flex_shrink < 1.0_f32 {
             (initial_free_space * sum_flex_shrink - total_main_axis_gap)
                 .maybe_max(constants.node_inner_size.main(constants.dir).maybe_sub(used_space))
         } else {
@@ -1299,17 +1299,17 @@ fn resolve_flexible_lengths(line: &mut FlexLine, constants: &AlgoConstants) {
         //        Do Nothing
 
         if free_space.is_normal() {
-            if growing && sum_flex_grow > 0.0 {
+            if growing && sum_flex_grow > 0.0_f32 {
                 for child in &mut unfrozen {
                     child
                         .target_size
                         .set_main(constants.dir, child.flex_basis + free_space * (child.flex_grow / sum_flex_grow));
                 }
-            } else if shrinking && sum_flex_shrink > 0.0 {
+            } else if shrinking && sum_flex_shrink > 0.0_f32 {
                 let sum_scaled_shrink_factor: f32 =
                     unfrozen.iter().map(|child| child.inner_flex_basis * child.flex_shrink).sum();
 
-                if sum_scaled_shrink_factor > 0.0 {
+                if sum_scaled_shrink_factor > 0.0_f32 {
                     for child in &mut unfrozen {
                         let scaled_shrink_factor = child.inner_flex_basis * child.flex_shrink;
                         child.target_size.set_main(
@@ -1326,10 +1326,10 @@ fn resolve_flexible_lengths(line: &mut FlexLine, constants: &AlgoConstants) {
         //    item’s target main size was made smaller by this, it’s a max violation.
         //    If the item’s target main size was made larger by this, it’s a min violation.
 
-        let total_violation = unfrozen.iter_mut().fold(0.0, |acc, child| -> f32 {
+        let total_violation = unfrozen.iter_mut().fold(0.0_f32, |acc, child| -> f32 {
             let resolved_min_main: Option<f32> = child.resolved_minimum_main_size.into();
             let max_main = child.max_size.main(constants.dir);
-            let clamped = child.target_size.main(constants.dir).maybe_clamp(resolved_min_main, max_main).max(0.0);
+            let clamped = child.target_size.main(constants.dir).maybe_clamp(resolved_min_main, max_main).max(0.0_f32);
             child.violation = clamped - child.target_size.main(constants.dir);
             child.target_size.set_main(constants.dir, clamped);
             child.outer_target_size.set_main(
@@ -1351,8 +1351,8 @@ fn resolve_flexible_lengths(line: &mut FlexLine, constants: &AlgoConstants) {
 
         for child in &mut unfrozen {
             match total_violation {
-                v if v > 0.0 => child.frozen = child.violation > 0.0,
-                v if v < 0.0 => child.frozen = child.violation < 0.0,
+                v if v > 0.0_f32 => child.frozen = child.violation > 0.0_f32,
+                v if v < 0.0_f32 => child.frozen = child.violation < 0.0_f32,
                 _ => child.frozen = true,
             }
         }
@@ -1363,7 +1363,7 @@ fn resolve_flexible_lengths(line: &mut FlexLine, constants: &AlgoConstants) {
 
 /// Determine the hypothetical cross size of each item.
 ///
-/// # [9.4. Cross Size Determination](https://www.w3.org/TR/css-flexbox-1/#cross-sizing)
+/// # [9.4_f32. Cross Size Determination](https://www.w3.org/TR/css-flexbox-1/#cross-sizing)
 ///
 /// - [**Determine the hypothetical cross size of each item**](https://www.w3.org/TR/css-flexbox-1/#algo-cross-item)
 ///   by performing layout with the used main size and the available space, treating auto as fit-content.
@@ -1487,7 +1487,7 @@ fn calculate_children_base_lines(
 
 /// Calculate the cross size of each flex line.
 ///
-/// # [9.4. Cross Size Determination](https://www.w3.org/TR/css-flexbox-1/#cross-sizing)
+/// # [9.4_f32. Cross Size Determination](https://www.w3.org/TR/css-flexbox-1/#cross-sizing)
 ///
 /// - [**Calculate the cross size of each flex line**](https://www.w3.org/TR/css-flexbox-1/#algo-cross-line).
 #[inline]
@@ -1502,8 +1502,8 @@ fn calculate_cross_size(flex_lines: &mut [FlexLine], node_size: Size<Option<f32>
             .cross(constants.dir)
             .maybe_clamp(cross_min_size, cross_max_size)
             .maybe_sub(cross_axis_padding_border)
-            .maybe_max(0.0)
-            .unwrap_or(0.0);
+            .maybe_max(0.0_f32)
+            .unwrap_or(0.0_f32);
     } else {
         // Otherwise, for each flex line:
         //
@@ -1519,7 +1519,7 @@ fn calculate_cross_size(flex_lines: &mut [FlexLine], node_size: Size<Option<f32>
         //    3. The used cross-size of the flex line is the largest of the numbers found in the
         //       previous two steps and zero.
         for line in flex_lines.iter_mut() {
-            let max_baseline: f32 = line.items.iter().map(|child| child.baseline).fold(0.0, |acc, x| acc.max(x));
+            let max_baseline: f32 = line.items.iter().map(|child| child.baseline).fold(0.0_f32, |acc, x| acc.max(x));
             line.cross_size = line
                 .items
                 .iter()
@@ -1533,11 +1533,11 @@ fn calculate_cross_size(flex_lines: &mut [FlexLine], node_size: Size<Option<f32>
                         child.hypothetical_outer_size.cross(constants.dir)
                     }
                 })
-                .fold(0.0, |acc, x| acc.max(x));
+                .fold(0.0_f32, |acc, x| acc.max(x));
         }
 
         // If the flex container is single-line, then clamp the line’s cross-size to be within the container’s computed min and max cross sizes.
-        // Note that if CSS 2.1’s definition of min/max-width/height applied more generally, this behavior would fall out automatically.
+        // Note that if CSS 2.1_f32’s definition of min/max-width/height applied more generally, this behavior would fall out automatically.
         if !constants.is_wrap {
             let cross_axis_padding_border = constants.content_box_inset.cross_axis_sum(constants.dir);
             let cross_min_size = constants.min_size.cross(constants.dir);
@@ -1552,7 +1552,7 @@ fn calculate_cross_size(flex_lines: &mut [FlexLine], node_size: Size<Option<f32>
 
 /// Handle 'align-content: stretch'.
 ///
-/// # [9.4. Cross Size Determination](https://www.w3.org/TR/css-flexbox-1/#cross-sizing)
+/// # [9.4_f32. Cross Size Determination](https://www.w3.org/TR/css-flexbox-1/#cross-sizing)
 ///
 /// - [**Handle 'align-content: stretch'**](https://www.w3.org/TR/css-flexbox-1/#algo-line-stretch). If the flex container has a definite cross size, align-content is stretch,
 ///   and the sum of the flex lines' cross sizes is less than the flex container’s inner cross size,
@@ -1568,8 +1568,8 @@ fn handle_align_content_stretch(flex_lines: &mut [FlexLine], node_size: Size<Opt
             .or(cross_min_size)
             .maybe_clamp(cross_min_size, cross_max_size)
             .maybe_sub(cross_axis_padding_border)
-            .maybe_max(0.0)
-            .unwrap_or(0.0);
+            .maybe_max(0.0_f32)
+            .unwrap_or(0.0_f32);
 
         let total_cross_axis_gap = sum_axis_gaps(constants.gap.cross(constants.dir), flex_lines.len());
         let lines_total_cross: f32 = flex_lines.iter().map(|line| line.cross_size).sum::<f32>() + total_cross_axis_gap;
@@ -1584,7 +1584,7 @@ fn handle_align_content_stretch(flex_lines: &mut [FlexLine], node_size: Size<Opt
 
 /// Determine the used cross size of each flex item.
 ///
-/// # [9.4. Cross Size Determination](https://www.w3.org/TR/css-flexbox-1/#cross-sizing)
+/// # [9.4_f32. Cross Size Determination](https://www.w3.org/TR/css-flexbox-1/#cross-sizing)
 ///
 /// - [**Determine the used cross size of each flex item**](https://www.w3.org/TR/css-flexbox-1/#algo-stretch). If a flex item has align-self: stretch, its computed cross size property is auto,
 ///   and neither of its cross-axis margins are auto, the used outer cross size is the used cross size of its flex line, clamped according to the item’s used min and max cross sizes.
@@ -1648,7 +1648,7 @@ fn determine_used_cross_size(
 
 /// Distribute any remaining free space.
 ///
-/// # [9.5. Main-Axis Alignment](https://www.w3.org/TR/css-flexbox-1/#main-alignment)
+/// # [9.5_f32. Main-Axis Alignment](https://www.w3.org/TR/css-flexbox-1/#main-alignment)
 ///
 /// - [**Distribute any remaining free space**](https://www.w3.org/TR/css-flexbox-1/#algo-main-align). For each flex line:
 ///
@@ -1674,7 +1674,7 @@ fn distribute_remaining_free_space(flex_lines: &mut [FlexLine], constants: &Algo
             }
         }
 
-        if free_space > 0.0 && num_auto_margins > 0 {
+        if free_space > 0.0_f32 && num_auto_margins > 0 {
             let margin = free_space / num_auto_margins as f32;
 
             for child in line.items.iter_mut() {
@@ -1716,7 +1716,7 @@ fn distribute_remaining_free_space(flex_lines: &mut [FlexLine], constants: &Algo
 
 /// Resolve cross-axis `auto` margins.
 ///
-/// # [9.6. Cross-Axis Alignment](https://www.w3.org/TR/css-flexbox-1/#cross-alignment)
+/// # [9.6_f32. Cross-Axis Alignment](https://www.w3.org/TR/css-flexbox-1/#cross-alignment)
 ///
 /// - [**Resolve cross-axis `auto` margins**](https://www.w3.org/TR/css-flexbox-1/#algo-cross-margins).
 ///   If a flex item has auto cross-axis margins:
@@ -1730,18 +1730,18 @@ fn distribute_remaining_free_space(flex_lines: &mut [FlexLine], constants: &Algo
 fn resolve_cross_axis_auto_margins(flex_lines: &mut [FlexLine], constants: &AlgoConstants) {
     for line in flex_lines {
         let line_cross_size = line.cross_size;
-        let max_baseline: f32 = line.items.iter_mut().map(|child| child.baseline).fold(0.0, |acc, x| acc.max(x));
+        let max_baseline: f32 = line.items.iter_mut().map(|child| child.baseline).fold(0.0_f32, |acc, x| acc.max(x));
 
         for child in line.items.iter_mut() {
             let free_space = line_cross_size - child.outer_target_size.cross(constants.dir);
 
             if child.margin_is_auto.cross_start(constants.dir) && child.margin_is_auto.cross_end(constants.dir) {
                 if constants.is_row {
-                    child.margin.top = free_space / 2.0;
-                    child.margin.bottom = free_space / 2.0;
+                    child.margin.top = free_space / 2.0_f32;
+                    child.margin.bottom = free_space / 2.0_f32;
                 } else {
-                    child.margin.left = free_space / 2.0;
-                    child.margin.right = free_space / 2.0;
+                    child.margin.left = free_space / 2.0_f32;
+                    child.margin.right = free_space / 2.0_f32;
                 }
             } else if child.margin_is_auto.cross_start(constants.dir) {
                 if constants.is_row {
@@ -1765,7 +1765,7 @@ fn resolve_cross_axis_auto_margins(flex_lines: &mut [FlexLine], constants: &Algo
 
 /// Align all flex items along the cross-axis.
 ///
-/// # [9.6. Cross-Axis Alignment](https://www.w3.org/TR/css-flexbox-1/#cross-alignment)
+/// # [9.6_f32. Cross-Axis Alignment](https://www.w3.org/TR/css-flexbox-1/#cross-alignment)
 ///
 /// - [**Align all flex items along the cross-axis**](https://www.w3.org/TR/css-flexbox-1/#algo-cross-align) per `align-self`,
 ///   if neither of the item's cross-axis margins are `auto`.
@@ -1780,45 +1780,45 @@ fn align_flex_items_along_cross_axis(
 
     // If align-self uses a "safe" overflow-position keyword and the item would overflow its
     // line cross size, fall back to logical Start to avoid data loss. See CSS Box Alignment 3
-    // §4.3 <https://www.w3.org/TR/css-align-3/#overflow-values>. Otherwise, strip the Safe*
-    // modifier so the regular match below sees only the position keyword.
-    let align_self = if child.align_self.is_safe() && free_space < 0.0 {
-        AlignSelf::Start
+    // §4.3_f32 <https://www.w3.org/TR/css-align-3/#overflow-values>. Otherwise, drop the safety
+    // field so the match below operates on a bare keyword and stays exhaustive.
+    let align_keyword = if child.align_self.is_safe() && free_space < 0.0_f32 {
+        AlignItemsKeyword::Start
     } else {
-        child.align_self.position()
+        child.align_self.keyword
     };
 
-    match align_self {
-        AlignSelf::Start => {
+    match align_keyword {
+        AlignItemsKeyword::Start => {
             if cross_axis_should_reverse {
                 free_space
             } else {
                 0.0
             }
         }
-        AlignSelf::FlexStart => {
+        AlignItemsKeyword::FlexStart => {
             if constants.is_wrap_reverse ^ cross_axis_should_reverse {
                 free_space
             } else {
                 0.0
             }
         }
-        AlignSelf::End => {
+        AlignItemsKeyword::End => {
             if cross_axis_should_reverse {
                 0.0
             } else {
                 free_space
             }
         }
-        AlignSelf::FlexEnd => {
+        AlignItemsKeyword::FlexEnd => {
             if constants.is_wrap_reverse ^ cross_axis_should_reverse {
                 0.0
             } else {
                 free_space
             }
         }
-        AlignSelf::Center => free_space / 2.0,
-        AlignSelf::Baseline => {
+        AlignItemsKeyword::Center => free_space / 2.0_f32,
+        AlignItemsKeyword::Baseline => {
             if constants.is_row {
                 max_baseline - child.baseline
             } else {
@@ -1832,27 +1832,19 @@ fn align_flex_items_along_cross_axis(
                 }
             }
         }
-        AlignSelf::Stretch => {
+        AlignItemsKeyword::Stretch => {
             if constants.is_wrap_reverse ^ cross_axis_should_reverse {
                 free_space
             } else {
                 0.0
             }
         }
-        AlignSelf::SafeStart
-        | AlignSelf::SafeEnd
-        | AlignSelf::SafeFlexStart
-        | AlignSelf::SafeFlexEnd
-        | AlignSelf::SafeCenter => {
-            // Unreachable: Safe* variants are stripped above into the underlying position keyword.
-            unreachable!()
-        }
     }
 }
 
 /// Determine the flex container’s used cross size.
 ///
-/// # [9.6. Cross-Axis Alignment](https://www.w3.org/TR/css-flexbox-1/#cross-alignment)
+/// # [9.6_f32. Cross-Axis Alignment](https://www.w3.org/TR/css-flexbox-1/#cross-alignment)
 ///
 /// - [**Determine the flex container’s used cross size**](https://www.w3.org/TR/css-flexbox-1/#algo-cross-container):
 ///
@@ -1878,7 +1870,7 @@ fn determine_container_cross_size(
         .unwrap_or(total_line_cross_size + total_cross_axis_gap + padding_border_sum)
         .maybe_clamp(min_cross_size, max_cross_size)
         .max(padding_border_sum - cross_scrollbar_gutter);
-    let inner_container_size = f32_max(outer_container_size - padding_border_sum, 0.0);
+    let inner_container_size = f32_max(outer_container_size - padding_border_sum, 0.0_f32);
 
     constants.container_size.set_cross(constants.dir, outer_container_size);
     constants.inner_container_size.set_cross(constants.dir, inner_container_size);
@@ -1888,7 +1880,7 @@ fn determine_container_cross_size(
 
 /// Align all flex lines per `align-content`.
 ///
-/// # [9.6. Cross-Axis Alignment](https://www.w3.org/TR/css-flexbox-1/#cross-alignment)
+/// # [9.6_f32. Cross-Axis Alignment](https://www.w3.org/TR/css-flexbox-1/#cross-alignment)
 ///
 /// - [**Align all flex lines**](https://www.w3.org/TR/css-flexbox-1/#algo-line-align) per `align-content`.
 #[inline]
@@ -1944,16 +1936,16 @@ fn calculate_flex_item(
     let is_rtl_row = direction.is_row() && layout_direction.is_rtl();
     let is_rtl_column = direction.is_column() && layout_direction.is_rtl();
     let main_relative_inset = if is_rtl_row {
-        item.inset.main_end(direction).or(item.inset.main_start(direction).map(|pos| -pos)).unwrap_or(0.0)
+        item.inset.main_end(direction).or(item.inset.main_start(direction).map(|pos| -pos)).unwrap_or(0.0_f32)
     } else {
-        item.inset.main_start(direction).or(item.inset.main_end(direction).map(|pos| -pos)).unwrap_or(0.0)
+        item.inset.main_start(direction).or(item.inset.main_end(direction).map(|pos| -pos)).unwrap_or(0.0_f32)
     };
     let cross_relative_inset = if is_rtl_column {
-        item.inset.cross_end(direction).map(|pos| -pos).or(item.inset.cross_start(direction)).unwrap_or(0.0)
+        item.inset.cross_end(direction).map(|pos| -pos).or(item.inset.cross_start(direction)).unwrap_or(0.0_f32)
     } else {
-        item.inset.cross_start(direction).or(item.inset.cross_end(direction).map(|pos| -pos)).unwrap_or(0.0)
+        item.inset.cross_start(direction).or(item.inset.cross_end(direction).map(|pos| -pos)).unwrap_or(0.0_f32)
     };
-    let effective_line_offset_cross = if is_rtl_column { 0.0 } else { line_offset_cross };
+    let effective_line_offset_cross = if is_rtl_column { 0.0_f32 } else { line_offset_cross };
 
     let offset_main = if is_rtl_row {
         *total_offset_main - item.offset_main - item.margin.main_end(direction) - main_relative_inset - size.width
@@ -1984,8 +1976,8 @@ fn calculate_flex_item(
         Point { x: offset_cross, y: offset_main }
     };
     let scrollbar_size = Size {
-        width: if item.overflow.y == Overflow::Scroll { item.scrollbar_width } else { 0.0 },
-        height: if item.overflow.x == Overflow::Scroll { item.scrollbar_width } else { 0.0 },
+        width: if item.overflow.y == Overflow::Scroll { item.scrollbar_width } else { 0.0_f32 },
+        height: if item.overflow.x == Overflow::Scroll { item.scrollbar_width } else { 0.0_f32 },
     };
 
     tree.set_unrounded_layout(
@@ -2224,7 +2216,7 @@ fn perform_absolute_layout_on_absolute_children(
         //   - Item has both left and right inset properties set
         if let (None, Some(left), Some(right)) = (known_dimensions.width, left, right) {
             let new_width_raw = inset_relative_size.width.maybe_sub(margin.left).maybe_sub(margin.right) - left - right;
-            known_dimensions.width = Some(f32_max(new_width_raw, 0.0));
+            known_dimensions.width = Some(f32_max(new_width_raw, 0.0_f32));
             known_dimensions = known_dimensions.maybe_apply_aspect_ratio(aspect_ratio).maybe_clamp(min_size, max_size);
         }
 
@@ -2234,7 +2226,7 @@ fn perform_absolute_layout_on_absolute_children(
         if let (None, Some(top), Some(bottom)) = (known_dimensions.height, top, bottom) {
             let new_height_raw =
                 inset_relative_size.height.maybe_sub(margin.top).maybe_sub(margin.bottom) - top - bottom;
-            known_dimensions.height = Some(f32_max(new_height_raw, 0.0));
+            known_dimensions.height = Some(f32_max(new_height_raw, 0.0_f32));
             known_dimensions = known_dimensions.maybe_apply_aspect_ratio(aspect_ratio).maybe_clamp(min_size, max_size);
         }
         let measured_size = tree.measure_child_size_both(
@@ -2262,7 +2254,7 @@ fn perform_absolute_layout_on_absolute_children(
             Line::FALSE,
         );
 
-        let non_auto_margin = margin.map(|m| m.unwrap_or(0.0));
+        let non_auto_margin = margin.map(|m| m.unwrap_or(0.0_f32));
 
         let free_space = Size {
             width: constants.container_size.width - final_size.width - non_auto_margin.horizontal_axis_sum(),
@@ -2309,12 +2301,12 @@ fn perform_absolute_layout_on_absolute_children(
         let main_axis_flex_start_reversed = constants.dir.is_reverse() ^ main_is_rtl;
         let cross_axis_flex_start_reversed = constants.is_wrap_reverse ^ cross_is_rtl;
         let main_start_scrollbar_offset =
-            if main_is_rtl { constants.scrollbar_gutter.main(constants.dir) } else { 0.0 };
+            if main_is_rtl { constants.scrollbar_gutter.main(constants.dir) } else { 0.0_f32 };
         let cross_start_scrollbar_offset =
-            if cross_is_rtl { constants.scrollbar_gutter.cross(constants.dir) } else { 0.0 };
-        let main_end_scrollbar_offset = if main_is_rtl { 0.0 } else { constants.scrollbar_gutter.main(constants.dir) };
+            if cross_is_rtl { constants.scrollbar_gutter.cross(constants.dir) } else { 0.0_f32 };
+        let main_end_scrollbar_offset = if main_is_rtl { 0.0_f32 } else { constants.scrollbar_gutter.main(constants.dir) };
         let cross_end_scrollbar_offset =
-            if cross_is_rtl { 0.0 } else { constants.scrollbar_gutter.cross(constants.dir) };
+            if cross_is_rtl { 0.0_f32 } else { constants.scrollbar_gutter.cross(constants.dir) };
 
         // Apply main-axis alignment
         // let free_main_space = free_space.main(constants.dir) - resolved_margin.main_axis_sum(constants.dir);
@@ -2324,7 +2316,7 @@ fn perform_absolute_layout_on_absolute_children(
                     - constants.border.main_end(constants.dir)
                     - main_end_scrollbar_offset
                     - final_size.main(constants.dir)
-                    - end_main.unwrap_or(0.0)
+                    - end_main.unwrap_or(0.0_f32)
                     - resolved_margin.main_end(constants.dir)
             } else if let Some(start) = start_main {
                 start
@@ -2336,7 +2328,7 @@ fn perform_absolute_layout_on_absolute_children(
                     - constants.border.main_end(constants.dir)
                     - main_end_scrollbar_offset
                     - final_size.main(constants.dir)
-                    - end_main.unwrap_or(0.0)
+                    - end_main.unwrap_or(0.0_f32)
                     - resolved_margin.main_end(constants.dir)
             }
         } else {
@@ -2344,41 +2336,43 @@ fn perform_absolute_layout_on_absolute_children(
             // treat it as if it wasn't set (and thus we default to FlexStart behaviour)
             // TODO (safe alignment): apply Start fallback when justify_content.is_safe() and the
             // resolved size overflows the containing block. Wired in a follow-up commit.
-            match (constants.justify_content.unwrap_or(JustifyContent::Start).position(), main_axis_flex_start_reversed)
+            match (constants.justify_content.unwrap_or(JustifyContent::Start).keyword(), main_axis_flex_start_reversed)
             {
-                (JustifyContent::SpaceBetween, _)
-                | (JustifyContent::Stretch, false)
-                | (JustifyContent::FlexStart, false)
-                | (JustifyContent::FlexEnd, true) => {
+                (AlignContentKeyword::SpaceBetween, _)
+                | (AlignContentKeyword::Stretch, false)
+                | (AlignContentKeyword::FlexStart, false)
+                | (AlignContentKeyword::FlexEnd, true) => {
                     constants.content_box_inset.main_start(constants.dir) + resolved_margin.main_start(constants.dir)
                 }
-                (JustifyContent::Start, false) => {
+                (AlignContentKeyword::Start, false) => {
                     constants.content_box_inset.main_start(constants.dir) + resolved_margin.main_start(constants.dir)
                 }
-                (JustifyContent::Start, true) => {
+                (AlignContentKeyword::Start, true) => {
                     constants.container_size.main(constants.dir)
                         - constants.content_box_inset.main_end(constants.dir)
                         - final_size.main(constants.dir)
                         - resolved_margin.main_end(constants.dir)
                 }
-                (JustifyContent::End, false) => {
+                (AlignContentKeyword::End, false) => {
                     constants.container_size.main(constants.dir)
                         - constants.content_box_inset.main_end(constants.dir)
                         - final_size.main(constants.dir)
                         - resolved_margin.main_end(constants.dir)
                 }
-                (JustifyContent::End, true) => {
+                (AlignContentKeyword::End, true) => {
                     constants.content_box_inset.main_start(constants.dir) + resolved_margin.main_start(constants.dir)
                 }
-                (JustifyContent::FlexEnd, false)
-                | (JustifyContent::FlexStart, true)
-                | (JustifyContent::Stretch, true) => {
+                (AlignContentKeyword::FlexEnd, false)
+                | (AlignContentKeyword::FlexStart, true)
+                | (AlignContentKeyword::Stretch, true) => {
                     constants.container_size.main(constants.dir)
                         - constants.content_box_inset.main_end(constants.dir)
                         - final_size.main(constants.dir)
                         - resolved_margin.main_end(constants.dir)
                 }
-                (JustifyContent::SpaceEvenly, _) | (JustifyContent::SpaceAround, _) | (JustifyContent::Center, _) => {
+                (AlignContentKeyword::SpaceEvenly, _)
+                | (AlignContentKeyword::SpaceAround, _)
+                | (AlignContentKeyword::Center, _) => {
                     (constants.container_size.main(constants.dir)
                         + constants.content_box_inset.main_start(constants.dir)
                         - constants.content_box_inset.main_end(constants.dir)
@@ -2386,17 +2380,6 @@ fn perform_absolute_layout_on_absolute_children(
                         + resolved_margin.main_start(constants.dir)
                         - resolved_margin.main_end(constants.dir))
                         / 2.0
-                }
-                (
-                    JustifyContent::SafeStart
-                    | JustifyContent::SafeEnd
-                    | JustifyContent::SafeFlexStart
-                    | JustifyContent::SafeFlexEnd
-                    | JustifyContent::SafeCenter,
-                    _,
-                ) => {
-                    // Unreachable: `position()` strips Safe* into the underlying position keyword.
-                    unreachable!()
                 }
             }
         };
@@ -2409,7 +2392,7 @@ fn perform_absolute_layout_on_absolute_children(
                     - constants.border.cross_end(constants.dir)
                     - cross_end_scrollbar_offset
                     - final_size.cross(constants.dir)
-                    - end_cross.unwrap_or(0.0)
+                    - end_cross.unwrap_or(0.0_f32)
                     - resolved_margin.cross_end(constants.dir)
             } else if let Some(start) = start_cross {
                 start
@@ -2421,46 +2404,46 @@ fn perform_absolute_layout_on_absolute_children(
                     - constants.border.cross_end(constants.dir)
                     - cross_end_scrollbar_offset
                     - final_size.cross(constants.dir)
-                    - end_cross.unwrap_or(0.0)
+                    - end_cross.unwrap_or(0.0_f32)
                     - resolved_margin.cross_end(constants.dir)
             }
         } else {
             // TODO (safe alignment): apply Start fallback when align_self.is_safe() and the
             // resolved size overflows the containing block. Wired in a follow-up commit.
-            match (align_self.position(), cross_axis_flex_start_reversed) {
+            match (align_self.keyword(), cross_axis_flex_start_reversed) {
                 // Stretch alignment does not apply to absolutely positioned items
                 // See "Example 3" at https://www.w3.org/TR/css-flexbox-1/#abspos-items
                 // Note: Stretch should be FlexStart not Start when we support both
-                (AlignSelf::Start, false) => {
+                (AlignItemsKeyword::Start, false) => {
                     constants.content_box_inset.cross_start(constants.dir) + resolved_margin.cross_start(constants.dir)
                 }
-                (AlignSelf::Start, true) => {
+                (AlignItemsKeyword::Start, true) => {
                     constants.container_size.cross(constants.dir)
                         - constants.content_box_inset.cross_end(constants.dir)
                         - final_size.cross(constants.dir)
                         - resolved_margin.cross_end(constants.dir)
                 }
-                (AlignSelf::End, false) => {
+                (AlignItemsKeyword::End, false) => {
                     constants.container_size.cross(constants.dir)
                         - constants.content_box_inset.cross_end(constants.dir)
                         - final_size.cross(constants.dir)
                         - resolved_margin.cross_end(constants.dir)
                 }
-                (AlignSelf::End, true) => {
+                (AlignItemsKeyword::End, true) => {
                     constants.content_box_inset.cross_start(constants.dir) + resolved_margin.cross_start(constants.dir)
                 }
-                (AlignSelf::Baseline | AlignSelf::Stretch | AlignSelf::FlexStart, false)
-                | (AlignSelf::FlexEnd, true) => {
+                (AlignItemsKeyword::Baseline | AlignItemsKeyword::Stretch | AlignItemsKeyword::FlexStart, false)
+                | (AlignItemsKeyword::FlexEnd, true) => {
                     constants.content_box_inset.cross_start(constants.dir) + resolved_margin.cross_start(constants.dir)
                 }
-                (AlignSelf::Baseline | AlignSelf::Stretch | AlignSelf::FlexStart, true)
-                | (AlignSelf::FlexEnd, false) => {
+                (AlignItemsKeyword::Baseline | AlignItemsKeyword::Stretch | AlignItemsKeyword::FlexStart, true)
+                | (AlignItemsKeyword::FlexEnd, false) => {
                     constants.container_size.cross(constants.dir)
                         - constants.content_box_inset.cross_end(constants.dir)
                         - final_size.cross(constants.dir)
                         - resolved_margin.cross_end(constants.dir)
                 }
-                (AlignSelf::Center, _) => {
+                (AlignItemsKeyword::Center, _) => {
                     (constants.container_size.cross(constants.dir)
                         + constants.content_box_inset.cross_start(constants.dir)
                         - constants.content_box_inset.cross_end(constants.dir)
@@ -2468,17 +2451,6 @@ fn perform_absolute_layout_on_absolute_children(
                         + resolved_margin.cross_start(constants.dir)
                         - resolved_margin.cross_end(constants.dir))
                         / 2.0
-                }
-                (
-                    AlignSelf::SafeStart
-                    | AlignSelf::SafeEnd
-                    | AlignSelf::SafeFlexStart
-                    | AlignSelf::SafeFlexEnd
-                    | AlignSelf::SafeCenter,
-                    _,
-                ) => {
-                    // Unreachable: `position()` strips Safe* into the underlying position keyword.
-                    unreachable!()
                 }
             }
         };
@@ -2488,8 +2460,8 @@ fn perform_absolute_layout_on_absolute_children(
             false => Point { x: offset_cross, y: offset_main },
         };
         let scrollbar_size = Size {
-            width: if overflow.y == Overflow::Scroll { scrollbar_width } else { 0.0 },
-            height: if overflow.x == Overflow::Scroll { scrollbar_width } else { 0.0 },
+            width: if overflow.y == Overflow::Scroll { scrollbar_width } else { 0.0_f32 },
+            height: if overflow.x == Overflow::Scroll { scrollbar_width } else { 0.0_f32 },
         };
         tree.set_unrounded_layout(
             child,
@@ -2521,7 +2493,7 @@ fn perform_absolute_layout_on_absolute_children(
             if size_content_size_contribution.has_non_zero_area() {
                 let absolute_area_offset = Point {
                     x: constants.border.left
-                        + if constants.layout_direction.is_rtl() { constants.scrollbar_gutter.x } else { 0.0 },
+                        + if constants.layout_direction.is_rtl() { constants.scrollbar_gutter.x } else { 0.0_f32 },
                     y: constants.border.top,
                 };
                 let relative_location =
@@ -2529,8 +2501,8 @@ fn perform_absolute_layout_on_absolute_children(
                 let content_size_contribution = Size {
                     width: if constants.layout_direction.is_rtl() {
                         let overflow_extra_width =
-                            f32_max(size_content_size_contribution.width - final_size.width, 0.0);
-                        f32_max(inset_relative_size.width - relative_location.x, 0.0) + overflow_extra_width
+                            f32_max(size_content_size_contribution.width - final_size.width, 0.0_f32);
+                        f32_max(inset_relative_size.width - relative_location.x, 0.0_f32) + overflow_extra_width
                     } else {
                         relative_location.x + size_content_size_contribution.width
                     },

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -1698,11 +1698,8 @@ fn distribute_remaining_free_space(flex_lines: &mut [FlexLine], constants: &Algo
         let num_items = line.items.len();
         let layout_reverse = constants.dir.is_reverse();
         let gap = constants.gap.main(constants.dir);
-        // The Safe* overflow-position modifier (if present on the resolved justify-content
-        // keyword) is folded into the `is_safe` flag inside `apply_alignment_fallback`.
-        let is_safe = false;
         let raw_justify_content_mode = constants.justify_content.unwrap_or(JustifyContent::FlexStart);
-        let justify_content_mode = apply_alignment_fallback(free_space, num_items, raw_justify_content_mode, is_safe);
+        let justify_content_mode = apply_alignment_fallback(free_space, num_items, raw_justify_content_mode);
 
         let justify_item = |(i, child): (usize, &mut FlexItem)| {
             child.offset_main =
@@ -1783,12 +1780,15 @@ fn align_flex_items_along_cross_axis(
 
     // If align-self uses a "safe" overflow-position keyword and the item would overflow its
     // line cross size, fall back to logical Start to avoid data loss. See CSS Box Alignment 3
-    // §4.3 <https://www.w3.org/TR/css-align-3/#overflow-values>.
-    if child.align_self.is_safe() && free_space < 0.0 {
-        return if cross_axis_should_reverse { free_space } else { 0.0 };
-    }
+    // §4.3 <https://www.w3.org/TR/css-align-3/#overflow-values>. Otherwise, strip the Safe*
+    // modifier so the regular match below sees only the position keyword.
+    let align_self = if child.align_self.is_safe() && free_space < 0.0 {
+        AlignSelf::Start
+    } else {
+        child.align_self.position()
+    };
 
-    match child.align_self.position() {
+    match align_self {
         AlignSelf::Start => {
             if cross_axis_should_reverse {
                 free_space
@@ -1844,7 +1844,7 @@ fn align_flex_items_along_cross_axis(
         | AlignSelf::SafeFlexStart
         | AlignSelf::SafeFlexEnd
         | AlignSelf::SafeCenter => {
-            // Unreachable: `position()` strips Safe* into the underlying position keyword.
+            // Unreachable: Safe* variants are stripped above into the underlying position keyword.
             unreachable!()
         }
     }
@@ -1897,11 +1897,8 @@ fn align_flex_lines_per_align_content(flex_lines: &mut [FlexLine], constants: &A
     let gap = constants.gap.cross(constants.dir);
     let total_cross_axis_gap = sum_axis_gaps(gap, num_lines);
     let free_space = constants.inner_container_size.cross(constants.dir) - total_cross_size - total_cross_axis_gap;
-    // The Safe* overflow-position modifier (if present on the resolved align-content keyword)
-    // is folded into the `is_safe` flag inside `apply_alignment_fallback`.
-    let is_safe = false;
 
-    let align_content_mode = apply_alignment_fallback(free_space, num_lines, constants.align_content, is_safe);
+    let align_content_mode = apply_alignment_fallback(free_space, num_lines, constants.align_content);
 
     let align_line = |(i, line): (usize, &mut FlexLine)| {
         line.offset_cross =

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -2347,7 +2347,8 @@ fn perform_absolute_layout_on_absolute_children(
             // treat it as if it wasn't set (and thus we default to FlexStart behaviour)
             // TODO (safe alignment): apply Start fallback when justify_content.is_safe() and the
             // resolved size overflows the containing block. Wired in a follow-up commit.
-            match (constants.justify_content.unwrap_or(JustifyContent::Start).position(), main_axis_flex_start_reversed) {
+            match (constants.justify_content.unwrap_or(JustifyContent::Start).position(), main_axis_flex_start_reversed)
+            {
                 (JustifyContent::SpaceBetween, _)
                 | (JustifyContent::Stretch, false)
                 | (JustifyContent::FlexStart, false)

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -1698,7 +1698,9 @@ fn distribute_remaining_free_space(flex_lines: &mut [FlexLine], constants: &Algo
         let num_items = line.items.len();
         let layout_reverse = constants.dir.is_reverse();
         let gap = constants.gap.main(constants.dir);
-        let is_safe = false; // TODO: Implement safe alignment
+        // The Safe* overflow-position modifier (if present on the resolved justify-content
+        // keyword) is folded into the `is_safe` flag inside `apply_alignment_fallback`.
+        let is_safe = false;
         let raw_justify_content_mode = constants.justify_content.unwrap_or(JustifyContent::FlexStart);
         let justify_content_mode = apply_alignment_fallback(free_space, num_items, raw_justify_content_mode, is_safe);
 
@@ -1779,8 +1781,13 @@ fn align_flex_items_along_cross_axis(
 ) -> f32 {
     let cross_axis_should_reverse = constants.is_column && matches!(constants.layout_direction, Direction::Rtl);
 
-    // TODO (safe alignment): when child.align_self.is_safe() and free_space < 0, fall back to
-    // literal Start. Wired in a follow-up commit (Phase T2b).
+    // If align-self uses a "safe" overflow-position keyword and the item would overflow its
+    // line cross size, fall back to logical Start to avoid data loss. See CSS Box Alignment 3
+    // §4.3 <https://www.w3.org/TR/css-align-3/#overflow-values>.
+    if child.align_self.is_safe() && free_space < 0.0 {
+        return if cross_axis_should_reverse { free_space } else { 0.0 };
+    }
+
     match child.align_self.position() {
         AlignSelf::Start => {
             if cross_axis_should_reverse {
@@ -1890,7 +1897,9 @@ fn align_flex_lines_per_align_content(flex_lines: &mut [FlexLine], constants: &A
     let gap = constants.gap.cross(constants.dir);
     let total_cross_axis_gap = sum_axis_gaps(gap, num_lines);
     let free_space = constants.inner_container_size.cross(constants.dir) - total_cross_size - total_cross_axis_gap;
-    let is_safe = false; // TODO: Implement safe alignment
+    // The Safe* overflow-position modifier (if present on the resolved align-content keyword)
+    // is folded into the `is_safe` flag inside `apply_alignment_fallback`.
+    let is_safe = false;
 
     let align_content_mode = apply_alignment_fallback(free_space, num_lines, constants.align_content, is_safe);
 

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -1779,7 +1779,9 @@ fn align_flex_items_along_cross_axis(
 ) -> f32 {
     let cross_axis_should_reverse = constants.is_column && matches!(constants.layout_direction, Direction::Rtl);
 
-    match child.align_self {
+    // TODO (safe alignment): when child.align_self.is_safe() and free_space < 0, fall back to
+    // literal Start. Wired in a follow-up commit (Phase T2b).
+    match child.align_self.position() {
         AlignSelf::Start => {
             if cross_axis_should_reverse {
                 free_space
@@ -1829,6 +1831,14 @@ fn align_flex_items_along_cross_axis(
             } else {
                 0.0
             }
+        }
+        AlignSelf::SafeStart
+        | AlignSelf::SafeEnd
+        | AlignSelf::SafeFlexStart
+        | AlignSelf::SafeFlexEnd
+        | AlignSelf::SafeCenter => {
+            // Unreachable: `position()` strips Safe* into the underlying position keyword.
+            unreachable!()
         }
     }
 }
@@ -2326,7 +2336,9 @@ fn perform_absolute_layout_on_absolute_children(
         } else {
             // Stretch is an invalid value for justify_content in the flexbox algorithm, so we
             // treat it as if it wasn't set (and thus we default to FlexStart behaviour)
-            match (constants.justify_content.unwrap_or(JustifyContent::Start), main_axis_flex_start_reversed) {
+            // TODO (safe alignment): apply Start fallback when justify_content.is_safe() and the
+            // resolved size overflows the containing block. Wired in a follow-up commit.
+            match (constants.justify_content.unwrap_or(JustifyContent::Start).position(), main_axis_flex_start_reversed) {
                 (JustifyContent::SpaceBetween, _)
                 | (JustifyContent::Stretch, false)
                 | (JustifyContent::FlexStart, false)
@@ -2368,6 +2380,17 @@ fn perform_absolute_layout_on_absolute_children(
                         - resolved_margin.main_end(constants.dir))
                         / 2.0
                 }
+                (
+                    JustifyContent::SafeStart
+                    | JustifyContent::SafeEnd
+                    | JustifyContent::SafeFlexStart
+                    | JustifyContent::SafeFlexEnd
+                    | JustifyContent::SafeCenter,
+                    _,
+                ) => {
+                    // Unreachable: `position()` strips Safe* into the underlying position keyword.
+                    unreachable!()
+                }
             }
         };
 
@@ -2395,7 +2418,9 @@ fn perform_absolute_layout_on_absolute_children(
                     - resolved_margin.cross_end(constants.dir)
             }
         } else {
-            match (align_self, cross_axis_flex_start_reversed) {
+            // TODO (safe alignment): apply Start fallback when align_self.is_safe() and the
+            // resolved size overflows the containing block. Wired in a follow-up commit.
+            match (align_self.position(), cross_axis_flex_start_reversed) {
                 // Stretch alignment does not apply to absolutely positioned items
                 // See "Example 3" at https://www.w3.org/TR/css-flexbox-1/#abspos-items
                 // Note: Stretch should be FlexStart not Start when we support both
@@ -2436,6 +2461,17 @@ fn perform_absolute_layout_on_absolute_children(
                         + resolved_margin.cross_start(constants.dir)
                         - resolved_margin.cross_end(constants.dir))
                         / 2.0
+                }
+                (
+                    AlignSelf::SafeStart
+                    | AlignSelf::SafeEnd
+                    | AlignSelf::SafeFlexStart
+                    | AlignSelf::SafeFlexEnd
+                    | AlignSelf::SafeCenter,
+                    _,
+                ) => {
+                    // Unreachable: `position()` strips Safe* into the underlying position keyword.
+                    unreachable!()
                 }
             }
         };

--- a/src/compute/grid/alignment.rs
+++ b/src/compute/grid/alignment.rs
@@ -2,7 +2,10 @@
 use super::types::GridTrack;
 use crate::compute::common::alignment::{apply_alignment_fallback, compute_alignment_offset};
 use crate::geometry::{InBothAbsAxis, Line, Point, Rect, Size};
-use crate::style::{AlignContent, AlignItems, AlignSelf, AvailableSpace, CoreStyle, GridItemStyle, Overflow, Position};
+use crate::style::{
+    AlignContent, AlignItems, AlignItemsKeyword, AlignSelf, AvailableSpace, CoreStyle, GridItemStyle, Overflow,
+    Position,
+};
 use crate::tree::{Layout, LayoutPartialTreeExt, NodeId, SizingMode};
 use crate::util::sys::f32_max;
 use crate::util::{MaybeMath, MaybeResolve, ResolveOrZero};
@@ -31,7 +34,7 @@ pub(super) fn align_tracks(
 
     // Grid layout treats gaps as full tracks rather than applying them at alignment so we
     // simply pass zero here. Grid layout is never reversed.
-    let gap = 0.0;
+    let gap = 0.0_f32;
     let layout_is_reversed = false;
     let track_alignment = apply_alignment_fallback(free_space, num_tracks, track_alignment_style);
     let track_alignment = if axis_is_reversed { track_alignment.reversed() } else { track_alignment };
@@ -155,7 +158,7 @@ pub(super) fn align_and_position_item(
         // positioned element being set
         if position == Position::Absolute {
             if let (Some(left), Some(right)) = (inset_horizontal.start, inset_horizontal.end) {
-                return Some(f32_max(grid_area_minus_item_margins_size.width - left - right, 0.0));
+                return Some(f32_max(grid_area_minus_item_margins_size.width - left - right, 0.0_f32));
             }
         }
 
@@ -180,7 +183,7 @@ pub(super) fn align_and_position_item(
     let height = height.or_else(|| {
         if position == Position::Absolute {
             if let (Some(top), Some(bottom)) = (inset_vertical.start, inset_vertical.end) {
-                return Some(f32_max(grid_area_minus_item_margins_size.height - top - bottom, 0.0));
+                return Some(f32_max(grid_area_minus_item_margins_size.height - top - bottom, 0.0_f32));
             }
         }
 
@@ -240,7 +243,7 @@ pub(super) fn align_and_position_item(
         position,
         inset_horizontal,
         margin.horizontal_components(),
-        0.0,
+        0.0_f32,
         direction,
     );
     let (y, y_margin) = align_item_within_area(
@@ -255,8 +258,8 @@ pub(super) fn align_and_position_item(
     );
 
     let scrollbar_size = Size {
-        width: if overflow.y == Overflow::Scroll { scrollbar_width } else { 0.0 },
-        height: if overflow.x == Overflow::Scroll { scrollbar_width } else { 0.0 },
+        width: if overflow.y == Overflow::Scroll { scrollbar_width } else { 0.0_f32 },
+        height: if overflow.x == Overflow::Scroll { scrollbar_width } else { 0.0_f32 },
     };
 
     let resolved_margin = Rect { left: x_margin.start, right: x_margin.end, top: y_margin.start, bottom: y_margin.end };
@@ -302,13 +305,13 @@ pub(super) fn align_item_within_area(
     direction: Direction,
 ) -> (f32, Line<f32>) {
     // Calculate grid area dimension in the axis
-    let non_auto_margin = Line { start: margin.start.unwrap_or(0.0) + baseline_shim, end: margin.end.unwrap_or(0.0) };
-    let grid_area_size = f32_max(grid_area.end - grid_area.start, 0.0);
-    let free_space = f32_max(grid_area_size - resolved_size - non_auto_margin.sum(), 0.0);
+    let non_auto_margin = Line { start: margin.start.unwrap_or(0.0_f32) + baseline_shim, end: margin.end.unwrap_or(0.0_f32) };
+    let grid_area_size = f32_max(grid_area.end - grid_area.start, 0.0_f32);
+    let free_space = f32_max(grid_area_size - resolved_size - non_auto_margin.sum(), 0.0_f32);
 
     // Expand auto margins to fill available space
     let auto_margin_count = margin.start.is_none() as u8 + margin.end.is_none() as u8;
-    let auto_margin_size = if auto_margin_count > 0 { free_space / auto_margin_count as f32 } else { 0.0 };
+    let auto_margin_size = if auto_margin_count > 0 { free_space / auto_margin_count as f32 } else { 0.0_f32 };
     let resolved_margin = Line {
         start: margin.start.unwrap_or(auto_margin_size) + baseline_shim,
         end: margin.end.unwrap_or(auto_margin_size),
@@ -316,40 +319,34 @@ pub(super) fn align_item_within_area(
 
     // If the alignment uses a "safe" overflow-position keyword and the item would overflow
     // its grid area, fall back to logical Start to avoid data loss. See CSS Box Alignment 3
-    // §4.3 <https://www.w3.org/TR/css-align-3/#overflow-values>. Otherwise, strip the
-    // Safe* modifier so the regular match below sees only the position keyword.
+    // §4.3_f32 <https://www.w3.org/TR/css-align-3/#overflow-values>. Otherwise, drop the safety
+    // field so the match below operates on a bare keyword and stays exhaustive.
     let overflows = resolved_size + non_auto_margin.sum() > grid_area_size;
-    let alignment_style = if alignment_style.is_safe() && overflows {
-        AlignSelf::Start
-    } else {
-        alignment_style.position()
-    };
+    let alignment_keyword =
+        if alignment_style.is_safe() && overflows { AlignItemsKeyword::Start } else { alignment_style.keyword() };
 
     // Compute offset in the axis
-    let alignment_based_offset = match alignment_style {
+    let alignment_based_offset = match alignment_keyword {
         // TODO: Add support for baseline alignment. For now we treat it as "start".
-        AlignSelf::Start | AlignSelf::FlexStart | AlignSelf::Baseline | AlignSelf::Stretch => {
+        AlignItemsKeyword::Start
+        | AlignItemsKeyword::FlexStart
+        | AlignItemsKeyword::Baseline
+        | AlignItemsKeyword::Stretch => {
             if direction.is_rtl() {
                 grid_area_size - resolved_size - resolved_margin.end
             } else {
                 resolved_margin.start
             }
         }
-        AlignSelf::End | AlignSelf::FlexEnd => {
+        AlignItemsKeyword::End | AlignItemsKeyword::FlexEnd => {
             if direction.is_rtl() {
                 resolved_margin.start
             } else {
                 grid_area_size - resolved_size - resolved_margin.end
             }
         }
-        AlignSelf::Center => (grid_area_size - resolved_size + resolved_margin.start - resolved_margin.end) / 2.0,
-        AlignSelf::SafeStart
-        | AlignSelf::SafeEnd
-        | AlignSelf::SafeFlexStart
-        | AlignSelf::SafeFlexEnd
-        | AlignSelf::SafeCenter => {
-            // Unreachable: Safe* variants are stripped above into the underlying position keyword.
-            unreachable!()
+        AlignItemsKeyword::Center => {
+            (grid_area_size - resolved_size + resolved_margin.start - resolved_margin.end) / 2.0
         }
     };
 
@@ -377,7 +374,7 @@ pub(super) fn align_item_within_area(
         } else {
             inset.start.or(inset.end.map(|pos| -pos))
         };
-        start += relative_inset.unwrap_or(0.0);
+        start += relative_inset.unwrap_or(0.0_f32);
     }
 
     (start, resolved_margin)

--- a/src/compute/grid/alignment.rs
+++ b/src/compute/grid/alignment.rs
@@ -316,7 +316,9 @@ pub(super) fn align_item_within_area(
     };
 
     // Compute offset in the axis
-    let alignment_based_offset = match alignment_style {
+    // TODO (safe alignment): when alignment_style.is_safe() and the resolved size exceeds the
+    // grid area, fall back to literal Start. Wired in a follow-up commit (Phase T2b).
+    let alignment_based_offset = match alignment_style.position() {
         // TODO: Add support for baseline alignment. For now we treat it as "start".
         AlignSelf::Start | AlignSelf::FlexStart | AlignSelf::Baseline | AlignSelf::Stretch => {
             if direction.is_rtl() {
@@ -333,6 +335,14 @@ pub(super) fn align_item_within_area(
             }
         }
         AlignSelf::Center => (grid_area_size - resolved_size + resolved_margin.start - resolved_margin.end) / 2.0,
+        AlignSelf::SafeStart
+        | AlignSelf::SafeEnd
+        | AlignSelf::SafeFlexStart
+        | AlignSelf::SafeFlexEnd
+        | AlignSelf::SafeCenter => {
+            // Unreachable: `position()` strips Safe* into the underlying position keyword.
+            unreachable!()
+        }
     };
 
     let offset_within_area = if position == Position::Absolute {

--- a/src/compute/grid/alignment.rs
+++ b/src/compute/grid/alignment.rs
@@ -33,10 +33,7 @@ pub(super) fn align_tracks(
     // simply pass zero here. Grid layout is never reversed.
     let gap = 0.0;
     let layout_is_reversed = false;
-    // The Safe* overflow-position modifier (if present on `track_alignment_style`) is folded
-    // into the `is_safe` flag inside `apply_alignment_fallback`.
-    let is_safe = false;
-    let track_alignment = apply_alignment_fallback(free_space, num_tracks, track_alignment_style, is_safe);
+    let track_alignment = apply_alignment_fallback(free_space, num_tracks, track_alignment_style);
     let track_alignment = if axis_is_reversed { track_alignment.reversed() } else { track_alignment };
 
     // Compute offsets
@@ -319,42 +316,40 @@ pub(super) fn align_item_within_area(
 
     // If the alignment uses a "safe" overflow-position keyword and the item would overflow
     // its grid area, fall back to logical Start to avoid data loss. See CSS Box Alignment 3
-    // §4.3 <https://www.w3.org/TR/css-align-3/#overflow-values>.
+    // §4.3 <https://www.w3.org/TR/css-align-3/#overflow-values>. Otherwise, strip the
+    // Safe* modifier so the regular match below sees only the position keyword.
     let overflows = resolved_size + non_auto_margin.sum() > grid_area_size;
+    let alignment_style = if alignment_style.is_safe() && overflows {
+        AlignSelf::Start
+    } else {
+        alignment_style.position()
+    };
 
     // Compute offset in the axis
-    let alignment_based_offset = if alignment_style.is_safe() && overflows {
-        if direction.is_rtl() {
-            grid_area_size - resolved_size - resolved_margin.end
-        } else {
-            resolved_margin.start
+    let alignment_based_offset = match alignment_style {
+        // TODO: Add support for baseline alignment. For now we treat it as "start".
+        AlignSelf::Start | AlignSelf::FlexStart | AlignSelf::Baseline | AlignSelf::Stretch => {
+            if direction.is_rtl() {
+                grid_area_size - resolved_size - resolved_margin.end
+            } else {
+                resolved_margin.start
+            }
         }
-    } else {
-        match alignment_style.position() {
-            // TODO: Add support for baseline alignment. For now we treat it as "start".
-            AlignSelf::Start | AlignSelf::FlexStart | AlignSelf::Baseline | AlignSelf::Stretch => {
-                if direction.is_rtl() {
-                    grid_area_size - resolved_size - resolved_margin.end
-                } else {
-                    resolved_margin.start
-                }
+        AlignSelf::End | AlignSelf::FlexEnd => {
+            if direction.is_rtl() {
+                resolved_margin.start
+            } else {
+                grid_area_size - resolved_size - resolved_margin.end
             }
-            AlignSelf::End | AlignSelf::FlexEnd => {
-                if direction.is_rtl() {
-                    resolved_margin.start
-                } else {
-                    grid_area_size - resolved_size - resolved_margin.end
-                }
-            }
-            AlignSelf::Center => (grid_area_size - resolved_size + resolved_margin.start - resolved_margin.end) / 2.0,
-            AlignSelf::SafeStart
-            | AlignSelf::SafeEnd
-            | AlignSelf::SafeFlexStart
-            | AlignSelf::SafeFlexEnd
-            | AlignSelf::SafeCenter => {
-                // Unreachable: `position()` strips Safe* into the underlying position keyword.
-                unreachable!()
-            }
+        }
+        AlignSelf::Center => (grid_area_size - resolved_size + resolved_margin.start - resolved_margin.end) / 2.0,
+        AlignSelf::SafeStart
+        | AlignSelf::SafeEnd
+        | AlignSelf::SafeFlexStart
+        | AlignSelf::SafeFlexEnd
+        | AlignSelf::SafeCenter => {
+            // Unreachable: Safe* variants are stripped above into the underlying position keyword.
+            unreachable!()
         }
     };
 

--- a/src/compute/grid/alignment.rs
+++ b/src/compute/grid/alignment.rs
@@ -34,7 +34,7 @@ pub(super) fn align_tracks(
 
     // Grid layout treats gaps as full tracks rather than applying them at alignment so we
     // simply pass zero here. Grid layout is never reversed.
-    let gap = 0.0_f32;
+    let gap = 0.0;
     let layout_is_reversed = false;
     let track_alignment = apply_alignment_fallback(free_space, num_tracks, track_alignment_style);
     let track_alignment = if axis_is_reversed { track_alignment.reversed() } else { track_alignment };
@@ -158,7 +158,7 @@ pub(super) fn align_and_position_item(
         // positioned element being set
         if position == Position::Absolute {
             if let (Some(left), Some(right)) = (inset_horizontal.start, inset_horizontal.end) {
-                return Some(f32_max(grid_area_minus_item_margins_size.width - left - right, 0.0_f32));
+                return Some(f32_max(grid_area_minus_item_margins_size.width - left - right, 0.0));
             }
         }
 
@@ -183,7 +183,7 @@ pub(super) fn align_and_position_item(
     let height = height.or_else(|| {
         if position == Position::Absolute {
             if let (Some(top), Some(bottom)) = (inset_vertical.start, inset_vertical.end) {
-                return Some(f32_max(grid_area_minus_item_margins_size.height - top - bottom, 0.0_f32));
+                return Some(f32_max(grid_area_minus_item_margins_size.height - top - bottom, 0.0));
             }
         }
 
@@ -243,7 +243,7 @@ pub(super) fn align_and_position_item(
         position,
         inset_horizontal,
         margin.horizontal_components(),
-        0.0_f32,
+        0.0,
         direction,
     );
     let (y, y_margin) = align_item_within_area(
@@ -258,8 +258,8 @@ pub(super) fn align_and_position_item(
     );
 
     let scrollbar_size = Size {
-        width: if overflow.y == Overflow::Scroll { scrollbar_width } else { 0.0_f32 },
-        height: if overflow.x == Overflow::Scroll { scrollbar_width } else { 0.0_f32 },
+        width: if overflow.y == Overflow::Scroll { scrollbar_width } else { 0.0 },
+        height: if overflow.x == Overflow::Scroll { scrollbar_width } else { 0.0 },
     };
 
     let resolved_margin = Rect { left: x_margin.start, right: x_margin.end, top: y_margin.start, bottom: y_margin.end };
@@ -305,13 +305,13 @@ pub(super) fn align_item_within_area(
     direction: Direction,
 ) -> (f32, Line<f32>) {
     // Calculate grid area dimension in the axis
-    let non_auto_margin = Line { start: margin.start.unwrap_or(0.0_f32) + baseline_shim, end: margin.end.unwrap_or(0.0_f32) };
-    let grid_area_size = f32_max(grid_area.end - grid_area.start, 0.0_f32);
-    let free_space = f32_max(grid_area_size - resolved_size - non_auto_margin.sum(), 0.0_f32);
+    let non_auto_margin = Line { start: margin.start.unwrap_or(0.0) + baseline_shim, end: margin.end.unwrap_or(0.0) };
+    let grid_area_size = f32_max(grid_area.end - grid_area.start, 0.0);
+    let free_space = f32_max(grid_area_size - resolved_size - non_auto_margin.sum(), 0.0);
 
     // Expand auto margins to fill available space
     let auto_margin_count = margin.start.is_none() as u8 + margin.end.is_none() as u8;
-    let auto_margin_size = if auto_margin_count > 0 { free_space / auto_margin_count as f32 } else { 0.0_f32 };
+    let auto_margin_size = if auto_margin_count > 0 { free_space / auto_margin_count as f32 } else { 0.0 };
     let resolved_margin = Line {
         start: margin.start.unwrap_or(auto_margin_size) + baseline_shim,
         end: margin.end.unwrap_or(auto_margin_size),
@@ -319,7 +319,7 @@ pub(super) fn align_item_within_area(
 
     // If the alignment uses a "safe" overflow-position keyword and the item would overflow
     // its grid area, fall back to logical Start to avoid data loss. See CSS Box Alignment 3
-    // §4.3_f32 <https://www.w3.org/TR/css-align-3/#overflow-values>. Otherwise, drop the safety
+    // §4.3 <https://www.w3.org/TR/css-align-3/#overflow-values>. Otherwise, drop the safety
     // field so the match below operates on a bare keyword and stays exhaustive.
     let overflows = resolved_size + non_auto_margin.sum() > grid_area_size;
     let alignment_keyword =
@@ -374,7 +374,7 @@ pub(super) fn align_item_within_area(
         } else {
             inset.start.or(inset.end.map(|pos| -pos))
         };
-        start += relative_inset.unwrap_or(0.0_f32);
+        start += relative_inset.unwrap_or(0.0);
     }
 
     (start, resolved_margin)

--- a/src/compute/grid/alignment.rs
+++ b/src/compute/grid/alignment.rs
@@ -33,7 +33,9 @@ pub(super) fn align_tracks(
     // simply pass zero here. Grid layout is never reversed.
     let gap = 0.0;
     let layout_is_reversed = false;
-    let is_safe = false; // TODO: Implement safe alignment
+    // The Safe* overflow-position modifier (if present on `track_alignment_style`) is folded
+    // into the `is_safe` flag inside `apply_alignment_fallback`.
+    let is_safe = false;
     let track_alignment = apply_alignment_fallback(free_space, num_tracks, track_alignment_style, is_safe);
     let track_alignment = if axis_is_reversed { track_alignment.reversed() } else { track_alignment };
 
@@ -315,33 +317,44 @@ pub(super) fn align_item_within_area(
         end: margin.end.unwrap_or(auto_margin_size),
     };
 
+    // If the alignment uses a "safe" overflow-position keyword and the item would overflow
+    // its grid area, fall back to logical Start to avoid data loss. See CSS Box Alignment 3
+    // §4.3 <https://www.w3.org/TR/css-align-3/#overflow-values>.
+    let overflows = resolved_size + non_auto_margin.sum() > grid_area_size;
+
     // Compute offset in the axis
-    // TODO (safe alignment): when alignment_style.is_safe() and the resolved size exceeds the
-    // grid area, fall back to literal Start. Wired in a follow-up commit (Phase T2b).
-    let alignment_based_offset = match alignment_style.position() {
-        // TODO: Add support for baseline alignment. For now we treat it as "start".
-        AlignSelf::Start | AlignSelf::FlexStart | AlignSelf::Baseline | AlignSelf::Stretch => {
-            if direction.is_rtl() {
-                grid_area_size - resolved_size - resolved_margin.end
-            } else {
-                resolved_margin.start
-            }
+    let alignment_based_offset = if alignment_style.is_safe() && overflows {
+        if direction.is_rtl() {
+            grid_area_size - resolved_size - resolved_margin.end
+        } else {
+            resolved_margin.start
         }
-        AlignSelf::End | AlignSelf::FlexEnd => {
-            if direction.is_rtl() {
-                resolved_margin.start
-            } else {
-                grid_area_size - resolved_size - resolved_margin.end
+    } else {
+        match alignment_style.position() {
+            // TODO: Add support for baseline alignment. For now we treat it as "start".
+            AlignSelf::Start | AlignSelf::FlexStart | AlignSelf::Baseline | AlignSelf::Stretch => {
+                if direction.is_rtl() {
+                    grid_area_size - resolved_size - resolved_margin.end
+                } else {
+                    resolved_margin.start
+                }
             }
-        }
-        AlignSelf::Center => (grid_area_size - resolved_size + resolved_margin.start - resolved_margin.end) / 2.0,
-        AlignSelf::SafeStart
-        | AlignSelf::SafeEnd
-        | AlignSelf::SafeFlexStart
-        | AlignSelf::SafeFlexEnd
-        | AlignSelf::SafeCenter => {
-            // Unreachable: `position()` strips Safe* into the underlying position keyword.
-            unreachable!()
+            AlignSelf::End | AlignSelf::FlexEnd => {
+                if direction.is_rtl() {
+                    resolved_margin.start
+                } else {
+                    grid_area_size - resolved_size - resolved_margin.end
+                }
+            }
+            AlignSelf::Center => (grid_area_size - resolved_size + resolved_margin.start - resolved_margin.end) / 2.0,
+            AlignSelf::SafeStart
+            | AlignSelf::SafeEnd
+            | AlignSelf::SafeFlexStart
+            | AlignSelf::SafeFlexEnd
+            | AlignSelf::SafeCenter => {
+                // Unreachable: `position()` strips Safe* into the underlying position keyword.
+                unreachable!()
+            }
         }
     };
 

--- a/src/compute/grid/track_sizing.rs
+++ b/src/compute/grid/track_sizing.rs
@@ -2,7 +2,7 @@
 //! <https://www.w3.org/TR/css-grid-1/#layout-algorithm>
 use super::types::{GridItem, GridTrack, TrackCounts};
 use crate::geometry::{AbstractAxis, Line, Size};
-use crate::style::{AlignContent, AlignSelf, AvailableSpace};
+use crate::style::{AlignContent, AlignContentKeyword, AlignSelf, AvailableSpace};
 use crate::style_helpers::TaffyMinContent;
 use crate::tree::{LayoutPartialTree, LayoutPartialTreeExt, SizingMode};
 use crate::util::sys::{f32_max, f32_min, Vec};
@@ -185,38 +185,38 @@ pub(super) fn compute_alignment_gutter_adjustment(
     tracks: &[GridTrack],
 ) -> f32 {
     if tracks.len() <= 1 {
-        return 0.0;
+        return 0.0_f32;
     }
 
-    // As items never cross the outermost gutters in a grid, we can simplify our calculations by treating
-    // AlignContent::Start and AlignContent::End the same. Safe* variants share the gutter weight
-    // of their underlying position; overflow fallback is handled when offsets are computed.
-    let outer_gutter_weight = match alignment {
-        AlignContent::Start | AlignContent::SafeStart => 1,
-        AlignContent::FlexStart | AlignContent::SafeFlexStart => 1,
-        AlignContent::End | AlignContent::SafeEnd => 1,
-        AlignContent::FlexEnd | AlignContent::SafeFlexEnd => 1,
-        AlignContent::Center | AlignContent::SafeCenter => 1,
-        AlignContent::Stretch => 0,
-        AlignContent::SpaceBetween => 0,
-        AlignContent::SpaceAround => 1,
-        AlignContent::SpaceEvenly => 1,
+    // As items never cross the outermost gutters in a grid, we can simplify our calculations by
+    // treating Start and End the same. The safety modifier doesn't influence gutter weight;
+    // overflow fallback is handled when offsets are computed.
+    let outer_gutter_weight = match alignment.keyword() {
+        AlignContentKeyword::Start
+        | AlignContentKeyword::FlexStart
+        | AlignContentKeyword::End
+        | AlignContentKeyword::FlexEnd
+        | AlignContentKeyword::Center => 1,
+        AlignContentKeyword::Stretch => 0,
+        AlignContentKeyword::SpaceBetween => 0,
+        AlignContentKeyword::SpaceAround => 1,
+        AlignContentKeyword::SpaceEvenly => 1,
     };
 
-    let inner_gutter_weight = match alignment {
-        AlignContent::FlexStart | AlignContent::SafeFlexStart => 0,
-        AlignContent::Start | AlignContent::SafeStart => 0,
-        AlignContent::FlexEnd | AlignContent::SafeFlexEnd => 0,
-        AlignContent::End | AlignContent::SafeEnd => 0,
-        AlignContent::Center | AlignContent::SafeCenter => 0,
-        AlignContent::Stretch => 0,
-        AlignContent::SpaceBetween => 1,
-        AlignContent::SpaceAround => 2,
-        AlignContent::SpaceEvenly => 1,
+    let inner_gutter_weight = match alignment.keyword() {
+        AlignContentKeyword::FlexStart
+        | AlignContentKeyword::Start
+        | AlignContentKeyword::FlexEnd
+        | AlignContentKeyword::End
+        | AlignContentKeyword::Center
+        | AlignContentKeyword::Stretch => 0,
+        AlignContentKeyword::SpaceBetween => 1,
+        AlignContentKeyword::SpaceAround => 2,
+        AlignContentKeyword::SpaceEvenly => 1,
     };
 
     if inner_gutter_weight == 0 {
-        return 0.0;
+        return 0.0_f32;
     }
 
     if let Some(axis_inner_node_size) = axis_inner_node_size {
@@ -224,8 +224,8 @@ pub(super) fn compute_alignment_gutter_adjustment(
             .iter()
             .map(|track| get_track_size_estimate(track, Some(axis_inner_node_size)))
             .sum::<Option<f32>>()
-            .map(|track_size_sum| f32_max(0.0, axis_inner_node_size - track_size_sum))
-            .unwrap_or(0.0);
+            .map(|track_size_sum| f32_max(0.0_f32, axis_inner_node_size - track_size_sum))
+            .unwrap_or(0.0_f32);
 
         let weighted_track_count =
             (((tracks.len() - 3) / 2) * inner_gutter_weight as usize) + (2 * outer_gutter_weight as usize);
@@ -282,12 +282,12 @@ pub(super) fn track_sizing_algorithm<Tree: LayoutPartialTree>(
     get_track_size_estimate: fn(&GridTrack, Option<f32>, &Tree) -> Option<f32>,
     has_baseline_aligned_item: bool,
 ) {
-    // 11.4 Initialise Track sizes
+    // 11.4_f32 Initialise Track sizes
     // Initialize each track’s base size and growth limit.
     let percentage_basis = inner_node_size.get(axis).or(axis_min_size);
     initialize_track_sizes(tree, axis_tracks, percentage_basis);
 
-    // 11.5.1 Shim item baselines
+    // 11.5_f32.1 Shim item baselines
     if has_baseline_aligned_item {
         resolve_item_baselines(tree, axis, items, inner_node_size);
     }
@@ -298,7 +298,7 @@ pub(super) fn track_sizing_algorithm<Tree: LayoutPartialTree>(
         return;
     }
 
-    // Pre-computations for 11.5 Resolve Intrinsic Track Sizes
+    // Pre-computations for 11.5_f32 Resolve Intrinsic Track Sizes
 
     // Compute an additional amount to add to each spanned gutter when computing item's estimated size in the
     // in the opposite axis based on the alignment, container size, and estimated track sizes in that axis
@@ -316,7 +316,7 @@ pub(super) fn track_sizing_algorithm<Tree: LayoutPartialTree>(
         }
     }
 
-    // 11.5 Resolve Intrinsic Track Sizes
+    // 11.5_f32 Resolve Intrinsic Track Sizes
     resolve_intrinsic_track_sizes(
         tree,
         axis,
@@ -328,7 +328,7 @@ pub(super) fn track_sizing_algorithm<Tree: LayoutPartialTree>(
         get_track_size_estimate,
     );
 
-    // 11.6. Maximise Tracks
+    // 11.6_f32. Maximise Tracks
     // Distributes free space (if any) to tracks with FINITE growth limits, up to their limits.
     maximise_tracks(axis_tracks, inner_node_size.get(axis), available_grid_space.get(axis));
 
@@ -345,7 +345,7 @@ pub(super) fn track_sizing_algorithm<Tree: LayoutPartialTree>(
         }
     };
 
-    // 11.7. Expand Flexible Tracks
+    // 11.7_f32. Expand Flexible Tracks
     // This step sizes flexible tracks using the largest value it can assign to an fr without exceeding the available space.
     expand_flexible_tracks(
         tree,
@@ -358,7 +358,7 @@ pub(super) fn track_sizing_algorithm<Tree: LayoutPartialTree>(
         inner_node_size,
     );
 
-    // 11.8. Stretch auto Tracks
+    // 11.8_f32. Stretch auto Tracks
     // This step expands tracks that have an auto max track sizing function by dividing any remaining positive, definite free space equally amongst them.
     if axis_alignment == AlignContent::Stretch {
         stretch_auto_tracks(axis_tracks, axis_min_size, axis_available_space_for_expansion);
@@ -382,7 +382,7 @@ enum IntrinsicContributionType {
 fn flush_planned_base_size_increases(tracks: &mut [GridTrack]) {
     for track in tracks {
         track.base_size += track.base_size_planned_increase;
-        track.base_size_planned_increase = 0.0;
+        track.base_size_planned_increase = 0.0_f32;
     }
 }
 
@@ -391,7 +391,7 @@ fn flush_planned_base_size_increases(tracks: &mut [GridTrack]) {
 #[inline(always)]
 fn flush_planned_growth_limit_increases(tracks: &mut [GridTrack], set_infinitely_growable: bool) {
     for track in tracks {
-        if track.growth_limit_planned_increase > 0.0 {
+        if track.growth_limit_planned_increase > 0.0_f32 {
             track.growth_limit = if track.growth_limit == f32::INFINITY {
                 track.base_size + track.growth_limit_planned_increase
             } else {
@@ -405,7 +405,7 @@ fn flush_planned_growth_limit_increases(tracks: &mut [GridTrack], set_infinitely
     }
 }
 
-/// 11.4 Initialise Track sizes
+/// 11.4_f32 Initialise Track sizes
 /// Initialize each track’s base size and growth limit.
 #[inline(always)]
 fn initialize_track_sizes(
@@ -423,7 +423,7 @@ fn initialize_track_sizes(
         track.base_size = track
             .min_track_sizing_function
             .definite_value(axis_inner_node_size, |val, basis| tree.calc(val, basis))
-            .unwrap_or(0.0);
+            .unwrap_or(0.0_f32);
 
         // For each track, if the track’s max track sizing function is:
         // - A fixed sizing function
@@ -444,7 +444,7 @@ fn initialize_track_sizes(
     }
 }
 
-/// 11.5.1 Shim baseline-aligned items so their intrinsic size contributions reflect their baseline alignment.
+/// 11.5_f32.1 Shim baseline-aligned items so their intrinsic size contributions reflect their baseline alignment.
 fn resolve_item_baselines(
     tree: &mut impl LayoutPartialTree,
     axis: AbstractAxis,
@@ -510,16 +510,16 @@ fn resolve_item_baselines(
 
         // Compute the max baseline of all items in the row
         let row_max_baseline =
-            row_items.iter().map(|item| item.baseline.unwrap_or(0.0)).max_by(|a, b| a.total_cmp(b)).unwrap();
+            row_items.iter().map(|item| item.baseline.unwrap_or(0.0_f32)).max_by(|a, b| a.total_cmp(b)).unwrap();
 
         // Compute the baseline shim for each item in the row
         for item in row_items.iter_mut() {
-            item.baseline_shim = row_max_baseline - item.baseline.unwrap_or(0.0);
+            item.baseline_shim = row_max_baseline - item.baseline.unwrap_or(0.0_f32);
         }
     }
 }
 
-/// 11.5 Resolve Intrinsic Track Sizes
+/// 11.5_f32 Resolve Intrinsic Track Sizes
 #[allow(clippy::too_many_arguments)]
 fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
     tree: &mut Tree,
@@ -550,7 +550,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
 
     // Compute item's intrinsic (content-based) sizes
     // Note: For items with a specified minimum size of auto (the initial value), the minimum contribution is usually equivalent
-    // to the min-content contribution—but can differ in some cases, see §6.6 Automatic Minimum Size of Grid Items.
+    // to the min-content contribution—but can differ in some cases, see §6.6_f32 Automatic Minimum Size of Grid Items.
     // Also, minimum contribution <= min-content contribution <= max-content contribution.
 
     let axis_inner_node_size = inner_node_size.get(axis);
@@ -658,7 +658,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
             }
 
             for track in axis_tracks.iter_mut() {
-                if track.growth_limit_planned_increase > 0.0 {
+                if track.growth_limit_planned_increase > 0.0_f32 {
                     track.growth_limit = if track.growth_limit == f32::INFINITY {
                         track.growth_limit_planned_increase
                     } else {
@@ -666,7 +666,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                     };
                 }
                 track.infinitely_growable = false;
-                track.growth_limit_planned_increase = 0.0;
+                track.growth_limit_planned_increase = 0.0_f32;
                 if track.growth_limit < track.base_size {
                     track.growth_limit = track.base_size;
                 }
@@ -675,7 +675,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
             continue;
         }
 
-        let use_flex_factor_for_distribution = is_flex && flex_factor_sum != 0.0;
+        let use_flex_factor_for_distribution = is_flex && flex_factor_sum != 0.0_f32;
 
         // 1. For intrinsic minimums:
         // First increase the base size of tracks with an intrinsic min track sizing function
@@ -703,7 +703,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                 _ => item_sizer.minimum_contribution(item, axis_tracks),
             };
             let tracks = &mut axis_tracks[item.track_range_excluding_lines(axis)];
-            if space > 0.0 {
+            if space > 0.0_f32 {
                 let has_intrinsic_min_track_sizing_function = |track: &GridTrack| {
                     track
                         .min_track_sizing_function
@@ -745,7 +745,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
         for item in batch.iter_mut() {
             let space = item_sizer.min_content_contribution(item);
             let tracks = &mut axis_tracks[item.track_range_excluding_lines(axis)];
-            if space > 0.0 {
+            if space > 0.0_f32 {
                 if item.overflow.get(axis).is_scroll_container() {
                     let fit_content_limit =
                         move |track: &GridTrack| track.fit_content_limited_growth_limit(axis_inner_node_size);
@@ -809,7 +809,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                 });
                 let space = axis_max_content_size.maybe_min(limit);
                 let tracks = &mut axis_tracks[item.track_range_excluding_lines(axis)];
-                if space > 0.0 {
+                if space > 0.0_f32 {
                     // If any of the tracks spanned by the item have a MaxContent min track sizing function then
                     // distribute space only to those tracks. Otherwise distribute space to tracks with an Auto min
                     // track sizing function.
@@ -856,7 +856,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
             let axis_max_content_size = item_sizer.max_content_contribution(item);
             let space = axis_max_content_size;
             let tracks = &mut axis_tracks[item.track_range_excluding_lines(axis)];
-            if space > 0.0 {
+            if space > 0.0_f32 {
                 distribute_item_space_to_base_size(
                     is_flex,
                     use_flex_factor_for_distribution,
@@ -888,7 +888,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                 let axis_min_content_size = item_sizer.min_content_contribution(item);
                 let space = axis_min_content_size;
                 let tracks = &mut axis_tracks[item.track_range_excluding_lines(axis)];
-                if space > 0.0 {
+                if space > 0.0_f32 {
                     distribute_item_space_to_growth_limit(
                         space,
                         tracks,
@@ -911,7 +911,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                 let axis_max_content_size = item_sizer.max_content_contribution(item);
                 let space = axis_max_content_size;
                 let tracks = &mut axis_tracks[item.track_range_excluding_lines(axis)];
-                if space > 0.0 {
+                if space > 0.0_f32 {
                     distribute_item_space_to_growth_limit(
                         space,
                         tracks,
@@ -934,7 +934,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
         .for_each(|track| track.growth_limit = track.base_size);
 }
 
-/// 11.5.1. Distributing Extra Space Across Spanned Tracks
+/// 11.5_f32.1. Distributing Extra Space Across Spanned Tracks
 /// https://www.w3.org/TR/css-grid-1/#extra-space
 #[inline(always)]
 fn distribute_item_space_to_base_size(
@@ -962,7 +962,7 @@ fn distribute_item_space_to_base_size(
                 space,
                 tracks,
                 filter,
-                |_| 1.0,
+                |_| 1.0_f32,
                 track_limit,
                 intrinsic_contribution_type,
             )
@@ -972,7 +972,7 @@ fn distribute_item_space_to_base_size(
             space,
             tracks,
             track_is_affected,
-            |_| 1.0,
+            |_| 1.0_f32,
             track_limit,
             intrinsic_contribution_type,
         )
@@ -991,7 +991,7 @@ fn distribute_item_space_to_base_size(
         // Skip this distribution if there is either
         //   - no space to distribute
         //   - no affected tracks to distribute space to
-        if space == 0.0 || !tracks.iter().any(&track_is_affected) {
+        if space == 0.0_f32 || !tracks.iter().any(&track_is_affected) {
             return;
         }
 
@@ -1001,7 +1001,7 @@ fn distribute_item_space_to_base_size(
 
         // 1. Find the space to distribute
         let track_sizes: f32 = tracks.iter().map(|track| track.base_size).sum();
-        let extra_space: f32 = f32_max(0.0, space - track_sizes);
+        let extra_space: f32 = f32_max(0.0_f32, space - track_sizes);
 
         // 2. Distribute space up to limits:
         // Note: there are two exit conditions to this loop:
@@ -1010,7 +1010,7 @@ fn distribute_item_space_to_base_size(
 
         /// Define a small constant to avoid infinite loops due to rounding errors. Rather than stopping distributing
         /// extra space when it gets to exactly zero, we will stop when it falls below this amount
-        const THRESHOLD: f32 = 0.000001;
+        const THRESHOLD: f32 = 0.000001_f32;
 
         let extra_space = distribute_space_up_to_limits(
             extra_space,
@@ -1064,12 +1064,12 @@ fn distribute_item_space_to_base_size(
             }
 
             // Reset the item_incurresed increase ready for the next space distribution
-            track.item_incurred_increase = 0.0;
+            track.item_incurred_increase = 0.0_f32;
         }
     }
 }
 
-/// 11.5.1. Distributing Extra Space Across Spanned Tracks
+/// 11.5_f32.1. Distributing Extra Space Across Spanned Tracks
 /// This is simplified (and faster) version of the algorithm for growth limits
 /// https://www.w3.org/TR/css-grid-1/#extra-space
 fn distribute_item_space_to_growth_limit(
@@ -1081,7 +1081,7 @@ fn distribute_item_space_to_growth_limit(
     // Skip this distribution if there is either
     //   - no space to distribute
     //   - no affected tracks to distribute space to
-    if space == 0.0 || tracks.iter().filter(|track| track_is_affected(track)).count() == 0 {
+    if space == 0.0_f32 || tracks.iter().filter(|track| track_is_affected(track)).count() == 0 {
         return;
     }
 
@@ -1090,7 +1090,7 @@ fn distribute_item_space_to_growth_limit(
         .iter()
         .map(|track| if track.growth_limit == f32::INFINITY { track.base_size } else { track.growth_limit })
         .sum();
-    let extra_space: f32 = f32_max(0.0, space - track_sizes);
+    let extra_space: f32 = f32_max(0.0_f32, space - track_sizes);
 
     // 2. Distribute space up to limits:
     // For growth limits the limit is either Infinity, or the growth limit itself. Which means that:
@@ -1118,7 +1118,7 @@ fn distribute_item_space_to_growth_limit(
             extra_space,
             tracks,
             track_is_affected,
-            |_| 1.0,
+            |_| 1.0_f32,
             |track| if track.growth_limit == f32::INFINITY { track.base_size } else { track.growth_limit },
             move |track| track.fit_content_limit(axis_inner_node_size),
         );
@@ -1132,11 +1132,11 @@ fn distribute_item_space_to_growth_limit(
         }
 
         // Reset the item_incurresed increase ready for the next space distribution
-        track.item_incurred_increase = 0.0;
+        track.item_incurred_increase = 0.0_f32;
     }
 }
 
-/// 11.6 Maximise Tracks
+/// 11.6_f32 Maximise Tracks
 /// Distributes free space (if any) to tracks with FINITE growth limits, up to their limits.
 #[inline(always)]
 fn maximise_tracks(
@@ -1148,23 +1148,23 @@ fn maximise_tracks(
     let free_space = axis_available_grid_space.compute_free_space(used_space);
     if free_space == f32::INFINITY {
         axis_tracks.iter_mut().for_each(|track| track.base_size = track.growth_limit);
-    } else if free_space > 0.0 {
+    } else if free_space > 0.0_f32 {
         distribute_space_up_to_limits(
             free_space,
             axis_tracks,
             |_| true,
-            |_| 1.0,
+            |_| 1.0_f32,
             |track| track.base_size,
             move |track: &GridTrack| track.fit_content_limited_growth_limit(axis_inner_node_size),
         );
         for track in axis_tracks.iter_mut() {
             track.base_size += track.item_incurred_increase;
-            track.item_incurred_increase = 0.0;
+            track.item_incurred_increase = 0.0_f32;
         }
     }
 }
 
-/// 11.7. Expand Flexible Tracks
+/// 11.7_f32. Expand Flexible Tracks
 /// This step sizes flexible tracks using the largest value it can assign to an fr without exceeding the available space.
 #[allow(clippy::too_many_arguments)]
 #[inline(always)]
@@ -1188,14 +1188,14 @@ fn expand_flexible_tracks(
         AvailableSpace::Definite(available_space) => {
             let used_space: f32 = axis_tracks.iter().map(|track| track.base_size).sum();
             let free_space = available_space - used_space;
-            if free_space <= 0.0 {
+            if free_space <= 0.0_f32 {
                 0.0
             } else {
                 find_size_of_fr(axis_tracks, available_space)
             }
         }
         // If ... sizing the grid container under a min-content constraint the used flex fraction is zero.
-        AvailableSpace::MinContent => 0.0,
+        AvailableSpace::MinContent => 0.0_f32,
         // Otherwise, if the free space is an indefinite length:
         AvailableSpace::MaxContent => {
             // The used flex fraction is the maximum of:
@@ -1207,14 +1207,14 @@ fn expand_flexible_tracks(
                     .filter(|track| track.max_track_sizing_function.is_fr())
                     .map(|track| {
                         let flex_factor = track.flex_factor();
-                        if flex_factor > 1.0 {
+                        if flex_factor > 1.0_f32 {
                             track.base_size / flex_factor
                         } else {
                             track.base_size
                         }
                     })
                     .max_by(|a, b| a.total_cmp(b))
-                    .unwrap_or(0.0),
+                    .unwrap_or(0.0_f32),
                 // For each grid item that crosses a flexible track, the result of finding the size of an fr using all the grid tracks
                 // that the item crosses and a space to fill of the item’s max-content contribution.
                 items
@@ -1228,7 +1228,7 @@ fn expand_flexible_tracks(
                         find_size_of_fr(tracks, max_content_contribution)
                     })
                     .max_by(|a, b| a.total_cmp(b))
-                    .unwrap_or(0.0),
+                    .unwrap_or(0.0_f32),
             );
 
             // If using this flex fraction would cause the grid to be smaller than the grid container’s min-width/height (or larger than the
@@ -1246,7 +1246,7 @@ fn expand_flexible_tracks(
                     }
                 })
                 .sum();
-            let axis_min_size = axis_min_size.unwrap_or(0.0);
+            let axis_min_size = axis_min_size.unwrap_or(0.0_f32);
             let axis_max_size = axis_max_size.unwrap_or(f32::INFINITY);
             if hypothetical_grid_size < axis_min_size {
                 find_size_of_fr(axis_tracks, axis_min_size)
@@ -1266,15 +1266,15 @@ fn expand_flexible_tracks(
     }
 }
 
-/// 11.7.1. Find the Size of an fr
+/// 11.7_f32.1. Find the Size of an fr
 /// This algorithm finds the largest size that an fr unit can be without exceeding the target size.
 /// It must be called with a set of grid tracks and some quantity of space to fill.
 #[inline(always)]
 fn find_size_of_fr(tracks: &[GridTrack], space_to_fill: f32) -> f32 {
     // Handle the trivial case where there is no space to fill
     // Do not remove as otherwise the loop below will loop infinitely
-    if space_to_fill == 0.0 {
-        return 0.0;
+    if space_to_fill == 0.0_f32 {
+        return 0.0_f32;
     }
 
     // If the product of the hypothetical fr size (computed below) and any flexible track’s flex factor
@@ -1287,8 +1287,8 @@ fn find_size_of_fr(tracks: &[GridTrack], space_to_fill: f32) -> f32 {
         // Let leftover space be the space to fill minus the base sizes of the non-flexible grid tracks.
         // Let flex factor sum be the sum of the flex factors of the flexible tracks. If this value is less than 1, set it to 1 instead.
         // We compute both of these in a single loop to avoid iterating over the data twice
-        let mut used_space = 0.0;
-        let mut naive_flex_factor_sum = 0.0;
+        let mut used_space = 0.0_f32;
+        let mut naive_flex_factor_sum = 0.0_f32;
         for track in tracks.iter() {
             // Tracks for which flex_factor * hypothetical_fr_size < track.base_size are treated as inflexible
             if track.max_track_sizing_function.is_fr()
@@ -1300,7 +1300,7 @@ fn find_size_of_fr(tracks: &[GridTrack], space_to_fill: f32) -> f32 {
             };
         }
         let leftover_space = space_to_fill - used_space;
-        let flex_factor = f32_max(naive_flex_factor_sum, 1.0);
+        let flex_factor = f32_max(naive_flex_factor_sum, 1.0_f32);
 
         // Let the hypothetical fr size be the leftover space divided by the flex factor sum.
         previous_iter_hypothetical_fr_size = hypothetical_fr_size;
@@ -1327,7 +1327,7 @@ fn find_size_of_fr(tracks: &[GridTrack], space_to_fill: f32) -> f32 {
     hypothetical_fr_size
 }
 
-/// 11.8. Stretch auto Tracks
+/// 11.8_f32. Stretch auto Tracks
 /// This step expands tracks that have an auto max track sizing function by dividing any remaining positive, definite free space equally amongst them.
 #[inline(always)]
 fn stretch_auto_tracks(
@@ -1346,10 +1346,10 @@ fn stretch_auto_tracks(
         } else {
             match axis_min_size {
                 Some(size) => size - used_space,
-                None => 0.0,
+                None => 0.0_f32,
             }
         };
-        if free_space > 0.0 {
+        if free_space > 0.0_f32 {
             let extra_space_per_auto_track = free_space / num_auto_tracks as f32;
             axis_tracks
                 .iter_mut()
@@ -1372,7 +1372,7 @@ fn distribute_space_up_to_limits(
 ) -> f32 {
     /// Define a small constant to avoid infinite loops due to rounding errors. Rather than stopping distributing
     /// extra space when it gets to exactly zero, we will stop when it falls below this amount
-    const THRESHOLD: f32 = 0.01;
+    const THRESHOLD: f32 = 0.01_f32;
 
     let mut space_to_distribute = space_to_distribute;
     while space_to_distribute > THRESHOLD {
@@ -1383,7 +1383,7 @@ fn distribute_space_up_to_limits(
             .map(&track_distribution_proportion)
             .sum();
 
-        if track_distribution_proportion_sum == 0.0 {
+        if track_distribution_proportion_sum == 0.0_f32 {
             break;
         }
 
@@ -1400,7 +1400,7 @@ fn distribute_space_up_to_limits(
 
         for track in tracks.iter_mut().filter(|track| track_is_affected(track)) {
             let increase = iteration_item_incurred_increase * track_distribution_proportion(track);
-            if increase > 0.0 && track_affected_property(track) + increase <= track_limit(track) + THRESHOLD {
+            if increase > 0.0_f32 && track_affected_property(track) + increase <= track_limit(track) + THRESHOLD {
                 track.item_incurred_increase += increase;
                 space_to_distribute -= increase;
             }

--- a/src/compute/grid/track_sizing.rs
+++ b/src/compute/grid/track_sizing.rs
@@ -185,7 +185,7 @@ pub(super) fn compute_alignment_gutter_adjustment(
     tracks: &[GridTrack],
 ) -> f32 {
     if tracks.len() <= 1 {
-        return 0.0_f32;
+        return 0.0;
     }
 
     // As items never cross the outermost gutters in a grid, we can simplify our calculations by
@@ -216,7 +216,7 @@ pub(super) fn compute_alignment_gutter_adjustment(
     };
 
     if inner_gutter_weight == 0 {
-        return 0.0_f32;
+        return 0.0;
     }
 
     if let Some(axis_inner_node_size) = axis_inner_node_size {
@@ -224,8 +224,8 @@ pub(super) fn compute_alignment_gutter_adjustment(
             .iter()
             .map(|track| get_track_size_estimate(track, Some(axis_inner_node_size)))
             .sum::<Option<f32>>()
-            .map(|track_size_sum| f32_max(0.0_f32, axis_inner_node_size - track_size_sum))
-            .unwrap_or(0.0_f32);
+            .map(|track_size_sum| f32_max(0.0, axis_inner_node_size - track_size_sum))
+            .unwrap_or(0.0);
 
         let weighted_track_count =
             (((tracks.len() - 3) / 2) * inner_gutter_weight as usize) + (2 * outer_gutter_weight as usize);
@@ -282,12 +282,12 @@ pub(super) fn track_sizing_algorithm<Tree: LayoutPartialTree>(
     get_track_size_estimate: fn(&GridTrack, Option<f32>, &Tree) -> Option<f32>,
     has_baseline_aligned_item: bool,
 ) {
-    // 11.4_f32 Initialise Track sizes
+    // 11.4 Initialise Track sizes
     // Initialize each track’s base size and growth limit.
     let percentage_basis = inner_node_size.get(axis).or(axis_min_size);
     initialize_track_sizes(tree, axis_tracks, percentage_basis);
 
-    // 11.5_f32.1 Shim item baselines
+    // 11.5.1 Shim item baselines
     if has_baseline_aligned_item {
         resolve_item_baselines(tree, axis, items, inner_node_size);
     }
@@ -298,7 +298,7 @@ pub(super) fn track_sizing_algorithm<Tree: LayoutPartialTree>(
         return;
     }
 
-    // Pre-computations for 11.5_f32 Resolve Intrinsic Track Sizes
+    // Pre-computations for 11.5 Resolve Intrinsic Track Sizes
 
     // Compute an additional amount to add to each spanned gutter when computing item's estimated size in the
     // in the opposite axis based on the alignment, container size, and estimated track sizes in that axis
@@ -316,7 +316,7 @@ pub(super) fn track_sizing_algorithm<Tree: LayoutPartialTree>(
         }
     }
 
-    // 11.5_f32 Resolve Intrinsic Track Sizes
+    // 11.5 Resolve Intrinsic Track Sizes
     resolve_intrinsic_track_sizes(
         tree,
         axis,
@@ -328,7 +328,7 @@ pub(super) fn track_sizing_algorithm<Tree: LayoutPartialTree>(
         get_track_size_estimate,
     );
 
-    // 11.6_f32. Maximise Tracks
+    // 11.6. Maximise Tracks
     // Distributes free space (if any) to tracks with FINITE growth limits, up to their limits.
     maximise_tracks(axis_tracks, inner_node_size.get(axis), available_grid_space.get(axis));
 
@@ -345,7 +345,7 @@ pub(super) fn track_sizing_algorithm<Tree: LayoutPartialTree>(
         }
     };
 
-    // 11.7_f32. Expand Flexible Tracks
+    // 11.7. Expand Flexible Tracks
     // This step sizes flexible tracks using the largest value it can assign to an fr without exceeding the available space.
     expand_flexible_tracks(
         tree,
@@ -358,7 +358,7 @@ pub(super) fn track_sizing_algorithm<Tree: LayoutPartialTree>(
         inner_node_size,
     );
 
-    // 11.8_f32. Stretch auto Tracks
+    // 11.8. Stretch auto Tracks
     // This step expands tracks that have an auto max track sizing function by dividing any remaining positive, definite free space equally amongst them.
     if axis_alignment == AlignContent::Stretch {
         stretch_auto_tracks(axis_tracks, axis_min_size, axis_available_space_for_expansion);
@@ -382,7 +382,7 @@ enum IntrinsicContributionType {
 fn flush_planned_base_size_increases(tracks: &mut [GridTrack]) {
     for track in tracks {
         track.base_size += track.base_size_planned_increase;
-        track.base_size_planned_increase = 0.0_f32;
+        track.base_size_planned_increase = 0.0;
     }
 }
 
@@ -391,7 +391,7 @@ fn flush_planned_base_size_increases(tracks: &mut [GridTrack]) {
 #[inline(always)]
 fn flush_planned_growth_limit_increases(tracks: &mut [GridTrack], set_infinitely_growable: bool) {
     for track in tracks {
-        if track.growth_limit_planned_increase > 0.0_f32 {
+        if track.growth_limit_planned_increase > 0.0 {
             track.growth_limit = if track.growth_limit == f32::INFINITY {
                 track.base_size + track.growth_limit_planned_increase
             } else {
@@ -405,7 +405,7 @@ fn flush_planned_growth_limit_increases(tracks: &mut [GridTrack], set_infinitely
     }
 }
 
-/// 11.4_f32 Initialise Track sizes
+/// 11.4 Initialise Track sizes
 /// Initialize each track’s base size and growth limit.
 #[inline(always)]
 fn initialize_track_sizes(
@@ -423,7 +423,7 @@ fn initialize_track_sizes(
         track.base_size = track
             .min_track_sizing_function
             .definite_value(axis_inner_node_size, |val, basis| tree.calc(val, basis))
-            .unwrap_or(0.0_f32);
+            .unwrap_or(0.0);
 
         // For each track, if the track’s max track sizing function is:
         // - A fixed sizing function
@@ -444,7 +444,7 @@ fn initialize_track_sizes(
     }
 }
 
-/// 11.5_f32.1 Shim baseline-aligned items so their intrinsic size contributions reflect their baseline alignment.
+/// 11.5.1 Shim baseline-aligned items so their intrinsic size contributions reflect their baseline alignment.
 fn resolve_item_baselines(
     tree: &mut impl LayoutPartialTree,
     axis: AbstractAxis,
@@ -510,16 +510,16 @@ fn resolve_item_baselines(
 
         // Compute the max baseline of all items in the row
         let row_max_baseline =
-            row_items.iter().map(|item| item.baseline.unwrap_or(0.0_f32)).max_by(|a, b| a.total_cmp(b)).unwrap();
+            row_items.iter().map(|item| item.baseline.unwrap_or(0.0)).max_by(|a, b| a.total_cmp(b)).unwrap();
 
         // Compute the baseline shim for each item in the row
         for item in row_items.iter_mut() {
-            item.baseline_shim = row_max_baseline - item.baseline.unwrap_or(0.0_f32);
+            item.baseline_shim = row_max_baseline - item.baseline.unwrap_or(0.0);
         }
     }
 }
 
-/// 11.5_f32 Resolve Intrinsic Track Sizes
+/// 11.5 Resolve Intrinsic Track Sizes
 #[allow(clippy::too_many_arguments)]
 fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
     tree: &mut Tree,
@@ -550,7 +550,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
 
     // Compute item's intrinsic (content-based) sizes
     // Note: For items with a specified minimum size of auto (the initial value), the minimum contribution is usually equivalent
-    // to the min-content contribution—but can differ in some cases, see §6.6_f32 Automatic Minimum Size of Grid Items.
+    // to the min-content contribution—but can differ in some cases, see §6.6 Automatic Minimum Size of Grid Items.
     // Also, minimum contribution <= min-content contribution <= max-content contribution.
 
     let axis_inner_node_size = inner_node_size.get(axis);
@@ -658,7 +658,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
             }
 
             for track in axis_tracks.iter_mut() {
-                if track.growth_limit_planned_increase > 0.0_f32 {
+                if track.growth_limit_planned_increase > 0.0 {
                     track.growth_limit = if track.growth_limit == f32::INFINITY {
                         track.growth_limit_planned_increase
                     } else {
@@ -666,7 +666,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                     };
                 }
                 track.infinitely_growable = false;
-                track.growth_limit_planned_increase = 0.0_f32;
+                track.growth_limit_planned_increase = 0.0;
                 if track.growth_limit < track.base_size {
                     track.growth_limit = track.base_size;
                 }
@@ -675,7 +675,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
             continue;
         }
 
-        let use_flex_factor_for_distribution = is_flex && flex_factor_sum != 0.0_f32;
+        let use_flex_factor_for_distribution = is_flex && flex_factor_sum != 0.0;
 
         // 1. For intrinsic minimums:
         // First increase the base size of tracks with an intrinsic min track sizing function
@@ -703,7 +703,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                 _ => item_sizer.minimum_contribution(item, axis_tracks),
             };
             let tracks = &mut axis_tracks[item.track_range_excluding_lines(axis)];
-            if space > 0.0_f32 {
+            if space > 0.0 {
                 let has_intrinsic_min_track_sizing_function = |track: &GridTrack| {
                     track
                         .min_track_sizing_function
@@ -745,7 +745,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
         for item in batch.iter_mut() {
             let space = item_sizer.min_content_contribution(item);
             let tracks = &mut axis_tracks[item.track_range_excluding_lines(axis)];
-            if space > 0.0_f32 {
+            if space > 0.0 {
                 if item.overflow.get(axis).is_scroll_container() {
                     let fit_content_limit =
                         move |track: &GridTrack| track.fit_content_limited_growth_limit(axis_inner_node_size);
@@ -809,7 +809,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                 });
                 let space = axis_max_content_size.maybe_min(limit);
                 let tracks = &mut axis_tracks[item.track_range_excluding_lines(axis)];
-                if space > 0.0_f32 {
+                if space > 0.0 {
                     // If any of the tracks spanned by the item have a MaxContent min track sizing function then
                     // distribute space only to those tracks. Otherwise distribute space to tracks with an Auto min
                     // track sizing function.
@@ -856,7 +856,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
             let axis_max_content_size = item_sizer.max_content_contribution(item);
             let space = axis_max_content_size;
             let tracks = &mut axis_tracks[item.track_range_excluding_lines(axis)];
-            if space > 0.0_f32 {
+            if space > 0.0 {
                 distribute_item_space_to_base_size(
                     is_flex,
                     use_flex_factor_for_distribution,
@@ -888,7 +888,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                 let axis_min_content_size = item_sizer.min_content_contribution(item);
                 let space = axis_min_content_size;
                 let tracks = &mut axis_tracks[item.track_range_excluding_lines(axis)];
-                if space > 0.0_f32 {
+                if space > 0.0 {
                     distribute_item_space_to_growth_limit(
                         space,
                         tracks,
@@ -911,7 +911,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                 let axis_max_content_size = item_sizer.max_content_contribution(item);
                 let space = axis_max_content_size;
                 let tracks = &mut axis_tracks[item.track_range_excluding_lines(axis)];
-                if space > 0.0_f32 {
+                if space > 0.0 {
                     distribute_item_space_to_growth_limit(
                         space,
                         tracks,
@@ -934,7 +934,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
         .for_each(|track| track.growth_limit = track.base_size);
 }
 
-/// 11.5_f32.1. Distributing Extra Space Across Spanned Tracks
+/// 11.5.1. Distributing Extra Space Across Spanned Tracks
 /// https://www.w3.org/TR/css-grid-1/#extra-space
 #[inline(always)]
 fn distribute_item_space_to_base_size(
@@ -962,7 +962,7 @@ fn distribute_item_space_to_base_size(
                 space,
                 tracks,
                 filter,
-                |_| 1.0_f32,
+                |_| 1.0,
                 track_limit,
                 intrinsic_contribution_type,
             )
@@ -972,7 +972,7 @@ fn distribute_item_space_to_base_size(
             space,
             tracks,
             track_is_affected,
-            |_| 1.0_f32,
+            |_| 1.0,
             track_limit,
             intrinsic_contribution_type,
         )
@@ -991,7 +991,7 @@ fn distribute_item_space_to_base_size(
         // Skip this distribution if there is either
         //   - no space to distribute
         //   - no affected tracks to distribute space to
-        if space == 0.0_f32 || !tracks.iter().any(&track_is_affected) {
+        if space == 0.0 || !tracks.iter().any(&track_is_affected) {
             return;
         }
 
@@ -1001,7 +1001,7 @@ fn distribute_item_space_to_base_size(
 
         // 1. Find the space to distribute
         let track_sizes: f32 = tracks.iter().map(|track| track.base_size).sum();
-        let extra_space: f32 = f32_max(0.0_f32, space - track_sizes);
+        let extra_space: f32 = f32_max(0.0, space - track_sizes);
 
         // 2. Distribute space up to limits:
         // Note: there are two exit conditions to this loop:
@@ -1010,7 +1010,7 @@ fn distribute_item_space_to_base_size(
 
         /// Define a small constant to avoid infinite loops due to rounding errors. Rather than stopping distributing
         /// extra space when it gets to exactly zero, we will stop when it falls below this amount
-        const THRESHOLD: f32 = 0.000001_f32;
+        const THRESHOLD: f32 = 0.000001;
 
         let extra_space = distribute_space_up_to_limits(
             extra_space,
@@ -1064,12 +1064,12 @@ fn distribute_item_space_to_base_size(
             }
 
             // Reset the item_incurresed increase ready for the next space distribution
-            track.item_incurred_increase = 0.0_f32;
+            track.item_incurred_increase = 0.0;
         }
     }
 }
 
-/// 11.5_f32.1. Distributing Extra Space Across Spanned Tracks
+/// 11.5.1. Distributing Extra Space Across Spanned Tracks
 /// This is simplified (and faster) version of the algorithm for growth limits
 /// https://www.w3.org/TR/css-grid-1/#extra-space
 fn distribute_item_space_to_growth_limit(
@@ -1081,7 +1081,7 @@ fn distribute_item_space_to_growth_limit(
     // Skip this distribution if there is either
     //   - no space to distribute
     //   - no affected tracks to distribute space to
-    if space == 0.0_f32 || tracks.iter().filter(|track| track_is_affected(track)).count() == 0 {
+    if space == 0.0 || tracks.iter().filter(|track| track_is_affected(track)).count() == 0 {
         return;
     }
 
@@ -1090,7 +1090,7 @@ fn distribute_item_space_to_growth_limit(
         .iter()
         .map(|track| if track.growth_limit == f32::INFINITY { track.base_size } else { track.growth_limit })
         .sum();
-    let extra_space: f32 = f32_max(0.0_f32, space - track_sizes);
+    let extra_space: f32 = f32_max(0.0, space - track_sizes);
 
     // 2. Distribute space up to limits:
     // For growth limits the limit is either Infinity, or the growth limit itself. Which means that:
@@ -1118,7 +1118,7 @@ fn distribute_item_space_to_growth_limit(
             extra_space,
             tracks,
             track_is_affected,
-            |_| 1.0_f32,
+            |_| 1.0,
             |track| if track.growth_limit == f32::INFINITY { track.base_size } else { track.growth_limit },
             move |track| track.fit_content_limit(axis_inner_node_size),
         );
@@ -1132,11 +1132,11 @@ fn distribute_item_space_to_growth_limit(
         }
 
         // Reset the item_incurresed increase ready for the next space distribution
-        track.item_incurred_increase = 0.0_f32;
+        track.item_incurred_increase = 0.0;
     }
 }
 
-/// 11.6_f32 Maximise Tracks
+/// 11.6 Maximise Tracks
 /// Distributes free space (if any) to tracks with FINITE growth limits, up to their limits.
 #[inline(always)]
 fn maximise_tracks(
@@ -1148,23 +1148,23 @@ fn maximise_tracks(
     let free_space = axis_available_grid_space.compute_free_space(used_space);
     if free_space == f32::INFINITY {
         axis_tracks.iter_mut().for_each(|track| track.base_size = track.growth_limit);
-    } else if free_space > 0.0_f32 {
+    } else if free_space > 0.0 {
         distribute_space_up_to_limits(
             free_space,
             axis_tracks,
             |_| true,
-            |_| 1.0_f32,
+            |_| 1.0,
             |track| track.base_size,
             move |track: &GridTrack| track.fit_content_limited_growth_limit(axis_inner_node_size),
         );
         for track in axis_tracks.iter_mut() {
             track.base_size += track.item_incurred_increase;
-            track.item_incurred_increase = 0.0_f32;
+            track.item_incurred_increase = 0.0;
         }
     }
 }
 
-/// 11.7_f32. Expand Flexible Tracks
+/// 11.7. Expand Flexible Tracks
 /// This step sizes flexible tracks using the largest value it can assign to an fr without exceeding the available space.
 #[allow(clippy::too_many_arguments)]
 #[inline(always)]
@@ -1188,14 +1188,14 @@ fn expand_flexible_tracks(
         AvailableSpace::Definite(available_space) => {
             let used_space: f32 = axis_tracks.iter().map(|track| track.base_size).sum();
             let free_space = available_space - used_space;
-            if free_space <= 0.0_f32 {
+            if free_space <= 0.0 {
                 0.0
             } else {
                 find_size_of_fr(axis_tracks, available_space)
             }
         }
         // If ... sizing the grid container under a min-content constraint the used flex fraction is zero.
-        AvailableSpace::MinContent => 0.0_f32,
+        AvailableSpace::MinContent => 0.0,
         // Otherwise, if the free space is an indefinite length:
         AvailableSpace::MaxContent => {
             // The used flex fraction is the maximum of:
@@ -1207,14 +1207,14 @@ fn expand_flexible_tracks(
                     .filter(|track| track.max_track_sizing_function.is_fr())
                     .map(|track| {
                         let flex_factor = track.flex_factor();
-                        if flex_factor > 1.0_f32 {
+                        if flex_factor > 1.0 {
                             track.base_size / flex_factor
                         } else {
                             track.base_size
                         }
                     })
                     .max_by(|a, b| a.total_cmp(b))
-                    .unwrap_or(0.0_f32),
+                    .unwrap_or(0.0),
                 // For each grid item that crosses a flexible track, the result of finding the size of an fr using all the grid tracks
                 // that the item crosses and a space to fill of the item’s max-content contribution.
                 items
@@ -1228,7 +1228,7 @@ fn expand_flexible_tracks(
                         find_size_of_fr(tracks, max_content_contribution)
                     })
                     .max_by(|a, b| a.total_cmp(b))
-                    .unwrap_or(0.0_f32),
+                    .unwrap_or(0.0),
             );
 
             // If using this flex fraction would cause the grid to be smaller than the grid container’s min-width/height (or larger than the
@@ -1246,7 +1246,7 @@ fn expand_flexible_tracks(
                     }
                 })
                 .sum();
-            let axis_min_size = axis_min_size.unwrap_or(0.0_f32);
+            let axis_min_size = axis_min_size.unwrap_or(0.0);
             let axis_max_size = axis_max_size.unwrap_or(f32::INFINITY);
             if hypothetical_grid_size < axis_min_size {
                 find_size_of_fr(axis_tracks, axis_min_size)
@@ -1266,15 +1266,15 @@ fn expand_flexible_tracks(
     }
 }
 
-/// 11.7_f32.1. Find the Size of an fr
+/// 11.7.1. Find the Size of an fr
 /// This algorithm finds the largest size that an fr unit can be without exceeding the target size.
 /// It must be called with a set of grid tracks and some quantity of space to fill.
 #[inline(always)]
 fn find_size_of_fr(tracks: &[GridTrack], space_to_fill: f32) -> f32 {
     // Handle the trivial case where there is no space to fill
     // Do not remove as otherwise the loop below will loop infinitely
-    if space_to_fill == 0.0_f32 {
-        return 0.0_f32;
+    if space_to_fill == 0.0 {
+        return 0.0;
     }
 
     // If the product of the hypothetical fr size (computed below) and any flexible track’s flex factor
@@ -1287,8 +1287,8 @@ fn find_size_of_fr(tracks: &[GridTrack], space_to_fill: f32) -> f32 {
         // Let leftover space be the space to fill minus the base sizes of the non-flexible grid tracks.
         // Let flex factor sum be the sum of the flex factors of the flexible tracks. If this value is less than 1, set it to 1 instead.
         // We compute both of these in a single loop to avoid iterating over the data twice
-        let mut used_space = 0.0_f32;
-        let mut naive_flex_factor_sum = 0.0_f32;
+        let mut used_space = 0.0;
+        let mut naive_flex_factor_sum = 0.0;
         for track in tracks.iter() {
             // Tracks for which flex_factor * hypothetical_fr_size < track.base_size are treated as inflexible
             if track.max_track_sizing_function.is_fr()
@@ -1300,7 +1300,7 @@ fn find_size_of_fr(tracks: &[GridTrack], space_to_fill: f32) -> f32 {
             };
         }
         let leftover_space = space_to_fill - used_space;
-        let flex_factor = f32_max(naive_flex_factor_sum, 1.0_f32);
+        let flex_factor = f32_max(naive_flex_factor_sum, 1.0);
 
         // Let the hypothetical fr size be the leftover space divided by the flex factor sum.
         previous_iter_hypothetical_fr_size = hypothetical_fr_size;
@@ -1327,7 +1327,7 @@ fn find_size_of_fr(tracks: &[GridTrack], space_to_fill: f32) -> f32 {
     hypothetical_fr_size
 }
 
-/// 11.8_f32. Stretch auto Tracks
+/// 11.8. Stretch auto Tracks
 /// This step expands tracks that have an auto max track sizing function by dividing any remaining positive, definite free space equally amongst them.
 #[inline(always)]
 fn stretch_auto_tracks(
@@ -1346,10 +1346,10 @@ fn stretch_auto_tracks(
         } else {
             match axis_min_size {
                 Some(size) => size - used_space,
-                None => 0.0_f32,
+                None => 0.0,
             }
         };
-        if free_space > 0.0_f32 {
+        if free_space > 0.0 {
             let extra_space_per_auto_track = free_space / num_auto_tracks as f32;
             axis_tracks
                 .iter_mut()
@@ -1372,7 +1372,7 @@ fn distribute_space_up_to_limits(
 ) -> f32 {
     /// Define a small constant to avoid infinite loops due to rounding errors. Rather than stopping distributing
     /// extra space when it gets to exactly zero, we will stop when it falls below this amount
-    const THRESHOLD: f32 = 0.01_f32;
+    const THRESHOLD: f32 = 0.01;
 
     let mut space_to_distribute = space_to_distribute;
     while space_to_distribute > THRESHOLD {
@@ -1383,7 +1383,7 @@ fn distribute_space_up_to_limits(
             .map(&track_distribution_proportion)
             .sum();
 
-        if track_distribution_proportion_sum == 0.0_f32 {
+        if track_distribution_proportion_sum == 0.0 {
             break;
         }
 
@@ -1400,7 +1400,7 @@ fn distribute_space_up_to_limits(
 
         for track in tracks.iter_mut().filter(|track| track_is_affected(track)) {
             let increase = iteration_item_incurred_increase * track_distribution_proportion(track);
-            if increase > 0.0_f32 && track_affected_property(track) + increase <= track_limit(track) + THRESHOLD {
+            if increase > 0.0 && track_affected_property(track) + increase <= track_limit(track) + THRESHOLD {
                 track.item_incurred_increase += increase;
                 space_to_distribute -= increase;
             }

--- a/src/compute/grid/track_sizing.rs
+++ b/src/compute/grid/track_sizing.rs
@@ -189,13 +189,14 @@ pub(super) fn compute_alignment_gutter_adjustment(
     }
 
     // As items never cross the outermost gutters in a grid, we can simplify our calculations by treating
-    // AlignContent::Start and AlignContent::End the same
+    // AlignContent::Start and AlignContent::End the same. Safe* variants share the gutter weight
+    // of their underlying position; overflow fallback is handled when offsets are computed.
     let outer_gutter_weight = match alignment {
-        AlignContent::Start => 1,
-        AlignContent::FlexStart => 1,
-        AlignContent::End => 1,
-        AlignContent::FlexEnd => 1,
-        AlignContent::Center => 1,
+        AlignContent::Start | AlignContent::SafeStart => 1,
+        AlignContent::FlexStart | AlignContent::SafeFlexStart => 1,
+        AlignContent::End | AlignContent::SafeEnd => 1,
+        AlignContent::FlexEnd | AlignContent::SafeFlexEnd => 1,
+        AlignContent::Center | AlignContent::SafeCenter => 1,
         AlignContent::Stretch => 0,
         AlignContent::SpaceBetween => 0,
         AlignContent::SpaceAround => 1,
@@ -203,11 +204,11 @@ pub(super) fn compute_alignment_gutter_adjustment(
     };
 
     let inner_gutter_weight = match alignment {
-        AlignContent::FlexStart => 0,
-        AlignContent::Start => 0,
-        AlignContent::FlexEnd => 0,
-        AlignContent::End => 0,
-        AlignContent::Center => 0,
+        AlignContent::FlexStart | AlignContent::SafeFlexStart => 0,
+        AlignContent::Start | AlignContent::SafeStart => 0,
+        AlignContent::FlexEnd | AlignContent::SafeFlexEnd => 0,
+        AlignContent::End | AlignContent::SafeEnd => 0,
+        AlignContent::Center | AlignContent::SafeCenter => 0,
         AlignContent::Stretch => 0,
         AlignContent::SpaceBetween => 1,
         AlignContent::SpaceAround => 2,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -3,8 +3,9 @@
 pub use crate::{
     geometry::{Line, Rect, Size},
     style::{
-        AlignContent, AlignItems, AlignSelf, AvailableSpace, BoxSizing, CompactLength, Dimension, Display,
-        JustifyContent, JustifyItems, JustifySelf, LengthPercentage, LengthPercentageAuto, Position, Style,
+        AlignContent, AlignContentKeyword, AlignItems, AlignItemsKeyword, AlignSelf, AlignmentSafety, AvailableSpace,
+        BoxSizing, CompactLength, Dimension, Display, JustifyContent, JustifyItems, JustifySelf, LengthPercentage,
+        LengthPercentageAuto, Position, Style,
     },
     style_helpers::{
         auto, fit_content, length, max_content, min_content, percent, zero, FromFr, FromLength, FromPercent, TaffyAuto,

--- a/src/style/alignment.rs
+++ b/src/style/alignment.rs
@@ -1,5 +1,8 @@
 //! Style types for controlling alignment
 
+#[cfg(feature = "parse")]
+use crate::util::parse::{CssParseResult, FromCss, Parser, Token};
+
 /// Used to control how child nodes are aligned.
 /// For Flexbox it controls alignment in the cross axis
 /// For Grid it controls alignment in the block axis
@@ -28,18 +31,89 @@ pub enum AlignItems {
     Baseline,
     /// Stretch to fill the container
     Stretch,
+    /// Like [`AlignItems::Start`], but falls back to [`AlignItems::Start`] when the
+    /// alignment subject overflows the alignment container, to avoid data loss.
+    SafeStart,
+    /// Like [`AlignItems::End`], but falls back to [`AlignItems::Start`] when the
+    /// alignment subject overflows the alignment container, to avoid data loss.
+    SafeEnd,
+    /// Like [`AlignItems::FlexStart`], but falls back to [`AlignItems::Start`] when the
+    /// alignment subject overflows the alignment container, to avoid data loss.
+    SafeFlexStart,
+    /// Like [`AlignItems::FlexEnd`], but falls back to [`AlignItems::Start`] when the
+    /// alignment subject overflows the alignment container, to avoid data loss.
+    SafeFlexEnd,
+    /// Like [`AlignItems::Center`], but falls back to [`AlignItems::Start`] when the
+    /// alignment subject overflows the alignment container, to avoid data loss.
+    SafeCenter,
+}
+
+impl AlignItems {
+    /// Returns true if this is a safe overflow-aware variant.
+    #[inline]
+    pub const fn is_safe(self) -> bool {
+        matches!(
+            self,
+            Self::SafeStart | Self::SafeEnd | Self::SafeFlexStart | Self::SafeFlexEnd | Self::SafeCenter
+        )
+    }
+
+    /// Strips the safe modifier and returns the underlying position keyword.
+    /// Non-safe variants are returned unchanged.
+    #[inline]
+    pub const fn position(self) -> Self {
+        match self {
+            Self::SafeStart => Self::Start,
+            Self::SafeEnd => Self::End,
+            Self::SafeFlexStart => Self::FlexStart,
+            Self::SafeFlexEnd => Self::FlexEnd,
+            Self::SafeCenter => Self::Center,
+            other => other,
+        }
+    }
 }
 
 #[cfg(feature = "parse")]
-crate::util::parse::impl_parse_for_keyword_enum!(AlignItems,
-    "start" => Start,
-    "end" => End,
-    "flex-start" => FlexStart,
-    "flex-end" => FlexEnd,
-    "center" => Center,
-    "baseline" => Baseline,
-    "stretch" => Stretch,
-);
+impl FromCss for AlignItems {
+    fn from_css<'i>(input: &mut Parser<'i, '_>) -> CssParseResult<'i, Self> {
+        let first = input.expect_ident()?.clone();
+        cssparser::match_ignore_ascii_case! { &*first,
+            "safe" => {
+                let pos = input.expect_ident()?.clone();
+                cssparser::match_ignore_ascii_case! { &*pos,
+                    "start" => Ok(Self::SafeStart),
+                    "end" => Ok(Self::SafeEnd),
+                    "flex-start" => Ok(Self::SafeFlexStart),
+                    "flex-end" => Ok(Self::SafeFlexEnd),
+                    "center" => Ok(Self::SafeCenter),
+                    _ => Err(input.new_unexpected_token_error(Token::Ident(pos))),
+                }
+            },
+            "unsafe" => {
+                let pos = input.expect_ident()?.clone();
+                cssparser::match_ignore_ascii_case! { &*pos,
+                    "start" => Ok(Self::Start),
+                    "end" => Ok(Self::End),
+                    "flex-start" => Ok(Self::FlexStart),
+                    "flex-end" => Ok(Self::FlexEnd),
+                    "center" => Ok(Self::Center),
+                    _ => Err(input.new_unexpected_token_error(Token::Ident(pos))),
+                }
+            },
+            "start" => Ok(Self::Start),
+            "end" => Ok(Self::End),
+            "flex-start" => Ok(Self::FlexStart),
+            "flex-end" => Ok(Self::FlexEnd),
+            "center" => Ok(Self::Center),
+            "baseline" => Ok(Self::Baseline),
+            "stretch" => Ok(Self::Stretch),
+            _ => Err(input.new_unexpected_token_error(Token::Ident(first))),
+        }
+    }
+}
+
+#[cfg(feature = "parse")]
+crate::util::parse::from_str_from_css!(AlignItems);
 
 /// Used to control how child nodes are aligned.
 /// Does not apply to Flexbox, and will be ignored if specified on a flex container
@@ -99,22 +173,47 @@ pub enum AlignContent {
     /// The gap between the first and last items is exactly HALF the gap between items.
     /// The gaps are distributed evenly in proportion to these ratios.
     SpaceAround,
+    /// Like [`AlignContent::Start`], but falls back to [`AlignContent::Start`] when the
+    /// content overflows the alignment container, to avoid data loss.
+    SafeStart,
+    /// Like [`AlignContent::End`], but falls back to [`AlignContent::Start`] when the
+    /// content overflows the alignment container, to avoid data loss.
+    SafeEnd,
+    /// Like [`AlignContent::FlexStart`], but falls back to [`AlignContent::Start`] when the
+    /// content overflows the alignment container, to avoid data loss.
+    SafeFlexStart,
+    /// Like [`AlignContent::FlexEnd`], but falls back to [`AlignContent::Start`] when the
+    /// content overflows the alignment container, to avoid data loss.
+    SafeFlexEnd,
+    /// Like [`AlignContent::Center`], but falls back to [`AlignContent::Start`] when the
+    /// content overflows the alignment container, to avoid data loss.
+    SafeCenter,
 }
 
-#[cfg(feature = "parse")]
-crate::util::parse::impl_parse_for_keyword_enum!(AlignContent,
-    "start" => Start,
-    "end" => End,
-    "flex-start" => FlexStart,
-    "flex-end" => FlexEnd,
-    "center" => Center,
-    "stretch" => Stretch,
-    "space-between" => SpaceBetween,
-    "space-evenly" => SpaceEvenly,
-    "space-around" => SpaceAround,
-);
-
 impl AlignContent {
+    /// Returns true if this is a safe overflow-aware variant.
+    #[inline]
+    pub const fn is_safe(self) -> bool {
+        matches!(
+            self,
+            Self::SafeStart | Self::SafeEnd | Self::SafeFlexStart | Self::SafeFlexEnd | Self::SafeCenter
+        )
+    }
+
+    /// Strips the safe modifier and returns the underlying position keyword.
+    /// Non-safe variants are returned unchanged.
+    #[inline]
+    pub const fn position(self) -> Self {
+        match self {
+            Self::SafeStart => Self::Start,
+            Self::SafeEnd => Self::End,
+            Self::SafeFlexStart => Self::FlexStart,
+            Self::SafeFlexEnd => Self::FlexEnd,
+            Self::SafeCenter => Self::Center,
+            other => other,
+        }
+    }
+
     /// Returns the reversed alignment for RTL (right-to-left) contexts.
     pub(crate) fn reversed(self) -> Self {
         match self {
@@ -123,10 +222,58 @@ impl AlignContent {
             Self::FlexStart => Self::FlexEnd,
             Self::FlexEnd => Self::FlexStart,
             Self::Stretch => Self::End,
+            Self::SafeStart => Self::SafeEnd,
+            Self::SafeEnd => Self::SafeStart,
+            Self::SafeFlexStart => Self::SafeFlexEnd,
+            Self::SafeFlexEnd => Self::SafeFlexStart,
             style => style,
         }
     }
 }
+
+#[cfg(feature = "parse")]
+impl FromCss for AlignContent {
+    fn from_css<'i>(input: &mut Parser<'i, '_>) -> CssParseResult<'i, Self> {
+        let first = input.expect_ident()?.clone();
+        cssparser::match_ignore_ascii_case! { &*first,
+            "safe" => {
+                let pos = input.expect_ident()?.clone();
+                cssparser::match_ignore_ascii_case! { &*pos,
+                    "start" => Ok(Self::SafeStart),
+                    "end" => Ok(Self::SafeEnd),
+                    "flex-start" => Ok(Self::SafeFlexStart),
+                    "flex-end" => Ok(Self::SafeFlexEnd),
+                    "center" => Ok(Self::SafeCenter),
+                    _ => Err(input.new_unexpected_token_error(Token::Ident(pos))),
+                }
+            },
+            "unsafe" => {
+                let pos = input.expect_ident()?.clone();
+                cssparser::match_ignore_ascii_case! { &*pos,
+                    "start" => Ok(Self::Start),
+                    "end" => Ok(Self::End),
+                    "flex-start" => Ok(Self::FlexStart),
+                    "flex-end" => Ok(Self::FlexEnd),
+                    "center" => Ok(Self::Center),
+                    _ => Err(input.new_unexpected_token_error(Token::Ident(pos))),
+                }
+            },
+            "start" => Ok(Self::Start),
+            "end" => Ok(Self::End),
+            "flex-start" => Ok(Self::FlexStart),
+            "flex-end" => Ok(Self::FlexEnd),
+            "center" => Ok(Self::Center),
+            "stretch" => Ok(Self::Stretch),
+            "space-between" => Ok(Self::SpaceBetween),
+            "space-evenly" => Ok(Self::SpaceEvenly),
+            "space-around" => Ok(Self::SpaceAround),
+            _ => Err(input.new_unexpected_token_error(Token::Ident(first))),
+        }
+    }
+}
+
+#[cfg(feature = "parse")]
+crate::util::parse::from_str_from_css!(AlignContent);
 
 /// Sets the distribution of space between and around content items
 /// For Flexbox it controls alignment in the main axis
@@ -134,3 +281,167 @@ impl AlignContent {
 ///
 /// [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content)
 pub type JustifyContent = AlignContent;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn align_items_is_safe() {
+        assert!(AlignItems::SafeStart.is_safe());
+        assert!(AlignItems::SafeEnd.is_safe());
+        assert!(AlignItems::SafeFlexStart.is_safe());
+        assert!(AlignItems::SafeFlexEnd.is_safe());
+        assert!(AlignItems::SafeCenter.is_safe());
+        assert!(!AlignItems::Start.is_safe());
+        assert!(!AlignItems::End.is_safe());
+        assert!(!AlignItems::FlexStart.is_safe());
+        assert!(!AlignItems::FlexEnd.is_safe());
+        assert!(!AlignItems::Center.is_safe());
+        assert!(!AlignItems::Baseline.is_safe());
+        assert!(!AlignItems::Stretch.is_safe());
+    }
+
+    #[test]
+    fn align_items_position_strips_safe() {
+        assert_eq!(AlignItems::SafeStart.position(), AlignItems::Start);
+        assert_eq!(AlignItems::SafeEnd.position(), AlignItems::End);
+        assert_eq!(AlignItems::SafeFlexStart.position(), AlignItems::FlexStart);
+        assert_eq!(AlignItems::SafeFlexEnd.position(), AlignItems::FlexEnd);
+        assert_eq!(AlignItems::SafeCenter.position(), AlignItems::Center);
+    }
+
+    #[test]
+    fn align_items_position_passthrough() {
+        assert_eq!(AlignItems::Start.position(), AlignItems::Start);
+        assert_eq!(AlignItems::Stretch.position(), AlignItems::Stretch);
+        assert_eq!(AlignItems::Baseline.position(), AlignItems::Baseline);
+        assert_eq!(AlignItems::FlexStart.position(), AlignItems::FlexStart);
+    }
+
+    #[test]
+    fn align_content_is_safe() {
+        assert!(AlignContent::SafeStart.is_safe());
+        assert!(AlignContent::SafeCenter.is_safe());
+        assert!(!AlignContent::SpaceBetween.is_safe());
+        assert!(!AlignContent::Stretch.is_safe());
+    }
+
+    #[test]
+    fn align_content_position_strips_safe() {
+        assert_eq!(AlignContent::SafeStart.position(), AlignContent::Start);
+        assert_eq!(AlignContent::SafeFlexEnd.position(), AlignContent::FlexEnd);
+        assert_eq!(AlignContent::SafeCenter.position(), AlignContent::Center);
+        assert_eq!(AlignContent::SpaceBetween.position(), AlignContent::SpaceBetween);
+    }
+
+    #[test]
+    fn align_content_reversed_pairs_safe_variants() {
+        assert_eq!(AlignContent::SafeStart.reversed(), AlignContent::SafeEnd);
+        assert_eq!(AlignContent::SafeEnd.reversed(), AlignContent::SafeStart);
+        assert_eq!(AlignContent::SafeFlexStart.reversed(), AlignContent::SafeFlexEnd);
+        assert_eq!(AlignContent::SafeFlexEnd.reversed(), AlignContent::SafeFlexStart);
+        assert_eq!(AlignContent::SafeCenter.reversed(), AlignContent::SafeCenter);
+    }
+
+    #[test]
+    fn align_content_reversed_existing_unchanged() {
+        assert_eq!(AlignContent::Start.reversed(), AlignContent::End);
+        assert_eq!(AlignContent::End.reversed(), AlignContent::Start);
+        assert_eq!(AlignContent::FlexStart.reversed(), AlignContent::FlexEnd);
+        assert_eq!(AlignContent::FlexEnd.reversed(), AlignContent::FlexStart);
+        assert_eq!(AlignContent::Stretch.reversed(), AlignContent::End);
+        assert_eq!(AlignContent::SpaceBetween.reversed(), AlignContent::SpaceBetween);
+        assert_eq!(AlignContent::SpaceAround.reversed(), AlignContent::SpaceAround);
+        assert_eq!(AlignContent::SpaceEvenly.reversed(), AlignContent::SpaceEvenly);
+        assert_eq!(AlignContent::Center.reversed(), AlignContent::Center);
+    }
+
+    #[cfg(feature = "parse")]
+    #[test]
+    fn parse_align_items_plain() {
+        assert_eq!("start".parse::<AlignItems>().unwrap(), AlignItems::Start);
+        assert_eq!("end".parse::<AlignItems>().unwrap(), AlignItems::End);
+        assert_eq!("flex-start".parse::<AlignItems>().unwrap(), AlignItems::FlexStart);
+        assert_eq!("flex-end".parse::<AlignItems>().unwrap(), AlignItems::FlexEnd);
+        assert_eq!("center".parse::<AlignItems>().unwrap(), AlignItems::Center);
+        assert_eq!("baseline".parse::<AlignItems>().unwrap(), AlignItems::Baseline);
+        assert_eq!("stretch".parse::<AlignItems>().unwrap(), AlignItems::Stretch);
+    }
+
+    #[cfg(feature = "parse")]
+    #[test]
+    fn parse_align_items_safe() {
+        assert_eq!("safe start".parse::<AlignItems>().unwrap(), AlignItems::SafeStart);
+        assert_eq!("safe end".parse::<AlignItems>().unwrap(), AlignItems::SafeEnd);
+        assert_eq!("safe flex-start".parse::<AlignItems>().unwrap(), AlignItems::SafeFlexStart);
+        assert_eq!("safe flex-end".parse::<AlignItems>().unwrap(), AlignItems::SafeFlexEnd);
+        assert_eq!("safe center".parse::<AlignItems>().unwrap(), AlignItems::SafeCenter);
+    }
+
+    #[cfg(feature = "parse")]
+    #[test]
+    fn parse_align_items_safe_case_insensitive() {
+        assert_eq!("SAFE Start".parse::<AlignItems>().unwrap(), AlignItems::SafeStart);
+        assert_eq!("Safe FLEX-end".parse::<AlignItems>().unwrap(), AlignItems::SafeFlexEnd);
+    }
+
+    #[cfg(feature = "parse")]
+    #[test]
+    fn parse_align_items_unsafe_drops_modifier() {
+        assert_eq!("unsafe start".parse::<AlignItems>().unwrap(), AlignItems::Start);
+        assert_eq!("unsafe end".parse::<AlignItems>().unwrap(), AlignItems::End);
+        assert_eq!("unsafe center".parse::<AlignItems>().unwrap(), AlignItems::Center);
+    }
+
+    #[cfg(feature = "parse")]
+    #[test]
+    fn parse_align_items_rejects_invalid_safe_combos() {
+        assert!("safe stretch".parse::<AlignItems>().is_err());
+        assert!("safe baseline".parse::<AlignItems>().is_err());
+        assert!("safe space-between".parse::<AlignItems>().is_err());
+        assert!("safe".parse::<AlignItems>().is_err());
+        assert!("safe garbage".parse::<AlignItems>().is_err());
+        assert!("unsafe stretch".parse::<AlignItems>().is_err());
+        assert!("unsafe baseline".parse::<AlignItems>().is_err());
+    }
+
+    #[cfg(feature = "parse")]
+    #[test]
+    fn parse_align_content_plain() {
+        assert_eq!("start".parse::<AlignContent>().unwrap(), AlignContent::Start);
+        assert_eq!("space-between".parse::<AlignContent>().unwrap(), AlignContent::SpaceBetween);
+        assert_eq!("space-evenly".parse::<AlignContent>().unwrap(), AlignContent::SpaceEvenly);
+        assert_eq!("space-around".parse::<AlignContent>().unwrap(), AlignContent::SpaceAround);
+        assert_eq!("stretch".parse::<AlignContent>().unwrap(), AlignContent::Stretch);
+    }
+
+    #[cfg(feature = "parse")]
+    #[test]
+    fn parse_align_content_safe() {
+        assert_eq!("safe start".parse::<AlignContent>().unwrap(), AlignContent::SafeStart);
+        assert_eq!("safe end".parse::<AlignContent>().unwrap(), AlignContent::SafeEnd);
+        assert_eq!("safe flex-start".parse::<AlignContent>().unwrap(), AlignContent::SafeFlexStart);
+        assert_eq!("safe flex-end".parse::<AlignContent>().unwrap(), AlignContent::SafeFlexEnd);
+        assert_eq!("safe center".parse::<AlignContent>().unwrap(), AlignContent::SafeCenter);
+    }
+
+    #[cfg(feature = "parse")]
+    #[test]
+    fn parse_align_content_unsafe_drops_modifier() {
+        assert_eq!("unsafe start".parse::<AlignContent>().unwrap(), AlignContent::Start);
+        assert_eq!("unsafe flex-end".parse::<AlignContent>().unwrap(), AlignContent::FlexEnd);
+    }
+
+    #[cfg(feature = "parse")]
+    #[test]
+    fn parse_align_content_rejects_invalid_safe_combos() {
+        assert!("safe stretch".parse::<AlignContent>().is_err());
+        assert!("safe space-between".parse::<AlignContent>().is_err());
+        assert!("safe space-evenly".parse::<AlignContent>().is_err());
+        assert!("safe space-around".parse::<AlignContent>().is_err());
+        assert!("safe".parse::<AlignContent>().is_err());
+        assert!("unsafe stretch".parse::<AlignContent>().is_err());
+        assert!("unsafe space-between".parse::<AlignContent>().is_err());
+    }
+}

--- a/src/style/alignment.rs
+++ b/src/style/alignment.rs
@@ -91,7 +91,7 @@ impl AlignContentKeyword {
     }
 }
 
-/// The overflow-position modifier per [CSS Box Alignment §4.3_f32][css-align-overflow].
+/// The overflow-position modifier per [CSS Box Alignment §4.3][css-align-overflow].
 ///
 /// `Safe` falls back to start-edge alignment when the alignment subject would
 /// overflow the alignment container, so the start of the content stays visible.

--- a/src/style/alignment.rs
+++ b/src/style/alignment.rs
@@ -1,72 +1,177 @@
-//! Style types for controlling alignment
+//! Style types for controlling alignment.
+//!
+//! The public alignment types ([`AlignItems`], [`AlignContent`], and their aliases) are
+//! structs with two orthogonal fields: a *position* keyword
+//! ([`AlignItemsKeyword`] / [`AlignContentKeyword`]) and an *overflow-position*
+//! modifier ([`AlignmentSafety`]). The pre-existing CSS spellings — `Start`, `End`,
+//! `FlexStart`, `FlexEnd`, `Center`, `Stretch`, `SpaceBetween`, …, `SafeStart`,
+//! `SafeEnd`, `SafeFlexStart`, `SafeFlexEnd`, `SafeCenter` — are exposed as associated
+//! constants on the structs, so call sites read identically to the previous enum form.
 
 #[cfg(feature = "parse")]
 use crate::util::parse::{CssParseResult, FromCss, Parser, Token};
 
-/// Used to control how child nodes are aligned.
-/// For Flexbox it controls alignment in the cross axis
-/// For Grid it controls alignment in the block axis
+/// The position-keyword half of [`AlignItems`] (and its aliases `AlignSelf`,
+/// `JustifyItems`, `JustifySelf`).
 ///
-/// [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items)
+/// Compute paths match on this enum directly so every match is exhaustive and
+/// requires no `Safe*` siblings.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum AlignItems {
-    /// Items are packed toward the start of the axis
+#[repr(u8)]
+pub enum AlignItemsKeyword {
+    /// Items are packed toward the start of the axis.
     Start,
-    /// Items are packed toward the end of the axis
+    /// Items are packed toward the end of the axis.
     End,
     /// Items are packed towards the flex-relative start of the axis.
     ///
-    /// For flex containers with flex_direction RowReverse or ColumnReverse this is equivalent
-    /// to End. In all other cases it is equivalent to Start.
+    /// For flex containers with flex_direction RowReverse or ColumnReverse this is
+    /// equivalent to End. In all other cases it is equivalent to Start.
     FlexStart,
     /// Items are packed towards the flex-relative end of the axis.
     ///
-    /// For flex containers with flex_direction RowReverse or ColumnReverse this is equivalent
-    /// to Start. In all other cases it is equivalent to End.
+    /// For flex containers with flex_direction RowReverse or ColumnReverse this is
+    /// equivalent to Start. In all other cases it is equivalent to End.
     FlexEnd,
-    /// Items are packed along the center of the cross axis
+    /// Items are packed along the center of the cross axis.
     Center,
-    /// Items are aligned such as their baselines align
+    /// Items are aligned such as their baselines align.
     Baseline,
-    /// Stretch to fill the container
+    /// Stretch to fill the container.
     Stretch,
-    /// Like [`AlignItems::Start`], but falls back to [`AlignItems::Start`] when the
-    /// alignment subject overflows the alignment container, to avoid data loss.
-    SafeStart,
-    /// Like [`AlignItems::End`], but falls back to [`AlignItems::Start`] when the
-    /// alignment subject overflows the alignment container, to avoid data loss.
-    SafeEnd,
-    /// Like [`AlignItems::FlexStart`], but falls back to [`AlignItems::Start`] when the
-    /// alignment subject overflows the alignment container, to avoid data loss.
-    SafeFlexStart,
-    /// Like [`AlignItems::FlexEnd`], but falls back to [`AlignItems::Start`] when the
-    /// alignment subject overflows the alignment container, to avoid data loss.
-    SafeFlexEnd,
-    /// Like [`AlignItems::Center`], but falls back to [`AlignItems::Start`] when the
-    /// alignment subject overflows the alignment container, to avoid data loss.
-    SafeCenter,
 }
 
+/// The position-keyword half of [`AlignContent`] (and its alias `JustifyContent`).
+///
+/// Compute paths match on this enum directly so every match is exhaustive and
+/// requires no `Safe*` siblings.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[repr(u8)]
+pub enum AlignContentKeyword {
+    /// Items are packed toward the start of the axis.
+    Start,
+    /// Items are packed toward the end of the axis.
+    End,
+    /// Items are packed towards the flex-relative start of the axis.
+    FlexStart,
+    /// Items are packed towards the flex-relative end of the axis.
+    FlexEnd,
+    /// Items are centered around the middle of the axis.
+    Center,
+    /// Items are stretched to fill the container.
+    Stretch,
+    /// The first and last items are aligned flush with the edges of the container
+    /// (no gap). The gap between items is distributed evenly.
+    SpaceBetween,
+    /// The gap between the first and last items is exactly THE SAME as the gap
+    /// between items. The gaps are distributed evenly.
+    SpaceEvenly,
+    /// The gap between the first and last items is exactly HALF the gap between
+    /// items. The gaps are distributed evenly in proportion to these ratios.
+    SpaceAround,
+}
+
+impl AlignContentKeyword {
+    /// Returns the reversed keyword for RTL (right-to-left) contexts: `Start`↔`End`,
+    /// `FlexStart`↔`FlexEnd`. `Stretch` maps to `End` to preserve the layout
+    /// algorithms' historical handling. Center and the distribution keywords
+    /// (`SpaceBetween`, `SpaceEvenly`, `SpaceAround`) are unaffected because their
+    /// visual placement is direction-symmetric.
+    pub(crate) fn reversed(self) -> Self {
+        match self {
+            Self::Start => Self::End,
+            Self::End => Self::Start,
+            Self::FlexStart => Self::FlexEnd,
+            Self::FlexEnd => Self::FlexStart,
+            Self::Stretch => Self::End,
+            Self::Center | Self::SpaceBetween | Self::SpaceEvenly | Self::SpaceAround => self,
+        }
+    }
+}
+
+/// The overflow-position modifier per [CSS Box Alignment §4.3_f32][css-align-overflow].
+///
+/// `Safe` falls back to start-edge alignment when the alignment subject would
+/// overflow the alignment container, so the start of the content stays visible.
+/// `Unsafe` (the default) keeps the requested alignment even when that causes
+/// overflow at the start edge.
+///
+/// CSS only defines `safe` / `unsafe` against the position values `start`, `end`,
+/// `flex-start`, `flex-end`, `center`. The struct shape does not enforce that
+/// constraint at the type level — the parser rejects invalid combinations, and
+/// the compute pass treats `Safe` paired with a non-position keyword (`Stretch`,
+/// `Baseline`, `Space*`) the same as `Unsafe`.
+///
+/// [css-align-overflow]: https://www.w3.org/TR/css-align-3/#overflow-values
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[repr(u8)]
+pub enum AlignmentSafety {
+    /// Default — keeps the requested alignment even when the subject overflows the
+    /// alignment container at the start edge.
+    Unsafe,
+    /// Falls back to the start edge when the subject would overflow, to avoid data
+    /// loss.
+    Safe,
+}
+
+/// Used to control how child nodes are aligned.
+/// For Flexbox it controls alignment in the cross axis.
+/// For Grid it controls alignment in the block axis.
+///
+/// [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items)
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct AlignItems {
+    /// Position keyword.
+    pub keyword: AlignItemsKeyword,
+    /// Overflow-position modifier (`safe` / `unsafe`).
+    pub safety: AlignmentSafety,
+}
+
+#[allow(non_upper_case_globals)]
 impl AlignItems {
-    /// Returns true if this is a safe overflow-aware variant.
+    /// Items are packed toward the start of the axis.
+    pub const Start: Self = Self { keyword: AlignItemsKeyword::Start, safety: AlignmentSafety::Unsafe };
+    /// Items are packed toward the end of the axis.
+    pub const End: Self = Self { keyword: AlignItemsKeyword::End, safety: AlignmentSafety::Unsafe };
+    /// Items are packed towards the flex-relative start of the axis.
+    pub const FlexStart: Self = Self { keyword: AlignItemsKeyword::FlexStart, safety: AlignmentSafety::Unsafe };
+    /// Items are packed towards the flex-relative end of the axis.
+    pub const FlexEnd: Self = Self { keyword: AlignItemsKeyword::FlexEnd, safety: AlignmentSafety::Unsafe };
+    /// Items are packed along the center of the cross axis.
+    pub const Center: Self = Self { keyword: AlignItemsKeyword::Center, safety: AlignmentSafety::Unsafe };
+    /// Items are aligned such as their baselines align.
+    pub const Baseline: Self = Self { keyword: AlignItemsKeyword::Baseline, safety: AlignmentSafety::Unsafe };
+    /// Stretch to fill the container.
+    pub const Stretch: Self = Self { keyword: AlignItemsKeyword::Stretch, safety: AlignmentSafety::Unsafe };
+    /// Like [`AlignItems::Start`], but falls back to [`AlignItems::Start`] when the
+    /// alignment subject overflows the alignment container, to avoid data loss.
+    pub const SafeStart: Self = Self { keyword: AlignItemsKeyword::Start, safety: AlignmentSafety::Safe };
+    /// Like [`AlignItems::End`], but falls back to [`AlignItems::Start`] when the
+    /// alignment subject overflows the alignment container, to avoid data loss.
+    pub const SafeEnd: Self = Self { keyword: AlignItemsKeyword::End, safety: AlignmentSafety::Safe };
+    /// Like [`AlignItems::FlexStart`], but falls back to [`AlignItems::Start`] when the
+    /// alignment subject overflows the alignment container, to avoid data loss.
+    pub const SafeFlexStart: Self = Self { keyword: AlignItemsKeyword::FlexStart, safety: AlignmentSafety::Safe };
+    /// Like [`AlignItems::FlexEnd`], but falls back to [`AlignItems::Start`] when the
+    /// alignment subject overflows the alignment container, to avoid data loss.
+    pub const SafeFlexEnd: Self = Self { keyword: AlignItemsKeyword::FlexEnd, safety: AlignmentSafety::Safe };
+    /// Like [`AlignItems::Center`], but falls back to [`AlignItems::Start`] when the
+    /// alignment subject overflows the alignment container, to avoid data loss.
+    pub const SafeCenter: Self = Self { keyword: AlignItemsKeyword::Center, safety: AlignmentSafety::Safe };
+
+    /// Returns `true` iff this carries the `safe` overflow-position modifier.
     #[inline]
     pub const fn is_safe(self) -> bool {
-        matches!(self, Self::SafeStart | Self::SafeEnd | Self::SafeFlexStart | Self::SafeFlexEnd | Self::SafeCenter)
+        matches!(self.safety, AlignmentSafety::Safe)
     }
 
-    /// Strips the safe modifier and returns the underlying position keyword.
-    /// Non-safe variants are returned unchanged.
+    /// Returns the underlying position keyword, discarding the safety modifier.
     #[inline]
-    pub const fn position(self) -> Self {
-        match self {
-            Self::SafeStart => Self::Start,
-            Self::SafeEnd => Self::End,
-            Self::SafeFlexStart => Self::FlexStart,
-            Self::SafeFlexEnd => Self::FlexEnd,
-            Self::SafeCenter => Self::Center,
-            other => other,
-        }
+    pub const fn keyword(self) -> AlignItemsKeyword {
+        self.keyword
     }
 }
 
@@ -113,115 +218,87 @@ impl FromCss for AlignItems {
 crate::util::parse::from_str_from_css!(AlignItems);
 
 /// Used to control how child nodes are aligned.
-/// Does not apply to Flexbox, and will be ignored if specified on a flex container
-/// For Grid it controls alignment in the inline axis
+/// Does not apply to Flexbox, and will be ignored if specified on a flex container.
+/// For Grid it controls alignment in the inline axis.
 ///
 /// [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-items)
 pub type JustifyItems = AlignItems;
-/// Controls alignment of an individual node
+/// Controls alignment of an individual node.
 ///
 /// Overrides the parent Node's `AlignItems` property.
-/// For Flexbox it controls alignment in the cross axis
-/// For Grid it controls alignment in the block axis
+/// For Flexbox it controls alignment in the cross axis.
+/// For Grid it controls alignment in the block axis.
 ///
 /// [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/align-self)
 pub type AlignSelf = AlignItems;
-/// Controls alignment of an individual node
+/// Controls alignment of an individual node.
 ///
 /// Overrides the parent Node's `JustifyItems` property.
-/// Does not apply to Flexbox, and will be ignored if specified on a flex child
-/// For Grid it controls alignment in the inline axis
+/// Does not apply to Flexbox, and will be ignored if specified on a flex child.
+/// For Grid it controls alignment in the inline axis.
 ///
 /// [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-self)
 pub type JustifySelf = AlignItems;
 
-/// Sets the distribution of space between and around content items
-/// For Flexbox it controls alignment in the cross axis
-/// For Grid it controls alignment in the block axis
+/// Sets the distribution of space between and around content items.
+/// For Flexbox it controls alignment in the cross axis.
+/// For Grid it controls alignment in the block axis.
 ///
 /// [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/align-content)
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum AlignContent {
-    /// Items are packed toward the start of the axis
-    Start,
-    /// Items are packed toward the end of the axis
-    End,
-    /// Items are packed towards the flex-relative start of the axis.
-    ///
-    /// For flex containers with flex_direction RowReverse or ColumnReverse this is equivalent
-    /// to End. In all other cases it is equivalent to Start.
-    FlexStart,
-    /// Items are packed towards the flex-relative end of the axis.
-    ///
-    /// For flex containers with flex_direction RowReverse or ColumnReverse this is equivalent
-    /// to Start. In all other cases it is equivalent to End.
-    FlexEnd,
-    /// Items are centered around the middle of the axis
-    Center,
-    /// Items are stretched to fill the container
-    Stretch,
-    /// The first and last items are aligned flush with the edges of the container (no gap)
-    /// The gap between items is distributed evenly.
-    SpaceBetween,
-    /// The gap between the first and last items is exactly THE SAME as the gap between items.
-    /// The gaps are distributed evenly
-    SpaceEvenly,
-    /// The gap between the first and last items is exactly HALF the gap between items.
-    /// The gaps are distributed evenly in proportion to these ratios.
-    SpaceAround,
-    /// Like [`AlignContent::Start`], but falls back to [`AlignContent::Start`] when the
-    /// content overflows the alignment container, to avoid data loss.
-    SafeStart,
-    /// Like [`AlignContent::End`], but falls back to [`AlignContent::Start`] when the
-    /// content overflows the alignment container, to avoid data loss.
-    SafeEnd,
-    /// Like [`AlignContent::FlexStart`], but falls back to [`AlignContent::Start`] when the
-    /// content overflows the alignment container, to avoid data loss.
-    SafeFlexStart,
-    /// Like [`AlignContent::FlexEnd`], but falls back to [`AlignContent::Start`] when the
-    /// content overflows the alignment container, to avoid data loss.
-    SafeFlexEnd,
-    /// Like [`AlignContent::Center`], but falls back to [`AlignContent::Start`] when the
-    /// content overflows the alignment container, to avoid data loss.
-    SafeCenter,
+pub struct AlignContent {
+    /// Position keyword.
+    pub keyword: AlignContentKeyword,
+    /// Overflow-position modifier (`safe` / `unsafe`).
+    pub safety: AlignmentSafety,
 }
 
+#[allow(non_upper_case_globals)]
 impl AlignContent {
-    /// Returns true if this is a safe overflow-aware variant.
+    /// Items are packed toward the start of the axis.
+    pub const Start: Self = Self { keyword: AlignContentKeyword::Start, safety: AlignmentSafety::Unsafe };
+    /// Items are packed toward the end of the axis.
+    pub const End: Self = Self { keyword: AlignContentKeyword::End, safety: AlignmentSafety::Unsafe };
+    /// Items are packed towards the flex-relative start of the axis.
+    pub const FlexStart: Self = Self { keyword: AlignContentKeyword::FlexStart, safety: AlignmentSafety::Unsafe };
+    /// Items are packed towards the flex-relative end of the axis.
+    pub const FlexEnd: Self = Self { keyword: AlignContentKeyword::FlexEnd, safety: AlignmentSafety::Unsafe };
+    /// Items are centered around the middle of the axis.
+    pub const Center: Self = Self { keyword: AlignContentKeyword::Center, safety: AlignmentSafety::Unsafe };
+    /// Items are stretched to fill the container.
+    pub const Stretch: Self = Self { keyword: AlignContentKeyword::Stretch, safety: AlignmentSafety::Unsafe };
+    /// The first and last items are aligned flush with the edges of the container.
+    pub const SpaceBetween: Self = Self { keyword: AlignContentKeyword::SpaceBetween, safety: AlignmentSafety::Unsafe };
+    /// The gap between the first and last items equals the gap between items.
+    pub const SpaceEvenly: Self = Self { keyword: AlignContentKeyword::SpaceEvenly, safety: AlignmentSafety::Unsafe };
+    /// The gap between the first and last items is half the gap between items.
+    pub const SpaceAround: Self = Self { keyword: AlignContentKeyword::SpaceAround, safety: AlignmentSafety::Unsafe };
+    /// Like [`AlignContent::Start`], but falls back to [`AlignContent::Start`] when the
+    /// content overflows the alignment container, to avoid data loss.
+    pub const SafeStart: Self = Self { keyword: AlignContentKeyword::Start, safety: AlignmentSafety::Safe };
+    /// Like [`AlignContent::End`], but falls back to [`AlignContent::Start`] when the
+    /// content overflows the alignment container, to avoid data loss.
+    pub const SafeEnd: Self = Self { keyword: AlignContentKeyword::End, safety: AlignmentSafety::Safe };
+    /// Like [`AlignContent::FlexStart`], but falls back to [`AlignContent::Start`] when
+    /// the content overflows the alignment container, to avoid data loss.
+    pub const SafeFlexStart: Self = Self { keyword: AlignContentKeyword::FlexStart, safety: AlignmentSafety::Safe };
+    /// Like [`AlignContent::FlexEnd`], but falls back to [`AlignContent::Start`] when the
+    /// content overflows the alignment container, to avoid data loss.
+    pub const SafeFlexEnd: Self = Self { keyword: AlignContentKeyword::FlexEnd, safety: AlignmentSafety::Safe };
+    /// Like [`AlignContent::Center`], but falls back to [`AlignContent::Start`] when the
+    /// content overflows the alignment container, to avoid data loss.
+    pub const SafeCenter: Self = Self { keyword: AlignContentKeyword::Center, safety: AlignmentSafety::Safe };
+
+    /// Returns `true` iff this carries the `safe` overflow-position modifier.
     #[inline]
     pub const fn is_safe(self) -> bool {
-        matches!(self, Self::SafeStart | Self::SafeEnd | Self::SafeFlexStart | Self::SafeFlexEnd | Self::SafeCenter)
+        matches!(self.safety, AlignmentSafety::Safe)
     }
 
-    /// Strips the safe modifier and returns the underlying position keyword.
-    /// Non-safe variants are returned unchanged.
+    /// Returns the underlying position keyword, discarding the safety modifier.
     #[inline]
-    pub const fn position(self) -> Self {
-        match self {
-            Self::SafeStart => Self::Start,
-            Self::SafeEnd => Self::End,
-            Self::SafeFlexStart => Self::FlexStart,
-            Self::SafeFlexEnd => Self::FlexEnd,
-            Self::SafeCenter => Self::Center,
-            other => other,
-        }
-    }
-
-    /// Returns the reversed alignment for RTL (right-to-left) contexts.
-    pub(crate) fn reversed(self) -> Self {
-        match self {
-            Self::Start => Self::End,
-            Self::End => Self::Start,
-            Self::FlexStart => Self::FlexEnd,
-            Self::FlexEnd => Self::FlexStart,
-            Self::Stretch => Self::End,
-            Self::SafeStart => Self::SafeEnd,
-            Self::SafeEnd => Self::SafeStart,
-            Self::SafeFlexStart => Self::SafeFlexEnd,
-            Self::SafeFlexEnd => Self::SafeFlexStart,
-            style => style,
-        }
+    pub const fn keyword(self) -> AlignContentKeyword {
+        self.keyword
     }
 }
 
@@ -269,16 +346,179 @@ impl FromCss for AlignContent {
 #[cfg(feature = "parse")]
 crate::util::parse::from_str_from_css!(AlignContent);
 
-/// Sets the distribution of space between and around content items
-/// For Flexbox it controls alignment in the main axis
-/// For Grid it controls alignment in the inline axis
+/// Sets the distribution of space between and around content items.
+/// For Flexbox it controls alignment in the main axis.
+/// For Grid it controls alignment in the inline axis.
 ///
 /// [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content)
 pub type JustifyContent = AlignContent;
 
+// ---------------------------------------------------------------------------
+// Serde — custom impls preserve the pre-struct wire format (single tag string
+// per public spelling) so consumers reading data serialized before the refactor
+// continue to deserialize correctly.
+// ---------------------------------------------------------------------------
+
+/// Canonical tag-string set accepted by [`AlignItems`] serde deserialization, used in
+/// `unknown_variant` errors. Mirrors the spellings produced by `Serialize`.
+#[cfg(feature = "serde")]
+const ALIGN_ITEMS_NAMES: &[&str] = &[
+    "Start",
+    "End",
+    "FlexStart",
+    "FlexEnd",
+    "Center",
+    "Baseline",
+    "Stretch",
+    "SafeStart",
+    "SafeEnd",
+    "SafeFlexStart",
+    "SafeFlexEnd",
+    "SafeCenter",
+];
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for AlignItems {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let name = match (self.keyword, self.safety) {
+            (AlignItemsKeyword::Start, AlignmentSafety::Unsafe) => "Start",
+            (AlignItemsKeyword::End, AlignmentSafety::Unsafe) => "End",
+            (AlignItemsKeyword::FlexStart, AlignmentSafety::Unsafe) => "FlexStart",
+            (AlignItemsKeyword::FlexEnd, AlignmentSafety::Unsafe) => "FlexEnd",
+            (AlignItemsKeyword::Center, AlignmentSafety::Unsafe) => "Center",
+            (AlignItemsKeyword::Baseline, _) => "Baseline",
+            (AlignItemsKeyword::Stretch, _) => "Stretch",
+            (AlignItemsKeyword::Start, AlignmentSafety::Safe) => "SafeStart",
+            (AlignItemsKeyword::End, AlignmentSafety::Safe) => "SafeEnd",
+            (AlignItemsKeyword::FlexStart, AlignmentSafety::Safe) => "SafeFlexStart",
+            (AlignItemsKeyword::FlexEnd, AlignmentSafety::Safe) => "SafeFlexEnd",
+            (AlignItemsKeyword::Center, AlignmentSafety::Safe) => "SafeCenter",
+        };
+        serializer.serialize_str(name)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for AlignItems {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct AlignItemsVisitor;
+        impl<'de> serde::de::Visitor<'de> for AlignItemsVisitor {
+            type Value = AlignItems;
+            fn expecting(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+                fmt.write_str("an AlignItems variant tag string")
+            }
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                Ok(match v {
+                    "Start" => AlignItems::Start,
+                    "End" => AlignItems::End,
+                    "FlexStart" => AlignItems::FlexStart,
+                    "FlexEnd" => AlignItems::FlexEnd,
+                    "Center" => AlignItems::Center,
+                    "Baseline" => AlignItems::Baseline,
+                    "Stretch" => AlignItems::Stretch,
+                    "SafeStart" => AlignItems::SafeStart,
+                    "SafeEnd" => AlignItems::SafeEnd,
+                    "SafeFlexStart" => AlignItems::SafeFlexStart,
+                    "SafeFlexEnd" => AlignItems::SafeFlexEnd,
+                    "SafeCenter" => AlignItems::SafeCenter,
+                    other => return Err(E::unknown_variant(other, ALIGN_ITEMS_NAMES)),
+                })
+            }
+        }
+        deserializer.deserialize_str(AlignItemsVisitor)
+    }
+}
+
+/// Canonical tag-string set accepted by [`AlignContent`] serde deserialization, used in
+/// `unknown_variant` errors. Mirrors the spellings produced by `Serialize`.
+#[cfg(feature = "serde")]
+const ALIGN_CONTENT_NAMES: &[&str] = &[
+    "Start",
+    "End",
+    "FlexStart",
+    "FlexEnd",
+    "Center",
+    "Stretch",
+    "SpaceBetween",
+    "SpaceEvenly",
+    "SpaceAround",
+    "SafeStart",
+    "SafeEnd",
+    "SafeFlexStart",
+    "SafeFlexEnd",
+    "SafeCenter",
+];
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for AlignContent {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let name = match (self.keyword, self.safety) {
+            (AlignContentKeyword::Start, AlignmentSafety::Unsafe) => "Start",
+            (AlignContentKeyword::End, AlignmentSafety::Unsafe) => "End",
+            (AlignContentKeyword::FlexStart, AlignmentSafety::Unsafe) => "FlexStart",
+            (AlignContentKeyword::FlexEnd, AlignmentSafety::Unsafe) => "FlexEnd",
+            (AlignContentKeyword::Center, AlignmentSafety::Unsafe) => "Center",
+            (AlignContentKeyword::Stretch, _) => "Stretch",
+            (AlignContentKeyword::SpaceBetween, _) => "SpaceBetween",
+            (AlignContentKeyword::SpaceEvenly, _) => "SpaceEvenly",
+            (AlignContentKeyword::SpaceAround, _) => "SpaceAround",
+            (AlignContentKeyword::Start, AlignmentSafety::Safe) => "SafeStart",
+            (AlignContentKeyword::End, AlignmentSafety::Safe) => "SafeEnd",
+            (AlignContentKeyword::FlexStart, AlignmentSafety::Safe) => "SafeFlexStart",
+            (AlignContentKeyword::FlexEnd, AlignmentSafety::Safe) => "SafeFlexEnd",
+            (AlignContentKeyword::Center, AlignmentSafety::Safe) => "SafeCenter",
+        };
+        serializer.serialize_str(name)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for AlignContent {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct AlignContentVisitor;
+        impl<'de> serde::de::Visitor<'de> for AlignContentVisitor {
+            type Value = AlignContent;
+            fn expecting(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+                fmt.write_str("an AlignContent variant tag string")
+            }
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                Ok(match v {
+                    "Start" => AlignContent::Start,
+                    "End" => AlignContent::End,
+                    "FlexStart" => AlignContent::FlexStart,
+                    "FlexEnd" => AlignContent::FlexEnd,
+                    "Center" => AlignContent::Center,
+                    "Stretch" => AlignContent::Stretch,
+                    "SpaceBetween" => AlignContent::SpaceBetween,
+                    "SpaceEvenly" => AlignContent::SpaceEvenly,
+                    "SpaceAround" => AlignContent::SpaceAround,
+                    "SafeStart" => AlignContent::SafeStart,
+                    "SafeEnd" => AlignContent::SafeEnd,
+                    "SafeFlexStart" => AlignContent::SafeFlexStart,
+                    "SafeFlexEnd" => AlignContent::SafeFlexEnd,
+                    "SafeCenter" => AlignContent::SafeCenter,
+                    other => return Err(E::unknown_variant(other, ALIGN_CONTENT_NAMES)),
+                })
+            }
+        }
+        deserializer.deserialize_str(AlignContentVisitor)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use core::mem::size_of;
+
+    // Size budget — struct = 1B keyword + 1B safety, no niche packing.
+    // Pre-refactor each was a single-byte enum; spec §V13 caps regression at +2B.
+    #[test]
+    fn align_types_within_size_budget() {
+        assert!(size_of::<AlignItems>() <= 2, "AlignItems grew to {}", size_of::<AlignItems>());
+        assert!(size_of::<AlignContent>() <= 2, "AlignContent grew to {}", size_of::<AlignContent>());
+        assert!(size_of::<Option<AlignItems>>() <= 3);
+        assert!(size_of::<Option<AlignContent>>() <= 3);
+    }
 
     #[test]
     fn align_items_is_safe() {
@@ -297,20 +537,20 @@ mod tests {
     }
 
     #[test]
-    fn align_items_position_strips_safe() {
-        assert_eq!(AlignItems::SafeStart.position(), AlignItems::Start);
-        assert_eq!(AlignItems::SafeEnd.position(), AlignItems::End);
-        assert_eq!(AlignItems::SafeFlexStart.position(), AlignItems::FlexStart);
-        assert_eq!(AlignItems::SafeFlexEnd.position(), AlignItems::FlexEnd);
-        assert_eq!(AlignItems::SafeCenter.position(), AlignItems::Center);
+    fn align_items_keyword_strips_safe() {
+        assert_eq!(AlignItems::SafeStart.keyword(), AlignItemsKeyword::Start);
+        assert_eq!(AlignItems::SafeEnd.keyword(), AlignItemsKeyword::End);
+        assert_eq!(AlignItems::SafeFlexStart.keyword(), AlignItemsKeyword::FlexStart);
+        assert_eq!(AlignItems::SafeFlexEnd.keyword(), AlignItemsKeyword::FlexEnd);
+        assert_eq!(AlignItems::SafeCenter.keyword(), AlignItemsKeyword::Center);
     }
 
     #[test]
-    fn align_items_position_passthrough() {
-        assert_eq!(AlignItems::Start.position(), AlignItems::Start);
-        assert_eq!(AlignItems::Stretch.position(), AlignItems::Stretch);
-        assert_eq!(AlignItems::Baseline.position(), AlignItems::Baseline);
-        assert_eq!(AlignItems::FlexStart.position(), AlignItems::FlexStart);
+    fn align_items_keyword_passthrough() {
+        assert_eq!(AlignItems::Start.keyword(), AlignItemsKeyword::Start);
+        assert_eq!(AlignItems::Stretch.keyword(), AlignItemsKeyword::Stretch);
+        assert_eq!(AlignItems::Baseline.keyword(), AlignItemsKeyword::Baseline);
+        assert_eq!(AlignItems::FlexStart.keyword(), AlignItemsKeyword::FlexStart);
     }
 
     #[test]
@@ -322,33 +562,25 @@ mod tests {
     }
 
     #[test]
-    fn align_content_position_strips_safe() {
-        assert_eq!(AlignContent::SafeStart.position(), AlignContent::Start);
-        assert_eq!(AlignContent::SafeFlexEnd.position(), AlignContent::FlexEnd);
-        assert_eq!(AlignContent::SafeCenter.position(), AlignContent::Center);
-        assert_eq!(AlignContent::SpaceBetween.position(), AlignContent::SpaceBetween);
+    fn align_content_keyword_strips_safe() {
+        assert_eq!(AlignContent::SafeStart.keyword(), AlignContentKeyword::Start);
+        assert_eq!(AlignContent::SafeFlexEnd.keyword(), AlignContentKeyword::FlexEnd);
+        assert_eq!(AlignContent::SafeCenter.keyword(), AlignContentKeyword::Center);
+        assert_eq!(AlignContent::SpaceBetween.keyword(), AlignContentKeyword::SpaceBetween);
     }
 
     #[test]
-    fn align_content_reversed_pairs_safe_variants() {
-        assert_eq!(AlignContent::SafeStart.reversed(), AlignContent::SafeEnd);
-        assert_eq!(AlignContent::SafeEnd.reversed(), AlignContent::SafeStart);
-        assert_eq!(AlignContent::SafeFlexStart.reversed(), AlignContent::SafeFlexEnd);
-        assert_eq!(AlignContent::SafeFlexEnd.reversed(), AlignContent::SafeFlexStart);
-        assert_eq!(AlignContent::SafeCenter.reversed(), AlignContent::SafeCenter);
-    }
-
-    #[test]
-    fn align_content_reversed_existing_unchanged() {
-        assert_eq!(AlignContent::Start.reversed(), AlignContent::End);
-        assert_eq!(AlignContent::End.reversed(), AlignContent::Start);
-        assert_eq!(AlignContent::FlexStart.reversed(), AlignContent::FlexEnd);
-        assert_eq!(AlignContent::FlexEnd.reversed(), AlignContent::FlexStart);
-        assert_eq!(AlignContent::Stretch.reversed(), AlignContent::End);
-        assert_eq!(AlignContent::SpaceBetween.reversed(), AlignContent::SpaceBetween);
-        assert_eq!(AlignContent::SpaceAround.reversed(), AlignContent::SpaceAround);
-        assert_eq!(AlignContent::SpaceEvenly.reversed(), AlignContent::SpaceEvenly);
-        assert_eq!(AlignContent::Center.reversed(), AlignContent::Center);
+    fn align_content_keyword_reversed_swaps_start_end() {
+        assert_eq!(AlignContentKeyword::Start.reversed(), AlignContentKeyword::End);
+        assert_eq!(AlignContentKeyword::End.reversed(), AlignContentKeyword::Start);
+        assert_eq!(AlignContentKeyword::FlexStart.reversed(), AlignContentKeyword::FlexEnd);
+        assert_eq!(AlignContentKeyword::FlexEnd.reversed(), AlignContentKeyword::FlexStart);
+        // Stretch reverses to End — preserves pre-refactor behaviour.
+        assert_eq!(AlignContentKeyword::Stretch.reversed(), AlignContentKeyword::End);
+        assert_eq!(AlignContentKeyword::Center.reversed(), AlignContentKeyword::Center);
+        assert_eq!(AlignContentKeyword::SpaceBetween.reversed(), AlignContentKeyword::SpaceBetween);
+        assert_eq!(AlignContentKeyword::SpaceEvenly.reversed(), AlignContentKeyword::SpaceEvenly);
+        assert_eq!(AlignContentKeyword::SpaceAround.reversed(), AlignContentKeyword::SpaceAround);
     }
 
     #[cfg(feature = "parse")]
@@ -437,5 +669,59 @@ mod tests {
         assert!("safe".parse::<AlignContent>().is_err());
         assert!("unsafe stretch".parse::<AlignContent>().is_err());
         assert!("unsafe space-between".parse::<AlignContent>().is_err());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_align_items_round_trip() {
+        let cases = [
+            (AlignItems::Start, "\"Start\""),
+            (AlignItems::End, "\"End\""),
+            (AlignItems::FlexStart, "\"FlexStart\""),
+            (AlignItems::FlexEnd, "\"FlexEnd\""),
+            (AlignItems::Center, "\"Center\""),
+            (AlignItems::Baseline, "\"Baseline\""),
+            (AlignItems::Stretch, "\"Stretch\""),
+            (AlignItems::SafeStart, "\"SafeStart\""),
+            (AlignItems::SafeEnd, "\"SafeEnd\""),
+            (AlignItems::SafeFlexStart, "\"SafeFlexStart\""),
+            (AlignItems::SafeFlexEnd, "\"SafeFlexEnd\""),
+            (AlignItems::SafeCenter, "\"SafeCenter\""),
+        ];
+        for (value, expected) in cases {
+            let serialized = serde_json::to_string(&value).unwrap();
+            assert_eq!(serialized, expected, "serialize {:?}", value);
+            let deserialized: AlignItems = serde_json::from_str(expected).unwrap();
+            assert_eq!(deserialized, value, "round-trip {:?}", value);
+        }
+        assert!(serde_json::from_str::<AlignItems>("\"NotAVariant\"").is_err());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_align_content_round_trip() {
+        let cases = [
+            (AlignContent::Start, "\"Start\""),
+            (AlignContent::End, "\"End\""),
+            (AlignContent::FlexStart, "\"FlexStart\""),
+            (AlignContent::FlexEnd, "\"FlexEnd\""),
+            (AlignContent::Center, "\"Center\""),
+            (AlignContent::Stretch, "\"Stretch\""),
+            (AlignContent::SpaceBetween, "\"SpaceBetween\""),
+            (AlignContent::SpaceEvenly, "\"SpaceEvenly\""),
+            (AlignContent::SpaceAround, "\"SpaceAround\""),
+            (AlignContent::SafeStart, "\"SafeStart\""),
+            (AlignContent::SafeEnd, "\"SafeEnd\""),
+            (AlignContent::SafeFlexStart, "\"SafeFlexStart\""),
+            (AlignContent::SafeFlexEnd, "\"SafeFlexEnd\""),
+            (AlignContent::SafeCenter, "\"SafeCenter\""),
+        ];
+        for (value, expected) in cases {
+            let serialized = serde_json::to_string(&value).unwrap();
+            assert_eq!(serialized, expected, "serialize {:?}", value);
+            let deserialized: AlignContent = serde_json::from_str(expected).unwrap();
+            assert_eq!(deserialized, value, "round-trip {:?}", value);
+        }
+        assert!(serde_json::from_str::<AlignContent>("\"NotAVariant\"").is_err());
     }
 }

--- a/src/style/alignment.rs
+++ b/src/style/alignment.rs
@@ -52,10 +52,7 @@ impl AlignItems {
     /// Returns true if this is a safe overflow-aware variant.
     #[inline]
     pub const fn is_safe(self) -> bool {
-        matches!(
-            self,
-            Self::SafeStart | Self::SafeEnd | Self::SafeFlexStart | Self::SafeFlexEnd | Self::SafeCenter
-        )
+        matches!(self, Self::SafeStart | Self::SafeEnd | Self::SafeFlexStart | Self::SafeFlexEnd | Self::SafeCenter)
     }
 
     /// Strips the safe modifier and returns the underlying position keyword.
@@ -194,10 +191,7 @@ impl AlignContent {
     /// Returns true if this is a safe overflow-aware variant.
     #[inline]
     pub const fn is_safe(self) -> bool {
-        matches!(
-            self,
-            Self::SafeStart | Self::SafeEnd | Self::SafeFlexStart | Self::SafeFlexEnd | Self::SafeCenter
-        )
+        matches!(self, Self::SafeStart | Self::SafeEnd | Self::SafeFlexStart | Self::SafeFlexEnd | Self::SafeCenter)
     }
 
     /// Strips the safe modifier and returns the underlying position keyword.

--- a/src/style/available_space.rs
+++ b/src/style/available_space.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 #[cfg(feature = "parse")]
-use crate::util::parse::{from_str_from_css, parse_css_str_entirely, CssParseResult, FromCss, Parser, Token};
+use crate::util::parse::{from_str_from_css, CssParseResult, FromCss, Parser, Token};
 
 /// The amount of space available to a node in a given axis
 /// <https://www.w3.org/TR/css-sizing-3/#available>

--- a/src/style/dimension.rs
+++ b/src/style/dimension.rs
@@ -3,7 +3,7 @@ use super::CompactLength;
 use crate::geometry::Rect;
 use crate::style_helpers::{FromLength, FromPercent, TaffyAuto, TaffyZero};
 #[cfg(feature = "parse")]
-use crate::util::parse::{from_str_from_css, parse_css_str_entirely, CssParseResult, FromCss, Parser, Token};
+use crate::util::parse::{from_str_from_css, CssParseResult, FromCss, Parser, Token};
 
 /// A unit of linear measurement
 ///

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -368,12 +368,12 @@ impl Overflow {
         }
     }
 
-    /// Returns `Some(0.0_f32)` if the overflow mode would cause the automatic minimum size of a Flexbox or CSS Grid item
+    /// Returns `Some(0.0)` if the overflow mode would cause the automatic minimum size of a Flexbox or CSS Grid item
     /// to be `0`. Else returns None.
     #[inline(always)]
     pub(crate) fn maybe_into_automatic_min_size(self) -> Option<f32> {
         match self.is_scroll_container() {
-            true => Some(0.0_f32),
+            true => Some(0.0),
             false => None,
         }
     }
@@ -538,12 +538,12 @@ pub struct Style<S: CheapCloneStr = DefaultCheapStr> {
     pub flex_basis: Dimension,
     /// The relative rate at which this item grows when it is expanding to fill space
     ///
-    /// 0.0_f32 is the default value, and this value must be positive.
+    /// 0.0 is the default value, and this value must be positive.
     #[cfg(feature = "flexbox")]
     pub flex_grow: f32,
     /// The relative rate at which this item shrinks when it is contracting to fit into space
     ///
-    /// 1.0_f32 is the default value, and this value must be positive.
+    /// 1.0 is the default value, and this value must be positive.
     #[cfg(feature = "flexbox")]
     pub flex_shrink: f32,
 
@@ -594,7 +594,7 @@ impl<S: CheapCloneStr> Style<S> {
         box_sizing: BoxSizing::BorderBox,
         direction: Direction::Ltr,
         overflow: Point { x: Overflow::Visible, y: Overflow::Visible },
-        scrollbar_width: 0.0_f32,
+        scrollbar_width: 0.0,
         #[cfg(feature = "float_layout")]
         float: Float::None,
         #[cfg(feature = "float_layout")]
@@ -632,9 +632,9 @@ impl<S: CheapCloneStr> Style<S> {
         #[cfg(feature = "flexbox")]
         flex_wrap: FlexWrap::NoWrap,
         #[cfg(feature = "flexbox")]
-        flex_grow: 0.0_f32,
+        flex_grow: 0.0,
         #[cfg(feature = "flexbox")]
-        flex_shrink: 1.0_f32,
+        flex_shrink: 1.0,
         #[cfg(feature = "flexbox")]
         flex_basis: Dimension::AUTO,
         // Grid
@@ -1205,7 +1205,7 @@ mod tests {
             clear: Default::default(),
             direction: Default::default(),
             overflow: Default::default(),
-            scrollbar_width: 0.0_f32,
+            scrollbar_width: 0.0,
             position: Default::default(),
             #[cfg(feature = "flexbox")]
             flex_direction: Default::default(),
@@ -1231,9 +1231,9 @@ mod tests {
             #[cfg(feature = "block_layout")]
             text_align: Default::default(),
             #[cfg(feature = "flexbox")]
-            flex_grow: 0.0_f32,
+            flex_grow: 0.0,
             #[cfg(feature = "flexbox")]
-            flex_shrink: 1.0_f32,
+            flex_shrink: 1.0,
             #[cfg(feature = "flexbox")]
             flex_basis: super::Dimension::AUTO,
             size: Size::auto(),

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -13,7 +13,10 @@ mod float;
 #[cfg(feature = "grid")]
 mod grid;
 
-pub use self::alignment::{AlignContent, AlignItems, AlignSelf, JustifyContent, JustifyItems, JustifySelf};
+pub use self::alignment::{
+    AlignContent, AlignContentKeyword, AlignItems, AlignItemsKeyword, AlignSelf, AlignmentSafety, JustifyContent,
+    JustifyItems, JustifySelf,
+};
 pub use self::available_space::AvailableSpace;
 pub use self::compact_length::CompactLength;
 pub use self::dimension::{Dimension, LengthPercentage, LengthPercentageAuto};
@@ -365,12 +368,12 @@ impl Overflow {
         }
     }
 
-    /// Returns `Some(0.0)` if the overflow mode would cause the automatic minimum size of a Flexbox or CSS Grid item
+    /// Returns `Some(0.0_f32)` if the overflow mode would cause the automatic minimum size of a Flexbox or CSS Grid item
     /// to be `0`. Else returns None.
     #[inline(always)]
     pub(crate) fn maybe_into_automatic_min_size(self) -> Option<f32> {
         match self.is_scroll_container() {
-            true => Some(0.0),
+            true => Some(0.0_f32),
             false => None,
         }
     }
@@ -535,12 +538,12 @@ pub struct Style<S: CheapCloneStr = DefaultCheapStr> {
     pub flex_basis: Dimension,
     /// The relative rate at which this item grows when it is expanding to fill space
     ///
-    /// 0.0 is the default value, and this value must be positive.
+    /// 0.0_f32 is the default value, and this value must be positive.
     #[cfg(feature = "flexbox")]
     pub flex_grow: f32,
     /// The relative rate at which this item shrinks when it is contracting to fit into space
     ///
-    /// 1.0 is the default value, and this value must be positive.
+    /// 1.0_f32 is the default value, and this value must be positive.
     #[cfg(feature = "flexbox")]
     pub flex_shrink: f32,
 
@@ -591,7 +594,7 @@ impl<S: CheapCloneStr> Style<S> {
         box_sizing: BoxSizing::BorderBox,
         direction: Direction::Ltr,
         overflow: Point { x: Overflow::Visible, y: Overflow::Visible },
-        scrollbar_width: 0.0,
+        scrollbar_width: 0.0_f32,
         #[cfg(feature = "float_layout")]
         float: Float::None,
         #[cfg(feature = "float_layout")]
@@ -629,9 +632,9 @@ impl<S: CheapCloneStr> Style<S> {
         #[cfg(feature = "flexbox")]
         flex_wrap: FlexWrap::NoWrap,
         #[cfg(feature = "flexbox")]
-        flex_grow: 0.0,
+        flex_grow: 0.0_f32,
         #[cfg(feature = "flexbox")]
-        flex_shrink: 1.0,
+        flex_shrink: 1.0_f32,
         #[cfg(feature = "flexbox")]
         flex_basis: Dimension::AUTO,
         // Grid
@@ -1202,7 +1205,7 @@ mod tests {
             clear: Default::default(),
             direction: Default::default(),
             overflow: Default::default(),
-            scrollbar_width: 0.0,
+            scrollbar_width: 0.0_f32,
             position: Default::default(),
             #[cfg(feature = "flexbox")]
             flex_direction: Default::default(),
@@ -1228,9 +1231,9 @@ mod tests {
             #[cfg(feature = "block_layout")]
             text_align: Default::default(),
             #[cfg(feature = "flexbox")]
-            flex_grow: 0.0,
+            flex_grow: 0.0_f32,
             #[cfg(feature = "flexbox")]
-            flex_shrink: 1.0,
+            flex_shrink: 1.0_f32,
             #[cfg(feature = "flexbox")]
             flex_basis: super::Dimension::AUTO,
             size: Size::auto(),
@@ -1306,10 +1309,16 @@ mod tests {
         assert_type_size::<Rect<LengthPercentageAuto>>(32);
         assert_type_size::<Rect<Dimension>>(32);
 
-        // Alignment
-        assert_type_size::<AlignContent>(1);
-        assert_type_size::<AlignItems>(1);
-        assert_type_size::<Option<AlignItems>>(1);
+        // Alignment — `AlignContent` and `AlignItems` are structs of two `#[repr(u8)]` enums
+        // (position keyword + safety modifier). Niche-packing in the safety byte (only 2 of
+        // 256 values used) lets `Option<_>` stay the same size as the bare struct.
+        assert_type_size::<AlignContentKeyword>(1);
+        assert_type_size::<AlignItemsKeyword>(1);
+        assert_type_size::<AlignmentSafety>(1);
+        assert_type_size::<AlignContent>(2);
+        assert_type_size::<AlignItems>(2);
+        assert_type_size::<Option<AlignItems>>(2);
+        assert_type_size::<Option<AlignContent>>(2);
 
         // Flexbox Container
         assert_type_size::<FlexDirection>(1);
@@ -1327,12 +1336,12 @@ mod tests {
         assert_type_size::<GridTemplateComponent<String>>(56);
         assert_type_size::<GridPlacement<String>>(32);
         assert_type_size::<Line<GridPlacement<String>>>(64);
-        assert_type_size::<Style<String>>(536);
+        assert_type_size::<Style<String>>(544);
 
         // String-type dependent (Arc<str>)
         assert_type_size::<GridTemplateComponent<Arc<str>>>(56);
         assert_type_size::<GridPlacement<Arc<str>>>(24);
         assert_type_size::<Line<GridPlacement<Arc<str>>>>(48);
-        assert_type_size::<Style<Arc<str>>>(504);
+        assert_type_size::<Style<Arc<str>>>(512);
     }
 }

--- a/src/util/parse.rs
+++ b/src/util/parse.rs
@@ -56,7 +56,7 @@ macro_rules! from_str_from_css {
         impl core::str::FromStr for $ty {
             type Err = $crate::ParseError;
             fn from_str(input: &str) -> Result<Self, Self::Err> {
-                parse_css_str_entirely(input)
+                $crate::util::parse::parse_css_str_entirely(input)
             }
         }
     };

--- a/test_fixtures/flex/flex_safe_align_content_end_overflow.html
+++ b/test_fixtures/flex/flex_safe_align_content_end_overflow.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; flex-wrap: wrap; width: 100px; height: 100px; align-content: safe end;">
+  <div style="width: 60px; height: 80px; flex-shrink: 0;"></div>
+  <div style="width: 60px; height: 80px; flex-shrink: 0;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/flex_safe_align_self_center_overflow.html
+++ b/test_fixtures/flex/flex_safe_align_self_center_overflow.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; width: 100px; height: 100px;">
+  <div style="width: 50px; height: 150px; flex-shrink: 0; align-self: safe center;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/flex_safe_align_self_end_overflow.html
+++ b/test_fixtures/flex/flex_safe_align_self_end_overflow.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; width: 100px; height: 100px;">
+  <div style="width: 50px; height: 150px; flex-shrink: 0; align-self: safe end;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/flex_safe_justify_content_center_overflow.html
+++ b/test_fixtures/flex/flex_safe_justify_content_center_overflow.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; width: 100px; height: 100px; justify-content: safe center;">
+  <div style="width: 80px; height: 50px; flex-shrink: 0;"></div>
+  <div style="width: 80px; height: 50px; flex-shrink: 0;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/flex_safe_justify_content_end_overflow.html
+++ b/test_fixtures/flex/flex_safe_justify_content_end_overflow.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; width: 100px; height: 100px; justify-content: safe end;">
+  <div style="width: 80px; height: 50px; flex-shrink: 0;"></div>
+  <div style="width: 80px; height: 50px; flex-shrink: 0;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/flex_unsafe_align_self_end_overflow.html
+++ b/test_fixtures/flex/flex_unsafe_align_self_end_overflow.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; width: 100px; height: 100px;">
+  <div style="width: 50px; height: 150px; flex-shrink: 0; align-self: unsafe end;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_safe_align_content_center_overflow.html
+++ b/test_fixtures/grid/grid_safe_align_content_center_overflow.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="height: 100px; width: 100px; display: grid; grid-template-columns: 40px 40px 40px; grid-template-rows: 40px 40px 40px; align-content: safe center;">
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_safe_align_content_end_overflow.html
+++ b/test_fixtures/grid/grid_safe_align_content_end_overflow.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="height: 100px; width: 100px; display: grid; grid-template-columns: 40px 40px 40px; grid-template-rows: 40px 40px 40px; align-content: safe end;">
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_safe_align_self_end_no_overflow.html
+++ b/test_fixtures/grid/grid_safe_align_self_end_no_overflow.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="height: 100px; width: 100px; display: grid; grid-template-columns: 100px; grid-template-rows: 100px;">
+  <div style="width: 50px; height: 40px; align-self: safe end;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_safe_align_self_end_overflow.html
+++ b/test_fixtures/grid/grid_safe_align_self_end_overflow.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="height: 100px; width: 100px; display: grid; grid-template-columns: 100px; grid-template-rows: 100px;">
+  <div style="width: 50px; height: 150px; align-self: safe end;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_safe_justify_content_center_overflow.html
+++ b/test_fixtures/grid/grid_safe_justify_content_center_overflow.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="height: 100px; width: 100px; display: grid; grid-template-columns: 40px 40px 40px; grid-template-rows: 40px 40px 40px; justify-content: safe center;">
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_safe_justify_content_end_no_overflow.html
+++ b/test_fixtures/grid/grid_safe_justify_content_end_no_overflow.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="height: 200px; width: 200px; display: grid; grid-template-columns: 40px 40px 40px; grid-template-rows: 40px 40px 40px; justify-content: safe end;">
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_safe_justify_content_end_overflow.html
+++ b/test_fixtures/grid/grid_safe_justify_content_end_overflow.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="height: 100px; width: 100px; display: grid; grid-template-columns: 40px 40px 40px; grid-template-rows: 40px 40px 40px; justify-content: safe end;">
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_safe_justify_self_center_overflow.html
+++ b/test_fixtures/grid/grid_safe_justify_self_center_overflow.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="height: 100px; width: 100px; display: grid; grid-template-columns: 100px; grid-template-rows: 100px;">
+  <div style="width: 150px; height: 50px; justify-self: safe center;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_safe_justify_self_end_overflow.html
+++ b/test_fixtures/grid/grid_safe_justify_self_end_overflow.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="height: 100px; width: 100px; display: grid; grid-template-columns: 100px; grid-template-rows: 100px;">
+  <div style="width: 150px; height: 50px; justify-self: safe end;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_unsafe_align_self_end_overflow.html
+++ b/test_fixtures/grid/grid_unsafe_align_self_end_overflow.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="height: 100px; width: 100px; display: grid; grid-template-columns: 100px; grid-template-rows: 100px;">
+  <div style="width: 50px; height: 150px; align-self: unsafe end;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_unsafe_justify_content_end_overflow.html
+++ b/test_fixtures/grid/grid_unsafe_justify_content_end_overflow.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="height: 100px; width: 100px; display: grid; grid-template-columns: 40px 40px 40px; grid-template-rows: 40px 40px 40px; justify-content: unsafe end;">
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+</div>
+
+</body>
+</html>

--- a/tests/hand_written.rs
+++ b/tests/hand_written.rs
@@ -6,5 +6,6 @@ mod hand_written {
     mod relayout;
     mod root_constraints;
     mod rounding;
+    mod safe_alignment;
     mod serde;
 }

--- a/tests/hand_written/safe_alignment.rs
+++ b/tests/hand_written/safe_alignment.rs
@@ -1,0 +1,308 @@
+//! Tests for the `safe` and `unsafe` overflow-position keywords on align-* and justify-*.
+//!
+//! Spec: <https://www.w3.org/TR/css-align-3/#overflow-values>
+//!
+//! When the alignment subject overflows the alignment container, a `safe` value behaves
+//! as logical `start`; an `unsafe` value (the default) keeps its requested position even
+//! when that causes data loss at the start edge.
+
+use taffy::prelude::*;
+use taffy::style::Direction;
+use taffy_test_helpers::new_test_tree;
+
+#[cfg(feature = "grid")]
+#[test]
+fn grid_safe_align_self_falls_back_to_start_on_overflow() {
+    let mut taffy = new_test_tree();
+    let child = taffy
+        .new_leaf(Style {
+            size: Size { width: length(50.0), height: length(150.0) },
+            align_self: Some(AlignSelf::SafeEnd),
+            ..Default::default()
+        })
+        .unwrap();
+    let root = taffy
+        .new_with_children(
+            Style {
+                display: Display::Grid,
+                size: Size { width: length(100.0), height: length(100.0) },
+                grid_template_rows: vec![length(100.0)],
+                grid_template_columns: vec![length(100.0)],
+                ..Default::default()
+            },
+            &[child],
+        )
+        .unwrap();
+
+    taffy.compute_layout(root, Size::MAX_CONTENT).unwrap();
+
+    // Child overflows the 100-tall grid area, so safe end falls back to start (y == 0).
+    assert_eq!(taffy.layout(child).unwrap().location.y, 0.0);
+}
+
+#[cfg(feature = "grid")]
+#[test]
+fn grid_safe_align_self_behaves_as_end_when_no_overflow() {
+    let mut taffy = new_test_tree();
+    let child = taffy
+        .new_leaf(Style {
+            size: Size { width: length(50.0), height: length(40.0) },
+            align_self: Some(AlignSelf::SafeEnd),
+            ..Default::default()
+        })
+        .unwrap();
+    let root = taffy
+        .new_with_children(
+            Style {
+                display: Display::Grid,
+                size: Size { width: length(100.0), height: length(100.0) },
+                grid_template_rows: vec![length(100.0)],
+                grid_template_columns: vec![length(100.0)],
+                ..Default::default()
+            },
+            &[child],
+        )
+        .unwrap();
+
+    taffy.compute_layout(root, Size::MAX_CONTENT).unwrap();
+
+    // No overflow, so safe end behaves as end: y == 100 - 40 == 60
+    assert_eq!(taffy.layout(child).unwrap().location.y, 60.0);
+}
+
+#[cfg(feature = "grid")]
+#[test]
+fn grid_unsafe_align_self_keeps_overflowing_position() {
+    let mut taffy = new_test_tree();
+    let child = taffy
+        .new_leaf(Style {
+            size: Size { width: length(50.0), height: length(150.0) },
+            align_self: Some(AlignSelf::End),
+            ..Default::default()
+        })
+        .unwrap();
+    let root = taffy
+        .new_with_children(
+            Style {
+                display: Display::Grid,
+                size: Size { width: length(100.0), height: length(100.0) },
+                grid_template_rows: vec![length(100.0)],
+                grid_template_columns: vec![length(100.0)],
+                ..Default::default()
+            },
+            &[child],
+        )
+        .unwrap();
+
+    taffy.compute_layout(root, Size::MAX_CONTENT).unwrap();
+
+    // Plain End with overflow keeps end alignment: y == 100 - 150 == -50
+    assert_eq!(taffy.layout(child).unwrap().location.y, -50.0);
+}
+
+#[cfg(feature = "grid")]
+#[test]
+fn grid_safe_justify_self_falls_back_to_start_on_overflow() {
+    let mut taffy = new_test_tree();
+    let child = taffy
+        .new_leaf(Style {
+            size: Size { width: length(150.0), height: length(50.0) },
+            justify_self: Some(JustifySelf::SafeEnd),
+            ..Default::default()
+        })
+        .unwrap();
+    let root = taffy
+        .new_with_children(
+            Style {
+                display: Display::Grid,
+                size: Size { width: length(100.0), height: length(100.0) },
+                grid_template_rows: vec![length(100.0)],
+                grid_template_columns: vec![length(100.0)],
+                ..Default::default()
+            },
+            &[child],
+        )
+        .unwrap();
+
+    taffy.compute_layout(root, Size::MAX_CONTENT).unwrap();
+
+    assert_eq!(taffy.layout(child).unwrap().location.x, 0.0);
+}
+
+#[cfg(feature = "grid")]
+#[test]
+fn grid_safe_justify_self_rtl_falls_back_to_rtl_start_edge() {
+    let mut taffy = new_test_tree();
+    let child = taffy
+        .new_leaf(Style {
+            size: Size { width: length(150.0), height: length(50.0) },
+            justify_self: Some(JustifySelf::SafeEnd),
+            ..Default::default()
+        })
+        .unwrap();
+    let root = taffy
+        .new_with_children(
+            Style {
+                display: Display::Grid,
+                direction: Direction::Rtl,
+                size: Size { width: length(100.0), height: length(100.0) },
+                grid_template_rows: vec![length(100.0)],
+                grid_template_columns: vec![length(100.0)],
+                ..Default::default()
+            },
+            &[child],
+        )
+        .unwrap();
+
+    taffy.compute_layout(root, Size::MAX_CONTENT).unwrap();
+
+    // In RTL the inline-start edge is the right side. The 150-wide child in the
+    // 100-wide container, anchored at the RTL Start edge, sits at x == -50.
+    assert_eq!(taffy.layout(child).unwrap().location.x, -50.0);
+}
+
+#[cfg(feature = "grid")]
+#[test]
+fn grid_safe_align_content_overflow_falls_back_to_start() {
+    let mut taffy = new_test_tree();
+    let child_a = taffy
+        .new_leaf(Style { size: Size { width: length(40.0), height: length(80.0) }, ..Default::default() })
+        .unwrap();
+    let child_b = taffy
+        .new_leaf(Style { size: Size { width: length(40.0), height: length(80.0) }, ..Default::default() })
+        .unwrap();
+    let root = taffy
+        .new_with_children(
+            Style {
+                display: Display::Grid,
+                size: Size { width: length(100.0), height: length(100.0) },
+                grid_template_rows: vec![length(80.0), length(80.0)],
+                grid_template_columns: vec![length(40.0)],
+                align_content: Some(AlignContent::SafeEnd),
+                ..Default::default()
+            },
+            &[child_a, child_b],
+        )
+        .unwrap();
+
+    taffy.compute_layout(root, Size::MAX_CONTENT).unwrap();
+
+    // Tracks total 160 in a 100-tall container — overflow. Safe end falls back to
+    // start: first track at y == 0.
+    assert_eq!(taffy.layout(child_a).unwrap().location.y, 0.0);
+}
+
+#[cfg(feature = "flexbox")]
+#[test]
+fn flex_safe_align_self_falls_back_to_start_on_overflow() {
+    let mut taffy = new_test_tree();
+    let child = taffy
+        .new_leaf(Style {
+            size: Size { width: length(50.0), height: length(150.0) },
+            align_self: Some(AlignSelf::SafeEnd),
+            ..Default::default()
+        })
+        .unwrap();
+    let root = taffy
+        .new_with_children(
+            Style {
+                display: Display::Flex,
+                size: Size { width: length(100.0), height: length(100.0) },
+                ..Default::default()
+            },
+            &[child],
+        )
+        .unwrap();
+
+    taffy.compute_layout(root, Size::MAX_CONTENT).unwrap();
+
+    // Cross-axis overflow: safe end falls back to start (y == 0).
+    assert_eq!(taffy.layout(child).unwrap().location.y, 0.0);
+}
+
+#[cfg(feature = "flexbox")]
+#[test]
+fn flex_unsafe_align_self_keeps_overflowing_position() {
+    let mut taffy = new_test_tree();
+    let child = taffy
+        .new_leaf(Style {
+            size: Size { width: length(50.0), height: length(150.0) },
+            align_self: Some(AlignSelf::End),
+            ..Default::default()
+        })
+        .unwrap();
+    let root = taffy
+        .new_with_children(
+            Style {
+                display: Display::Flex,
+                size: Size { width: length(100.0), height: length(100.0) },
+                ..Default::default()
+            },
+            &[child],
+        )
+        .unwrap();
+
+    taffy.compute_layout(root, Size::MAX_CONTENT).unwrap();
+
+    // Plain End with cross-axis overflow keeps end alignment: y == 100 - 150 == -50
+    assert_eq!(taffy.layout(child).unwrap().location.y, -50.0);
+}
+
+#[cfg(feature = "flexbox")]
+#[test]
+fn flex_safe_justify_content_falls_back_to_start_on_overflow() {
+    let mut taffy = new_test_tree();
+    let child_a = taffy
+        .new_leaf(Style { size: Size { width: length(80.0), height: length(50.0) }, ..Default::default() })
+        .unwrap();
+    let child_b = taffy
+        .new_leaf(Style { size: Size { width: length(80.0), height: length(50.0) }, ..Default::default() })
+        .unwrap();
+    let root = taffy
+        .new_with_children(
+            Style {
+                display: Display::Flex,
+                size: Size { width: length(100.0), height: length(100.0) },
+                justify_content: Some(JustifyContent::SafeEnd),
+                ..Default::default()
+            },
+            &[child_a, child_b],
+        )
+        .unwrap();
+
+    taffy.compute_layout(root, Size::MAX_CONTENT).unwrap();
+
+    // Items total 160 in a 100-wide container — overflow. Safe end falls back to
+    // start: first item anchored at x == 0.
+    assert_eq!(taffy.layout(child_a).unwrap().location.x, 0.0);
+}
+
+#[cfg(feature = "flexbox")]
+#[test]
+fn flex_safe_align_content_falls_back_to_start_on_multiline_overflow() {
+    let mut taffy = new_test_tree();
+    let child_a = taffy
+        .new_leaf(Style { size: Size { width: length(60.0), height: length(80.0) }, ..Default::default() })
+        .unwrap();
+    let child_b = taffy
+        .new_leaf(Style { size: Size { width: length(60.0), height: length(80.0) }, ..Default::default() })
+        .unwrap();
+    let root = taffy
+        .new_with_children(
+            Style {
+                display: Display::Flex,
+                flex_wrap: FlexWrap::Wrap,
+                size: Size { width: length(100.0), height: length(100.0) },
+                align_content: Some(AlignContent::SafeEnd),
+                ..Default::default()
+            },
+            &[child_a, child_b],
+        )
+        .unwrap();
+
+    taffy.compute_layout(root, Size::MAX_CONTENT).unwrap();
+
+    // Two 80-tall lines wrap and overflow the 100-tall container. Safe end falls back
+    // to start: first line at y == 0.
+    assert_eq!(taffy.layout(child_a).unwrap().location.y, 0.0);
+}

--- a/tests/xml/flex/flex_safe_align_content_end_overflow__border_box_ltr.xml
+++ b/tests/xml/flex/flex_safe_align_content_end_overflow__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="flex_safe_align_content_end_overflow__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" flex-wrap="wrap" align-content="safe end" width="100px" height="100px">
+      <div direction="ltr" flex-shrink="0" width="60px" height="80px"/>
+      <div direction="ltr" flex-shrink="0" width="60px" height="80px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="60" height="80"/>
+      <node x="0" y="80" width="60" height="80"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_safe_align_content_end_overflow__border_box_rtl.xml
+++ b/tests/xml/flex/flex_safe_align_content_end_overflow__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="flex_safe_align_content_end_overflow__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" flex-wrap="wrap" align-content="safe end" width="100px" height="100px">
+      <div direction="rtl" flex-shrink="0" width="60px" height="80px"/>
+      <div direction="rtl" flex-shrink="0" width="60px" height="80px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="40" y="0" width="60" height="80"/>
+      <node x="40" y="80" width="60" height="80"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_safe_align_content_end_overflow__content_box_ltr.xml
+++ b/tests/xml/flex/flex_safe_align_content_end_overflow__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="flex_safe_align_content_end_overflow__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" flex-wrap="wrap" align-content="safe end" width="100px" height="100px">
+      <div box-sizing="content-box" direction="ltr" flex-shrink="0" width="60px" height="80px"/>
+      <div box-sizing="content-box" direction="ltr" flex-shrink="0" width="60px" height="80px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="60" height="80"/>
+      <node x="0" y="80" width="60" height="80"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_safe_align_content_end_overflow__content_box_rtl.xml
+++ b/tests/xml/flex/flex_safe_align_content_end_overflow__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="flex_safe_align_content_end_overflow__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" flex-wrap="wrap" align-content="safe end" width="100px" height="100px">
+      <div box-sizing="content-box" direction="rtl" flex-shrink="0" width="60px" height="80px"/>
+      <div box-sizing="content-box" direction="rtl" flex-shrink="0" width="60px" height="80px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="40" y="0" width="60" height="80"/>
+      <node x="40" y="80" width="60" height="80"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_safe_align_self_center_overflow__border_box_ltr.xml
+++ b/tests/xml/flex/flex_safe_align_self_center_overflow__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="flex_safe_align_self_center_overflow__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" width="100px" height="100px">
+      <div direction="ltr" align-self="safe center" flex-shrink="0" width="50px" height="150px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="50" height="150"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_safe_align_self_center_overflow__border_box_rtl.xml
+++ b/tests/xml/flex/flex_safe_align_self_center_overflow__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="flex_safe_align_self_center_overflow__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" width="100px" height="100px">
+      <div direction="rtl" align-self="safe center" flex-shrink="0" width="50px" height="150px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="50" y="0" width="50" height="150"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_safe_align_self_center_overflow__content_box_ltr.xml
+++ b/tests/xml/flex/flex_safe_align_self_center_overflow__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="flex_safe_align_self_center_overflow__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" width="100px" height="100px">
+      <div box-sizing="content-box" direction="ltr" align-self="safe center" flex-shrink="0" width="50px" height="150px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="50" height="150"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_safe_align_self_center_overflow__content_box_rtl.xml
+++ b/tests/xml/flex/flex_safe_align_self_center_overflow__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="flex_safe_align_self_center_overflow__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" width="100px" height="100px">
+      <div box-sizing="content-box" direction="rtl" align-self="safe center" flex-shrink="0" width="50px" height="150px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="50" y="0" width="50" height="150"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_safe_align_self_end_overflow__border_box_ltr.xml
+++ b/tests/xml/flex/flex_safe_align_self_end_overflow__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="flex_safe_align_self_end_overflow__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" width="100px" height="100px">
+      <div direction="ltr" align-self="safe end" flex-shrink="0" width="50px" height="150px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="50" height="150"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_safe_align_self_end_overflow__border_box_rtl.xml
+++ b/tests/xml/flex/flex_safe_align_self_end_overflow__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="flex_safe_align_self_end_overflow__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" width="100px" height="100px">
+      <div direction="rtl" align-self="safe end" flex-shrink="0" width="50px" height="150px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="50" y="0" width="50" height="150"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_safe_align_self_end_overflow__content_box_ltr.xml
+++ b/tests/xml/flex/flex_safe_align_self_end_overflow__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="flex_safe_align_self_end_overflow__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" width="100px" height="100px">
+      <div box-sizing="content-box" direction="ltr" align-self="safe end" flex-shrink="0" width="50px" height="150px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="50" height="150"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_safe_align_self_end_overflow__content_box_rtl.xml
+++ b/tests/xml/flex/flex_safe_align_self_end_overflow__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="flex_safe_align_self_end_overflow__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" width="100px" height="100px">
+      <div box-sizing="content-box" direction="rtl" align-self="safe end" flex-shrink="0" width="50px" height="150px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="50" y="0" width="50" height="150"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_safe_justify_content_center_overflow__border_box_ltr.xml
+++ b/tests/xml/flex/flex_safe_justify_content_center_overflow__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="flex_safe_justify_content_center_overflow__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" justify-content="safe center" width="100px" height="100px">
+      <div direction="ltr" flex-shrink="0" width="80px" height="50px"/>
+      <div direction="ltr" flex-shrink="0" width="80px" height="50px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="80" height="50"/>
+      <node x="80" y="0" width="80" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_safe_justify_content_center_overflow__border_box_rtl.xml
+++ b/tests/xml/flex/flex_safe_justify_content_center_overflow__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="flex_safe_justify_content_center_overflow__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" justify-content="safe center" width="100px" height="100px">
+      <div direction="rtl" flex-shrink="0" width="80px" height="50px"/>
+      <div direction="rtl" flex-shrink="0" width="80px" height="50px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="20" y="0" width="80" height="50"/>
+      <node x="-60" y="0" width="80" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_safe_justify_content_center_overflow__content_box_ltr.xml
+++ b/tests/xml/flex/flex_safe_justify_content_center_overflow__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="flex_safe_justify_content_center_overflow__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" justify-content="safe center" width="100px" height="100px">
+      <div box-sizing="content-box" direction="ltr" flex-shrink="0" width="80px" height="50px"/>
+      <div box-sizing="content-box" direction="ltr" flex-shrink="0" width="80px" height="50px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="80" height="50"/>
+      <node x="80" y="0" width="80" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_safe_justify_content_center_overflow__content_box_rtl.xml
+++ b/tests/xml/flex/flex_safe_justify_content_center_overflow__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="flex_safe_justify_content_center_overflow__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" justify-content="safe center" width="100px" height="100px">
+      <div box-sizing="content-box" direction="rtl" flex-shrink="0" width="80px" height="50px"/>
+      <div box-sizing="content-box" direction="rtl" flex-shrink="0" width="80px" height="50px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="20" y="0" width="80" height="50"/>
+      <node x="-60" y="0" width="80" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_safe_justify_content_end_overflow__border_box_ltr.xml
+++ b/tests/xml/flex/flex_safe_justify_content_end_overflow__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="flex_safe_justify_content_end_overflow__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" justify-content="safe end" width="100px" height="100px">
+      <div direction="ltr" flex-shrink="0" width="80px" height="50px"/>
+      <div direction="ltr" flex-shrink="0" width="80px" height="50px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="80" height="50"/>
+      <node x="80" y="0" width="80" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_safe_justify_content_end_overflow__border_box_rtl.xml
+++ b/tests/xml/flex/flex_safe_justify_content_end_overflow__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="flex_safe_justify_content_end_overflow__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" justify-content="safe end" width="100px" height="100px">
+      <div direction="rtl" flex-shrink="0" width="80px" height="50px"/>
+      <div direction="rtl" flex-shrink="0" width="80px" height="50px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="20" y="0" width="80" height="50"/>
+      <node x="-60" y="0" width="80" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_safe_justify_content_end_overflow__content_box_ltr.xml
+++ b/tests/xml/flex/flex_safe_justify_content_end_overflow__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="flex_safe_justify_content_end_overflow__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" justify-content="safe end" width="100px" height="100px">
+      <div box-sizing="content-box" direction="ltr" flex-shrink="0" width="80px" height="50px"/>
+      <div box-sizing="content-box" direction="ltr" flex-shrink="0" width="80px" height="50px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="80" height="50"/>
+      <node x="80" y="0" width="80" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_safe_justify_content_end_overflow__content_box_rtl.xml
+++ b/tests/xml/flex/flex_safe_justify_content_end_overflow__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="flex_safe_justify_content_end_overflow__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" justify-content="safe end" width="100px" height="100px">
+      <div box-sizing="content-box" direction="rtl" flex-shrink="0" width="80px" height="50px"/>
+      <div box-sizing="content-box" direction="rtl" flex-shrink="0" width="80px" height="50px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="20" y="0" width="80" height="50"/>
+      <node x="-60" y="0" width="80" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_unsafe_align_self_end_overflow__border_box_ltr.xml
+++ b/tests/xml/flex/flex_unsafe_align_self_end_overflow__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="flex_unsafe_align_self_end_overflow__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" width="100px" height="100px">
+      <div direction="ltr" align-self="unsafe end" flex-shrink="0" width="50px" height="150px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="-50" width="50" height="150"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_unsafe_align_self_end_overflow__border_box_rtl.xml
+++ b/tests/xml/flex/flex_unsafe_align_self_end_overflow__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="flex_unsafe_align_self_end_overflow__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" width="100px" height="100px">
+      <div direction="rtl" align-self="unsafe end" flex-shrink="0" width="50px" height="150px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="50" y="-50" width="50" height="150"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_unsafe_align_self_end_overflow__content_box_ltr.xml
+++ b/tests/xml/flex/flex_unsafe_align_self_end_overflow__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="flex_unsafe_align_self_end_overflow__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" width="100px" height="100px">
+      <div box-sizing="content-box" direction="ltr" align-self="unsafe end" flex-shrink="0" width="50px" height="150px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="-50" width="50" height="150"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_unsafe_align_self_end_overflow__content_box_rtl.xml
+++ b/tests/xml/flex/flex_unsafe_align_self_end_overflow__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="flex_unsafe_align_self_end_overflow__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" width="100px" height="100px">
+      <div box-sizing="content-box" direction="rtl" align-self="unsafe end" flex-shrink="0" width="50px" height="150px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="50" y="-50" width="50" height="150"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_safe_align_content_center_overflow__border_box_ltr.xml
+++ b/tests/xml/grid/grid_safe_align_content_center_overflow__border_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="grid_safe_align_content_center_overflow__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" align-content="safe center" width="100px" height="100px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="40" height="40"/>
+      <node x="40" y="0" width="40" height="40"/>
+      <node x="80" y="0" width="40" height="40"/>
+      <node x="0" y="40" width="40" height="40"/>
+      <node x="40" y="40" width="40" height="40"/>
+      <node x="80" y="40" width="40" height="40"/>
+      <node x="0" y="80" width="40" height="40"/>
+      <node x="40" y="80" width="40" height="40"/>
+      <node x="80" y="80" width="40" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_safe_align_content_center_overflow__border_box_rtl.xml
+++ b/tests/xml/grid/grid_safe_align_content_center_overflow__border_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="grid_safe_align_content_center_overflow__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" align-content="safe center" width="100px" height="100px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="60" y="0" width="40" height="40"/>
+      <node x="20" y="0" width="40" height="40"/>
+      <node x="-20" y="0" width="40" height="40"/>
+      <node x="60" y="40" width="40" height="40"/>
+      <node x="20" y="40" width="40" height="40"/>
+      <node x="-20" y="40" width="40" height="40"/>
+      <node x="60" y="80" width="40" height="40"/>
+      <node x="20" y="80" width="40" height="40"/>
+      <node x="-20" y="80" width="40" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_safe_align_content_center_overflow__content_box_ltr.xml
+++ b/tests/xml/grid/grid_safe_align_content_center_overflow__content_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="grid_safe_align_content_center_overflow__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" align-content="safe center" width="100px" height="100px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="40" height="40"/>
+      <node x="40" y="0" width="40" height="40"/>
+      <node x="80" y="0" width="40" height="40"/>
+      <node x="0" y="40" width="40" height="40"/>
+      <node x="40" y="40" width="40" height="40"/>
+      <node x="80" y="40" width="40" height="40"/>
+      <node x="0" y="80" width="40" height="40"/>
+      <node x="40" y="80" width="40" height="40"/>
+      <node x="80" y="80" width="40" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_safe_align_content_center_overflow__content_box_rtl.xml
+++ b/tests/xml/grid/grid_safe_align_content_center_overflow__content_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="grid_safe_align_content_center_overflow__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" align-content="safe center" width="100px" height="100px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="60" y="0" width="40" height="40"/>
+      <node x="20" y="0" width="40" height="40"/>
+      <node x="-20" y="0" width="40" height="40"/>
+      <node x="60" y="40" width="40" height="40"/>
+      <node x="20" y="40" width="40" height="40"/>
+      <node x="-20" y="40" width="40" height="40"/>
+      <node x="60" y="80" width="40" height="40"/>
+      <node x="20" y="80" width="40" height="40"/>
+      <node x="-20" y="80" width="40" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_safe_align_content_end_overflow__border_box_ltr.xml
+++ b/tests/xml/grid/grid_safe_align_content_end_overflow__border_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="grid_safe_align_content_end_overflow__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" align-content="safe end" width="100px" height="100px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="40" height="40"/>
+      <node x="40" y="0" width="40" height="40"/>
+      <node x="80" y="0" width="40" height="40"/>
+      <node x="0" y="40" width="40" height="40"/>
+      <node x="40" y="40" width="40" height="40"/>
+      <node x="80" y="40" width="40" height="40"/>
+      <node x="0" y="80" width="40" height="40"/>
+      <node x="40" y="80" width="40" height="40"/>
+      <node x="80" y="80" width="40" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_safe_align_content_end_overflow__border_box_rtl.xml
+++ b/tests/xml/grid/grid_safe_align_content_end_overflow__border_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="grid_safe_align_content_end_overflow__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" align-content="safe end" width="100px" height="100px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="60" y="0" width="40" height="40"/>
+      <node x="20" y="0" width="40" height="40"/>
+      <node x="-20" y="0" width="40" height="40"/>
+      <node x="60" y="40" width="40" height="40"/>
+      <node x="20" y="40" width="40" height="40"/>
+      <node x="-20" y="40" width="40" height="40"/>
+      <node x="60" y="80" width="40" height="40"/>
+      <node x="20" y="80" width="40" height="40"/>
+      <node x="-20" y="80" width="40" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_safe_align_content_end_overflow__content_box_ltr.xml
+++ b/tests/xml/grid/grid_safe_align_content_end_overflow__content_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="grid_safe_align_content_end_overflow__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" align-content="safe end" width="100px" height="100px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="40" height="40"/>
+      <node x="40" y="0" width="40" height="40"/>
+      <node x="80" y="0" width="40" height="40"/>
+      <node x="0" y="40" width="40" height="40"/>
+      <node x="40" y="40" width="40" height="40"/>
+      <node x="80" y="40" width="40" height="40"/>
+      <node x="0" y="80" width="40" height="40"/>
+      <node x="40" y="80" width="40" height="40"/>
+      <node x="80" y="80" width="40" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_safe_align_content_end_overflow__content_box_rtl.xml
+++ b/tests/xml/grid/grid_safe_align_content_end_overflow__content_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="grid_safe_align_content_end_overflow__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" align-content="safe end" width="100px" height="100px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="60" y="0" width="40" height="40"/>
+      <node x="20" y="0" width="40" height="40"/>
+      <node x="-20" y="0" width="40" height="40"/>
+      <node x="60" y="40" width="40" height="40"/>
+      <node x="20" y="40" width="40" height="40"/>
+      <node x="-20" y="40" width="40" height="40"/>
+      <node x="60" y="80" width="40" height="40"/>
+      <node x="20" y="80" width="40" height="40"/>
+      <node x="-20" y="80" width="40" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_safe_align_self_end_no_overflow__border_box_ltr.xml
+++ b/tests/xml/grid/grid_safe_align_self_end_no_overflow__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_safe_align_self_end_no_overflow__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="100px" height="100px" grid-template-rows="100px" grid-template-columns="100px">
+      <div direction="ltr" align-self="safe end" width="50px" height="40px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="60" width="50" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_safe_align_self_end_no_overflow__border_box_rtl.xml
+++ b/tests/xml/grid/grid_safe_align_self_end_no_overflow__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_safe_align_self_end_no_overflow__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="100px" height="100px" grid-template-rows="100px" grid-template-columns="100px">
+      <div direction="rtl" align-self="safe end" width="50px" height="40px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="50" y="60" width="50" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_safe_align_self_end_no_overflow__content_box_ltr.xml
+++ b/tests/xml/grid/grid_safe_align_self_end_no_overflow__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_safe_align_self_end_no_overflow__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="100px" height="100px" grid-template-rows="100px" grid-template-columns="100px">
+      <div box-sizing="content-box" direction="ltr" align-self="safe end" width="50px" height="40px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="60" width="50" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_safe_align_self_end_no_overflow__content_box_rtl.xml
+++ b/tests/xml/grid/grid_safe_align_self_end_no_overflow__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_safe_align_self_end_no_overflow__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="100px" height="100px" grid-template-rows="100px" grid-template-columns="100px">
+      <div box-sizing="content-box" direction="rtl" align-self="safe end" width="50px" height="40px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="50" y="60" width="50" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_safe_align_self_end_overflow__border_box_ltr.xml
+++ b/tests/xml/grid/grid_safe_align_self_end_overflow__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_safe_align_self_end_overflow__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="100px" height="100px" grid-template-rows="100px" grid-template-columns="100px">
+      <div direction="ltr" align-self="safe end" width="50px" height="150px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="50" height="150"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_safe_align_self_end_overflow__border_box_rtl.xml
+++ b/tests/xml/grid/grid_safe_align_self_end_overflow__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_safe_align_self_end_overflow__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="100px" height="100px" grid-template-rows="100px" grid-template-columns="100px">
+      <div direction="rtl" align-self="safe end" width="50px" height="150px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="50" y="0" width="50" height="150"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_safe_align_self_end_overflow__content_box_ltr.xml
+++ b/tests/xml/grid/grid_safe_align_self_end_overflow__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_safe_align_self_end_overflow__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="100px" height="100px" grid-template-rows="100px" grid-template-columns="100px">
+      <div box-sizing="content-box" direction="ltr" align-self="safe end" width="50px" height="150px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="50" height="150"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_safe_align_self_end_overflow__content_box_rtl.xml
+++ b/tests/xml/grid/grid_safe_align_self_end_overflow__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_safe_align_self_end_overflow__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="100px" height="100px" grid-template-rows="100px" grid-template-columns="100px">
+      <div box-sizing="content-box" direction="rtl" align-self="safe end" width="50px" height="150px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="50" y="0" width="50" height="150"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_safe_justify_content_center_overflow__border_box_ltr.xml
+++ b/tests/xml/grid/grid_safe_justify_content_center_overflow__border_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="grid_safe_justify_content_center_overflow__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" justify-content="safe center" width="100px" height="100px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="40" height="40"/>
+      <node x="40" y="0" width="40" height="40"/>
+      <node x="80" y="0" width="40" height="40"/>
+      <node x="0" y="40" width="40" height="40"/>
+      <node x="40" y="40" width="40" height="40"/>
+      <node x="80" y="40" width="40" height="40"/>
+      <node x="0" y="80" width="40" height="40"/>
+      <node x="40" y="80" width="40" height="40"/>
+      <node x="80" y="80" width="40" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_safe_justify_content_center_overflow__border_box_rtl.xml
+++ b/tests/xml/grid/grid_safe_justify_content_center_overflow__border_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="grid_safe_justify_content_center_overflow__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" justify-content="safe center" width="100px" height="100px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="60" y="0" width="40" height="40"/>
+      <node x="20" y="0" width="40" height="40"/>
+      <node x="-20" y="0" width="40" height="40"/>
+      <node x="60" y="40" width="40" height="40"/>
+      <node x="20" y="40" width="40" height="40"/>
+      <node x="-20" y="40" width="40" height="40"/>
+      <node x="60" y="80" width="40" height="40"/>
+      <node x="20" y="80" width="40" height="40"/>
+      <node x="-20" y="80" width="40" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_safe_justify_content_center_overflow__content_box_ltr.xml
+++ b/tests/xml/grid/grid_safe_justify_content_center_overflow__content_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="grid_safe_justify_content_center_overflow__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" justify-content="safe center" width="100px" height="100px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="40" height="40"/>
+      <node x="40" y="0" width="40" height="40"/>
+      <node x="80" y="0" width="40" height="40"/>
+      <node x="0" y="40" width="40" height="40"/>
+      <node x="40" y="40" width="40" height="40"/>
+      <node x="80" y="40" width="40" height="40"/>
+      <node x="0" y="80" width="40" height="40"/>
+      <node x="40" y="80" width="40" height="40"/>
+      <node x="80" y="80" width="40" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_safe_justify_content_center_overflow__content_box_rtl.xml
+++ b/tests/xml/grid/grid_safe_justify_content_center_overflow__content_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="grid_safe_justify_content_center_overflow__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" justify-content="safe center" width="100px" height="100px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="60" y="0" width="40" height="40"/>
+      <node x="20" y="0" width="40" height="40"/>
+      <node x="-20" y="0" width="40" height="40"/>
+      <node x="60" y="40" width="40" height="40"/>
+      <node x="20" y="40" width="40" height="40"/>
+      <node x="-20" y="40" width="40" height="40"/>
+      <node x="60" y="80" width="40" height="40"/>
+      <node x="20" y="80" width="40" height="40"/>
+      <node x="-20" y="80" width="40" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_safe_justify_content_end_no_overflow__border_box_ltr.xml
+++ b/tests/xml/grid/grid_safe_justify_content_end_no_overflow__border_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="grid_safe_justify_content_end_no_overflow__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" justify-content="safe end" width="200px" height="200px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="80" y="0" width="40" height="40"/>
+      <node x="120" y="0" width="40" height="40"/>
+      <node x="160" y="0" width="40" height="40"/>
+      <node x="80" y="40" width="40" height="40"/>
+      <node x="120" y="40" width="40" height="40"/>
+      <node x="160" y="40" width="40" height="40"/>
+      <node x="80" y="80" width="40" height="40"/>
+      <node x="120" y="80" width="40" height="40"/>
+      <node x="160" y="80" width="40" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_safe_justify_content_end_no_overflow__border_box_rtl.xml
+++ b/tests/xml/grid/grid_safe_justify_content_end_no_overflow__border_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="grid_safe_justify_content_end_no_overflow__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" justify-content="safe end" width="200px" height="200px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="80" y="0" width="40" height="40"/>
+      <node x="40" y="0" width="40" height="40"/>
+      <node x="0" y="0" width="40" height="40"/>
+      <node x="80" y="40" width="40" height="40"/>
+      <node x="40" y="40" width="40" height="40"/>
+      <node x="0" y="40" width="40" height="40"/>
+      <node x="80" y="80" width="40" height="40"/>
+      <node x="40" y="80" width="40" height="40"/>
+      <node x="0" y="80" width="40" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_safe_justify_content_end_no_overflow__content_box_ltr.xml
+++ b/tests/xml/grid/grid_safe_justify_content_end_no_overflow__content_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="grid_safe_justify_content_end_no_overflow__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" justify-content="safe end" width="200px" height="200px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="80" y="0" width="40" height="40"/>
+      <node x="120" y="0" width="40" height="40"/>
+      <node x="160" y="0" width="40" height="40"/>
+      <node x="80" y="40" width="40" height="40"/>
+      <node x="120" y="40" width="40" height="40"/>
+      <node x="160" y="40" width="40" height="40"/>
+      <node x="80" y="80" width="40" height="40"/>
+      <node x="120" y="80" width="40" height="40"/>
+      <node x="160" y="80" width="40" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_safe_justify_content_end_no_overflow__content_box_rtl.xml
+++ b/tests/xml/grid/grid_safe_justify_content_end_no_overflow__content_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="grid_safe_justify_content_end_no_overflow__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" justify-content="safe end" width="200px" height="200px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="80" y="0" width="40" height="40"/>
+      <node x="40" y="0" width="40" height="40"/>
+      <node x="0" y="0" width="40" height="40"/>
+      <node x="80" y="40" width="40" height="40"/>
+      <node x="40" y="40" width="40" height="40"/>
+      <node x="0" y="40" width="40" height="40"/>
+      <node x="80" y="80" width="40" height="40"/>
+      <node x="40" y="80" width="40" height="40"/>
+      <node x="0" y="80" width="40" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_safe_justify_content_end_overflow__border_box_ltr.xml
+++ b/tests/xml/grid/grid_safe_justify_content_end_overflow__border_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="grid_safe_justify_content_end_overflow__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" justify-content="safe end" width="100px" height="100px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="40" height="40"/>
+      <node x="40" y="0" width="40" height="40"/>
+      <node x="80" y="0" width="40" height="40"/>
+      <node x="0" y="40" width="40" height="40"/>
+      <node x="40" y="40" width="40" height="40"/>
+      <node x="80" y="40" width="40" height="40"/>
+      <node x="0" y="80" width="40" height="40"/>
+      <node x="40" y="80" width="40" height="40"/>
+      <node x="80" y="80" width="40" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_safe_justify_content_end_overflow__border_box_rtl.xml
+++ b/tests/xml/grid/grid_safe_justify_content_end_overflow__border_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="grid_safe_justify_content_end_overflow__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" justify-content="safe end" width="100px" height="100px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="60" y="0" width="40" height="40"/>
+      <node x="20" y="0" width="40" height="40"/>
+      <node x="-20" y="0" width="40" height="40"/>
+      <node x="60" y="40" width="40" height="40"/>
+      <node x="20" y="40" width="40" height="40"/>
+      <node x="-20" y="40" width="40" height="40"/>
+      <node x="60" y="80" width="40" height="40"/>
+      <node x="20" y="80" width="40" height="40"/>
+      <node x="-20" y="80" width="40" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_safe_justify_content_end_overflow__content_box_ltr.xml
+++ b/tests/xml/grid/grid_safe_justify_content_end_overflow__content_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="grid_safe_justify_content_end_overflow__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" justify-content="safe end" width="100px" height="100px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="40" height="40"/>
+      <node x="40" y="0" width="40" height="40"/>
+      <node x="80" y="0" width="40" height="40"/>
+      <node x="0" y="40" width="40" height="40"/>
+      <node x="40" y="40" width="40" height="40"/>
+      <node x="80" y="40" width="40" height="40"/>
+      <node x="0" y="80" width="40" height="40"/>
+      <node x="40" y="80" width="40" height="40"/>
+      <node x="80" y="80" width="40" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_safe_justify_content_end_overflow__content_box_rtl.xml
+++ b/tests/xml/grid/grid_safe_justify_content_end_overflow__content_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="grid_safe_justify_content_end_overflow__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" justify-content="safe end" width="100px" height="100px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="60" y="0" width="40" height="40"/>
+      <node x="20" y="0" width="40" height="40"/>
+      <node x="-20" y="0" width="40" height="40"/>
+      <node x="60" y="40" width="40" height="40"/>
+      <node x="20" y="40" width="40" height="40"/>
+      <node x="-20" y="40" width="40" height="40"/>
+      <node x="60" y="80" width="40" height="40"/>
+      <node x="20" y="80" width="40" height="40"/>
+      <node x="-20" y="80" width="40" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_safe_justify_self_center_overflow__border_box_ltr.xml
+++ b/tests/xml/grid/grid_safe_justify_self_center_overflow__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_safe_justify_self_center_overflow__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="100px" height="100px" grid-template-rows="100px" grid-template-columns="100px">
+      <div direction="ltr" justify-self="safe center" width="150px" height="50px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="150" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_safe_justify_self_center_overflow__border_box_rtl.xml
+++ b/tests/xml/grid/grid_safe_justify_self_center_overflow__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_safe_justify_self_center_overflow__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="100px" height="100px" grid-template-rows="100px" grid-template-columns="100px">
+      <div direction="rtl" justify-self="safe center" width="150px" height="50px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="-50" y="0" width="150" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_safe_justify_self_center_overflow__content_box_ltr.xml
+++ b/tests/xml/grid/grid_safe_justify_self_center_overflow__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_safe_justify_self_center_overflow__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="100px" height="100px" grid-template-rows="100px" grid-template-columns="100px">
+      <div box-sizing="content-box" direction="ltr" justify-self="safe center" width="150px" height="50px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="150" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_safe_justify_self_center_overflow__content_box_rtl.xml
+++ b/tests/xml/grid/grid_safe_justify_self_center_overflow__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_safe_justify_self_center_overflow__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="100px" height="100px" grid-template-rows="100px" grid-template-columns="100px">
+      <div box-sizing="content-box" direction="rtl" justify-self="safe center" width="150px" height="50px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="-50" y="0" width="150" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_safe_justify_self_end_overflow__border_box_ltr.xml
+++ b/tests/xml/grid/grid_safe_justify_self_end_overflow__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_safe_justify_self_end_overflow__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="100px" height="100px" grid-template-rows="100px" grid-template-columns="100px">
+      <div direction="ltr" justify-self="safe end" width="150px" height="50px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="150" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_safe_justify_self_end_overflow__border_box_rtl.xml
+++ b/tests/xml/grid/grid_safe_justify_self_end_overflow__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_safe_justify_self_end_overflow__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="100px" height="100px" grid-template-rows="100px" grid-template-columns="100px">
+      <div direction="rtl" justify-self="safe end" width="150px" height="50px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="-50" y="0" width="150" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_safe_justify_self_end_overflow__content_box_ltr.xml
+++ b/tests/xml/grid/grid_safe_justify_self_end_overflow__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_safe_justify_self_end_overflow__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="100px" height="100px" grid-template-rows="100px" grid-template-columns="100px">
+      <div box-sizing="content-box" direction="ltr" justify-self="safe end" width="150px" height="50px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="150" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_safe_justify_self_end_overflow__content_box_rtl.xml
+++ b/tests/xml/grid/grid_safe_justify_self_end_overflow__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_safe_justify_self_end_overflow__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="100px" height="100px" grid-template-rows="100px" grid-template-columns="100px">
+      <div box-sizing="content-box" direction="rtl" justify-self="safe end" width="150px" height="50px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="-50" y="0" width="150" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_unsafe_align_self_end_overflow__border_box_ltr.xml
+++ b/tests/xml/grid/grid_unsafe_align_self_end_overflow__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_unsafe_align_self_end_overflow__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="100px" height="100px" grid-template-rows="100px" grid-template-columns="100px">
+      <div direction="ltr" align-self="unsafe end" width="50px" height="150px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="-50" width="50" height="150"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_unsafe_align_self_end_overflow__border_box_rtl.xml
+++ b/tests/xml/grid/grid_unsafe_align_self_end_overflow__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_unsafe_align_self_end_overflow__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="100px" height="100px" grid-template-rows="100px" grid-template-columns="100px">
+      <div direction="rtl" align-self="unsafe end" width="50px" height="150px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="50" y="-50" width="50" height="150"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_unsafe_align_self_end_overflow__content_box_ltr.xml
+++ b/tests/xml/grid/grid_unsafe_align_self_end_overflow__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_unsafe_align_self_end_overflow__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="100px" height="100px" grid-template-rows="100px" grid-template-columns="100px">
+      <div box-sizing="content-box" direction="ltr" align-self="unsafe end" width="50px" height="150px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="-50" width="50" height="150"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_unsafe_align_self_end_overflow__content_box_rtl.xml
+++ b/tests/xml/grid/grid_unsafe_align_self_end_overflow__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_unsafe_align_self_end_overflow__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="100px" height="100px" grid-template-rows="100px" grid-template-columns="100px">
+      <div box-sizing="content-box" direction="rtl" align-self="unsafe end" width="50px" height="150px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="50" y="-50" width="50" height="150"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_unsafe_justify_content_end_overflow__border_box_ltr.xml
+++ b/tests/xml/grid/grid_unsafe_justify_content_end_overflow__border_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="grid_unsafe_justify_content_end_overflow__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" justify-content="unsafe end" width="100px" height="100px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="-20" y="0" width="40" height="40"/>
+      <node x="20" y="0" width="40" height="40"/>
+      <node x="60" y="0" width="40" height="40"/>
+      <node x="-20" y="40" width="40" height="40"/>
+      <node x="20" y="40" width="40" height="40"/>
+      <node x="60" y="40" width="40" height="40"/>
+      <node x="-20" y="80" width="40" height="40"/>
+      <node x="20" y="80" width="40" height="40"/>
+      <node x="60" y="80" width="40" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_unsafe_justify_content_end_overflow__border_box_rtl.xml
+++ b/tests/xml/grid/grid_unsafe_justify_content_end_overflow__border_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="grid_unsafe_justify_content_end_overflow__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" justify-content="unsafe end" width="100px" height="100px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="80" y="0" width="40" height="40"/>
+      <node x="40" y="0" width="40" height="40"/>
+      <node x="0" y="0" width="40" height="40"/>
+      <node x="80" y="40" width="40" height="40"/>
+      <node x="40" y="40" width="40" height="40"/>
+      <node x="0" y="40" width="40" height="40"/>
+      <node x="80" y="80" width="40" height="40"/>
+      <node x="40" y="80" width="40" height="40"/>
+      <node x="0" y="80" width="40" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_unsafe_justify_content_end_overflow__content_box_ltr.xml
+++ b/tests/xml/grid/grid_unsafe_justify_content_end_overflow__content_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="grid_unsafe_justify_content_end_overflow__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" justify-content="unsafe end" width="100px" height="100px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="-20" y="0" width="40" height="40"/>
+      <node x="20" y="0" width="40" height="40"/>
+      <node x="60" y="0" width="40" height="40"/>
+      <node x="-20" y="40" width="40" height="40"/>
+      <node x="20" y="40" width="40" height="40"/>
+      <node x="60" y="40" width="40" height="40"/>
+      <node x="-20" y="80" width="40" height="40"/>
+      <node x="20" y="80" width="40" height="40"/>
+      <node x="60" y="80" width="40" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_unsafe_justify_content_end_overflow__content_box_rtl.xml
+++ b/tests/xml/grid/grid_unsafe_justify_content_end_overflow__content_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="grid_unsafe_justify_content_end_overflow__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" justify-content="unsafe end" width="100px" height="100px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="80" y="0" width="40" height="40"/>
+      <node x="40" y="0" width="40" height="40"/>
+      <node x="0" y="0" width="40" height="40"/>
+      <node x="80" y="40" width="40" height="40"/>
+      <node x="40" y="40" width="40" height="40"/>
+      <node x="0" y="40" width="40" height="40"/>
+      <node x="80" y="80" width="40" height="40"/>
+      <node x="40" y="80" width="40" height="40"/>
+      <node x="0" y="80" width="40" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -10282,6 +10282,106 @@ mod flex {
     }
 
     #[test]
+    fn flex_safe_align_content_end_overflow__border_box_ltr() {
+        crate::run_xml_test("flex", "flex_safe_align_content_end_overflow__border_box_ltr");
+    }
+
+    #[test]
+    fn flex_safe_align_content_end_overflow__content_box_ltr() {
+        crate::run_xml_test("flex", "flex_safe_align_content_end_overflow__content_box_ltr");
+    }
+
+    #[test]
+    fn flex_safe_align_content_end_overflow__border_box_rtl() {
+        crate::run_xml_test("flex", "flex_safe_align_content_end_overflow__border_box_rtl");
+    }
+
+    #[test]
+    fn flex_safe_align_content_end_overflow__content_box_rtl() {
+        crate::run_xml_test("flex", "flex_safe_align_content_end_overflow__content_box_rtl");
+    }
+
+    #[test]
+    fn flex_safe_align_self_center_overflow__border_box_ltr() {
+        crate::run_xml_test("flex", "flex_safe_align_self_center_overflow__border_box_ltr");
+    }
+
+    #[test]
+    fn flex_safe_align_self_center_overflow__content_box_ltr() {
+        crate::run_xml_test("flex", "flex_safe_align_self_center_overflow__content_box_ltr");
+    }
+
+    #[test]
+    fn flex_safe_align_self_center_overflow__border_box_rtl() {
+        crate::run_xml_test("flex", "flex_safe_align_self_center_overflow__border_box_rtl");
+    }
+
+    #[test]
+    fn flex_safe_align_self_center_overflow__content_box_rtl() {
+        crate::run_xml_test("flex", "flex_safe_align_self_center_overflow__content_box_rtl");
+    }
+
+    #[test]
+    fn flex_safe_align_self_end_overflow__border_box_ltr() {
+        crate::run_xml_test("flex", "flex_safe_align_self_end_overflow__border_box_ltr");
+    }
+
+    #[test]
+    fn flex_safe_align_self_end_overflow__content_box_ltr() {
+        crate::run_xml_test("flex", "flex_safe_align_self_end_overflow__content_box_ltr");
+    }
+
+    #[test]
+    fn flex_safe_align_self_end_overflow__border_box_rtl() {
+        crate::run_xml_test("flex", "flex_safe_align_self_end_overflow__border_box_rtl");
+    }
+
+    #[test]
+    fn flex_safe_align_self_end_overflow__content_box_rtl() {
+        crate::run_xml_test("flex", "flex_safe_align_self_end_overflow__content_box_rtl");
+    }
+
+    #[test]
+    fn flex_safe_justify_content_center_overflow__border_box_ltr() {
+        crate::run_xml_test("flex", "flex_safe_justify_content_center_overflow__border_box_ltr");
+    }
+
+    #[test]
+    fn flex_safe_justify_content_center_overflow__content_box_ltr() {
+        crate::run_xml_test("flex", "flex_safe_justify_content_center_overflow__content_box_ltr");
+    }
+
+    #[test]
+    fn flex_safe_justify_content_center_overflow__border_box_rtl() {
+        crate::run_xml_test("flex", "flex_safe_justify_content_center_overflow__border_box_rtl");
+    }
+
+    #[test]
+    fn flex_safe_justify_content_center_overflow__content_box_rtl() {
+        crate::run_xml_test("flex", "flex_safe_justify_content_center_overflow__content_box_rtl");
+    }
+
+    #[test]
+    fn flex_safe_justify_content_end_overflow__border_box_ltr() {
+        crate::run_xml_test("flex", "flex_safe_justify_content_end_overflow__border_box_ltr");
+    }
+
+    #[test]
+    fn flex_safe_justify_content_end_overflow__content_box_ltr() {
+        crate::run_xml_test("flex", "flex_safe_justify_content_end_overflow__content_box_ltr");
+    }
+
+    #[test]
+    fn flex_safe_justify_content_end_overflow__border_box_rtl() {
+        crate::run_xml_test("flex", "flex_safe_justify_content_end_overflow__border_box_rtl");
+    }
+
+    #[test]
+    fn flex_safe_justify_content_end_overflow__content_box_rtl() {
+        crate::run_xml_test("flex", "flex_safe_justify_content_end_overflow__content_box_rtl");
+    }
+
+    #[test]
     fn flex_shrink_by_outer_margin_with_max_size__border_box_ltr() {
         crate::run_xml_test("flex", "flex_shrink_by_outer_margin_with_max_size__border_box_ltr");
     }
@@ -10359,6 +10459,26 @@ mod flex {
     #[test]
     fn flex_shrink_to_zero__content_box_rtl() {
         crate::run_xml_test("flex", "flex_shrink_to_zero__content_box_rtl");
+    }
+
+    #[test]
+    fn flex_unsafe_align_self_end_overflow__border_box_ltr() {
+        crate::run_xml_test("flex", "flex_unsafe_align_self_end_overflow__border_box_ltr");
+    }
+
+    #[test]
+    fn flex_unsafe_align_self_end_overflow__content_box_ltr() {
+        crate::run_xml_test("flex", "flex_unsafe_align_self_end_overflow__content_box_ltr");
+    }
+
+    #[test]
+    fn flex_unsafe_align_self_end_overflow__border_box_rtl() {
+        crate::run_xml_test("flex", "flex_unsafe_align_self_end_overflow__border_box_rtl");
+    }
+
+    #[test]
+    fn flex_unsafe_align_self_end_overflow__content_box_rtl() {
+        crate::run_xml_test("flex", "flex_unsafe_align_self_end_overflow__content_box_rtl");
     }
 
     #[test]
@@ -21887,6 +22007,222 @@ mod grid {
 
     #[cfg(feature = "grid")]
     #[test]
+    fn grid_safe_align_content_center_overflow__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_safe_align_content_center_overflow__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_safe_align_content_center_overflow__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_safe_align_content_center_overflow__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_safe_align_content_center_overflow__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_safe_align_content_center_overflow__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_safe_align_content_center_overflow__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_safe_align_content_center_overflow__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_safe_align_content_end_overflow__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_safe_align_content_end_overflow__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_safe_align_content_end_overflow__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_safe_align_content_end_overflow__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_safe_align_content_end_overflow__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_safe_align_content_end_overflow__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_safe_align_content_end_overflow__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_safe_align_content_end_overflow__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_safe_align_self_end_no_overflow__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_safe_align_self_end_no_overflow__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_safe_align_self_end_no_overflow__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_safe_align_self_end_no_overflow__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_safe_align_self_end_no_overflow__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_safe_align_self_end_no_overflow__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_safe_align_self_end_no_overflow__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_safe_align_self_end_no_overflow__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_safe_align_self_end_overflow__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_safe_align_self_end_overflow__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_safe_align_self_end_overflow__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_safe_align_self_end_overflow__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_safe_align_self_end_overflow__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_safe_align_self_end_overflow__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_safe_align_self_end_overflow__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_safe_align_self_end_overflow__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_safe_justify_content_center_overflow__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_safe_justify_content_center_overflow__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_safe_justify_content_center_overflow__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_safe_justify_content_center_overflow__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_safe_justify_content_center_overflow__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_safe_justify_content_center_overflow__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_safe_justify_content_center_overflow__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_safe_justify_content_center_overflow__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_safe_justify_content_end_no_overflow__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_safe_justify_content_end_no_overflow__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_safe_justify_content_end_no_overflow__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_safe_justify_content_end_no_overflow__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_safe_justify_content_end_no_overflow__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_safe_justify_content_end_no_overflow__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_safe_justify_content_end_no_overflow__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_safe_justify_content_end_no_overflow__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_safe_justify_content_end_overflow__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_safe_justify_content_end_overflow__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_safe_justify_content_end_overflow__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_safe_justify_content_end_overflow__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_safe_justify_content_end_overflow__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_safe_justify_content_end_overflow__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_safe_justify_content_end_overflow__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_safe_justify_content_end_overflow__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_safe_justify_self_center_overflow__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_safe_justify_self_center_overflow__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_safe_justify_self_center_overflow__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_safe_justify_self_center_overflow__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_safe_justify_self_center_overflow__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_safe_justify_self_center_overflow__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_safe_justify_self_center_overflow__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_safe_justify_self_center_overflow__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_safe_justify_self_end_overflow__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_safe_justify_self_end_overflow__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_safe_justify_self_end_overflow__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_safe_justify_self_end_overflow__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_safe_justify_self_end_overflow__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_safe_justify_self_end_overflow__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_safe_justify_self_end_overflow__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_safe_justify_self_end_overflow__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
     fn grid_scrollbar_rtl__border_box_ltr() {
         crate::run_xml_test("grid", "grid_scrollbar_rtl__border_box_ltr");
     }
@@ -22483,6 +22819,54 @@ mod grid {
     #[test]
     fn grid_taffy_issue_624__content_box_rtl() {
         crate::run_xml_test("grid", "grid_taffy_issue_624__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_unsafe_align_self_end_overflow__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_unsafe_align_self_end_overflow__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_unsafe_align_self_end_overflow__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_unsafe_align_self_end_overflow__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_unsafe_align_self_end_overflow__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_unsafe_align_self_end_overflow__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_unsafe_align_self_end_overflow__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_unsafe_align_self_end_overflow__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_unsafe_justify_content_end_overflow__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_unsafe_justify_content_end_overflow__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_unsafe_justify_content_end_overflow__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_unsafe_justify_content_end_overflow__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_unsafe_justify_content_end_overflow__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_unsafe_justify_content_end_overflow__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_unsafe_justify_content_end_overflow__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_unsafe_justify_content_end_overflow__content_box_rtl");
     }
 }
 


### PR DESCRIPTION
## Summary

Implements the CSS `safe` / `unsafe` overflow-position keywords for all alignment properties in Flexbox and CSS Grid. Closes #550.

`safe` falls back to logical `Start` when the alignment subject overflows its container, preventing data loss at the start edge. Existing variants are unchanged and remain equivalent to `unsafe`.

## Changes

- **Types**: 5 new variants: `SafeStart`, `SafeEnd`, `SafeFlexStart`, `SafeFlexEnd`, `SafeCenter` on `AlignItems` and `AlignContent` (aliases `AlignSelf` / `JustifyItems` / `JustifySelf` / `JustifyContent` inherit them). Added `is_safe()` and `position()` helpers. `AlignContent::reversed()` extended for RTL pairing.
- **Parser**: hand-rolled `FromCss` for `safe <position>` and `unsafe <position>`. Rejects spec-invalid combinations (`safe stretch`, `safe baseline`, `safe space-*`).
- **Compute**: `apply_alignment_fallback` folds the `Safe*` modifier into its `is_safe` flag, so grid-track, flex `justify-content`, and flex `align-content` are wired through automatically. Self-alignment paths (`align_item_within_area` for grid, `align_flex_items_along_cross_axis` for flex) explicitly apply the Start fallback on overflow, RTL- and wrap-reverse-aware.
- **Docs**: new section in `docs/style-properties.md`.

## Tests

- 16 unit tests (helpers, `reversed()`, parser).
- 10 hand-written integration tests covering safe overflow, no-overflow, unsafe regression, RTL fallback, and multi-line flex `align-content`.
- 17 gentest fixtures → 68 generated XML expectations. All match the local Chrome render.

4500 tests pass, 0 failures.

## Known limitation

The two absolutely-positioned flex paths in `compute/flexbox.rs` strip `Safe*` via `.position()` but do not apply the Start overflow fallback. Marked `TODO (safe alignment)` in code. Happy to land as a follow-up.

## Test plan

- [x] `cargo build --all-features`
- [x] `cargo test --all-features`
- [x] `cargo doc --all-features --no-deps`
- [x] `cargo run -p gentest` — 68 new fixtures match Chrome byte-for-byte
- [ ] Confirm `Safe*`-variants approach over a `safe: bool` field
- [ ] Confirm CHANGELOG handling (left untouched per release-prep convention)
