### PR TITLE
Fix layout gaps

### DIFF
--- a/scripts/gentest/test_helper.js
+++ b/scripts/gentest/test_helper.js
@@ -317,8 +317,8 @@ function describeElement(e) {
     smartRoundedLayout: {
       width: Math.round(boundingRect.right) - Math.round(boundingRect.left),
       height: Math.round(boundingRect.bottom) - Math.round(boundingRect.top),
-      x: Math.round(boundingRect.x - parentBoundingRect.x),
-      y: Math.round(boundingRect.y - parentBoundingRect.y),
+      x: Math.round(boundingRect.x) - Math.round(parentBoundingRect.x),
+      y: Math.round(boundingRect.y) - Math.round(parentBoundingRect.y),
       scrollWidth: e.scrollWidth,
       scrollHeight: e.scrollHeight,
       clientWidth: e.clientWidth,

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -227,8 +227,8 @@ pub fn round_layout(tree: &mut impl RoundTree, node_id: NodeId) {
         let abs_x = parent_abs_x + unrounded_layout.location.x;
         let abs_y = parent_abs_y + unrounded_layout.location.y;
 
-        layout.location.x = round(unrounded_layout.location.x);
-        layout.location.y = round(unrounded_layout.location.y);
+        layout.location.x = round(abs_x) - round(parent_abs_x);
+        layout.location.y = round(abs_y) - round(parent_abs_y);
         layout.size.width = round(abs_x + unrounded_layout.size.width) - round(abs_x);
         layout.size.height = round(abs_y + unrounded_layout.size.height) - round(abs_y);
         layout.scrollbar_size.width = round(unrounded_layout.scrollbar_size.width);

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -220,41 +220,41 @@ pub fn round_layout(tree: &mut impl RoundTree, node_id: NodeId) {
     return round_layout_inner(tree, node_id, 0.0, 0.0);
 
     /// Recursive function to apply rounding to all descendents
-    fn round_layout_inner(tree: &mut impl RoundTree, node_id: NodeId, cumulative_x: f32, cumulative_y: f32) {
+    fn round_layout_inner(tree: &mut impl RoundTree, node_id: NodeId, parent_abs_x: f32, parent_abs_y: f32) {
         let unrounded_layout = tree.get_unrounded_layout(node_id);
         let mut layout = unrounded_layout;
 
-        let cumulative_x = cumulative_x + unrounded_layout.location.x;
-        let cumulative_y = cumulative_y + unrounded_layout.location.y;
+        let abs_x = parent_abs_x + unrounded_layout.location.x;
+        let abs_y = parent_abs_y + unrounded_layout.location.y;
 
         layout.location.x = round(unrounded_layout.location.x);
         layout.location.y = round(unrounded_layout.location.y);
-        layout.size.width = round(cumulative_x + unrounded_layout.size.width) - round(cumulative_x);
-        layout.size.height = round(cumulative_y + unrounded_layout.size.height) - round(cumulative_y);
+        layout.size.width = round(abs_x + unrounded_layout.size.width) - round(abs_x);
+        layout.size.height = round(abs_y + unrounded_layout.size.height) - round(abs_y);
         layout.scrollbar_size.width = round(unrounded_layout.scrollbar_size.width);
         layout.scrollbar_size.height = round(unrounded_layout.scrollbar_size.height);
-        layout.border.left = round(cumulative_x + unrounded_layout.border.left) - round(cumulative_x);
-        layout.border.right = round(cumulative_x + unrounded_layout.size.width)
-            - round(cumulative_x + unrounded_layout.size.width - unrounded_layout.border.right);
-        layout.border.top = round(cumulative_y + unrounded_layout.border.top) - round(cumulative_y);
-        layout.border.bottom = round(cumulative_y + unrounded_layout.size.height)
-            - round(cumulative_y + unrounded_layout.size.height - unrounded_layout.border.bottom);
-        layout.padding.left = round(cumulative_x + unrounded_layout.padding.left) - round(cumulative_x);
-        layout.padding.right = round(cumulative_x + unrounded_layout.size.width)
-            - round(cumulative_x + unrounded_layout.size.width - unrounded_layout.padding.right);
-        layout.padding.top = round(cumulative_y + unrounded_layout.padding.top) - round(cumulative_y);
-        layout.padding.bottom = round(cumulative_y + unrounded_layout.size.height)
-            - round(cumulative_y + unrounded_layout.size.height - unrounded_layout.padding.bottom);
+        layout.border.left = round(abs_x + unrounded_layout.border.left) - round(abs_x);
+        layout.border.right = round(abs_x + unrounded_layout.size.width)
+            - round(abs_x + unrounded_layout.size.width - unrounded_layout.border.right);
+        layout.border.top = round(abs_y + unrounded_layout.border.top) - round(abs_y);
+        layout.border.bottom = round(abs_y + unrounded_layout.size.height)
+            - round(abs_y + unrounded_layout.size.height - unrounded_layout.border.bottom);
+        layout.padding.left = round(abs_x + unrounded_layout.padding.left) - round(abs_x);
+        layout.padding.right = round(abs_x + unrounded_layout.size.width)
+            - round(abs_x + unrounded_layout.size.width - unrounded_layout.padding.right);
+        layout.padding.top = round(abs_y + unrounded_layout.padding.top) - round(abs_y);
+        layout.padding.bottom = round(abs_y + unrounded_layout.size.height)
+            - round(abs_y + unrounded_layout.size.height - unrounded_layout.padding.bottom);
 
         #[cfg(feature = "content_size")]
-        round_content_size(&mut layout, unrounded_layout.content_size, cumulative_x, cumulative_y);
+        round_content_size(&mut layout, unrounded_layout.content_size, abs_x, abs_y);
 
         tree.set_final_layout(node_id, &layout);
 
         let child_count = tree.child_count(node_id);
         for index in 0..child_count {
             let child = tree.get_child_id(node_id, index);
-            round_layout_inner(tree, child, cumulative_x, cumulative_y);
+            round_layout_inner(tree, child, abs_x, abs_y);
         }
     }
 
@@ -262,14 +262,9 @@ pub fn round_layout(tree: &mut impl RoundTree, node_id: NodeId) {
     #[inline(always)]
     /// Round content size variables.
     /// This is split into a separate function to make it easier to feature flag.
-    fn round_content_size(
-        layout: &mut Layout,
-        unrounded_content_size: Size<f32>,
-        cumulative_x: f32,
-        cumulative_y: f32,
-    ) {
-        layout.content_size.width = round(cumulative_x + unrounded_content_size.width) - round(cumulative_x);
-        layout.content_size.height = round(cumulative_y + unrounded_content_size.height) - round(cumulative_y);
+    fn round_content_size(layout: &mut Layout, unrounded_content_size: Size<f32>, abs_x: f32, abs_y: f32) {
+        layout.content_size.width = round(abs_x + unrounded_content_size.width) - round(abs_x);
+        layout.content_size.height = round(abs_y + unrounded_content_size.height) - round(abs_y);
     }
 }
 

--- a/tests/xml/flex/align_baseline_child_margin_percent__border_box_ltr.xml
+++ b/tests/xml/flex/align_baseline_child_margin_percent__border_box_ltr.xml
@@ -12,7 +12,7 @@
     <node x="0" y="0" width="100" height="100">
       <node x="5" y="5" width="40" height="50"/>
       <node x="50" y="45" width="50" height="20">
-        <node x="1" y="1" width="50" height="10"/>
+        <node x="1" y="0" width="50" height="10"/>
       </node>
     </node>
   </expectations>

--- a/tests/xml/flex/align_baseline_child_margin_percent__border_box_rtl.xml
+++ b/tests/xml/flex/align_baseline_child_margin_percent__border_box_rtl.xml
@@ -12,7 +12,7 @@
     <node x="0" y="0" width="100" height="100">
       <node x="55" y="5" width="40" height="50"/>
       <node x="0" y="45" width="50" height="20">
-        <node x="0" y="1" width="50" height="10"/>
+        <node x="0" y="0" width="50" height="10"/>
       </node>
     </node>
   </expectations>

--- a/tests/xml/flex/align_baseline_child_margin_percent__content_box_ltr.xml
+++ b/tests/xml/flex/align_baseline_child_margin_percent__content_box_ltr.xml
@@ -12,7 +12,7 @@
     <node x="0" y="0" width="100" height="100">
       <node x="5" y="5" width="40" height="50"/>
       <node x="50" y="45" width="50" height="20">
-        <node x="1" y="1" width="50" height="10"/>
+        <node x="1" y="0" width="50" height="10"/>
       </node>
     </node>
   </expectations>

--- a/tests/xml/flex/align_baseline_child_margin_percent__content_box_rtl.xml
+++ b/tests/xml/flex/align_baseline_child_margin_percent__content_box_rtl.xml
@@ -12,7 +12,7 @@
     <node x="0" y="0" width="100" height="100">
       <node x="55" y="5" width="40" height="50"/>
       <node x="0" y="45" width="50" height="20">
-        <node x="0" y="1" width="50" height="10"/>
+        <node x="0" y="0" width="50" height="10"/>
       </node>
     </node>
   </expectations>

--- a/tests/xml/flex/rounding_fractial_input_6__border_box_rtl.xml
+++ b/tests/xml/flex/rounding_fractial_input_6__border_box_rtl.xml
@@ -15,8 +15,8 @@
   <expectations>
     <node x="0" y="0" width="7" height="20">
       <node x="4" y="0" width="3" height="20">
-        <node x="2" y="0" width="2" height="10"/>
-        <node x="2" y="10" width="2" height="10"/>
+        <node x="1" y="0" width="2" height="10"/>
+        <node x="1" y="10" width="2" height="10"/>
       </node>
       <node x="0" y="0" width="4" height="20">
         <node x="2" y="0" width="2" height="10"/>

--- a/tests/xml/flex/rounding_fractial_input_6__content_box_rtl.xml
+++ b/tests/xml/flex/rounding_fractial_input_6__content_box_rtl.xml
@@ -15,8 +15,8 @@
   <expectations>
     <node x="0" y="0" width="7" height="20">
       <node x="4" y="0" width="3" height="20">
-        <node x="2" y="0" width="2" height="10"/>
-        <node x="2" y="10" width="2" height="10"/>
+        <node x="1" y="0" width="2" height="10"/>
+        <node x="1" y="10" width="2" height="10"/>
       </node>
       <node x="0" y="0" width="4" height="20">
         <node x="2" y="0" width="2" height="10"/>

--- a/tests/xml/flex/rounding_fractial_input_7__border_box_rtl.xml
+++ b/tests/xml/flex/rounding_fractial_input_7__border_box_rtl.xml
@@ -27,8 +27,8 @@
         <node x="1" y="10" width="1" height="10"/>
       </node>
       <node x="4" y="0" width="1" height="20">
-        <node x="1" y="0" width="1" height="10"/>
-        <node x="1" y="10" width="1" height="10"/>
+        <node x="0" y="0" width="1" height="10"/>
+        <node x="0" y="10" width="1" height="10"/>
       </node>
       <node x="2" y="0" width="2" height="20">
         <node x="1" y="0" width="1" height="10"/>

--- a/tests/xml/flex/rounding_fractial_input_7__content_box_rtl.xml
+++ b/tests/xml/flex/rounding_fractial_input_7__content_box_rtl.xml
@@ -27,8 +27,8 @@
         <node x="1" y="10" width="1" height="10"/>
       </node>
       <node x="4" y="0" width="1" height="20">
-        <node x="1" y="0" width="1" height="10"/>
-        <node x="1" y="10" width="1" height="10"/>
+        <node x="0" y="0" width="1" height="10"/>
+        <node x="0" y="10" width="1" height="10"/>
       </node>
       <node x="2" y="0" width="2" height="20">
         <node x="1" y="0" width="1" height="10"/>


### PR DESCRIPTION
# Objective

Fixes #834 

## Context

Changed as described in https://github.com/DioxusLabs/taffy/issues/834#issuecomment-2931809833
Has to use the accumulated absolute position instead of the relative position of the node. As described in [the link](https://github.com/facebook/yoga/commit/aa5b296ac78f7a22e1aeaf4891243c6bb76488e2) in the function documentation.

## Feedback wanted

I took the liberty of renaming and splitting cumulative_x/y because it made it a little clearer to me what was going on, tell me if it's unwanted. 
