### PR TITLE
Block: return margin-collapsing outputs from vertical axis `ComputeSize` calls

### DIFF
--- a/scripts/gentest/src/main.rs
+++ b/scripts/gentest/src/main.rs
@@ -68,7 +68,7 @@ async fn main() {
     let test_descs: Vec<_> = test_descs
         .iter()
         .flat_map(|(name, fixture_path, description)| {
-            debug!("generating test contents for {}", &name);
+            debug!("generating test contents for {}", name);
 
             let border_box_ltr_test =
                 generate_test(format!("{name}__border_box_ltr"), &description["borderBoxLtrData"]);
@@ -136,7 +136,7 @@ async fn main() {
 
         let mut test_filename = test_path.join(&name);
         test_filename.set_extension("xml");
-        debug!("writing {} to disk...", &name);
+        debug!("writing {} to disk...", name);
         fs::write(test_filename, test_body).unwrap();
     }
 

--- a/scripts/import-yoga-tests/src/main.rs
+++ b/scripts/import-yoga-tests/src/main.rs
@@ -72,7 +72,7 @@ fn main() {
             new_fixture_path.set_extension("html");
             let new_fixture_content = fixture_template.replace("__HTML_GOES_HERE__", &fixture.content);
 
-            println!("Writing new fixture {}", &fixture.name);
+            println!("Writing new fixture {}", fixture.name);
             fs::write(new_fixture_path, new_fixture_content).unwrap();
         }
     }

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -534,9 +534,39 @@ fn compute_inner(
         }
     }
 
-    // Short-circuit if computing size
+    // Determine whether this node can be collapsed through
+    let all_in_flow_children_can_be_collapsed_through =
+        items.iter().all(|item| item.position == Position::Absolute || item.can_be_collapsed_through);
+    let can_be_collapsed_through =
+        !has_styles_preventing_being_collapsed_through && all_in_flow_children_can_be_collapsed_through;
+
+    let mut output = LayoutOutput {
+        size: final_outer_size,
+        #[cfg(feature = "content_size")]
+        content_size: Size::ZERO,
+        first_baselines: Point::NONE,
+        top_margin: if own_margins_collapse_with_children.start {
+            first_child_top_margin_set
+        } else {
+            let margin_top = raw_margin.top.resolve_or_zero(parent_size.width, |val, basis| tree.calc(val, basis));
+            CollapsibleMarginSet::from_margin(margin_top)
+        },
+        bottom_margin: if own_margins_collapse_with_children.end {
+            last_child_bottom_margin_set
+        } else {
+            let margin_bottom =
+                raw_margin.bottom.resolve_or_zero(parent_size.width, |val, basis| tree.calc(val, basis));
+            CollapsibleMarginSet::from_margin(margin_bottom)
+        },
+        margins_can_collapse_through: can_be_collapsed_through,
+    };
+
+    // Short-circuit if computing size.
+    //
+    // Note: it is important that we return the margin-collapsing related outputs here as Parent block containers
+    // rely on the `top_margin`/`bottom_margin` of their children to compute their own intrinsic height.
     if run_mode == RunMode::ComputeSize {
-        return LayoutOutput::from_outer_size(final_outer_size);
+        return output;
     }
 
     // Commit deferred in-flow layouts to the tree. Floated items already wrote their own layouts.
@@ -558,6 +588,11 @@ fn compute_inner(
         direction,
     );
 
+    #[cfg(feature = "content_size")]
+    {
+        output.content_size = inflow_content_size.f32_max(absolute_content_size);
+    }
+
     // 5. Perform hidden layout on hidden children
     let len = tree.child_count(node_id);
     for order in 0..len {
@@ -577,35 +612,7 @@ fn compute_inner(
         }
     }
 
-    // 7. Determine whether this node can be collapsed through
-    let all_in_flow_children_can_be_collapsed_through =
-        items.iter().all(|item| item.position == Position::Absolute || item.can_be_collapsed_through);
-    let can_be_collapsed_through =
-        !has_styles_preventing_being_collapsed_through && all_in_flow_children_can_be_collapsed_through;
-
-    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
-    let content_size = inflow_content_size.f32_max(absolute_content_size);
-
-    LayoutOutput {
-        size: final_outer_size,
-        #[cfg(feature = "content_size")]
-        content_size,
-        first_baselines: Point::NONE,
-        top_margin: if own_margins_collapse_with_children.start {
-            first_child_top_margin_set
-        } else {
-            let margin_top = raw_margin.top.resolve_or_zero(parent_size.width, |val, basis| tree.calc(val, basis));
-            CollapsibleMarginSet::from_margin(margin_top)
-        },
-        bottom_margin: if own_margins_collapse_with_children.end {
-            last_child_bottom_margin_set
-        } else {
-            let margin_bottom =
-                raw_margin.bottom.resolve_or_zero(parent_size.width, |val, basis| tree.calc(val, basis));
-            CollapsibleMarginSet::from_margin(margin_bottom)
-        },
-        margins_can_collapse_through: can_be_collapsed_through,
-    }
+    output
 }
 
 /// Create a `Vec` of `BlockItem` structs where each item in the `Vec` represents a child of the current node


### PR DESCRIPTION
# Objective

Fix intrinsic height computations of block-size containers.

## Context

Block layout needs to process margin-collapsing when calculating intrinsic height. Otherwise you can end up with intrinsically sized nodes laying out at a larger height than they compute for their height, which causes either spurious scrolling or overlapping content depending on the clipping mode.
