### PR TITLE
block: in-flow children's vertical available space is indefinite, not a min-content constraint

### DIFF
--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -734,8 +734,15 @@ fn perform_final_layout_on_in_flow_children(
     let container_percentage_resolution_height =
         container_percentage_resolution_height.maybe_sub(resolved_content_box_inset.vertical_axis_sum());
     let parent_size = Size { width: Some(container_inner_width), height: container_percentage_resolution_height };
+    // Vertical available space in block flow is indefinite, NOT a min-content
+    // constraint: MaxContent is taffy's representation of "indefinite".
+    // Passing MinContent here made every descendant grid believe it was being
+    // sized under a min-content constraint, in which the maximize-tracks step
+    // has zero free space — so auto rows containing only scroll-container
+    // items (overflow != visible, automatic minimum size = 0) collapsed to
+    // zero height. Browsers size such rows to the item's content.
     let available_space =
-        Size { width: AvailableSpace::Definite(container_inner_width), height: AvailableSpace::MinContent };
+        Size { width: AvailableSpace::Definite(container_inner_width), height: AvailableSpace::MaxContent };
 
     // TODO: handle nested blocks with different widths
     #[cfg(feature = "float_layout")]


### PR DESCRIPTION
`perform_final_layout_on_in_flow_children` passes `available_space.height = AvailableSpace::MinContent` for auto-height block containers. `MinContent` doesn't mean "height unknown" — it means "sized under a min-content constraint", under which the grid spec's maximize-tracks step has zero free space, so grid items that are scroll containers (`overflow != visible`; automatic minimum size = zero) collapse auto rows to 0 height. Browsers size such rows to the item's content.

Minimal repro: `body(block, width 800, height auto) > grid(600px, "1fr 1fr" columns) > card(block, overflow:hidden) > child(168px tall)` → card height 0; Chrome/Firefox/WebKit give 168. The same tree with the grid as the layout root (available space `MAX_CONTENT`) already produced 168 — the constraint only arrives via the block parent.

Switching the propagated value to `MaxContent` (the existing representation of "indefinite") fixes it:

- taffy's own suite: all green (107 unit + 45 hand-written + 4409 fixtures).
- WPT `css/css-grid` + `css/css-flexbox` via blitz's runner: 8 new passes (`flexbox_rowspan*`, `align-content-wrap-004`, `percentage-max-height-004`, `grid-gutters-and-flex-content-001`, `subgrid-scroller-auto-height-padding`, `flexbox-align-self-baseline-compatability`), 2 regressions (`flex-sizing-rows-indefinite-height`, `grid-template-flexible-rerun-track-sizing`).

The two regressions come from grid's "max-content minimums" step (step 3 of intrinsic track sizing, gated on `axis_available_grid_space == AvailableSpace::MaxContent`) now firing for indefinite-height grids: `AvailableSpace` cannot distinguish "indefinite" from "sized under a max-content constraint". A complete fix probably needs that distinction made explicit (an `Indefinite` variant, or threading the constraint separately) — opening this PR as much for that design question as for the fix itself; happy to rework in whichever direction you prefer.

Found via blitz/Dioxus Native: a real app's card grid (block overflow-hidden cards in an auto-row grid under an auto-height page) rendered every card 1px tall.
