### PR TITLE
Pin time to 0.3.47 (fixes build - time 0.3.48 is broken)

### DIFF
--- a/scripts/gentest/Cargo.toml
+++ b/scripts/gentest/Cargo.toml
@@ -12,3 +12,6 @@ serde_json = "1"
 tokio = { version = "1.18", features = ["full"] }
 walkdir = "2.3.3"
 xmlwriter = "0.1"
+
+# Pin time to fix https://github.com/time-rs/time/issues/783
+time = "=0.3.47"


### PR DESCRIPTION
# Objective

Fixes build (test generator)

## Context

- https://github.com/time-rs/time/issues/783