### PR TITLE
block: derive definite height from aspect-ratio at final layout

### DIFF
--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -363,7 +363,6 @@ fn compute_inner(
     let padding_border = padding + border;
     let padding_border_size = padding_border.sum_axes();
     let content_box_inset = padding_border + scrollbar_gutter;
-    let container_content_box_size = known_dimensions.maybe_sub(content_box_inset.sum_axes());
 
     // Apply content box inset
     #[cfg(feature = "float_layout")]
@@ -386,6 +385,19 @@ fn compute_inner(
         .maybe_resolve(parent_size, |val, basis| tree.calc(val, basis))
         .maybe_apply_aspect_ratio(aspect_ratio)
         .maybe_add(box_sizing_adjustment);
+
+    // css-sizing-4: a definite size in one axis transfers through `aspect-ratio`
+    // to make the other definite. Deriving it from `known_dimensions` self-gates
+    // the transfer — a block parent fills an axis only when it's a real
+    // constraint (e.g. the stretched width at final layout) and leaves it None
+    // while probing intrinsic sizes, so measure passes stay content-based. Only a
+    // newly-filled axis is adopted (and clamped); an incoming known size is left
+    // as the parent resolved it (re-clamping would undo padding/border overrides).
+    let known_dimensions = {
+        let derived = known_dimensions.maybe_apply_aspect_ratio(aspect_ratio).maybe_clamp(min_size, max_size);
+        Size { width: known_dimensions.width.or(derived.width), height: known_dimensions.height.or(derived.height) }
+    };
+    let container_content_box_size = known_dimensions.maybe_sub(content_box_inset.sum_axes());
 
     let overflow = style.overflow();
     let is_scroll_container = overflow.x.is_scroll_container() || overflow.y.is_scroll_container();

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -734,8 +734,15 @@ fn perform_final_layout_on_in_flow_children(
     let container_percentage_resolution_height =
         container_percentage_resolution_height.maybe_sub(resolved_content_box_inset.vertical_axis_sum());
     let parent_size = Size { width: Some(container_inner_width), height: container_percentage_resolution_height };
+    // Vertical available space in block flow is indefinite, NOT a min-content
+    // constraint: MaxContent is taffy's representation of "indefinite".
+    // Passing MinContent here made every descendant grid believe it was being
+    // sized under a min-content constraint, in which the maximize-tracks step
+    // has zero free space — so auto rows containing only scroll-container
+    // items (overflow != visible, automatic minimum size = 0) collapsed to
+    // zero height. Browsers size such rows to the item's content.
     let available_space =
-        Size { width: AvailableSpace::Definite(container_inner_width), height: AvailableSpace::MinContent };
+        Size { width: AvailableSpace::Definite(container_inner_width), height: AvailableSpace::MaxContent };
 
     // TODO: handle nested blocks with different widths
     #[cfg(feature = "float_layout")]

--- a/test_fixtures/block/block_aspect_ratio_stretch_width.html
+++ b/test_fixtures/block/block_aspect_ratio_stretch_width.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px; height: 200px;">
+  <div style="display: block; aspect-ratio: 1;">
+    <div style="display: block;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/block/block_aspect_ratio_stretch_width_max_height.html
+++ b/test_fixtures/block/block_aspect_ratio_stretch_width_max_height.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px; height: 200px;">
+  <div style="display: block; aspect-ratio: 1; max-height: 40px;">
+    <div style="display: block;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/block/block_aspect_ratio_stretch_width_percentage_child.html
+++ b/test_fixtures/block/block_aspect_ratio_stretch_width_percentage_child.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px; height: 200px;">
+  <div style="display: block; aspect-ratio: 2;">
+    <div style="display: block; height: 100%;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/block/block_aspect_ratio_stretch_width__border_box_ltr.xml
+++ b/tests/xml/block/block_aspect_ratio_stretch_width__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_stretch_width__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px" height="200px">
+      <div display="block" direction="ltr" aspect-ratio="1">
+        <div display="block" direction="ltr"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="200">
+      <node x="0" y="0" width="100" height="100">
+        <node x="0" y="0" width="100" height="0"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_stretch_width__border_box_rtl.xml
+++ b/tests/xml/block/block_aspect_ratio_stretch_width__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_stretch_width__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px" height="200px">
+      <div display="block" direction="rtl" aspect-ratio="1">
+        <div display="block" direction="rtl"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="200">
+      <node x="0" y="0" width="100" height="100">
+        <node x="0" y="0" width="100" height="0"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_stretch_width__content_box_ltr.xml
+++ b/tests/xml/block/block_aspect_ratio_stretch_width__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_stretch_width__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px" height="200px">
+      <div display="block" box-sizing="content-box" direction="ltr" aspect-ratio="1">
+        <div display="block" box-sizing="content-box" direction="ltr"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="200">
+      <node x="0" y="0" width="100" height="100">
+        <node x="0" y="0" width="100" height="0"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_stretch_width__content_box_rtl.xml
+++ b/tests/xml/block/block_aspect_ratio_stretch_width__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_stretch_width__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px" height="200px">
+      <div display="block" box-sizing="content-box" direction="rtl" aspect-ratio="1">
+        <div display="block" box-sizing="content-box" direction="rtl"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="200">
+      <node x="0" y="0" width="100" height="100">
+        <node x="0" y="0" width="100" height="0"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_stretch_width_max_height__border_box_ltr.xml
+++ b/tests/xml/block/block_aspect_ratio_stretch_width_max_height__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_stretch_width_max_height__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px" height="200px">
+      <div display="block" direction="ltr" max-height="40px" aspect-ratio="1">
+        <div display="block" direction="ltr"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="200">
+      <node x="0" y="0" width="40" height="40">
+        <node x="0" y="0" width="40" height="0"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_stretch_width_max_height__border_box_rtl.xml
+++ b/tests/xml/block/block_aspect_ratio_stretch_width_max_height__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_stretch_width_max_height__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px" height="200px">
+      <div display="block" direction="rtl" max-height="40px" aspect-ratio="1">
+        <div display="block" direction="rtl"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="200">
+      <node x="60" y="0" width="40" height="40">
+        <node x="0" y="0" width="40" height="0"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_stretch_width_max_height__content_box_ltr.xml
+++ b/tests/xml/block/block_aspect_ratio_stretch_width_max_height__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_stretch_width_max_height__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px" height="200px">
+      <div display="block" box-sizing="content-box" direction="ltr" max-height="40px" aspect-ratio="1">
+        <div display="block" box-sizing="content-box" direction="ltr"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="200">
+      <node x="0" y="0" width="40" height="40">
+        <node x="0" y="0" width="40" height="0"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_stretch_width_max_height__content_box_rtl.xml
+++ b/tests/xml/block/block_aspect_ratio_stretch_width_max_height__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_stretch_width_max_height__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px" height="200px">
+      <div display="block" box-sizing="content-box" direction="rtl" max-height="40px" aspect-ratio="1">
+        <div display="block" box-sizing="content-box" direction="rtl"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="200">
+      <node x="60" y="0" width="40" height="40">
+        <node x="0" y="0" width="40" height="0"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_stretch_width_percentage_child__border_box_ltr.xml
+++ b/tests/xml/block/block_aspect_ratio_stretch_width_percentage_child__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_stretch_width_percentage_child__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px" height="200px">
+      <div display="block" direction="ltr" aspect-ratio="2">
+        <div display="block" direction="ltr" height="100%"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="200">
+      <node x="0" y="0" width="100" height="50">
+        <node x="0" y="0" width="100" height="50"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_stretch_width_percentage_child__border_box_rtl.xml
+++ b/tests/xml/block/block_aspect_ratio_stretch_width_percentage_child__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_stretch_width_percentage_child__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px" height="200px">
+      <div display="block" direction="rtl" aspect-ratio="2">
+        <div display="block" direction="rtl" height="100%"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="200">
+      <node x="0" y="0" width="100" height="50">
+        <node x="0" y="0" width="100" height="50"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_stretch_width_percentage_child__content_box_ltr.xml
+++ b/tests/xml/block/block_aspect_ratio_stretch_width_percentage_child__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_stretch_width_percentage_child__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px" height="200px">
+      <div display="block" box-sizing="content-box" direction="ltr" aspect-ratio="2">
+        <div display="block" box-sizing="content-box" direction="ltr" height="100%"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="200">
+      <node x="0" y="0" width="100" height="50">
+        <node x="0" y="0" width="100" height="50"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_stretch_width_percentage_child__content_box_rtl.xml
+++ b/tests/xml/block/block_aspect_ratio_stretch_width_percentage_child__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_stretch_width_percentage_child__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px" height="200px">
+      <div display="block" box-sizing="content-box" direction="rtl" aspect-ratio="2">
+        <div display="block" box-sizing="content-box" direction="rtl" height="100%"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="200">
+      <node x="0" y="0" width="100" height="50">
+        <node x="0" y="0" width="100" height="50"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -1666,6 +1666,66 @@ mod block {
     }
 
     #[test]
+    fn block_aspect_ratio_stretch_width__border_box_ltr() {
+        crate::run_xml_test("block", "block_aspect_ratio_stretch_width__border_box_ltr");
+    }
+
+    #[test]
+    fn block_aspect_ratio_stretch_width__content_box_ltr() {
+        crate::run_xml_test("block", "block_aspect_ratio_stretch_width__content_box_ltr");
+    }
+
+    #[test]
+    fn block_aspect_ratio_stretch_width__border_box_rtl() {
+        crate::run_xml_test("block", "block_aspect_ratio_stretch_width__border_box_rtl");
+    }
+
+    #[test]
+    fn block_aspect_ratio_stretch_width__content_box_rtl() {
+        crate::run_xml_test("block", "block_aspect_ratio_stretch_width__content_box_rtl");
+    }
+
+    #[test]
+    fn block_aspect_ratio_stretch_width_max_height__border_box_ltr() {
+        crate::run_xml_test("block", "block_aspect_ratio_stretch_width_max_height__border_box_ltr");
+    }
+
+    #[test]
+    fn block_aspect_ratio_stretch_width_max_height__content_box_ltr() {
+        crate::run_xml_test("block", "block_aspect_ratio_stretch_width_max_height__content_box_ltr");
+    }
+
+    #[test]
+    fn block_aspect_ratio_stretch_width_max_height__border_box_rtl() {
+        crate::run_xml_test("block", "block_aspect_ratio_stretch_width_max_height__border_box_rtl");
+    }
+
+    #[test]
+    fn block_aspect_ratio_stretch_width_max_height__content_box_rtl() {
+        crate::run_xml_test("block", "block_aspect_ratio_stretch_width_max_height__content_box_rtl");
+    }
+
+    #[test]
+    fn block_aspect_ratio_stretch_width_percentage_child__border_box_ltr() {
+        crate::run_xml_test("block", "block_aspect_ratio_stretch_width_percentage_child__border_box_ltr");
+    }
+
+    #[test]
+    fn block_aspect_ratio_stretch_width_percentage_child__content_box_ltr() {
+        crate::run_xml_test("block", "block_aspect_ratio_stretch_width_percentage_child__content_box_ltr");
+    }
+
+    #[test]
+    fn block_aspect_ratio_stretch_width_percentage_child__border_box_rtl() {
+        crate::run_xml_test("block", "block_aspect_ratio_stretch_width_percentage_child__border_box_rtl");
+    }
+
+    #[test]
+    fn block_aspect_ratio_stretch_width_percentage_child__content_box_rtl() {
+        crate::run_xml_test("block", "block_aspect_ratio_stretch_width_percentage_child__content_box_rtl");
+    }
+
+    #[test]
     fn block_basic__border_box_ltr() {
         crate::run_xml_test("block", "block_basic__border_box_ltr");
     }


### PR DESCRIPTION
A block container with `aspect-ratio` and an auto height never became definite when its width was resolved (stretched or filled) rather than explicitly specified: children's percentage heights resolved to nothing, and the container grew to its content height, violating the ratio.

Real-world shape (via blitz/Dioxus Native + Tailwind): an `aspect-square` card containing an `<img>` with `width/height: 100%` — Tailwind's preflight makes images `display: block`, so this is pure block layout. The card sized 16:9 from the image's intrinsic ratio instead of staying square, and after fixing the container the image still letterboxed because its `height: 100%` had been resolved against the then-unknown container height.

Two changes in `compute_inner`:

1. Derive a definite height from `aspect-ratio` + the resolved width (clamped by min/max) — used both as the children's percentage-resolution height and as the container's final height (css-sizing-4: a definite width transfers through the ratio).
2. Re-resolve item sizes against that height, so percentage heights become definite (they were resolved in `generate_item_list` before the width — and hence the derived height — existed).

Both are gated to `RunMode::PerformLayout`: widths in measure passes are tentative and must not transfer through the ratio, keeping intrinsic contributions content-based (the `flex-aspect-ratio-percentage-height-stale-width` semantics).

Validation: the full fixture suite passes (4409) plus unit and hand-written suites. Via blitz's WPT runner, `css/css-sizing` gains 36 aspect-ratio test passes; two `css/css-grid/grid-lanes` tests flip to FAIL because they exercise the unimplemented grid-lanes display type and previously passed only because an `aspect-ratio` marker element collapsed to zero height (the same accidental-pass mechanism this PR fixes).
