### PR TITLE
Clamp scroll-container flex baselines

### DIFF
--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -1495,7 +1495,16 @@ fn calculate_children_base_lines(
             let baseline = measured_size_and_baselines.first_baselines.y;
             let height = measured_size_and_baselines.size.height;
 
-            child.baseline = baseline.unwrap_or(height) + child.margin.top;
+            // Scroll containers' baselines are determined from their content as if scrolled to the
+            // initial position, but are additionally clamped to their border box.
+            // See https://github.com/w3c/csswg-drafts/issues/7660
+            let baseline = if child.overflow.y.is_scroll_container() {
+                baseline.unwrap_or(height).min(height).max(0.0)
+            } else {
+                baseline.unwrap_or(height)
+            };
+
+            child.baseline = baseline + child.margin.top;
         }
     }
 }
@@ -1977,7 +1986,17 @@ fn calculate_flex_item(
     if direction.is_row() {
         let baseline_offset_cross =
             total_offset_cross + item.offset_cross + effective_line_offset_cross + item.margin.cross_start(direction);
-        let inner_baseline = layout_output.first_baselines.y.unwrap_or(size.height);
+        // Scroll containers' baselines are determined from their content as if scrolled to the initial
+        // position, but are additionally clamped to their border box.
+        // See https://github.com/w3c/csswg-drafts/issues/7660
+        let inner_baseline = {
+            let baseline = layout_output.first_baselines.y.unwrap_or(size.height);
+            if item.overflow.y.is_scroll_container() {
+                baseline.min(size.height).max(0.0)
+            } else {
+                baseline
+            }
+        };
         item.baseline = baseline_offset_cross + inner_baseline;
     } else {
         let baseline_offset_main = *total_offset_main + item.offset_main + item.margin.main_start(direction);


### PR DESCRIPTION
# Objective

Clamp flex-item baselines for scroll containers to their border box, as required by the Flexbox baseline rules.

## Context

Scroll-container baselines are derived from content at the initial scroll position, but must be clamped to the container’s border box. This applies both while calculating child baselines and while calculating the final flex-item baseline.

This is the second split PR from the original baseline-fixes PR. The related flex container synthesis and wrap-reverse alignment changes are in PR #987.

## Feedback wanted

Please review whether both baseline calculation paths cover all flex layout modes and overflow directions.

Link to Devin session: https://app.devin.ai/sessions/aeca5969ff4b42aa8aeca4aee0b79f3f
Requested by: @nicoburns
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://dioxus.staging.devinenterprise.com/review/DioxusLabs/taffy/pull/995?analyze=true)

<a href="https://dioxus.staging.devinenterprise.com/review/DioxusLabs/taffy/pull/995" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->