### PR TITLE
Add `#[inline(always)]` to functions and methods in style_helpers.rs

### DIFF
--- a/src/style_helpers.rs
+++ b/src/style_helpers.rs
@@ -19,6 +19,7 @@ use core::fmt::Debug;
 
 /// Returns an auto-repeated track definition
 #[cfg(feature = "grid")]
+#[inline(always)]
 pub fn repeat<Input, S>(repetition_kind: Input, tracks: Vec<TrackSizingFunction>) -> GridTemplateComponent<S>
 where
     Input: TryInto<RepetitionCount>,
@@ -34,6 +35,7 @@ where
 
 #[cfg(feature = "grid")]
 /// Returns a grid template containing `count` evenly sized tracks
+#[inline(always)]
 pub fn evenly_sized_tracks<S: CheapCloneStr>(count: u16) -> Vec<GridTemplateComponent<S>> {
     use crate::util::sys::new_vec_with_capacity;
     let mut repeated_tracks = new_vec_with_capacity(1);
@@ -47,6 +49,7 @@ pub fn evenly_sized_tracks<S: CheapCloneStr>(count: u16) -> Vec<GridTemplateComp
 ///  - Positive indices count upwards from the start (top or left) of the explicit grid
 ///  - Negative indices count downwards from the end (bottom or right) of the explicit grid
 ///  - ZERO IS INVALID index, and will be treated as a GridPlacement::Auto.
+#[inline(always)]
 pub fn line<T: TaffyGridLine>(index: i16) -> T {
     T::from_line_index(index)
 }
@@ -57,6 +60,7 @@ pub trait TaffyGridLine {
 }
 
 /// Returns a GridPlacement::Span
+#[inline(always)]
 pub fn span<T: TaffyGridSpan>(span: u16) -> T {
     T::from_span(span)
 }
@@ -68,6 +72,7 @@ pub trait TaffyGridSpan {
 
 /// Returns a MinMax with min value of min and max value of max
 #[cfg(feature = "grid")]
+#[inline(always)]
 pub fn minmax<Output>(min: MinTrackSizingFunction, max: MaxTrackSizingFunction) -> Output
 where
     Output: From<MinMax<MinTrackSizingFunction, MaxTrackSizingFunction>>,
@@ -77,6 +82,7 @@ where
 
 /// Shorthand for minmax(0, Nfr). Probably what you want if you want exactly evenly sized tracks.
 #[cfg(feature = "grid")]
+#[inline(always)]
 pub fn flex<Input, Output>(flex_fraction: Input) -> Output
 where
     Input: Into<f64> + Copy,
@@ -86,6 +92,7 @@ where
 }
 
 /// Returns the zero value for that type
+#[inline(always)]
 pub const fn zero<T: TaffyZero>() -> T {
     T::ZERO
 }
@@ -107,6 +114,7 @@ impl<T: TaffyZero> TaffyZero for Point<T> {
 impl<T: TaffyZero> Point<T> {
     /// Returns a Point where both the x and y values are the zero value of the contained type
     /// (e.g. 0.0, Some(0.0), or Dimension::Length(0.0))
+    #[inline(always)]
     pub const fn zero() -> Self {
         zero::<Self>()
     }
@@ -117,6 +125,7 @@ impl<T: TaffyZero> TaffyZero for Line<T> {
 impl<T: TaffyZero> Line<T> {
     /// Returns a Line where both the start and end values are the zero value of the contained type
     /// (e.g. 0.0, Some(0.0), or Dimension::Length(0.0))
+    #[inline(always)]
     pub const fn zero() -> Self {
         zero::<Self>()
     }
@@ -127,6 +136,7 @@ impl<T: TaffyZero> TaffyZero for Size<T> {
 impl<T: TaffyZero> Size<T> {
     /// Returns a Size where both the width and height values are the zero value of the contained type
     /// (e.g. 0.0, Some(0.0), or Dimension::Length(0.0))
+    #[inline(always)]
     pub const fn zero() -> Self {
         zero::<Self>()
     }
@@ -137,12 +147,14 @@ impl<T: TaffyZero> TaffyZero for Rect<T> {
 impl<T: TaffyZero> Rect<T> {
     /// Returns a Rect where the left, right, top, and bottom values are all the zero value of the contained type
     /// (e.g. 0.0, Some(0.0), or Dimension::Length(0.0))
+    #[inline(always)]
     pub const fn zero() -> Self {
         zero::<Self>()
     }
 }
 
 /// Returns the auto value for that type
+#[inline(always)]
 pub const fn auto<T: TaffyAuto>() -> T {
     T::AUTO
 }
@@ -161,6 +173,7 @@ impl<T: TaffyAuto> TaffyAuto for Point<T> {
 impl<T: TaffyAuto> Point<T> {
     /// Returns a Point where both the x and y values are the auto value of the contained type
     /// (e.g. Dimension::Auto or LengthPercentageAuto::Auto)
+    #[inline(always)]
     pub const fn auto() -> Self {
         auto::<Self>()
     }
@@ -171,6 +184,7 @@ impl<T: TaffyAuto> TaffyAuto for Line<T> {
 impl<T: TaffyAuto> Line<T> {
     /// Returns a Line where both the start and end values are the auto value of the contained type
     /// (e.g. Dimension::Auto or LengthPercentageAuto::Auto)
+    #[inline(always)]
     pub const fn auto() -> Self {
         auto::<Self>()
     }
@@ -181,6 +195,7 @@ impl<T: TaffyAuto> TaffyAuto for Size<T> {
 impl<T: TaffyAuto> Size<T> {
     /// Returns a Size where both the width and height values are the auto value of the contained type
     /// (e.g. Dimension::Auto or LengthPercentageAuto::Auto)
+    #[inline(always)]
     pub const fn auto() -> Self {
         auto::<Self>()
     }
@@ -191,12 +206,14 @@ impl<T: TaffyAuto> TaffyAuto for Rect<T> {
 impl<T: TaffyAuto> Rect<T> {
     /// Returns a Rect where the left, right, top, and bottom values are all the auto value of the contained type
     /// (e.g. Dimension::Auto or LengthPercentageAuto::Auto)
+    #[inline(always)]
     pub const fn auto() -> Self {
         auto::<Self>()
     }
 }
 
 /// Returns the auto value for that type
+#[inline(always)]
 pub const fn min_content<T: TaffyMinContent>() -> T {
     T::MIN_CONTENT
 }
@@ -215,6 +232,7 @@ impl<T: TaffyMinContent> TaffyMinContent for Point<T> {
 impl<T: TaffyMinContent> Point<T> {
     /// Returns a Point where both the x and y values are the min_content value of the contained type
     /// (e.g. Dimension::Auto or LengthPercentageAuto::Auto)
+    #[inline(always)]
     pub const fn min_content() -> Self {
         min_content::<Self>()
     }
@@ -225,6 +243,7 @@ impl<T: TaffyMinContent> TaffyMinContent for Line<T> {
 impl<T: TaffyMinContent> Line<T> {
     /// Returns a Line where both the start and end values are the min_content value of the contained type
     /// (e.g. Dimension::Auto or LengthPercentageAuto::Auto)
+    #[inline(always)]
     pub const fn min_content() -> Self {
         min_content::<Self>()
     }
@@ -235,6 +254,7 @@ impl<T: TaffyMinContent> TaffyMinContent for Size<T> {
 impl<T: TaffyMinContent> Size<T> {
     /// Returns a Size where both the width and height values are the min_content value of the contained type
     /// (e.g. Dimension::Auto or LengthPercentageAuto::Auto)
+    #[inline(always)]
     pub const fn min_content() -> Self {
         min_content::<Self>()
     }
@@ -246,12 +266,14 @@ impl<T: TaffyMinContent> TaffyMinContent for Rect<T> {
 impl<T: TaffyMinContent> Rect<T> {
     /// Returns a Rect where the left, right, top, and bottom values are all the min_content value of the contained type
     /// (e.g. Dimension::Auto or LengthPercentageAuto::Auto)
+    #[inline(always)]
     pub const fn min_content() -> Self {
         min_content::<Self>()
     }
 }
 
 /// Returns the auto value for that type
+#[inline(always)]
 pub const fn max_content<T: TaffyMaxContent>() -> T {
     T::MAX_CONTENT
 }
@@ -270,6 +292,7 @@ impl<T: TaffyMaxContent> TaffyMaxContent for Point<T> {
 impl<T: TaffyMaxContent> Point<T> {
     /// Returns a Point where both the x and y values are the max_content value of the contained type
     /// (e.g. Dimension::Auto or LengthPercentageAuto::Auto)
+    #[inline(always)]
     pub const fn max_content() -> Self {
         max_content::<Self>()
     }
@@ -280,6 +303,7 @@ impl<T: TaffyMaxContent> TaffyMaxContent for Line<T> {
 impl<T: TaffyMaxContent> Line<T> {
     /// Returns a Line where both the start and end values are the max_content value of the contained type
     /// (e.g. Dimension::Auto or LengthPercentageAuto::Auto)
+    #[inline(always)]
     pub const fn max_content() -> Self {
         max_content::<Self>()
     }
@@ -290,6 +314,7 @@ impl<T: TaffyMaxContent> TaffyMaxContent for Size<T> {
 impl<T: TaffyMaxContent> Size<T> {
     /// Returns a Size where both the width and height values are the max_content value of the contained type
     /// (e.g. Dimension::Auto or LengthPercentageAuto::Auto)
+    #[inline(always)]
     pub const fn max_content() -> Self {
         max_content::<Self>()
     }
@@ -301,6 +326,7 @@ impl<T: TaffyMaxContent> TaffyMaxContent for Rect<T> {
 impl<T: TaffyMaxContent> Rect<T> {
     /// Returns a Rect where the left, right, top, and bottom values are all the max_content value of the contained type
     /// (e.g. Dimension::Auto or LengthPercentageAuto::Auto)
+    #[inline(always)]
     pub const fn max_content() -> Self {
         max_content::<Self>()
     }
@@ -308,6 +334,7 @@ impl<T: TaffyMaxContent> Rect<T> {
 
 /// Returns a value of the inferred type which represent a `fit-content(…)` value
 /// with the given argument.
+#[inline(always)]
 pub fn fit_content<T: TaffyFitContent>(argument: LengthPercentage) -> T {
     T::fit_content(argument)
 }
@@ -318,6 +345,7 @@ pub trait TaffyFitContent {
     fn fit_content(argument: LengthPercentage) -> Self;
 }
 impl<T: TaffyFitContent> TaffyFitContent for Point<T> {
+    #[inline(always)]
     fn fit_content(argument: LengthPercentage) -> Self {
         Point { x: T::fit_content(argument), y: T::fit_content(argument) }
     }
@@ -325,11 +353,13 @@ impl<T: TaffyFitContent> TaffyFitContent for Point<T> {
 impl<T: TaffyFitContent> Point<T> {
     /// Returns a Point with x and y set to the same `fit-content(…)` value
     /// with the given argument.
+    #[inline(always)]
     pub fn fit_content(argument: LengthPercentage) -> Self {
         fit_content(argument)
     }
 }
 impl<T: TaffyFitContent> TaffyFitContent for Line<T> {
+    #[inline(always)]
     fn fit_content(argument: LengthPercentage) -> Self {
         Line { start: T::fit_content(argument), end: T::fit_content(argument) }
     }
@@ -337,11 +367,13 @@ impl<T: TaffyFitContent> TaffyFitContent for Line<T> {
 impl<T: TaffyFitContent> Line<T> {
     /// Returns a Line with start and end set to the same `fit-content(…)` value
     /// with the given argument.
+    #[inline(always)]
     pub fn fit_content(argument: LengthPercentage) -> Self {
         fit_content(argument)
     }
 }
 impl<T: TaffyFitContent> TaffyFitContent for Size<T> {
+    #[inline(always)]
     fn fit_content(argument: LengthPercentage) -> Self {
         Size { width: T::fit_content(argument), height: T::fit_content(argument) }
     }
@@ -349,11 +381,13 @@ impl<T: TaffyFitContent> TaffyFitContent for Size<T> {
 impl<T: TaffyFitContent> Size<T> {
     /// Returns a Size where with width and height set to the same `fit-content(…)` value
     /// with the given argument.
+    #[inline(always)]
     pub fn fit_content(argument: LengthPercentage) -> Self {
         fit_content(argument)
     }
 }
 impl<T: TaffyFitContent> TaffyFitContent for Rect<T> {
+    #[inline(always)]
     fn fit_content(argument: LengthPercentage) -> Self {
         Rect {
             left: T::fit_content(argument),
@@ -366,12 +400,14 @@ impl<T: TaffyFitContent> TaffyFitContent for Rect<T> {
 impl<T: TaffyFitContent> Rect<T> {
     /// Returns a Rect where the left, right, top and bottom values are all constant fit_content value of the contained type
     /// (e.g. 2.1, Some(2.1), or Dimension::Length(2.1))
+    #[inline(always)]
     pub fn fit_content(argument: LengthPercentage) -> Self {
         fit_content(argument)
     }
 }
 
 /// Returns a value of the inferred type which represent an absolute length
+#[inline(always)]
 pub fn length<Input: Into<f64> + Copy, T: FromLength>(value: Input) -> T {
     T::from_length(value)
 }
@@ -382,49 +418,58 @@ pub trait FromLength {
     fn from_length<Input: Into<f64> + Copy>(value: Input) -> Self;
 }
 impl FromLength for f32 {
+    #[inline(always)]
     fn from_length<Input: Into<f64> + Copy>(value: Input) -> Self {
         value.into() as f32
     }
 }
 impl FromLength for Option<f32> {
+    #[inline(always)]
     fn from_length<Input: Into<f64> + Copy>(value: Input) -> Self {
         Some(value.into() as f32)
     }
 }
 impl<T: FromLength> FromLength for Point<T> {
+    #[inline(always)]
     fn from_length<Input: Into<f64> + Copy>(value: Input) -> Self {
         Point { x: T::from_length(value), y: T::from_length(value) }
     }
 }
 impl<T: FromLength> Point<T> {
     /// Returns a Point where x and y values are the same given absolute length
+    #[inline(always)]
     pub fn length<Input: Into<f64> + Copy>(value: Input) -> Self {
         length::<Input, Self>(value)
     }
 }
 impl<T: FromLength> FromLength for Line<T> {
+    #[inline(always)]
     fn from_length<Input: Into<f64> + Copy>(value: Input) -> Self {
         Line { start: T::from_length(value), end: T::from_length(value) }
     }
 }
 impl<T: FromLength> Line<T> {
     /// Returns a Line where both the start and end values are the same given absolute length
+    #[inline(always)]
     pub fn length<Input: Into<f64> + Copy>(value: Input) -> Self {
         length::<Input, Self>(value)
     }
 }
 impl<T: FromLength> FromLength for Size<T> {
+    #[inline(always)]
     fn from_length<Input: Into<f64> + Copy>(value: Input) -> Self {
         Size { width: T::from_length(value), height: T::from_length(value) }
     }
 }
 impl<T: FromLength> Size<T> {
     /// Returns a Size where both the width and height values the same given absolute length
+    #[inline(always)]
     pub fn length<Input: Into<f64> + Copy>(value: Input) -> Self {
         length::<Input, Self>(value)
     }
 }
 impl<T: FromLength> FromLength for Rect<T> {
+    #[inline(always)]
     fn from_length<Input: Into<f64> + Copy>(value: Input) -> Self {
         Rect {
             left: T::from_length(value),
@@ -436,12 +481,14 @@ impl<T: FromLength> FromLength for Rect<T> {
 }
 impl<T: FromLength> Rect<T> {
     /// Returns a Rect where the left, right, top and bottom values are all the same given absolute length
+    #[inline(always)]
     pub fn length<Input: Into<f64> + Copy>(value: Input) -> Self {
         length::<Input, Self>(value)
     }
 }
 
 /// Returns a value of the inferred type which represent a percentage
+#[inline(always)]
 pub fn percent<Input: Into<f64> + Copy, T: FromPercent>(percent: Input) -> T {
     T::from_percent(percent)
 }
@@ -452,16 +499,19 @@ pub trait FromPercent {
     fn from_percent<Input: Into<f64> + Copy>(percent: Input) -> Self;
 }
 impl FromPercent for f32 {
+    #[inline(always)]
     fn from_percent<Input: Into<f64> + Copy>(percent: Input) -> Self {
         percent.into() as f32
     }
 }
 impl FromPercent for Option<f32> {
+    #[inline(always)]
     fn from_percent<Input: Into<f64> + Copy>(percent: Input) -> Self {
         Some(percent.into() as f32)
     }
 }
 impl<T: FromPercent> FromPercent for Point<T> {
+    #[inline(always)]
     fn from_percent<Input: Into<f64> + Copy>(percent: Input) -> Self {
         Point { x: T::from_percent(percent), y: T::from_percent(percent) }
     }
@@ -469,11 +519,13 @@ impl<T: FromPercent> FromPercent for Point<T> {
 impl<T: FromPercent> Point<T> {
     /// Returns a Point where both the x and y values are the constant percent value of the contained type
     /// (e.g. 2.1, Some(2.1), or Dimension::Length(2.1))
+    #[inline(always)]
     pub fn percent<Input: Into<f64> + Copy>(percent_value: Input) -> Self {
         percent::<Input, Self>(percent_value)
     }
 }
 impl<T: FromPercent> FromPercent for Line<T> {
+    #[inline(always)]
     fn from_percent<Input: Into<f64> + Copy>(percent: Input) -> Self {
         Line { start: T::from_percent(percent), end: T::from_percent(percent) }
     }
@@ -481,11 +533,13 @@ impl<T: FromPercent> FromPercent for Line<T> {
 impl<T: FromPercent> Line<T> {
     /// Returns a Line where both the start and end values are the constant percent value of the contained type
     /// (e.g. 2.1, Some(2.1), or Dimension::Length(2.1))
+    #[inline(always)]
     pub fn percent<Input: Into<f64> + Copy>(percent_value: Input) -> Self {
         percent::<Input, Self>(percent_value)
     }
 }
 impl<T: FromPercent> FromPercent for Size<T> {
+    #[inline(always)]
     fn from_percent<Input: Into<f64> + Copy>(percent: Input) -> Self {
         Size { width: T::from_percent(percent), height: T::from_percent(percent) }
     }
@@ -493,11 +547,13 @@ impl<T: FromPercent> FromPercent for Size<T> {
 impl<T: FromPercent> Size<T> {
     /// Returns a Size where both the width and height values are the constant percent value of the contained type
     /// (e.g. 2.1, Some(2.1), or Dimension::Length(2.1))
+    #[inline(always)]
     pub fn percent<Input: Into<f64> + Copy>(percent_value: Input) -> Self {
         percent::<Input, Self>(percent_value)
     }
 }
 impl<T: FromPercent> FromPercent for Rect<T> {
+    #[inline(always)]
     fn from_percent<Input: Into<f64> + Copy>(percent: Input) -> Self {
         Rect {
             left: T::from_percent(percent),
@@ -510,6 +566,7 @@ impl<T: FromPercent> FromPercent for Rect<T> {
 impl<T: FromPercent> Rect<T> {
     /// Returns a Rect where the left, right, top and bottom values are all constant percent value of the contained type
     /// (e.g. 2.1, Some(2.1), or Dimension::Length(2.1))
+    #[inline(always)]
     pub fn percent<Input: Into<f64> + Copy>(percent_value: Input) -> Self {
         percent::<Input, Self>(percent_value)
     }
@@ -517,6 +574,7 @@ impl<T: FromPercent> Rect<T> {
 
 /// Create a `Fraction` track sizing function (`fr` in CSS)
 #[cfg(feature = "grid")]
+#[inline(always)]
 pub fn fr<Input: Into<f64> + Copy, T: FromFr>(flex: Input) -> T {
     T::from_fr(flex)
 }

--- a/src/style_helpers.rs
+++ b/src/style_helpers.rs
@@ -35,7 +35,6 @@ where
 
 #[cfg(feature = "grid")]
 /// Returns a grid template containing `count` evenly sized tracks
-#[inline(always)]
 pub fn evenly_sized_tracks<S: CheapCloneStr>(count: u16) -> Vec<GridTemplateComponent<S>> {
     use crate::util::sys::new_vec_with_capacity;
     let mut repeated_tracks = new_vec_with_capacity(1);


### PR DESCRIPTION
# Objective

Add `#[inline(always)]` to the functions and methods in `src/style_helpers.rs`. These are tiny constructor/forwarding helpers so forcing inlining avoids call overhead at usage sites. It also likely allows `f64` -> `f32` conversions to be compiled out.

No functional change. `cargo test --all-features`, `cargo fmt --all -- --check`, and `cargo clippy --workspace -- -D warnings` all pass.