### PR TITLE
Fix grid content size calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- CSS Grid content size now includes explicit track extents and auto-placed item positions (#954)
+
 ## 0.10.1
 
 ### Fixed

--- a/src/compute/grid/alignment.rs
+++ b/src/compute/grid/alignment.rs
@@ -68,6 +68,7 @@ pub(super) fn align_and_position_item(
     node: NodeId,
     order: u32,
     grid_area: Rect<f32>,
+    content_box_origin: Point<f32>,
     container_alignment_styles: InBothAbsAxis<Option<AlignItems>>,
     baseline_shim: f32,
     direction: Direction,
@@ -279,7 +280,7 @@ pub(super) fn align_and_position_item(
 
     #[cfg(feature = "content_size")]
     let contribution = compute_content_size_contribution(
-        Point { x: x - grid_area.left, y: y - grid_area.top },
+        Point { x: x - content_box_origin.x, y: y - content_box_origin.y },
         Size { width, height },
         layout_output.content_size,
         overflow,

--- a/src/compute/grid/alignment.rs
+++ b/src/compute/grid/alignment.rs
@@ -63,6 +63,7 @@ pub(super) fn align_tracks(
 }
 
 /// Align and size a grid item into it's final position
+#[allow(clippy::too_many_arguments)]
 pub(super) fn align_and_position_item(
     tree: &mut impl LayoutGridContainer,
     node: NodeId,

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -521,7 +521,14 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
 
     // 9. Size, Align, and Position Grid Items
 
-    #[cfg_attr(not(feature = "content_size"), allow(unused_mut))]
+    let content_box_origin = Point { x: content_box_inset.left, y: content_box_inset.top };
+
+    #[cfg(feature = "content_size")]
+    let mut item_content_size_contribution = Size {
+        width: grid_axis_content_size_contribution(&columns, content_box_origin.x),
+        height: grid_axis_content_size_contribution(&rows, content_box_origin.y),
+    };
+    #[cfg(not(feature = "content_size"))]
     let mut item_content_size_contribution = Size::ZERO;
 
     // Sort items back into original order to allow them to be matched up with styles
@@ -543,6 +550,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
             item.node,
             index as u32,
             grid_area,
+            content_box_origin,
             container_alignment_styles,
             item.baseline_shim,
             direction,
@@ -637,8 +645,16 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
 
             // TODO: Baseline alignment support for absolutely positioned items (should check if is actually specified)
             #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
-            let (content_size_contribution, _, _) =
-                align_and_position_item(tree, child, order, grid_area, container_alignment_styles, 0.0, direction);
+            let (content_size_contribution, _, _) = align_and_position_item(
+                tree,
+                child,
+                order,
+                grid_area,
+                content_box_origin,
+                container_alignment_styles,
+                0.0,
+                direction,
+            );
             #[cfg(feature = "content_size")]
             {
                 item_content_size_contribution = item_content_size_contribution.f32_max(content_size_contribution);
@@ -661,7 +677,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
 
     // If there are not items then return just the container size (no baseline)
     if items.is_empty() {
-        return LayoutOutput::from_outer_size(container_border_box);
+        return LayoutOutput::from_sizes(container_border_box, item_content_size_contribution);
     }
 
     // Determine the grid container baseline(s) (currently we only compute the first baseline)
@@ -692,6 +708,13 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
         item_content_size_contribution,
         Point { x: None, y: Some(grid_container_baseline) },
     )
+}
+
+#[cfg(feature = "content_size")]
+fn grid_axis_content_size_contribution(tracks: &[GridTrack], content_box_start: f32) -> f32 {
+    tracks
+        .iter()
+        .fold(0.0, |content_size, track| f32_max(content_size, track.offset + track.base_size - content_box_start))
 }
 
 /// Reverses only non-gutter column tracks in-place while preserving line/gutter slots.

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -711,6 +711,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
 }
 
 #[cfg(feature = "content_size")]
+/// Compute the content-size contribution of a grid axis from its aligned track extents.
 fn grid_axis_content_size_contribution(tracks: &[GridTrack], content_box_start: f32) -> f32 {
     tracks
         .iter()

--- a/tests/hand_written.rs
+++ b/tests/hand_written.rs
@@ -1,6 +1,7 @@
 mod hand_written {
     mod border_and_padding;
     mod caching;
+    mod grid_content_size;
     mod measure;
     mod min_max_overrides;
     mod relayout;

--- a/tests/hand_written/grid_content_size.rs
+++ b/tests/hand_written/grid_content_size.rs
@@ -1,0 +1,54 @@
+use taffy::prelude::*;
+use taffy::{Overflow, Point};
+
+#[test]
+#[cfg(feature = "grid")]
+fn grid_content_size_includes_explicit_tracks() {
+    let mut taffy: TaffyTree<()> = TaffyTree::new();
+
+    let child = taffy
+        .new_leaf(Style { size: Size { width: length(50.0), height: length(50.0) }, ..Default::default() })
+        .unwrap();
+
+    let grid = taffy
+        .new_with_children(
+            Style {
+                display: Display::Grid,
+                size: Size { width: length(100.0), height: length(100.0) },
+                grid_template_rows: vec![length(500.0)],
+                overflow: Point { x: Overflow::Scroll, y: Overflow::Scroll },
+                ..Default::default()
+            },
+            &[child],
+        )
+        .unwrap();
+
+    taffy.compute_layout(grid, Size::MAX_CONTENT).unwrap();
+
+    assert_eq!(taffy.layout(grid).unwrap().content_size.height, 500.0);
+}
+
+#[test]
+#[cfg(feature = "grid")]
+fn grid_content_size_includes_auto_placed_rows() {
+    let mut taffy: TaffyTree<()> = TaffyTree::new();
+
+    let child_style = Style { size: Size { width: length(100.0), height: length(100.0) }, ..Default::default() };
+    let children = (0..6).map(|_| taffy.new_leaf(child_style.clone()).unwrap()).collect::<Vec<_>>();
+
+    let grid = taffy
+        .new_with_children(
+            Style {
+                display: Display::Grid,
+                size: Size { width: length(200.0), height: length(150.0) },
+                grid_template_columns: vec![minmax(length(100.0), fr(1.0))],
+                ..Default::default()
+            },
+            &children,
+        )
+        .unwrap();
+
+    taffy.compute_layout(grid, Size::MAX_CONTENT).unwrap();
+
+    assert_eq!(taffy.layout(grid).unwrap().content_size.height, 600.0);
+}


### PR DESCRIPTION
# Objective

Fixes #954

Correct CSS Grid content-size computation so it accounts for explicit track extents and the actual content-box-relative position of placed items. This fixes cases where scrollable grid content only reflected one item or a smaller child instead of the full grid track span.

# Context

Previously grid item content-size contribution was calculated relative to each item's grid area. That reset the contribution for every row, so stacked auto-placed items all appeared to start at zero. Grid content size also started from zero, so an explicit track larger than its item was ignored.

This change seeds grid content size from the aligned track extents and measures item contribution from the grid content box origin.

# Tests

- `CARGO_HOME=$PWD/.cargo-home CARGO_TARGET_DIR=$PWD/target cargo test --test hand_written grid_content_size`
- `CARGO_HOME=$PWD/.cargo-home CARGO_TARGET_DIR=$PWD/target cargo test --test hand_written`
- `CARGO_HOME=$PWD/.cargo-home CARGO_TARGET_DIR=$PWD/target cargo test --lib`
- `CARGO_HOME=$PWD/.cargo-home CARGO_TARGET_DIR=$PWD/target cargo test --test xml content_size`
- `CARGO_HOME=$PWD/.cargo-home CARGO_TARGET_DIR=$PWD/target cargo test --workspace`
- `CARGO_HOME=$PWD/.cargo-home CARGO_TARGET_DIR=$PWD/target cargo fmt --all -- --check`
- `git diff --check`
