### PR TITLE
Pass through run mode rather when performing final layout on block children

### DIFF
--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -470,6 +470,7 @@ fn compute_inner(
     let (mut inflow_content_size, mut intrinsic_outer_height, first_child_top_margin_set, last_child_bottom_margin_set) =
         perform_final_layout_on_in_flow_children(
             tree,
+            run_mode,
             &mut items,
             container_outer_width,
             container_percentage_resolution_height,
@@ -742,6 +743,7 @@ fn determine_content_based_container_width(
 #[allow(clippy::too_many_arguments)]
 fn perform_final_layout_on_in_flow_children(
     tree: &mut impl LayoutBlockContainer,
+    run_mode: RunMode,
     items: &mut [BlockItem],
     container_outer_width: f32,
     container_percentage_resolution_height: Option<f32>,
@@ -928,7 +930,7 @@ fn perform_final_layout_on_in_flow_children(
             //
 
             let inputs = LayoutInput {
-                run_mode: RunMode::PerformLayout,
+                run_mode,
                 sizing_mode: SizingMode::InherentSize,
                 axis: RequestedAxis::Both,
                 known_dimensions,


### PR DESCRIPTION
# Objective

This fixes a critical bug in Taffy 0.12 where it never performs layout on in-flow block children.

## Context

This bug was introduced in https://github.com/DioxusLabs/taffy/pull/911 which optimised block layout by sizing children with `RunMode::MeasureSize` rather than `RunMode::PerformLayout`. This is incorrect. The correct thing to do is pass through the run mode that the block container itself is being laid out under (if it's just being measured, then it only needs to measure it's children, but if it's having final layout performed then it needs to perform final layout on it's children)