### PR TITLE
Fix flex container baseline synthesis and wrap-reverse alignment

### DIFF
--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -410,19 +410,16 @@ fn compute_preliminary(tree: &mut impl LayoutFlexboxContainer, node: NodeId, inp
 
     // 8.5. Flex Container Baselines: calculate the flex container's first baseline
     // See https://www.w3.org/TR/css-flexbox-1/#flex-baselines
-    let first_vertical_baseline = if flex_lines.is_empty() {
-        None
-    } else {
-        flex_lines[0]
-            .items
+    // For wrap-reverse containers the cross-start-most line is the last line rather than the first,
+    // and it is that line which the container's first baseline is generated from.
+    let first_line = if constants.is_wrap_reverse { flex_lines.last() } else { flex_lines.first() };
+    let first_vertical_baseline = first_line.and_then(|line| {
+        line.items
             .iter()
             .find(|item| constants.is_column || item.align_self == AlignSelf::BASELINE)
-            .or_else(|| flex_lines[0].items.iter().next())
-            .map(|child| {
-                let offset_vertical = if constants.is_row { child.offset_cross } else { child.offset_main };
-                offset_vertical + child.baseline
-            })
-    };
+            .or_else(|| line.items.iter().next())
+            .map(|child| child.baseline)
+    });
 
     LayoutOutput::from_sizes_and_baselines(
         constants.container_size,
@@ -1774,6 +1771,12 @@ fn resolve_cross_axis_auto_margins(flex_lines: &mut [FlexLine], constants: &Algo
     for line in flex_lines {
         let line_cross_size = line.cross_size;
         let max_baseline: f32 = line.items.iter_mut().map(|child| child.baseline).fold(0.0, |acc, x| acc.max(x));
+        let max_baseline_to_bottom_distance: f32 = line
+            .items
+            .iter_mut()
+            .filter(|child| child.align_self == AlignSelf::BASELINE)
+            .map(|child| child.outer_target_size.cross(constants.dir) - child.baseline)
+            .fold(0.0, |acc, x| acc.max(x));
 
         for child in line.items.iter_mut() {
             let free_space = line_cross_size - child.outer_target_size.cross(constants.dir);
@@ -1800,7 +1803,13 @@ fn resolve_cross_axis_auto_margins(flex_lines: &mut [FlexLine], constants: &Algo
                 }
             } else {
                 // 14. Align all flex items along the cross-axis.
-                child.offset_cross = align_flex_items_along_cross_axis(child, free_space, max_baseline, constants);
+                child.offset_cross = align_flex_items_along_cross_axis(
+                    child,
+                    free_space,
+                    max_baseline,
+                    max_baseline_to_bottom_distance,
+                    constants,
+                );
             }
         }
     }
@@ -1817,6 +1826,7 @@ fn align_flex_items_along_cross_axis(
     child: &FlexItem,
     free_space: f32,
     max_baseline: f32,
+    max_baseline_to_bottom_distance: f32,
     constants: &AlgoConstants,
 ) -> f32 {
     let cross_axis_should_reverse = constants.is_column && matches!(constants.layout_direction, Direction::Rtl);
@@ -1863,7 +1873,14 @@ fn align_flex_items_along_cross_axis(
         AlignItemsKeyword::Center => free_space / 2.0,
         AlignItemsKeyword::Baseline => {
             if constants.is_row {
-                max_baseline - child.baseline
+                if constants.is_wrap_reverse {
+                    // In a wrap-reverse container the cross axis is flipped, so the baseline-aligned
+                    // group of items is aligned to the cross-start edge, which is the bottom of the line.
+                    let line_cross_size = free_space + child.outer_target_size.cross(constants.dir);
+                    line_cross_size - max_baseline_to_bottom_distance - child.baseline
+                } else {
+                    max_baseline - child.baseline
+                }
             } else {
                 // Until we support vertical writing modes, baseline alignment only makes sense if
                 // the constants.direction is row, so we treat it as flex-start alignment in columns.

--- a/test_fixtures/flex/align_baseline_nested_container.html
+++ b/test_fixtures/flex/align_baseline_nested_container.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Baseline synthesis for a nested flex container
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 100px; height: 100px; align-items: baseline;">
+  <div style="width: 50px; height: 50px;"></div>
+  <div style="width: 50px; height: 40px; flex-direction: column; padding-top: 5px;">
+    <div style="width: 25px; height: 10px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/align_baseline_wrap_reverse.html
+++ b/test_fixtures/flex/align_baseline_wrap_reverse.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Baseline alignment in a wrap-reverse flex container
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 100px; height: 100px; flex-wrap: wrap-reverse; align-items: baseline;">
+  <div style="width: 60px; height: 20px;"></div>
+  <div style="width: 40px; height: 40px;"></div>
+  <div style="width: 60px; height: 30px;"></div>
+  <div style="width: 40px; height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/flex/align_baseline_nested_container__border_box_ltr.xml
+++ b/tests/xml/flex/align_baseline_nested_container__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="align_baseline_nested_container__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="border-box" direction="ltr" align-items="baseline" width="100px" height="100px">
+      <div box-sizing="border-box" direction="ltr" width="50px" height="50px"/>
+      <div box-sizing="border-box" direction="ltr" flex-direction="column" width="50px" height="40px" padding-top="5px">
+        <div box-sizing="border-box" direction="ltr" width="25px" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="50" height="50"/>
+      <node x="50" y="35" width="50" height="40">
+        <node x="0" y="5" width="25" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_baseline_nested_container__border_box_rtl.xml
+++ b/tests/xml/flex/align_baseline_nested_container__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="align_baseline_nested_container__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="border-box" direction="rtl" align-items="baseline" width="100px" height="100px">
+      <div box-sizing="border-box" direction="rtl" width="50px" height="50px"/>
+      <div box-sizing="border-box" direction="rtl" flex-direction="column" width="50px" height="40px" padding-top="5px">
+        <div box-sizing="border-box" direction="rtl" width="25px" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="50" y="0" width="50" height="50"/>
+      <node x="0" y="35" width="50" height="40">
+        <node x="25" y="5" width="25" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_baseline_nested_container__content_box_ltr.xml
+++ b/tests/xml/flex/align_baseline_nested_container__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="align_baseline_nested_container__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" align-items="baseline" width="100px" height="100px">
+      <div box-sizing="content-box" direction="ltr" width="50px" height="50px"/>
+      <div box-sizing="content-box" direction="ltr" flex-direction="column" width="50px" height="40px" padding-top="5px">
+        <div box-sizing="content-box" direction="ltr" width="25px" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="50" height="50"/>
+      <node x="50" y="35" width="50" height="45">
+        <node x="0" y="5" width="25" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_baseline_nested_container__content_box_rtl.xml
+++ b/tests/xml/flex/align_baseline_nested_container__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="align_baseline_nested_container__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" align-items="baseline" width="100px" height="100px">
+      <div box-sizing="content-box" direction="rtl" width="50px" height="50px"/>
+      <div box-sizing="content-box" direction="rtl" flex-direction="column" width="50px" height="40px" padding-top="5px">
+        <div box-sizing="content-box" direction="rtl" width="25px" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="50" y="0" width="50" height="50"/>
+      <node x="0" y="35" width="50" height="45">
+        <node x="25" y="5" width="25" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_baseline_wrap_reverse__border_box_ltr.xml
+++ b/tests/xml/flex/align_baseline_wrap_reverse__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="align_baseline_wrap_reverse__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="border-box" direction="ltr" flex-wrap="wrap-reverse" align-items="baseline" width="100px" height="100px">
+      <div box-sizing="border-box" direction="ltr" width="60px" height="20px"/>
+      <div box-sizing="border-box" direction="ltr" width="40px" height="40px"/>
+      <div box-sizing="border-box" direction="ltr" width="60px" height="30px"/>
+      <div box-sizing="border-box" direction="ltr" width="40px" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="80" width="60" height="20"/>
+      <node x="60" y="60" width="40" height="40"/>
+      <node x="0" y="15" width="60" height="30"/>
+      <node x="60" y="35" width="40" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_baseline_wrap_reverse__border_box_rtl.xml
+++ b/tests/xml/flex/align_baseline_wrap_reverse__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="align_baseline_wrap_reverse__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="border-box" direction="rtl" flex-wrap="wrap-reverse" align-items="baseline" width="100px" height="100px">
+      <div box-sizing="border-box" direction="rtl" width="60px" height="20px"/>
+      <div box-sizing="border-box" direction="rtl" width="40px" height="40px"/>
+      <div box-sizing="border-box" direction="rtl" width="60px" height="30px"/>
+      <div box-sizing="border-box" direction="rtl" width="40px" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="40" y="80" width="60" height="20"/>
+      <node x="0" y="60" width="40" height="40"/>
+      <node x="40" y="15" width="60" height="30"/>
+      <node x="0" y="35" width="40" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_baseline_wrap_reverse__content_box_ltr.xml
+++ b/tests/xml/flex/align_baseline_wrap_reverse__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="align_baseline_wrap_reverse__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" flex-wrap="wrap-reverse" align-items="baseline" width="100px" height="100px">
+      <div box-sizing="content-box" direction="ltr" width="60px" height="20px"/>
+      <div box-sizing="content-box" direction="ltr" width="40px" height="40px"/>
+      <div box-sizing="content-box" direction="ltr" width="60px" height="30px"/>
+      <div box-sizing="content-box" direction="ltr" width="40px" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="80" width="60" height="20"/>
+      <node x="60" y="60" width="40" height="40"/>
+      <node x="0" y="15" width="60" height="30"/>
+      <node x="60" y="35" width="40" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_baseline_wrap_reverse__content_box_rtl.xml
+++ b/tests/xml/flex/align_baseline_wrap_reverse__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="align_baseline_wrap_reverse__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" flex-wrap="wrap-reverse" align-items="baseline" width="100px" height="100px">
+      <div box-sizing="content-box" direction="rtl" width="60px" height="20px"/>
+      <div box-sizing="content-box" direction="rtl" width="40px" height="40px"/>
+      <div box-sizing="content-box" direction="rtl" width="60px" height="30px"/>
+      <div box-sizing="content-box" direction="rtl" width="40px" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="40" y="80" width="60" height="20"/>
+      <node x="0" y="60" width="40" height="40"/>
+      <node x="40" y="15" width="60" height="30"/>
+      <node x="0" y="35" width="40" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -4984,6 +4984,46 @@ mod blockgrid {
 
 mod flex {
     #[test]
+    fn align_baseline_wrap_reverse__border_box_ltr() {
+        crate::run_xml_test("flex", "align_baseline_wrap_reverse__border_box_ltr");
+    }
+
+    #[test]
+    fn align_baseline_wrap_reverse__content_box_ltr() {
+        crate::run_xml_test("flex", "align_baseline_wrap_reverse__content_box_ltr");
+    }
+
+    #[test]
+    fn align_baseline_wrap_reverse__border_box_rtl() {
+        crate::run_xml_test("flex", "align_baseline_wrap_reverse__border_box_rtl");
+    }
+
+    #[test]
+    fn align_baseline_wrap_reverse__content_box_rtl() {
+        crate::run_xml_test("flex", "align_baseline_wrap_reverse__content_box_rtl");
+    }
+
+    #[test]
+    fn align_baseline_nested_container__border_box_ltr() {
+        crate::run_xml_test("flex", "align_baseline_nested_container__border_box_ltr");
+    }
+
+    #[test]
+    fn align_baseline_nested_container__content_box_ltr() {
+        crate::run_xml_test("flex", "align_baseline_nested_container__content_box_ltr");
+    }
+
+    #[test]
+    fn align_baseline_nested_container__border_box_rtl() {
+        crate::run_xml_test("flex", "align_baseline_nested_container__border_box_rtl");
+    }
+
+    #[test]
+    fn align_baseline_nested_container__content_box_rtl() {
+        crate::run_xml_test("flex", "align_baseline_nested_container__content_box_rtl");
+    }
+
+    #[test]
     fn absolute_aspect_ratio_aspect_ratio_overrides_height_of_full_inset__border_box_ltr() {
         crate::run_xml_test(
             "flex",


### PR DESCRIPTION
# Objective

Correct flex container first-baseline synthesis and baseline alignment for `wrap-reverse` rows.

## Context

Taffy previously selected the wrong line for a `wrap-reverse` container baseline and double-counted the child offset because `child.baseline` already includes the final position. Baseline groups in wrap-reverse rows also need to align from the visual cross-start edge.

This is the first split PR from the original baseline-fixes PR. The scroll-container clamping and block-baseline propagation changes are in separate follow-up PRs.

## Feedback wanted

Please review the baseline-group positioning formula for wrap-reverse rows, especially mixed-size baseline-aligned items.

Link to Devin session: https://app.devin.ai/sessions/aeca5969ff4b42aa8aeca4aee0b79f3f
Requested by: @nicoburns
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://dioxus.staging.devinenterprise.com/review/DioxusLabs/taffy/pull/987?analyze=true)

<a href="https://dioxus.staging.devinenterprise.com/review/DioxusLabs/taffy/pull/987" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->