### PR TITLE
Block: don't  set_unrounded_layout when measuring

### DIFF
--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -533,16 +533,16 @@ fn compute_inner(
         }
     }
 
+    // Short-circuit if computing size
+    if run_mode == RunMode::ComputeSize {
+        return LayoutOutput::from_outer_size(final_outer_size);
+    }
+
     // Commit deferred in-flow layouts to the tree. Floated items already wrote their own layouts.
     for item in items.iter() {
         if let Some(layout) = item.final_layout.as_ref() {
             tree.set_unrounded_layout(item.node_id, layout);
         }
-    }
-
-    // Short-circuit if computing size
-    if run_mode == RunMode::ComputeSize {
-        return LayoutOutput::from_outer_size(final_outer_size);
     }
 
     // 4. Layout absolutely positioned children


### PR DESCRIPTION
# Objective

The layout for a node should only be set when performing final layout. This corrects a bug in Block layout where this was also being set while measuring. I'm unsure if this actually affects anything, but the change here is definitely more correct.

## Context

- Introduced in https://github.com/DioxusLabs/taffy/commit/dcdb0ede8ab755f3357268aa4b72be80e85a88cf
