### PR TITLE
Block layout: fix float placement, clearance position, and percentage margin resolution

### DIFF
--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -808,7 +808,7 @@ fn perform_final_layout_on_in_flow_children(
         } else {
             let item_margin = item
                 .margin
-                .map(|margin| margin.resolve_to_option(container_outer_width, |val, basis| tree.calc(val, basis)));
+                .map(|margin| margin.resolve_to_option(container_inner_width, |val, basis| tree.calc(val, basis)));
             let item_non_auto_margin = item_margin.map(|m| m.unwrap_or(0.0));
             let item_non_auto_x_margin_sum = item_non_auto_margin.horizontal_axis_sum();
 
@@ -947,9 +947,9 @@ fn perform_final_layout_on_in_flow_children(
             };
 
             #[cfg(feature = "float_layout")]
-            let clear_pos = block_ctx.cleared_threshold(item.clear).unwrap_or(0.0);
+            let clear_pos = block_ctx.cleared_threshold(item.clear).unwrap_or(f32::NEG_INFINITY);
             #[cfg(not(feature = "float_layout"))]
-            let clear_pos = 0.0;
+            let clear_pos = f32::NEG_INFINITY;
 
             let item_layout = if item.is_in_same_bfc {
                 let width = known_dimensions
@@ -1059,7 +1059,7 @@ fn perform_final_layout_on_in_flow_children(
                                 + inset_offset.x
                         }
                     },
-                    y: committed_y_offset.max(clear_pos) + y_margin_offset + inset_offset.y,
+                    y: (committed_y_offset + y_margin_offset).max(clear_pos) + inset_offset.y,
                 }
             } else {
                 // TODO: handle inset and margins
@@ -1148,7 +1148,7 @@ fn perform_final_layout_on_in_flow_children(
                 y_offset_for_absolute = committed_y_offset + active_collapsible_margin_set.resolve();
                 #[cfg(feature = "float_layout")]
                 {
-                    y_offset_for_float = committed_y_offset;
+                    y_offset_for_float = committed_y_offset + active_collapsible_margin_set.resolve();
                 }
             }
         }


### PR DESCRIPTION
# Objective

Fix three block-layout bugs found by running Blitz against the WPT `css/CSS2/margin-padding-clear` suite. Together with a Blitz-side table fix, these take the suite from 518 → 649 passing (of 682 run).

Three one-line fixes in `perform_final_layout_on_in_flow_children`:

1. **Float placement ignored pending collapsed margins.** `y_offset_for_float` was updated to `committed_y_offset` only, so a float following a sibling with a bottom margin was placed too high. It now includes the active collapsible margin set, matching `y_offset_for_absolute`:
   ```diff
   -  y_offset_for_float = committed_y_offset;
   +  y_offset_for_float = committed_y_offset + active_collapsible_margin_set.resolve();
   ```
   This fixed ~100 WPT tests (many `margin-padding-clear` references use floats).

2. **Clearance applied before margins instead of to the margin-adjusted position.** Per CSS 2.1 §9.5.2, clearance is only introduced if the element's *hypothetical position* (including collapsed margins) is above the relevant float's bottom. Previously the clear threshold was applied to `committed_y_offset` and then the margin added on top, double-shifting cleared elements whose margins already carried them past the float:
   ```diff
   -  y: committed_y_offset.max(clear_pos) + y_margin_offset + inset_offset.y,
   +  y: (committed_y_offset + y_margin_offset).max(clear_pos) + inset_offset.y,
   ```
   `clear_pos` now defaults to `f32::NEG_INFINITY` instead of `0.0` when there is no cleared threshold, so the `max` doesn't clamp legitimately-negative positions from negative margins (this default previously happened to be harmless only because the `max` was applied before margins).

3. **Percentage margins resolved against the wrong width.** In-flow children's margins were resolved against `container_outer_width`; percentage margins resolve against the containing block's *content* width, i.e. `container_inner_width`.

## Context

All existing tests pass (`cargo test`, `cargo test --features float_layout`, `cargo test --all-features`). Verified against WPT via Blitz: `css/CSS2/floats` + `css/CSS2/floats-clear` go from 116 → 146 passing with no regressions.

Not updating RELEASES.md since these are behavior bug-fixes with no API change — happy to add an entry if desired.

Link to Devin session: https://app.devin.ai/sessions/21f1724c57344d11b11401eff9508133
Requested by: @nicoburns
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://dioxus.staging.devinenterprise.com/review/DioxusLabs/taffy/pull/990?analyze=true)

<a href="https://dioxus.staging.devinenterprise.com/review/DioxusLabs/taffy/pull/990" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->