### PR TITLE
Lay out floats with definite available width for shrink-to-fit sizing

### DIFF
--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -822,12 +822,14 @@ fn perform_final_layout_on_in_flow_children(
             if let Some(float_direction) = item.float.float_direction() {
                 has_active_floats = true;
 
+                // A float with `width: auto` is shrink-to-fit (fit-content) sized: the available
+                // space clamped between its min-content and max-content sizes.
+                let available_width = container_inner_width - item_non_auto_x_margin_sum;
                 let item_layout = tree.perform_child_layout(
                     item.node_id,
                     Size::NONE,
                     parent_size,
-                    // available_space,
-                    Size::MAX_CONTENT,
+                    Size { width: AvailableSpace::Definite(available_width), height: AvailableSpace::MaxContent },
                     SizingMode::InherentSize,
                     Line::TRUE,
                 );


### PR DESCRIPTION
## Summary

Floats in block layout were laid out with `Size::MAX_CONTENT` available space, so a float with `width: auto` was always sized to its max-content width — it could overflow its container instead of shrink-to-fit (fit-content) sizing to the available space.

`perform_final_layout_on_in_flow_children` now passes a definite available width instead:

```diff
+ let available_width = container_inner_width - item_non_auto_x_margin_sum;
  let item_layout = tree.perform_child_layout(
      item.node_id,
      Size::NONE,
      parent_size,
-     Size::MAX_CONTENT,
+     Size { width: AvailableSpace::Definite(available_width), height: AvailableSpace::MaxContent },
      SizingMode::InherentSize,
      Line::TRUE,
  );
```

The child's own sizing then clamps this between its min-content and max-content sizes, giving CSS shrink-to-fit behavior for auto-width floats.

Found via WPT `css/css-text` (e.g. `white-space/white-space-intrinsic-size-001/004`) while testing parley#680 integration in blitz; fixes float sizing there together with a corresponding blitz-side change to its inline measure function. All taffy tests pass with `--features float_layout`.

Link to Devin session: https://app.devin.ai/sessions/f0e260cc5efa4c42aa65125d9f15c3b7
Requested by: @nicoburns
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://dioxus.staging.devinenterprise.com/review/DioxusLabs/taffy/pull/994?analyze=true)

<a href="https://dioxus.staging.devinenterprise.com/review/DioxusLabs/taffy/pull/994" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->