### PR TITLE
Use SCREAMING_SNAKE_CASE for alignment constants

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -11,7 +11,7 @@ fn main() -> Result<(), taffy::TaffyError> {
     let node = taffy.new_with_children(
         Style {
             size: Size { width: Dimension::from_length(100.0), height: Dimension::from_length(100.0) },
-            justify_content: Some(JustifyContent::Center),
+            justify_content: Some(JustifyContent::CENTER),
             ..Default::default()
         },
         &[child],

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -399,7 +399,7 @@ fn compute_preliminary(tree: &mut impl LayoutFlexboxContainer, node: NodeId, inp
         flex_lines[0]
             .items
             .iter()
-            .find(|item| constants.is_column || item.align_self == AlignSelf::Baseline)
+            .find(|item| constants.is_column || item.align_self == AlignSelf::BASELINE)
             .or_else(|| flex_lines[0].items.iter().next())
             .map(|child| {
                 let offset_vertical = if constants.is_row { child.offset_cross } else { child.offset_main };
@@ -436,8 +436,8 @@ fn compute_constants(
     let box_sizing_adjustment =
         if style.box_sizing() == BoxSizing::ContentBox { padding_border_sum } else { Size::ZERO };
 
-    let align_items = style.align_items().unwrap_or(AlignItems::Stretch);
-    let align_content = style.align_content().unwrap_or(AlignContent::Stretch);
+    let align_items = style.align_items().unwrap_or(AlignItems::STRETCH);
+    let align_content = style.align_content().unwrap_or(AlignContent::STRETCH);
     let justify_content = style.justify_content();
     let layout_direction = style.direction();
 
@@ -683,7 +683,7 @@ fn determine_flex_base_size(
         // Known dimensions for child sizing
         let child_known_dimensions = {
             let mut ckd = child.size.with_main(dir, None);
-            if child.align_self == AlignSelf::Stretch
+            if child.align_self == AlignSelf::STRETCH
                 && !child.margin_is_auto.cross_start(constants.dir)
                 && !child.margin_is_auto.cross_end(constants.dir)
                 && ckd.cross(dir).is_none()
@@ -1048,7 +1048,7 @@ fn determine_container_main_size(
                                 // Known dimensions for child sizing
                                 let child_known_dimensions = {
                                     let mut ckd = item.size.with_main(dir, None);
-                                    if item.align_self == AlignSelf::Stretch && ckd.cross(dir).is_none() {
+                                    if item.align_self == AlignSelf::STRETCH && ckd.cross(dir).is_none() {
                                         ckd.set_cross(
                                             dir,
                                             cross_axis_available_space
@@ -1435,14 +1435,14 @@ fn calculate_children_base_lines(
     for line in flex_lines {
         // If a flex line has one or zero items participating in baseline alignment then baseline alignment is a no-op so we skip
         let line_baseline_child_count =
-            line.items.iter().filter(|child| child.align_self == AlignSelf::Baseline).count();
+            line.items.iter().filter(|child| child.align_self == AlignSelf::BASELINE).count();
         if line_baseline_child_count <= 1 {
             continue;
         }
 
         for child in line.items.iter_mut() {
             // Only calculate baselines for children participating in baseline alignment
-            if child.align_self != AlignSelf::Baseline {
+            if child.align_self != AlignSelf::BASELINE {
                 continue;
             }
 
@@ -1524,7 +1524,7 @@ fn calculate_cross_size(flex_lines: &mut [FlexLine], node_size: Size<Option<f32>
                 .items
                 .iter()
                 .map(|child| {
-                    if child.align_self == AlignSelf::Baseline
+                    if child.align_self == AlignSelf::BASELINE
                         && !child.margin_is_auto.cross_start(constants.dir)
                         && !child.margin_is_auto.cross_end(constants.dir)
                     {
@@ -1559,7 +1559,7 @@ fn calculate_cross_size(flex_lines: &mut [FlexLine], node_size: Size<Option<f32>
 ///   increase the cross size of each flex line by equal amounts such that the sum of their cross sizes exactly equals the flex container’s inner cross size.
 #[inline]
 fn handle_align_content_stretch(flex_lines: &mut [FlexLine], node_size: Size<Option<f32>>, constants: &AlgoConstants) {
-    if constants.align_content == AlignContent::Stretch {
+    if constants.align_content == AlignContent::STRETCH {
         let cross_axis_padding_border = constants.content_box_inset.cross_axis_sum(constants.dir);
         let cross_min_size = constants.min_size.cross(constants.dir);
         let cross_max_size = constants.max_size.cross(constants.dir);
@@ -1606,7 +1606,7 @@ fn determine_used_cross_size(
             let child_style = tree.get_flexbox_child_style(child.node);
             child.target_size.set_cross(
                 constants.dir,
-                if child.align_self == AlignSelf::Stretch
+                if child.align_self == AlignSelf::STRETCH
                     && !child.margin_is_auto.cross_start(constants.dir)
                     && !child.margin_is_auto.cross_end(constants.dir)
                     && child_style.size().cross(constants.dir).is_auto()
@@ -1698,7 +1698,7 @@ fn distribute_remaining_free_space(flex_lines: &mut [FlexLine], constants: &Algo
         let num_items = line.items.len();
         let layout_reverse = constants.dir.is_reverse();
         let gap = constants.gap.main(constants.dir);
-        let raw_justify_content_mode = constants.justify_content.unwrap_or(JustifyContent::FlexStart);
+        let raw_justify_content_mode = constants.justify_content.unwrap_or(JustifyContent::FLEX_START);
         let justify_content_mode = apply_alignment_fallback(free_space, num_items, raw_justify_content_mode);
 
         let justify_item = |(i, child): (usize, &mut FlexItem)| {
@@ -2336,7 +2336,7 @@ fn perform_absolute_layout_on_absolute_children(
             // treat it as if it wasn't set (and thus we default to FlexStart behaviour)
             // TODO (safe alignment): apply Start fallback when justify_content.is_safe() and the
             // resolved size overflows the containing block. Wired in a follow-up commit.
-            match (constants.justify_content.unwrap_or(JustifyContent::Start).keyword(), main_axis_flex_start_reversed)
+            match (constants.justify_content.unwrap_or(JustifyContent::START).keyword(), main_axis_flex_start_reversed)
             {
                 (AlignContentKeyword::SpaceBetween, _)
                 | (AlignContentKeyword::Stretch, false)

--- a/src/compute/grid/alignment.rs
+++ b/src/compute/grid/alignment.rs
@@ -127,16 +127,16 @@ pub(super) fn align_and_position_item(
     let alignment_styles = InBothAbsAxis {
         horizontal: justify_self.or(container_alignment_styles.horizontal).unwrap_or_else(|| {
             if inherent_size.width.is_some() {
-                AlignSelf::Start
+                AlignSelf::START
             } else {
-                AlignSelf::Stretch
+                AlignSelf::STRETCH
             }
         }),
         vertical: align_self.or(container_alignment_styles.vertical).unwrap_or_else(|| {
             if inherent_size.height.is_some() || aspect_ratio.is_some() {
-                AlignSelf::Start
+                AlignSelf::START
             } else {
-                AlignSelf::Stretch
+                AlignSelf::STRETCH
             }
         }),
     };
@@ -168,7 +168,7 @@ pub(super) fn align_and_position_item(
         //  - The node does not have auto margins in this axis.
         if margin.left.is_some()
             && margin.right.is_some()
-            && alignment_styles.horizontal == AlignSelf::Stretch
+            && alignment_styles.horizontal == AlignSelf::STRETCH
             && position != Position::Absolute
         {
             return Some(grid_area_minus_item_margins_size.width);
@@ -193,7 +193,7 @@ pub(super) fn align_and_position_item(
         //  - The node does not have auto margins in this axis.
         if margin.top.is_some()
             && margin.bottom.is_some()
-            && alignment_styles.vertical == AlignSelf::Stretch
+            && alignment_styles.vertical == AlignSelf::STRETCH
             && position != Position::Absolute
         {
             return Some(grid_area_minus_item_margins_size.height);

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -95,8 +95,8 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
         Direction::Rtl => content_box_inset.left += scrollbar_gutter.x,
     };
 
-    let align_content = style.align_content().unwrap_or(AlignContent::Stretch);
-    let justify_content = style.justify_content().unwrap_or(JustifyContent::Stretch);
+    let align_content = style.align_content().unwrap_or(AlignContent::STRETCH);
+    let justify_content = style.justify_content().unwrap_or(JustifyContent::STRETCH);
     let align_items = style.align_items();
     let justify_items = style.justify_items();
 
@@ -215,8 +215,8 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
         in_flow_children_iter,
         direction,
         style.grid_auto_flow(),
-        align_items.unwrap_or(AlignItems::Stretch),
-        justify_items.unwrap_or(AlignItems::Stretch),
+        align_items.unwrap_or(AlignItems::STRETCH),
+        justify_items.unwrap_or(AlignItems::STRETCH),
         &name_resolver,
     );
 
@@ -272,7 +272,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
     determine_if_item_crosses_flexible_or_intrinsic_tracks(&mut items, &columns, &rows);
 
     // Determine if the grid has any baseline aligned items
-    let has_baseline_aligned_item = items.iter().any(|item| item.align_self == AlignSelf::Baseline);
+    let has_baseline_aligned_item = items.iter().any(|item| item.align_self == AlignSelf::BASELINE);
 
     // Run track sizing algorithm for Inline axis
     track_sizing_algorithm(
@@ -717,10 +717,10 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
         let first_row_items = &items[0..].split(|item| item.row_indexes.start != first_row).next().unwrap();
 
         // Check if any items in *this row* are baseline aligned
-        let row_has_baseline_item = first_row_items.iter().any(|item| item.align_self == AlignSelf::Baseline);
+        let row_has_baseline_item = first_row_items.iter().any(|item| item.align_self == AlignSelf::BASELINE);
 
         let item = if row_has_baseline_item {
-            first_row_items.iter().find(|item| item.align_self == AlignSelf::Baseline).unwrap()
+            first_row_items.iter().find(|item| item.align_self == AlignSelf::BASELINE).unwrap()
         } else {
             &first_row_items[0]
         };

--- a/src/compute/grid/placement.rs
+++ b/src/compute/grid/placement.rs
@@ -545,8 +545,8 @@ mod tests {
                 children_iter,
                 Direction::Ltr,
                 flow,
-                AlignSelf::Start,
-                AlignSelf::Start,
+                AlignSelf::START,
+                AlignSelf::START,
                 // TODO: actually test named line resolution
                 &name_resolver,
             );

--- a/src/compute/grid/track_sizing.rs
+++ b/src/compute/grid/track_sizing.rs
@@ -362,7 +362,7 @@ pub(super) fn track_sizing_algorithm<Tree: LayoutPartialTree>(
 
     // 11.8. Stretch auto Tracks
     // This step expands tracks that have an auto max track sizing function by dividing any remaining positive, definite free space equally amongst them.
-    if axis_alignment == AlignContent::Stretch {
+    if axis_alignment == AlignContent::STRETCH {
         stretch_auto_tracks(axis_tracks, axis_min_size, axis_available_space_for_expansion);
     }
 }
@@ -485,7 +485,7 @@ fn resolve_item_baselines(
         // Count how many items in *this row* are baseline aligned
         // If a row has one or zero items participating in baseline alignment then baseline alignment is a no-op
         // for those items and we skip further computations for that row
-        let row_baseline_item_count = row_items.iter().filter(|item| item.align_self == AlignSelf::Baseline).count();
+        let row_baseline_item_count = row_items.iter().filter(|item| item.align_self == AlignSelf::BASELINE).count();
         if row_baseline_item_count <= 1 {
             continue;
         }

--- a/src/compute/grid/types/grid_item.rs
+++ b/src/compute/grid/types/grid_item.rs
@@ -285,7 +285,7 @@ impl GridItem {
             //  - Alignment style is "stretch"
             //  - The node is not absolutely positioned
             //  - The node does not have auto margins in this axis.
-            if !self.margin.left.is_auto() && !self.margin.right.is_auto() && self.justify_self == AlignSelf::Stretch {
+            if !self.margin.left.is_auto() && !self.margin.right.is_auto() && self.justify_self == AlignSelf::STRETCH {
                 return grid_area_minus_item_margins_size.width;
             }
 
@@ -300,7 +300,7 @@ impl GridItem {
             //  - Alignment style is "stretch"
             //  - The node is not absolutely positioned
             //  - The node does not have auto margins in this axis.
-            if !self.margin.top.is_auto() && !self.margin.bottom.is_auto() && self.align_self == AlignSelf::Stretch {
+            if !self.margin.top.is_auto() && !self.margin.bottom.is_auto() && self.align_self == AlignSelf::STRETCH {
                 return grid_area_minus_item_margins_size.height;
             }
 

--- a/src/style/alignment.rs
+++ b/src/style/alignment.rs
@@ -130,37 +130,36 @@ pub struct AlignItems {
     pub safety: AlignmentSafety,
 }
 
-#[allow(non_upper_case_globals)]
 impl AlignItems {
     /// Items are packed toward the start of the axis.
-    pub const Start: Self = Self { keyword: AlignItemsKeyword::Start, safety: AlignmentSafety::Unsafe };
+    pub const START: Self = Self { keyword: AlignItemsKeyword::Start, safety: AlignmentSafety::Unsafe };
     /// Items are packed toward the end of the axis.
-    pub const End: Self = Self { keyword: AlignItemsKeyword::End, safety: AlignmentSafety::Unsafe };
+    pub const END: Self = Self { keyword: AlignItemsKeyword::End, safety: AlignmentSafety::Unsafe };
     /// Items are packed towards the flex-relative start of the axis.
-    pub const FlexStart: Self = Self { keyword: AlignItemsKeyword::FlexStart, safety: AlignmentSafety::Unsafe };
+    pub const FLEX_START: Self = Self { keyword: AlignItemsKeyword::FlexStart, safety: AlignmentSafety::Unsafe };
     /// Items are packed towards the flex-relative end of the axis.
-    pub const FlexEnd: Self = Self { keyword: AlignItemsKeyword::FlexEnd, safety: AlignmentSafety::Unsafe };
+    pub const FLEX_END: Self = Self { keyword: AlignItemsKeyword::FlexEnd, safety: AlignmentSafety::Unsafe };
     /// Items are packed along the center of the cross axis.
-    pub const Center: Self = Self { keyword: AlignItemsKeyword::Center, safety: AlignmentSafety::Unsafe };
+    pub const CENTER: Self = Self { keyword: AlignItemsKeyword::Center, safety: AlignmentSafety::Unsafe };
     /// Items are aligned such as their baselines align.
-    pub const Baseline: Self = Self { keyword: AlignItemsKeyword::Baseline, safety: AlignmentSafety::Unsafe };
+    pub const BASELINE: Self = Self { keyword: AlignItemsKeyword::Baseline, safety: AlignmentSafety::Unsafe };
     /// Stretch to fill the container.
-    pub const Stretch: Self = Self { keyword: AlignItemsKeyword::Stretch, safety: AlignmentSafety::Unsafe };
-    /// Like [`AlignItems::Start`], but falls back to [`AlignItems::Start`] when the
+    pub const STRETCH: Self = Self { keyword: AlignItemsKeyword::Stretch, safety: AlignmentSafety::Unsafe };
+    /// Like [`AlignItems::START`], but falls back to [`AlignItems::START`] when the
     /// alignment subject overflows the alignment container, to avoid data loss.
-    pub const SafeStart: Self = Self { keyword: AlignItemsKeyword::Start, safety: AlignmentSafety::Safe };
-    /// Like [`AlignItems::End`], but falls back to [`AlignItems::Start`] when the
+    pub const SAFE_START: Self = Self { keyword: AlignItemsKeyword::Start, safety: AlignmentSafety::Safe };
+    /// Like [`AlignItems::END`], but falls back to [`AlignItems::START`] when the
     /// alignment subject overflows the alignment container, to avoid data loss.
-    pub const SafeEnd: Self = Self { keyword: AlignItemsKeyword::End, safety: AlignmentSafety::Safe };
-    /// Like [`AlignItems::FlexStart`], but falls back to [`AlignItems::Start`] when the
+    pub const SAFE_END: Self = Self { keyword: AlignItemsKeyword::End, safety: AlignmentSafety::Safe };
+    /// Like [`AlignItems::FLEX_START`], but falls back to [`AlignItems::START`] when the
     /// alignment subject overflows the alignment container, to avoid data loss.
-    pub const SafeFlexStart: Self = Self { keyword: AlignItemsKeyword::FlexStart, safety: AlignmentSafety::Safe };
-    /// Like [`AlignItems::FlexEnd`], but falls back to [`AlignItems::Start`] when the
+    pub const SAFE_FLEX_START: Self = Self { keyword: AlignItemsKeyword::FlexStart, safety: AlignmentSafety::Safe };
+    /// Like [`AlignItems::FLEX_END`], but falls back to [`AlignItems::START`] when the
     /// alignment subject overflows the alignment container, to avoid data loss.
-    pub const SafeFlexEnd: Self = Self { keyword: AlignItemsKeyword::FlexEnd, safety: AlignmentSafety::Safe };
-    /// Like [`AlignItems::Center`], but falls back to [`AlignItems::Start`] when the
+    pub const SAFE_FLEX_END: Self = Self { keyword: AlignItemsKeyword::FlexEnd, safety: AlignmentSafety::Safe };
+    /// Like [`AlignItems::CENTER`], but falls back to [`AlignItems::START`] when the
     /// alignment subject overflows the alignment container, to avoid data loss.
-    pub const SafeCenter: Self = Self { keyword: AlignItemsKeyword::Center, safety: AlignmentSafety::Safe };
+    pub const SAFE_CENTER: Self = Self { keyword: AlignItemsKeyword::Center, safety: AlignmentSafety::Safe };
 
     /// Returns `true` iff this carries the `safe` overflow-position modifier.
     #[inline]
@@ -183,32 +182,32 @@ impl FromCss for AlignItems {
             "safe" => {
                 let pos = input.expect_ident()?.clone();
                 cssparser::match_ignore_ascii_case! { &*pos,
-                    "start" => Ok(Self::SafeStart),
-                    "end" => Ok(Self::SafeEnd),
-                    "flex-start" => Ok(Self::SafeFlexStart),
-                    "flex-end" => Ok(Self::SafeFlexEnd),
-                    "center" => Ok(Self::SafeCenter),
+                    "start" => Ok(Self::SAFE_START),
+                    "end" => Ok(Self::SAFE_END),
+                    "flex-start" => Ok(Self::SAFE_FLEX_START),
+                    "flex-end" => Ok(Self::SAFE_FLEX_END),
+                    "center" => Ok(Self::SAFE_CENTER),
                     _ => Err(input.new_unexpected_token_error(Token::Ident(pos))),
                 }
             },
             "unsafe" => {
                 let pos = input.expect_ident()?.clone();
                 cssparser::match_ignore_ascii_case! { &*pos,
-                    "start" => Ok(Self::Start),
-                    "end" => Ok(Self::End),
-                    "flex-start" => Ok(Self::FlexStart),
-                    "flex-end" => Ok(Self::FlexEnd),
-                    "center" => Ok(Self::Center),
+                    "start" => Ok(Self::START),
+                    "end" => Ok(Self::END),
+                    "flex-start" => Ok(Self::FLEX_START),
+                    "flex-end" => Ok(Self::FLEX_END),
+                    "center" => Ok(Self::CENTER),
                     _ => Err(input.new_unexpected_token_error(Token::Ident(pos))),
                 }
             },
-            "start" => Ok(Self::Start),
-            "end" => Ok(Self::End),
-            "flex-start" => Ok(Self::FlexStart),
-            "flex-end" => Ok(Self::FlexEnd),
-            "center" => Ok(Self::Center),
-            "baseline" => Ok(Self::Baseline),
-            "stretch" => Ok(Self::Stretch),
+            "start" => Ok(Self::START),
+            "end" => Ok(Self::END),
+            "flex-start" => Ok(Self::FLEX_START),
+            "flex-end" => Ok(Self::FLEX_END),
+            "center" => Ok(Self::CENTER),
+            "baseline" => Ok(Self::BASELINE),
+            "stretch" => Ok(Self::STRETCH),
             _ => Err(input.new_unexpected_token_error(Token::Ident(first))),
         }
     }
@@ -253,41 +252,41 @@ pub struct AlignContent {
     pub safety: AlignmentSafety,
 }
 
-#[allow(non_upper_case_globals)]
 impl AlignContent {
     /// Items are packed toward the start of the axis.
-    pub const Start: Self = Self { keyword: AlignContentKeyword::Start, safety: AlignmentSafety::Unsafe };
+    pub const START: Self = Self { keyword: AlignContentKeyword::Start, safety: AlignmentSafety::Unsafe };
     /// Items are packed toward the end of the axis.
-    pub const End: Self = Self { keyword: AlignContentKeyword::End, safety: AlignmentSafety::Unsafe };
+    pub const END: Self = Self { keyword: AlignContentKeyword::End, safety: AlignmentSafety::Unsafe };
     /// Items are packed towards the flex-relative start of the axis.
-    pub const FlexStart: Self = Self { keyword: AlignContentKeyword::FlexStart, safety: AlignmentSafety::Unsafe };
+    pub const FLEX_START: Self = Self { keyword: AlignContentKeyword::FlexStart, safety: AlignmentSafety::Unsafe };
     /// Items are packed towards the flex-relative end of the axis.
-    pub const FlexEnd: Self = Self { keyword: AlignContentKeyword::FlexEnd, safety: AlignmentSafety::Unsafe };
+    pub const FLEX_END: Self = Self { keyword: AlignContentKeyword::FlexEnd, safety: AlignmentSafety::Unsafe };
     /// Items are centered around the middle of the axis.
-    pub const Center: Self = Self { keyword: AlignContentKeyword::Center, safety: AlignmentSafety::Unsafe };
+    pub const CENTER: Self = Self { keyword: AlignContentKeyword::Center, safety: AlignmentSafety::Unsafe };
     /// Items are stretched to fill the container.
-    pub const Stretch: Self = Self { keyword: AlignContentKeyword::Stretch, safety: AlignmentSafety::Unsafe };
+    pub const STRETCH: Self = Self { keyword: AlignContentKeyword::Stretch, safety: AlignmentSafety::Unsafe };
     /// The first and last items are aligned flush with the edges of the container.
-    pub const SpaceBetween: Self = Self { keyword: AlignContentKeyword::SpaceBetween, safety: AlignmentSafety::Unsafe };
+    pub const SPACE_BETWEEN: Self =
+        Self { keyword: AlignContentKeyword::SpaceBetween, safety: AlignmentSafety::Unsafe };
     /// The gap between the first and last items equals the gap between items.
-    pub const SpaceEvenly: Self = Self { keyword: AlignContentKeyword::SpaceEvenly, safety: AlignmentSafety::Unsafe };
+    pub const SPACE_EVENLY: Self = Self { keyword: AlignContentKeyword::SpaceEvenly, safety: AlignmentSafety::Unsafe };
     /// The gap between the first and last items is half the gap between items.
-    pub const SpaceAround: Self = Self { keyword: AlignContentKeyword::SpaceAround, safety: AlignmentSafety::Unsafe };
-    /// Like [`AlignContent::Start`], but falls back to [`AlignContent::Start`] when the
+    pub const SPACE_AROUND: Self = Self { keyword: AlignContentKeyword::SpaceAround, safety: AlignmentSafety::Unsafe };
+    /// Like [`AlignContent::START`], but falls back to [`AlignContent::START`] when the
     /// content overflows the alignment container, to avoid data loss.
-    pub const SafeStart: Self = Self { keyword: AlignContentKeyword::Start, safety: AlignmentSafety::Safe };
-    /// Like [`AlignContent::End`], but falls back to [`AlignContent::Start`] when the
+    pub const SAFE_START: Self = Self { keyword: AlignContentKeyword::Start, safety: AlignmentSafety::Safe };
+    /// Like [`AlignContent::END`], but falls back to [`AlignContent::START`] when the
     /// content overflows the alignment container, to avoid data loss.
-    pub const SafeEnd: Self = Self { keyword: AlignContentKeyword::End, safety: AlignmentSafety::Safe };
-    /// Like [`AlignContent::FlexStart`], but falls back to [`AlignContent::Start`] when
+    pub const SAFE_END: Self = Self { keyword: AlignContentKeyword::End, safety: AlignmentSafety::Safe };
+    /// Like [`AlignContent::FLEX_START`], but falls back to [`AlignContent::START`] when
     /// the content overflows the alignment container, to avoid data loss.
-    pub const SafeFlexStart: Self = Self { keyword: AlignContentKeyword::FlexStart, safety: AlignmentSafety::Safe };
-    /// Like [`AlignContent::FlexEnd`], but falls back to [`AlignContent::Start`] when the
+    pub const SAFE_FLEX_START: Self = Self { keyword: AlignContentKeyword::FlexStart, safety: AlignmentSafety::Safe };
+    /// Like [`AlignContent::FLEX_END`], but falls back to [`AlignContent::START`] when the
     /// content overflows the alignment container, to avoid data loss.
-    pub const SafeFlexEnd: Self = Self { keyword: AlignContentKeyword::FlexEnd, safety: AlignmentSafety::Safe };
-    /// Like [`AlignContent::Center`], but falls back to [`AlignContent::Start`] when the
+    pub const SAFE_FLEX_END: Self = Self { keyword: AlignContentKeyword::FlexEnd, safety: AlignmentSafety::Safe };
+    /// Like [`AlignContent::CENTER`], but falls back to [`AlignContent::START`] when the
     /// content overflows the alignment container, to avoid data loss.
-    pub const SafeCenter: Self = Self { keyword: AlignContentKeyword::Center, safety: AlignmentSafety::Safe };
+    pub const SAFE_CENTER: Self = Self { keyword: AlignContentKeyword::Center, safety: AlignmentSafety::Safe };
 
     /// Returns `true` iff this carries the `safe` overflow-position modifier.
     #[inline]
@@ -310,34 +309,34 @@ impl FromCss for AlignContent {
             "safe" => {
                 let pos = input.expect_ident()?.clone();
                 cssparser::match_ignore_ascii_case! { &*pos,
-                    "start" => Ok(Self::SafeStart),
-                    "end" => Ok(Self::SafeEnd),
-                    "flex-start" => Ok(Self::SafeFlexStart),
-                    "flex-end" => Ok(Self::SafeFlexEnd),
-                    "center" => Ok(Self::SafeCenter),
+                    "start" => Ok(Self::SAFE_START),
+                    "end" => Ok(Self::SAFE_END),
+                    "flex-start" => Ok(Self::SAFE_FLEX_START),
+                    "flex-end" => Ok(Self::SAFE_FLEX_END),
+                    "center" => Ok(Self::SAFE_CENTER),
                     _ => Err(input.new_unexpected_token_error(Token::Ident(pos))),
                 }
             },
             "unsafe" => {
                 let pos = input.expect_ident()?.clone();
                 cssparser::match_ignore_ascii_case! { &*pos,
-                    "start" => Ok(Self::Start),
-                    "end" => Ok(Self::End),
-                    "flex-start" => Ok(Self::FlexStart),
-                    "flex-end" => Ok(Self::FlexEnd),
-                    "center" => Ok(Self::Center),
+                    "start" => Ok(Self::START),
+                    "end" => Ok(Self::END),
+                    "flex-start" => Ok(Self::FLEX_START),
+                    "flex-end" => Ok(Self::FLEX_END),
+                    "center" => Ok(Self::CENTER),
                     _ => Err(input.new_unexpected_token_error(Token::Ident(pos))),
                 }
             },
-            "start" => Ok(Self::Start),
-            "end" => Ok(Self::End),
-            "flex-start" => Ok(Self::FlexStart),
-            "flex-end" => Ok(Self::FlexEnd),
-            "center" => Ok(Self::Center),
-            "stretch" => Ok(Self::Stretch),
-            "space-between" => Ok(Self::SpaceBetween),
-            "space-evenly" => Ok(Self::SpaceEvenly),
-            "space-around" => Ok(Self::SpaceAround),
+            "start" => Ok(Self::START),
+            "end" => Ok(Self::END),
+            "flex-start" => Ok(Self::FLEX_START),
+            "flex-end" => Ok(Self::FLEX_END),
+            "center" => Ok(Self::CENTER),
+            "stretch" => Ok(Self::STRETCH),
+            "space-between" => Ok(Self::SPACE_BETWEEN),
+            "space-evenly" => Ok(Self::SPACE_EVENLY),
+            "space-around" => Ok(Self::SPACE_AROUND),
             _ => Err(input.new_unexpected_token_error(Token::Ident(first))),
         }
     }
@@ -409,18 +408,18 @@ impl<'de> serde::Deserialize<'de> for AlignItems {
             }
             fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
                 Ok(match v {
-                    "Start" => AlignItems::Start,
-                    "End" => AlignItems::End,
-                    "FlexStart" => AlignItems::FlexStart,
-                    "FlexEnd" => AlignItems::FlexEnd,
-                    "Center" => AlignItems::Center,
-                    "Baseline" => AlignItems::Baseline,
-                    "Stretch" => AlignItems::Stretch,
-                    "SafeStart" => AlignItems::SafeStart,
-                    "SafeEnd" => AlignItems::SafeEnd,
-                    "SafeFlexStart" => AlignItems::SafeFlexStart,
-                    "SafeFlexEnd" => AlignItems::SafeFlexEnd,
-                    "SafeCenter" => AlignItems::SafeCenter,
+                    "Start" => AlignItems::START,
+                    "End" => AlignItems::END,
+                    "FlexStart" => AlignItems::FLEX_START,
+                    "FlexEnd" => AlignItems::FLEX_END,
+                    "Center" => AlignItems::CENTER,
+                    "Baseline" => AlignItems::BASELINE,
+                    "Stretch" => AlignItems::STRETCH,
+                    "SafeStart" => AlignItems::SAFE_START,
+                    "SafeEnd" => AlignItems::SAFE_END,
+                    "SafeFlexStart" => AlignItems::SAFE_FLEX_START,
+                    "SafeFlexEnd" => AlignItems::SAFE_FLEX_END,
+                    "SafeCenter" => AlignItems::SAFE_CENTER,
                     other => return Err(E::unknown_variant(other, ALIGN_ITEMS_NAMES)),
                 })
             }
@@ -483,20 +482,20 @@ impl<'de> serde::Deserialize<'de> for AlignContent {
             }
             fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
                 Ok(match v {
-                    "Start" => AlignContent::Start,
-                    "End" => AlignContent::End,
-                    "FlexStart" => AlignContent::FlexStart,
-                    "FlexEnd" => AlignContent::FlexEnd,
-                    "Center" => AlignContent::Center,
-                    "Stretch" => AlignContent::Stretch,
-                    "SpaceBetween" => AlignContent::SpaceBetween,
-                    "SpaceEvenly" => AlignContent::SpaceEvenly,
-                    "SpaceAround" => AlignContent::SpaceAround,
-                    "SafeStart" => AlignContent::SafeStart,
-                    "SafeEnd" => AlignContent::SafeEnd,
-                    "SafeFlexStart" => AlignContent::SafeFlexStart,
-                    "SafeFlexEnd" => AlignContent::SafeFlexEnd,
-                    "SafeCenter" => AlignContent::SafeCenter,
+                    "Start" => AlignContent::START,
+                    "End" => AlignContent::END,
+                    "FlexStart" => AlignContent::FLEX_START,
+                    "FlexEnd" => AlignContent::FLEX_END,
+                    "Center" => AlignContent::CENTER,
+                    "Stretch" => AlignContent::STRETCH,
+                    "SpaceBetween" => AlignContent::SPACE_BETWEEN,
+                    "SpaceEvenly" => AlignContent::SPACE_EVENLY,
+                    "SpaceAround" => AlignContent::SPACE_AROUND,
+                    "SafeStart" => AlignContent::SAFE_START,
+                    "SafeEnd" => AlignContent::SAFE_END,
+                    "SafeFlexStart" => AlignContent::SAFE_FLEX_START,
+                    "SafeFlexEnd" => AlignContent::SAFE_FLEX_END,
+                    "SafeCenter" => AlignContent::SAFE_CENTER,
                     other => return Err(E::unknown_variant(other, ALIGN_CONTENT_NAMES)),
                 })
             }
@@ -522,51 +521,51 @@ mod tests {
 
     #[test]
     fn align_items_is_safe() {
-        assert!(AlignItems::SafeStart.is_safe());
-        assert!(AlignItems::SafeEnd.is_safe());
-        assert!(AlignItems::SafeFlexStart.is_safe());
-        assert!(AlignItems::SafeFlexEnd.is_safe());
-        assert!(AlignItems::SafeCenter.is_safe());
-        assert!(!AlignItems::Start.is_safe());
-        assert!(!AlignItems::End.is_safe());
-        assert!(!AlignItems::FlexStart.is_safe());
-        assert!(!AlignItems::FlexEnd.is_safe());
-        assert!(!AlignItems::Center.is_safe());
-        assert!(!AlignItems::Baseline.is_safe());
-        assert!(!AlignItems::Stretch.is_safe());
+        assert!(AlignItems::SAFE_START.is_safe());
+        assert!(AlignItems::SAFE_END.is_safe());
+        assert!(AlignItems::SAFE_FLEX_START.is_safe());
+        assert!(AlignItems::SAFE_FLEX_END.is_safe());
+        assert!(AlignItems::SAFE_CENTER.is_safe());
+        assert!(!AlignItems::START.is_safe());
+        assert!(!AlignItems::END.is_safe());
+        assert!(!AlignItems::FLEX_START.is_safe());
+        assert!(!AlignItems::FLEX_END.is_safe());
+        assert!(!AlignItems::CENTER.is_safe());
+        assert!(!AlignItems::BASELINE.is_safe());
+        assert!(!AlignItems::STRETCH.is_safe());
     }
 
     #[test]
     fn align_items_keyword_strips_safe() {
-        assert_eq!(AlignItems::SafeStart.keyword(), AlignItemsKeyword::Start);
-        assert_eq!(AlignItems::SafeEnd.keyword(), AlignItemsKeyword::End);
-        assert_eq!(AlignItems::SafeFlexStart.keyword(), AlignItemsKeyword::FlexStart);
-        assert_eq!(AlignItems::SafeFlexEnd.keyword(), AlignItemsKeyword::FlexEnd);
-        assert_eq!(AlignItems::SafeCenter.keyword(), AlignItemsKeyword::Center);
+        assert_eq!(AlignItems::SAFE_START.keyword(), AlignItemsKeyword::Start);
+        assert_eq!(AlignItems::SAFE_END.keyword(), AlignItemsKeyword::End);
+        assert_eq!(AlignItems::SAFE_FLEX_START.keyword(), AlignItemsKeyword::FlexStart);
+        assert_eq!(AlignItems::SAFE_FLEX_END.keyword(), AlignItemsKeyword::FlexEnd);
+        assert_eq!(AlignItems::SAFE_CENTER.keyword(), AlignItemsKeyword::Center);
     }
 
     #[test]
     fn align_items_keyword_passthrough() {
-        assert_eq!(AlignItems::Start.keyword(), AlignItemsKeyword::Start);
-        assert_eq!(AlignItems::Stretch.keyword(), AlignItemsKeyword::Stretch);
-        assert_eq!(AlignItems::Baseline.keyword(), AlignItemsKeyword::Baseline);
-        assert_eq!(AlignItems::FlexStart.keyword(), AlignItemsKeyword::FlexStart);
+        assert_eq!(AlignItems::START.keyword(), AlignItemsKeyword::Start);
+        assert_eq!(AlignItems::STRETCH.keyword(), AlignItemsKeyword::Stretch);
+        assert_eq!(AlignItems::BASELINE.keyword(), AlignItemsKeyword::Baseline);
+        assert_eq!(AlignItems::FLEX_START.keyword(), AlignItemsKeyword::FlexStart);
     }
 
     #[test]
     fn align_content_is_safe() {
-        assert!(AlignContent::SafeStart.is_safe());
-        assert!(AlignContent::SafeCenter.is_safe());
-        assert!(!AlignContent::SpaceBetween.is_safe());
-        assert!(!AlignContent::Stretch.is_safe());
+        assert!(AlignContent::SAFE_START.is_safe());
+        assert!(AlignContent::SAFE_CENTER.is_safe());
+        assert!(!AlignContent::SPACE_BETWEEN.is_safe());
+        assert!(!AlignContent::STRETCH.is_safe());
     }
 
     #[test]
     fn align_content_keyword_strips_safe() {
-        assert_eq!(AlignContent::SafeStart.keyword(), AlignContentKeyword::Start);
-        assert_eq!(AlignContent::SafeFlexEnd.keyword(), AlignContentKeyword::FlexEnd);
-        assert_eq!(AlignContent::SafeCenter.keyword(), AlignContentKeyword::Center);
-        assert_eq!(AlignContent::SpaceBetween.keyword(), AlignContentKeyword::SpaceBetween);
+        assert_eq!(AlignContent::SAFE_START.keyword(), AlignContentKeyword::Start);
+        assert_eq!(AlignContent::SAFE_FLEX_END.keyword(), AlignContentKeyword::FlexEnd);
+        assert_eq!(AlignContent::SAFE_CENTER.keyword(), AlignContentKeyword::Center);
+        assert_eq!(AlignContent::SPACE_BETWEEN.keyword(), AlignContentKeyword::SpaceBetween);
     }
 
     #[test]
@@ -586,38 +585,38 @@ mod tests {
     #[cfg(feature = "parse")]
     #[test]
     fn parse_align_items_plain() {
-        assert_eq!("start".parse::<AlignItems>().unwrap(), AlignItems::Start);
-        assert_eq!("end".parse::<AlignItems>().unwrap(), AlignItems::End);
-        assert_eq!("flex-start".parse::<AlignItems>().unwrap(), AlignItems::FlexStart);
-        assert_eq!("flex-end".parse::<AlignItems>().unwrap(), AlignItems::FlexEnd);
-        assert_eq!("center".parse::<AlignItems>().unwrap(), AlignItems::Center);
-        assert_eq!("baseline".parse::<AlignItems>().unwrap(), AlignItems::Baseline);
-        assert_eq!("stretch".parse::<AlignItems>().unwrap(), AlignItems::Stretch);
+        assert_eq!("start".parse::<AlignItems>().unwrap(), AlignItems::START);
+        assert_eq!("end".parse::<AlignItems>().unwrap(), AlignItems::END);
+        assert_eq!("flex-start".parse::<AlignItems>().unwrap(), AlignItems::FLEX_START);
+        assert_eq!("flex-end".parse::<AlignItems>().unwrap(), AlignItems::FLEX_END);
+        assert_eq!("center".parse::<AlignItems>().unwrap(), AlignItems::CENTER);
+        assert_eq!("baseline".parse::<AlignItems>().unwrap(), AlignItems::BASELINE);
+        assert_eq!("stretch".parse::<AlignItems>().unwrap(), AlignItems::STRETCH);
     }
 
     #[cfg(feature = "parse")]
     #[test]
     fn parse_align_items_safe() {
-        assert_eq!("safe start".parse::<AlignItems>().unwrap(), AlignItems::SafeStart);
-        assert_eq!("safe end".parse::<AlignItems>().unwrap(), AlignItems::SafeEnd);
-        assert_eq!("safe flex-start".parse::<AlignItems>().unwrap(), AlignItems::SafeFlexStart);
-        assert_eq!("safe flex-end".parse::<AlignItems>().unwrap(), AlignItems::SafeFlexEnd);
-        assert_eq!("safe center".parse::<AlignItems>().unwrap(), AlignItems::SafeCenter);
+        assert_eq!("safe start".parse::<AlignItems>().unwrap(), AlignItems::SAFE_START);
+        assert_eq!("safe end".parse::<AlignItems>().unwrap(), AlignItems::SAFE_END);
+        assert_eq!("safe flex-start".parse::<AlignItems>().unwrap(), AlignItems::SAFE_FLEX_START);
+        assert_eq!("safe flex-end".parse::<AlignItems>().unwrap(), AlignItems::SAFE_FLEX_END);
+        assert_eq!("safe center".parse::<AlignItems>().unwrap(), AlignItems::SAFE_CENTER);
     }
 
     #[cfg(feature = "parse")]
     #[test]
     fn parse_align_items_safe_case_insensitive() {
-        assert_eq!("SAFE Start".parse::<AlignItems>().unwrap(), AlignItems::SafeStart);
-        assert_eq!("Safe FLEX-end".parse::<AlignItems>().unwrap(), AlignItems::SafeFlexEnd);
+        assert_eq!("SAFE Start".parse::<AlignItems>().unwrap(), AlignItems::SAFE_START);
+        assert_eq!("Safe FLEX-end".parse::<AlignItems>().unwrap(), AlignItems::SAFE_FLEX_END);
     }
 
     #[cfg(feature = "parse")]
     #[test]
     fn parse_align_items_unsafe_drops_modifier() {
-        assert_eq!("unsafe start".parse::<AlignItems>().unwrap(), AlignItems::Start);
-        assert_eq!("unsafe end".parse::<AlignItems>().unwrap(), AlignItems::End);
-        assert_eq!("unsafe center".parse::<AlignItems>().unwrap(), AlignItems::Center);
+        assert_eq!("unsafe start".parse::<AlignItems>().unwrap(), AlignItems::START);
+        assert_eq!("unsafe end".parse::<AlignItems>().unwrap(), AlignItems::END);
+        assert_eq!("unsafe center".parse::<AlignItems>().unwrap(), AlignItems::CENTER);
     }
 
     #[cfg(feature = "parse")]
@@ -635,28 +634,28 @@ mod tests {
     #[cfg(feature = "parse")]
     #[test]
     fn parse_align_content_plain() {
-        assert_eq!("start".parse::<AlignContent>().unwrap(), AlignContent::Start);
-        assert_eq!("space-between".parse::<AlignContent>().unwrap(), AlignContent::SpaceBetween);
-        assert_eq!("space-evenly".parse::<AlignContent>().unwrap(), AlignContent::SpaceEvenly);
-        assert_eq!("space-around".parse::<AlignContent>().unwrap(), AlignContent::SpaceAround);
-        assert_eq!("stretch".parse::<AlignContent>().unwrap(), AlignContent::Stretch);
+        assert_eq!("start".parse::<AlignContent>().unwrap(), AlignContent::START);
+        assert_eq!("space-between".parse::<AlignContent>().unwrap(), AlignContent::SPACE_BETWEEN);
+        assert_eq!("space-evenly".parse::<AlignContent>().unwrap(), AlignContent::SPACE_EVENLY);
+        assert_eq!("space-around".parse::<AlignContent>().unwrap(), AlignContent::SPACE_AROUND);
+        assert_eq!("stretch".parse::<AlignContent>().unwrap(), AlignContent::STRETCH);
     }
 
     #[cfg(feature = "parse")]
     #[test]
     fn parse_align_content_safe() {
-        assert_eq!("safe start".parse::<AlignContent>().unwrap(), AlignContent::SafeStart);
-        assert_eq!("safe end".parse::<AlignContent>().unwrap(), AlignContent::SafeEnd);
-        assert_eq!("safe flex-start".parse::<AlignContent>().unwrap(), AlignContent::SafeFlexStart);
-        assert_eq!("safe flex-end".parse::<AlignContent>().unwrap(), AlignContent::SafeFlexEnd);
-        assert_eq!("safe center".parse::<AlignContent>().unwrap(), AlignContent::SafeCenter);
+        assert_eq!("safe start".parse::<AlignContent>().unwrap(), AlignContent::SAFE_START);
+        assert_eq!("safe end".parse::<AlignContent>().unwrap(), AlignContent::SAFE_END);
+        assert_eq!("safe flex-start".parse::<AlignContent>().unwrap(), AlignContent::SAFE_FLEX_START);
+        assert_eq!("safe flex-end".parse::<AlignContent>().unwrap(), AlignContent::SAFE_FLEX_END);
+        assert_eq!("safe center".parse::<AlignContent>().unwrap(), AlignContent::SAFE_CENTER);
     }
 
     #[cfg(feature = "parse")]
     #[test]
     fn parse_align_content_unsafe_drops_modifier() {
-        assert_eq!("unsafe start".parse::<AlignContent>().unwrap(), AlignContent::Start);
-        assert_eq!("unsafe flex-end".parse::<AlignContent>().unwrap(), AlignContent::FlexEnd);
+        assert_eq!("unsafe start".parse::<AlignContent>().unwrap(), AlignContent::START);
+        assert_eq!("unsafe flex-end".parse::<AlignContent>().unwrap(), AlignContent::FLEX_END);
     }
 
     #[cfg(feature = "parse")]
@@ -675,18 +674,18 @@ mod tests {
     #[test]
     fn serde_align_items_round_trip() {
         let cases = [
-            (AlignItems::Start, "\"Start\""),
-            (AlignItems::End, "\"End\""),
-            (AlignItems::FlexStart, "\"FlexStart\""),
-            (AlignItems::FlexEnd, "\"FlexEnd\""),
-            (AlignItems::Center, "\"Center\""),
-            (AlignItems::Baseline, "\"Baseline\""),
-            (AlignItems::Stretch, "\"Stretch\""),
-            (AlignItems::SafeStart, "\"SafeStart\""),
-            (AlignItems::SafeEnd, "\"SafeEnd\""),
-            (AlignItems::SafeFlexStart, "\"SafeFlexStart\""),
-            (AlignItems::SafeFlexEnd, "\"SafeFlexEnd\""),
-            (AlignItems::SafeCenter, "\"SafeCenter\""),
+            (AlignItems::START, "\"Start\""),
+            (AlignItems::END, "\"End\""),
+            (AlignItems::FLEX_START, "\"FlexStart\""),
+            (AlignItems::FLEX_END, "\"FlexEnd\""),
+            (AlignItems::CENTER, "\"Center\""),
+            (AlignItems::BASELINE, "\"Baseline\""),
+            (AlignItems::STRETCH, "\"Stretch\""),
+            (AlignItems::SAFE_START, "\"SafeStart\""),
+            (AlignItems::SAFE_END, "\"SafeEnd\""),
+            (AlignItems::SAFE_FLEX_START, "\"SafeFlexStart\""),
+            (AlignItems::SAFE_FLEX_END, "\"SafeFlexEnd\""),
+            (AlignItems::SAFE_CENTER, "\"SafeCenter\""),
         ];
         for (value, expected) in cases {
             let serialized = serde_json::to_string(&value).unwrap();
@@ -701,20 +700,20 @@ mod tests {
     #[test]
     fn serde_align_content_round_trip() {
         let cases = [
-            (AlignContent::Start, "\"Start\""),
-            (AlignContent::End, "\"End\""),
-            (AlignContent::FlexStart, "\"FlexStart\""),
-            (AlignContent::FlexEnd, "\"FlexEnd\""),
-            (AlignContent::Center, "\"Center\""),
-            (AlignContent::Stretch, "\"Stretch\""),
-            (AlignContent::SpaceBetween, "\"SpaceBetween\""),
-            (AlignContent::SpaceEvenly, "\"SpaceEvenly\""),
-            (AlignContent::SpaceAround, "\"SpaceAround\""),
-            (AlignContent::SafeStart, "\"SafeStart\""),
-            (AlignContent::SafeEnd, "\"SafeEnd\""),
-            (AlignContent::SafeFlexStart, "\"SafeFlexStart\""),
-            (AlignContent::SafeFlexEnd, "\"SafeFlexEnd\""),
-            (AlignContent::SafeCenter, "\"SafeCenter\""),
+            (AlignContent::START, "\"Start\""),
+            (AlignContent::END, "\"End\""),
+            (AlignContent::FLEX_START, "\"FlexStart\""),
+            (AlignContent::FLEX_END, "\"FlexEnd\""),
+            (AlignContent::CENTER, "\"Center\""),
+            (AlignContent::STRETCH, "\"Stretch\""),
+            (AlignContent::SPACE_BETWEEN, "\"SpaceBetween\""),
+            (AlignContent::SPACE_EVENLY, "\"SpaceEvenly\""),
+            (AlignContent::SPACE_AROUND, "\"SpaceAround\""),
+            (AlignContent::SAFE_START, "\"SafeStart\""),
+            (AlignContent::SAFE_END, "\"SafeEnd\""),
+            (AlignContent::SAFE_FLEX_START, "\"SafeFlexStart\""),
+            (AlignContent::SAFE_FLEX_END, "\"SafeFlexEnd\""),
+            (AlignContent::SAFE_CENTER, "\"SafeCenter\""),
         ];
         for (value, expected) in cases {
             let serialized = serde_json::to_string(&value).unwrap();

--- a/src/style/grid.rs
+++ b/src/style/grid.rs
@@ -229,8 +229,8 @@ pub trait GridContainerStyle: CoreStyle {
     #[inline(always)]
     fn grid_align_content(&self, axis: AbstractAxis) -> AlignContent {
         match axis {
-            AbstractAxis::Inline => self.justify_content().unwrap_or(AlignContent::Stretch),
-            AbstractAxis::Block => self.align_content().unwrap_or(AlignContent::Stretch),
+            AbstractAxis::Inline => self.justify_content().unwrap_or(AlignContent::STRETCH),
+            AbstractAxis::Block => self.align_content().unwrap_or(AlignContent::STRETCH),
         }
     }
 }

--- a/tests/hand_written/measure.rs
+++ b/tests/hand_written/measure.rs
@@ -160,7 +160,7 @@ mod measure {
             .new_with_children(
                 Style {
                     size: Size { width: Dimension::from_length(100.0), height: auto() },
-                    align_items: Some(AlignItems::Start),
+                    align_items: Some(AlignItems::START),
                     ..Default::default()
                 },
                 &[child0, child1],
@@ -191,7 +191,7 @@ mod measure {
             .new_with_children(
                 Style {
                     size: Size { width: Dimension::from_length(100.0), height: auto() },
-                    align_items: Some(AlignItems::Start),
+                    align_items: Some(AlignItems::START),
                     ..Default::default()
                 },
                 &[child0, child1],

--- a/tests/hand_written/relayout.rs
+++ b/tests/hand_written/relayout.rs
@@ -13,7 +13,7 @@ fn relayout() {
     let node0 = taffy
         .new_with_children(
             taffy::style::Style {
-                align_self: Some(taffy::prelude::AlignSelf::Center),
+                align_self: Some(taffy::prelude::AlignSelf::CENTER),
                 size: taffy::geometry::Size { width: Dimension::AUTO, height: Dimension::AUTO },
                 // size: taffy::geometry::Size { width: Dimension::Percent(1.0), height: Dimension::Percent(1.0) },
                 ..Default::default()
@@ -341,7 +341,7 @@ fn relayout_is_stable_with_rounding() {
         .new_with_children(
             Style {
                 size: Size { width: length(150.), height: auto() },
-                justify_content: Some(JustifyContent::End),
+                justify_content: Some(JustifyContent::END),
                 ..Default::default()
             },
             &[inner],

--- a/tests/hand_written/rounding.rs
+++ b/tests/hand_written/rounding.rs
@@ -14,7 +14,7 @@ fn rounding_doesnt_leave_gaps() {
         .new_with_children(
             Style {
                 size: Size { width: length(963.3333), height: length(1000.) },
-                justify_content: Some(JustifyContent::Center),
+                justify_content: Some(JustifyContent::CENTER),
                 ..Default::default()
             },
             &[child_a, child_b],

--- a/tests/hand_written/safe_alignment.rs
+++ b/tests/hand_written/safe_alignment.rs
@@ -17,7 +17,7 @@ fn grid_safe_align_self_falls_back_to_start_on_overflow() {
     let child = taffy
         .new_leaf(Style {
             size: Size { width: length(50.0), height: length(150.0) },
-            align_self: Some(AlignSelf::SafeEnd),
+            align_self: Some(AlignSelf::SAFE_END),
             ..Default::default()
         })
         .unwrap();
@@ -47,7 +47,7 @@ fn grid_safe_align_self_behaves_as_end_when_no_overflow() {
     let child = taffy
         .new_leaf(Style {
             size: Size { width: length(50.0), height: length(40.0) },
-            align_self: Some(AlignSelf::SafeEnd),
+            align_self: Some(AlignSelf::SAFE_END),
             ..Default::default()
         })
         .unwrap();
@@ -77,7 +77,7 @@ fn grid_unsafe_align_self_keeps_overflowing_position() {
     let child = taffy
         .new_leaf(Style {
             size: Size { width: length(50.0), height: length(150.0) },
-            align_self: Some(AlignSelf::End),
+            align_self: Some(AlignSelf::END),
             ..Default::default()
         })
         .unwrap();
@@ -107,7 +107,7 @@ fn grid_safe_justify_self_falls_back_to_start_on_overflow() {
     let child = taffy
         .new_leaf(Style {
             size: Size { width: length(150.0), height: length(50.0) },
-            justify_self: Some(JustifySelf::SafeEnd),
+            justify_self: Some(JustifySelf::SAFE_END),
             ..Default::default()
         })
         .unwrap();
@@ -136,7 +136,7 @@ fn grid_safe_justify_self_rtl_falls_back_to_rtl_start_edge() {
     let child = taffy
         .new_leaf(Style {
             size: Size { width: length(150.0), height: length(50.0) },
-            justify_self: Some(JustifySelf::SafeEnd),
+            justify_self: Some(JustifySelf::SAFE_END),
             ..Default::default()
         })
         .unwrap();
@@ -178,7 +178,7 @@ fn grid_safe_align_content_overflow_falls_back_to_start() {
                 size: Size { width: length(100.0), height: length(100.0) },
                 grid_template_rows: vec![length(80.0), length(80.0)],
                 grid_template_columns: vec![length(40.0)],
-                align_content: Some(AlignContent::SafeEnd),
+                align_content: Some(AlignContent::SAFE_END),
                 ..Default::default()
             },
             &[child_a, child_b],
@@ -199,7 +199,7 @@ fn flex_safe_align_self_falls_back_to_start_on_overflow() {
     let child = taffy
         .new_leaf(Style {
             size: Size { width: length(50.0), height: length(150.0) },
-            align_self: Some(AlignSelf::SafeEnd),
+            align_self: Some(AlignSelf::SAFE_END),
             ..Default::default()
         })
         .unwrap();
@@ -227,7 +227,7 @@ fn flex_unsafe_align_self_keeps_overflowing_position() {
     let child = taffy
         .new_leaf(Style {
             size: Size { width: length(50.0), height: length(150.0) },
-            align_self: Some(AlignSelf::End),
+            align_self: Some(AlignSelf::END),
             ..Default::default()
         })
         .unwrap();
@@ -263,7 +263,7 @@ fn flex_safe_justify_content_falls_back_to_start_on_overflow() {
             Style {
                 display: Display::Flex,
                 size: Size { width: length(100.0), height: length(100.0) },
-                justify_content: Some(JustifyContent::SafeEnd),
+                justify_content: Some(JustifyContent::SAFE_END),
                 ..Default::default()
             },
             &[child_a, child_b],
@@ -293,7 +293,7 @@ fn flex_safe_align_content_falls_back_to_start_on_multiline_overflow() {
                 display: Display::Flex,
                 flex_wrap: FlexWrap::Wrap,
                 size: Size { width: length(100.0), height: length(100.0) },
-                align_content: Some(AlignContent::SafeEnd),
+                align_content: Some(AlignContent::SAFE_END),
                 ..Default::default()
             },
             &[child_a, child_b],


### PR DESCRIPTION
# Objective

Remove clippy lint ignore and use idiomatic Rust naming convention for constants