### PR TITLE
Remove time pin

### DIFF
--- a/scripts/gentest/Cargo.toml
+++ b/scripts/gentest/Cargo.toml
@@ -12,6 +12,3 @@ serde_json = "1"
 tokio = { version = "1.18", features = ["full"] }
 walkdir = "2.3.3"
 xmlwriter = "0.1"
-
-# Pin time to fix https://github.com/time-rs/time/issues/783
-time = "=0.3.49"


### PR DESCRIPTION
# Objective

The bug in `time` that we were working around with the pin has been fixed. We can revert to a regular semver-based dependency specification.

## Context

- We were pinning to work around time 0.3.48 being broken https://github.com/time-rs/time/issues/783
