### PR TITLE
Use `Into<f64>` in style helpers to avoid future compat lint with f32 fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Numeric style helpers (`length`, `percent`, `fr`, `flex`) now accept `Input: Into<f64>` instead of `Input: Into<f32>`. This allows bare float literals such as `length(800.0)` to be used without triggering the `float_literal_f32_fallback` future-compatibility lint, while widening the set of accepted numeric input types (#974)
+
 ## 0.12.2
 
 ### Fixed

--- a/src/style/available_space.rs
+++ b/src/style/available_space.rs
@@ -30,8 +30,8 @@ impl TaffyMinContent for AvailableSpace {
     const MIN_CONTENT: Self = Self::MinContent;
 }
 impl FromLength for AvailableSpace {
-    fn from_length<Input: Into<f32> + Copy>(value: Input) -> Self {
-        Self::Definite(value.into())
+    fn from_length<Input: Into<f64> + Copy>(value: Input) -> Self {
+        Self::Definite(value.into() as f32)
     }
 }
 

--- a/src/style/compact_length.rs
+++ b/src/style/compact_length.rs
@@ -467,18 +467,18 @@ impl TaffyMaxContent for CompactLength {
     const MAX_CONTENT: Self = Self::max_content();
 }
 impl FromLength for CompactLength {
-    fn from_length<Input: Into<f32> + Copy>(value: Input) -> Self {
-        Self::length(value.into())
+    fn from_length<Input: Into<f64> + Copy>(value: Input) -> Self {
+        Self::length(value.into() as f32)
     }
 }
 impl FromPercent for CompactLength {
-    fn from_percent<Input: Into<f32> + Copy>(value: Input) -> Self {
-        Self::percent(value.into())
+    fn from_percent<Input: Into<f64> + Copy>(value: Input) -> Self {
+        Self::percent(value.into() as f32)
     }
 }
 impl FromFr for CompactLength {
-    fn from_fr<Input: Into<f32> + Copy>(value: Input) -> Self {
-        Self::fr(value.into())
+    fn from_fr<Input: Into<f64> + Copy>(value: Input) -> Self {
+        Self::fr(value.into() as f32)
     }
 }
 impl TaffyFitContent for CompactLength {

--- a/src/style/dimension.rs
+++ b/src/style/dimension.rs
@@ -15,13 +15,13 @@ impl TaffyZero for LengthPercentage {
     const ZERO: Self = Self(CompactLength::ZERO);
 }
 impl FromLength for LengthPercentage {
-    fn from_length<Input: Into<f32> + Copy>(value: Input) -> Self {
-        Self::length(value.into())
+    fn from_length<Input: Into<f64> + Copy>(value: Input) -> Self {
+        Self::length(value.into() as f32)
     }
 }
 impl FromPercent for LengthPercentage {
-    fn from_percent<Input: Into<f32> + Copy>(value: Input) -> Self {
-        Self::percent(value.into())
+    fn from_percent<Input: Into<f64> + Copy>(value: Input) -> Self {
+        Self::percent(value.into() as f32)
     }
 }
 
@@ -107,13 +107,13 @@ impl TaffyAuto for LengthPercentageAuto {
     const AUTO: Self = Self(CompactLength::AUTO);
 }
 impl FromLength for LengthPercentageAuto {
-    fn from_length<Input: Into<f32> + Copy>(value: Input) -> Self {
-        Self::length(value.into())
+    fn from_length<Input: Into<f64> + Copy>(value: Input) -> Self {
+        Self::length(value.into() as f32)
     }
 }
 impl FromPercent for LengthPercentageAuto {
-    fn from_percent<Input: Into<f32> + Copy>(value: Input) -> Self {
-        Self::percent(value.into())
+    fn from_percent<Input: Into<f64> + Copy>(value: Input) -> Self {
+        Self::percent(value.into() as f32)
     }
 }
 impl From<LengthPercentage> for LengthPercentageAuto {
@@ -234,13 +234,13 @@ impl TaffyAuto for Dimension {
     const AUTO: Self = Self(CompactLength::AUTO);
 }
 impl FromLength for Dimension {
-    fn from_length<Input: Into<f32> + Copy>(value: Input) -> Self {
-        Self::length(value.into())
+    fn from_length<Input: Into<f64> + Copy>(value: Input) -> Self {
+        Self::length(value.into() as f32)
     }
 }
 impl FromPercent for Dimension {
-    fn from_percent<Input: Into<f32> + Copy>(value: Input) -> Self {
-        Self::percent(value.into())
+    fn from_percent<Input: Into<f64> + Copy>(value: Input) -> Self {
+        Self::percent(value.into() as f32)
     }
 }
 impl From<LengthPercentage> for Dimension {

--- a/src/style/grid.rs
+++ b/src/style/grid.rs
@@ -688,13 +688,13 @@ impl TaffyMaxContent for MaxTrackSizingFunction {
     const MAX_CONTENT: Self = Self(CompactLength::MAX_CONTENT);
 }
 impl FromLength for MaxTrackSizingFunction {
-    fn from_length<Input: Into<f32> + Copy>(value: Input) -> Self {
-        Self::length(value.into())
+    fn from_length<Input: Into<f64> + Copy>(value: Input) -> Self {
+        Self::length(value.into() as f32)
     }
 }
 impl FromPercent for MaxTrackSizingFunction {
-    fn from_percent<Input: Into<f32> + Copy>(value: Input) -> Self {
-        Self::percent(value.into())
+    fn from_percent<Input: Into<f64> + Copy>(value: Input) -> Self {
+        Self::percent(value.into() as f32)
     }
 }
 impl TaffyFitContent for MaxTrackSizingFunction {
@@ -703,8 +703,8 @@ impl TaffyFitContent for MaxTrackSizingFunction {
     }
 }
 impl FromFr for MaxTrackSizingFunction {
-    fn from_fr<Input: Into<f32> + Copy>(value: Input) -> Self {
-        Self::fr(value.into())
+    fn from_fr<Input: Into<f64> + Copy>(value: Input) -> Self {
+        Self::fr(value.into() as f32)
     }
 }
 impl From<LengthPercentage> for MaxTrackSizingFunction {
@@ -1018,13 +1018,13 @@ impl TaffyMaxContent for MinTrackSizingFunction {
     const MAX_CONTENT: Self = Self(CompactLength::MAX_CONTENT);
 }
 impl FromLength for MinTrackSizingFunction {
-    fn from_length<Input: Into<f32> + Copy>(value: Input) -> Self {
-        Self::length(value.into())
+    fn from_length<Input: Into<f64> + Copy>(value: Input) -> Self {
+        Self::length(value.into() as f32)
     }
 }
 impl FromPercent for MinTrackSizingFunction {
-    fn from_percent<Input: Into<f32> + Copy>(value: Input) -> Self {
-        Self::percent(value.into())
+    fn from_percent<Input: Into<f64> + Copy>(value: Input) -> Self {
+        Self::percent(value.into() as f32)
     }
 }
 impl From<LengthPercentage> for MinTrackSizingFunction {
@@ -1276,17 +1276,17 @@ impl TaffyZero for TrackSizingFunction {
     const ZERO: Self = Self { min: MinTrackSizingFunction::ZERO, max: MaxTrackSizingFunction::ZERO };
 }
 impl FromLength for TrackSizingFunction {
-    fn from_length<Input: Into<f32> + Copy>(value: Input) -> Self {
+    fn from_length<Input: Into<f64> + Copy>(value: Input) -> Self {
         Self { min: MinTrackSizingFunction::from_length(value), max: MaxTrackSizingFunction::from_length(value) }
     }
 }
 impl FromPercent for TrackSizingFunction {
-    fn from_percent<Input: Into<f32> + Copy>(percent: Input) -> Self {
+    fn from_percent<Input: Into<f64> + Copy>(percent: Input) -> Self {
         Self { min: MinTrackSizingFunction::from_percent(percent), max: MaxTrackSizingFunction::from_percent(percent) }
     }
 }
 impl FromFr for TrackSizingFunction {
-    fn from_fr<Input: Into<f32> + Copy>(flex: Input) -> Self {
+    fn from_fr<Input: Into<f64> + Copy>(flex: Input) -> Self {
         Self { min: MinTrackSizingFunction::AUTO, max: MaxTrackSizingFunction::from_fr(flex) }
     }
 }
@@ -1477,17 +1477,17 @@ impl<S: CheapCloneStr> TaffyZero for GridTemplateComponent<S> {
     const ZERO: Self = Self::Single(TrackSizingFunction::ZERO);
 }
 impl<S: CheapCloneStr> FromLength for GridTemplateComponent<S> {
-    fn from_length<Input: Into<f32> + Copy>(value: Input) -> Self {
+    fn from_length<Input: Into<f64> + Copy>(value: Input) -> Self {
         Self::Single(TrackSizingFunction::from_length(value))
     }
 }
 impl<S: CheapCloneStr> FromPercent for GridTemplateComponent<S> {
-    fn from_percent<Input: Into<f32> + Copy>(percent: Input) -> Self {
+    fn from_percent<Input: Into<f64> + Copy>(percent: Input) -> Self {
         Self::Single(TrackSizingFunction::from_percent(percent))
     }
 }
 impl<S: CheapCloneStr> FromFr for GridTemplateComponent<S> {
-    fn from_fr<Input: Into<f32> + Copy>(flex: Input) -> Self {
+    fn from_fr<Input: Into<f64> + Copy>(flex: Input) -> Self {
         Self::Single(TrackSizingFunction::from_fr(flex))
     }
 }

--- a/src/style_helpers.rs
+++ b/src/style_helpers.rs
@@ -79,10 +79,10 @@ where
 #[cfg(feature = "grid")]
 pub fn flex<Input, Output>(flex_fraction: Input) -> Output
 where
-    Input: Into<f32> + Copy,
+    Input: Into<f64> + Copy,
     Output: From<MinMax<MinTrackSizingFunction, MaxTrackSizingFunction>>,
 {
-    MinMax { min: zero(), max: fr(flex_fraction.into()) }.into()
+    MinMax { min: zero(), max: fr(flex_fraction) }.into()
 }
 
 /// Returns the zero value for that type
@@ -372,159 +372,159 @@ impl<T: TaffyFitContent> Rect<T> {
 }
 
 /// Returns a value of the inferred type which represent an absolute length
-pub fn length<Input: Into<f32> + Copy, T: FromLength>(value: Input) -> T {
+pub fn length<Input: Into<f64> + Copy, T: FromLength>(value: Input) -> T {
     T::from_length(value)
 }
 
 /// Trait to create absolute length values from plain numbers
 pub trait FromLength {
-    /// Converts into an `Into<f32>` into Self
-    fn from_length<Input: Into<f32> + Copy>(value: Input) -> Self;
+    /// Converts into an `Into<f64>` into Self
+    fn from_length<Input: Into<f64> + Copy>(value: Input) -> Self;
 }
 impl FromLength for f32 {
-    fn from_length<Input: Into<f32> + Copy>(value: Input) -> Self {
-        value.into()
+    fn from_length<Input: Into<f64> + Copy>(value: Input) -> Self {
+        value.into() as f32
     }
 }
 impl FromLength for Option<f32> {
-    fn from_length<Input: Into<f32> + Copy>(value: Input) -> Self {
-        Some(value.into())
+    fn from_length<Input: Into<f64> + Copy>(value: Input) -> Self {
+        Some(value.into() as f32)
     }
 }
 impl<T: FromLength> FromLength for Point<T> {
-    fn from_length<Input: Into<f32> + Copy>(value: Input) -> Self {
-        Point { x: T::from_length(value.into()), y: T::from_length(value.into()) }
+    fn from_length<Input: Into<f64> + Copy>(value: Input) -> Self {
+        Point { x: T::from_length(value), y: T::from_length(value) }
     }
 }
 impl<T: FromLength> Point<T> {
     /// Returns a Point where x and y values are the same given absolute length
-    pub fn length<Input: Into<f32> + Copy>(value: Input) -> Self {
+    pub fn length<Input: Into<f64> + Copy>(value: Input) -> Self {
         length::<Input, Self>(value)
     }
 }
 impl<T: FromLength> FromLength for Line<T> {
-    fn from_length<Input: Into<f32> + Copy>(value: Input) -> Self {
-        Line { start: T::from_length(value.into()), end: T::from_length(value.into()) }
+    fn from_length<Input: Into<f64> + Copy>(value: Input) -> Self {
+        Line { start: T::from_length(value), end: T::from_length(value) }
     }
 }
 impl<T: FromLength> Line<T> {
     /// Returns a Line where both the start and end values are the same given absolute length
-    pub fn length<Input: Into<f32> + Copy>(value: Input) -> Self {
+    pub fn length<Input: Into<f64> + Copy>(value: Input) -> Self {
         length::<Input, Self>(value)
     }
 }
 impl<T: FromLength> FromLength for Size<T> {
-    fn from_length<Input: Into<f32> + Copy>(value: Input) -> Self {
-        Size { width: T::from_length(value.into()), height: T::from_length(value.into()) }
+    fn from_length<Input: Into<f64> + Copy>(value: Input) -> Self {
+        Size { width: T::from_length(value), height: T::from_length(value) }
     }
 }
 impl<T: FromLength> Size<T> {
     /// Returns a Size where both the width and height values the same given absolute length
-    pub fn length<Input: Into<f32> + Copy>(value: Input) -> Self {
+    pub fn length<Input: Into<f64> + Copy>(value: Input) -> Self {
         length::<Input, Self>(value)
     }
 }
 impl<T: FromLength> FromLength for Rect<T> {
-    fn from_length<Input: Into<f32> + Copy>(value: Input) -> Self {
+    fn from_length<Input: Into<f64> + Copy>(value: Input) -> Self {
         Rect {
-            left: T::from_length(value.into()),
-            right: T::from_length(value.into()),
-            top: T::from_length(value.into()),
-            bottom: T::from_length(value.into()),
+            left: T::from_length(value),
+            right: T::from_length(value),
+            top: T::from_length(value),
+            bottom: T::from_length(value),
         }
     }
 }
 impl<T: FromLength> Rect<T> {
     /// Returns a Rect where the left, right, top and bottom values are all the same given absolute length
-    pub fn length<Input: Into<f32> + Copy>(value: Input) -> Self {
+    pub fn length<Input: Into<f64> + Copy>(value: Input) -> Self {
         length::<Input, Self>(value)
     }
 }
 
 /// Returns a value of the inferred type which represent a percentage
-pub fn percent<Input: Into<f32> + Copy, T: FromPercent>(percent: Input) -> T {
+pub fn percent<Input: Into<f64> + Copy, T: FromPercent>(percent: Input) -> T {
     T::from_percent(percent)
 }
 
 /// Trait to create constant percent values from plain numbers
 pub trait FromPercent {
-    /// Converts into an `Into<f32>` into Self
-    fn from_percent<Input: Into<f32> + Copy>(percent: Input) -> Self;
+    /// Converts into an `Into<f64>` into Self
+    fn from_percent<Input: Into<f64> + Copy>(percent: Input) -> Self;
 }
 impl FromPercent for f32 {
-    fn from_percent<Input: Into<f32> + Copy>(percent: Input) -> Self {
-        percent.into()
+    fn from_percent<Input: Into<f64> + Copy>(percent: Input) -> Self {
+        percent.into() as f32
     }
 }
 impl FromPercent for Option<f32> {
-    fn from_percent<Input: Into<f32> + Copy>(percent: Input) -> Self {
-        Some(percent.into())
+    fn from_percent<Input: Into<f64> + Copy>(percent: Input) -> Self {
+        Some(percent.into() as f32)
     }
 }
 impl<T: FromPercent> FromPercent for Point<T> {
-    fn from_percent<Input: Into<f32> + Copy>(percent: Input) -> Self {
-        Point { x: T::from_percent(percent.into()), y: T::from_percent(percent.into()) }
+    fn from_percent<Input: Into<f64> + Copy>(percent: Input) -> Self {
+        Point { x: T::from_percent(percent), y: T::from_percent(percent) }
     }
 }
 impl<T: FromPercent> Point<T> {
     /// Returns a Point where both the x and y values are the constant percent value of the contained type
     /// (e.g. 2.1, Some(2.1), or Dimension::Length(2.1))
-    pub fn percent<Input: Into<f32> + Copy>(percent_value: Input) -> Self {
+    pub fn percent<Input: Into<f64> + Copy>(percent_value: Input) -> Self {
         percent::<Input, Self>(percent_value)
     }
 }
 impl<T: FromPercent> FromPercent for Line<T> {
-    fn from_percent<Input: Into<f32> + Copy>(percent: Input) -> Self {
-        Line { start: T::from_percent(percent.into()), end: T::from_percent(percent.into()) }
+    fn from_percent<Input: Into<f64> + Copy>(percent: Input) -> Self {
+        Line { start: T::from_percent(percent), end: T::from_percent(percent) }
     }
 }
 impl<T: FromPercent> Line<T> {
     /// Returns a Line where both the start and end values are the constant percent value of the contained type
     /// (e.g. 2.1, Some(2.1), or Dimension::Length(2.1))
-    pub fn percent<Input: Into<f32> + Copy>(percent_value: Input) -> Self {
+    pub fn percent<Input: Into<f64> + Copy>(percent_value: Input) -> Self {
         percent::<Input, Self>(percent_value)
     }
 }
 impl<T: FromPercent> FromPercent for Size<T> {
-    fn from_percent<Input: Into<f32> + Copy>(percent: Input) -> Self {
-        Size { width: T::from_percent(percent.into()), height: T::from_percent(percent.into()) }
+    fn from_percent<Input: Into<f64> + Copy>(percent: Input) -> Self {
+        Size { width: T::from_percent(percent), height: T::from_percent(percent) }
     }
 }
 impl<T: FromPercent> Size<T> {
     /// Returns a Size where both the width and height values are the constant percent value of the contained type
     /// (e.g. 2.1, Some(2.1), or Dimension::Length(2.1))
-    pub fn percent<Input: Into<f32> + Copy>(percent_value: Input) -> Self {
+    pub fn percent<Input: Into<f64> + Copy>(percent_value: Input) -> Self {
         percent::<Input, Self>(percent_value)
     }
 }
 impl<T: FromPercent> FromPercent for Rect<T> {
-    fn from_percent<Input: Into<f32> + Copy>(percent: Input) -> Self {
+    fn from_percent<Input: Into<f64> + Copy>(percent: Input) -> Self {
         Rect {
-            left: T::from_percent(percent.into()),
-            right: T::from_percent(percent.into()),
-            top: T::from_percent(percent.into()),
-            bottom: T::from_percent(percent.into()),
+            left: T::from_percent(percent),
+            right: T::from_percent(percent),
+            top: T::from_percent(percent),
+            bottom: T::from_percent(percent),
         }
     }
 }
 impl<T: FromPercent> Rect<T> {
     /// Returns a Rect where the left, right, top and bottom values are all constant percent value of the contained type
     /// (e.g. 2.1, Some(2.1), or Dimension::Length(2.1))
-    pub fn percent<Input: Into<f32> + Copy>(percent_value: Input) -> Self {
+    pub fn percent<Input: Into<f64> + Copy>(percent_value: Input) -> Self {
         percent::<Input, Self>(percent_value)
     }
 }
 
 /// Create a `Fraction` track sizing function (`fr` in CSS)
 #[cfg(feature = "grid")]
-pub fn fr<Input: Into<f32> + Copy, T: FromFr>(flex: Input) -> T {
+pub fn fr<Input: Into<f64> + Copy, T: FromFr>(flex: Input) -> T {
     T::from_fr(flex)
 }
 
 /// Trait to create constant percent values from plain numbers
 pub trait FromFr {
-    /// Converts into an `Into<f32>` into Self
-    fn from_fr<Input: Into<f32> + Copy>(flex: Input) -> Self;
+    /// Converts into an `Into<f64>` into Self
+    fn from_fr<Input: Into<f64> + Copy>(flex: Input) -> Self;
 }
 
 #[cfg(feature = "grid")]


### PR DESCRIPTION
# Objective

Fixes #974.

The README code example (run as a doctest via `#![doc = include_str!("../README.md")]`) emits the `float_literal_f32_fallback` warning, which [will become a hard error in a future Rust release](https://github.com/rust-lang/rust/issues/154024).

The cause is the generic bound on the numeric style helpers, e.g.:

```rust
pub fn length<Input: Into<f32> + Copy, T: FromLength>(value: Input) -> T
```

Since `f32` is *currently* the only float type that implements `Into<f32>`, a bare literal like `length(800.0)` has its type picked as f32 rather than the f64 default. However, in future this will break when `f16` is introduced, which will also implement `Into<f32>`.

## Context

Rather than annotating the literals in the README with `_f32` suffixes (which just papers over the ergonomic wart), this changes the helper bound from `Into<f32>` to `Into<f64>`:

```rust
// before
pub fn length<Input: Into<f32> + Copy, T: FromLength>(value: Input) -> T
// after
pub fn length<Input: Into<f64> + Copy, T: FromLength>(value: Input) -> T
```

With `Into<f64>`, a bare `800.0` resolves to `f64` (the normal float-literal default), so no f32-fallback is involved and the lint no longer fires. The value is narrowed to the internally-stored `f32` at the leaf conversion sites via `value.into() as f32` (lossless for `f32` inputs and in-range integers).

Applied to `length`, `percent`, `fr`, `flex`, the inherent `Point`/`Line`/`Size`/`Rect` methods, and the `FromLength`/`FromPercent`/`FromFr` trait methods.

Verified on nightly (`rustc 1.99`):

`cargo test --all-features`, `cargo fmt --all --check`, and `cargo clippy --workspace -- -D warnings` all pass.