### PR TITLE
Fixing grid content size computation

### DIFF
--- a/src/compute/grid/alignment.rs
+++ b/src/compute/grid/alignment.rs
@@ -278,12 +278,8 @@ pub(super) fn align_and_position_item(
     );
 
     #[cfg(feature = "content_size")]
-    let contribution = compute_content_size_contribution(
-        Point { x: x - grid_area.left, y: y - grid_area.top },
-        Size { width, height },
-        layout_output.content_size,
-        overflow,
-    );
+    let contribution =
+        compute_content_size_contribution(Point { x, y }, Size { width, height }, layout_output.content_size, overflow);
     #[cfg(not(feature = "content_size"))]
     let contribution = Size::ZERO;
 

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -648,6 +648,20 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
         }
     });
 
+    #[cfg(feature = "content_size")]
+    let final_content_size = Size {
+        width: crate::util::sys::f32_max(
+            item_content_size_contribution.width,
+            columns.iter().map(|t| t.base_size).sum::<f32>() + padding_border_size.width,
+        ),
+        height: crate::util::sys::f32_max(
+            item_content_size_contribution.height,
+            rows.iter().map(|t| t.base_size).sum::<f32>() + padding_border_size.height,
+        ),
+    };
+    #[cfg(not(feature = "content_size"))]
+    let final_content_size = Size::ZERO;
+
     // Set detailed grid information
     #[cfg(feature = "detailed_layout_info")]
     tree.set_detailed_grid_info(
@@ -689,7 +703,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
 
     LayoutOutput::from_sizes_and_baselines(
         container_border_box,
-        item_content_size_contribution,
+        final_content_size,
         Point { x: None, y: Some(grid_container_baseline) },
     )
 }

--- a/tests/grid_empty_track.rs
+++ b/tests/grid_empty_track.rs
@@ -1,0 +1,30 @@
+use taffy::prelude::*;
+use taffy::{Overflow, Point};
+
+#[test]
+fn grid_content_size_empty_track() {
+    let mut taffy: TaffyTree<()> = TaffyTree::new();
+
+    let child_style = Style { size: Size { width: length(50.0), height: length(50.0) }, ..Default::default() };
+
+    let child = taffy.new_leaf(child_style).unwrap();
+
+    let grid_style = Style {
+        display: Display::Grid,
+        size: Size { width: length(100.0), height: length(100.0) },
+        grid_template_rows: vec![length(500.0)],
+        overflow: Point { x: Overflow::Scroll, y: Overflow::Scroll },
+        ..Default::default()
+    };
+
+    let grid = taffy.new_with_children(grid_style, &[child]).unwrap();
+
+    taffy.compute_layout(grid, Size::MAX_CONTENT).unwrap();
+
+    let layout = taffy.layout(grid).unwrap();
+    println!("Grid layout size: {:?}", layout.size);
+    println!("Grid layout content_size: {:?}", layout.content_size);
+
+    // The content size should be at least 500.0 because of the explicit track!
+    assert_eq!(layout.content_size.height, 500.0, "Content height should include empty tracks");
+}

--- a/tests/grid_scroll.rs
+++ b/tests/grid_scroll.rs
@@ -1,0 +1,29 @@
+use taffy::prelude::*;
+
+#[test]
+fn grid_content_size_overflow() {
+    let mut taffy: TaffyTree<()> = TaffyTree::new();
+
+    let child_style = Style { size: Size { width: length(100.0), height: length(100.0) }, ..Default::default() };
+
+    let children = (0..6).map(|_| taffy.new_leaf(child_style.clone()).unwrap()).collect::<Vec<_>>();
+
+    let grid_style = Style {
+        display: Display::Grid,
+        size: Size { width: length(200.0), height: length(150.0) },
+        grid_template_columns: vec![minmax(length(100.0), fr(1.0))],
+        ..Default::default()
+    };
+
+    let grid = taffy.new_with_children(grid_style, &children).unwrap();
+
+    taffy.compute_layout(grid, Size::MAX_CONTENT).unwrap();
+
+    let layout = taffy.layout(grid).unwrap();
+    println!("Grid layout size: {:?}", layout.size);
+    println!("Grid layout content_size: {:?}", layout.content_size);
+    for child in children {
+        println!("Child layout: {:?}", taffy.layout(child).unwrap());
+    }
+    assert_eq!(layout.content_size.height, 600.0, "Content height should include all tracks");
+}


### PR DESCRIPTION
# Objective

This PR fixes #954 

## Context

I realized that scrolling wasn't working on Blitz and I figured out it was because the content size was incorrectly computed. The whole issue is described in #954.

## Feedback wanted

Let me know if you want me to re-organize the tests somehow.