### PR TITLE
Grid: don't grow tracks past their limits during space distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Grid: tracks no longer grow past their growth limits when distributing free space to multiple tracks with asymmetric limits (in the "maximise tracks" step and when distributing item contributions to base sizes). Previously a track could be assigned space beyond its limit in later distribution iterations, causing `auto` tracks to overflow a definite container (#1000)
+
 - Flexbox: min/max sizes transferred through the aspect ratio now clamp the flex base size, the automatic minimum size, and the hypothetical main/cross sizes of flex items, instead of being baked into the item's used min/max sizes. This matches browser behaviour for replaced elements and items with `aspect-ratio` combined with min/max constraints in the opposite axis ([w3c/csswg-drafts#10997](https://github.com/w3c/csswg-drafts/issues/10997))
 
 - Numeric style helpers (`length`, `percent`, `fr`, `flex`) now accept `Input: Into<f64>` instead of `Input: Into<f32>`. This allows bare float literals such as `length(800.0)` to be used without triggering the `float_literal_f32_fallback` future-compatibility lint, while widening the set of accepted numeric input types (#974)

--- a/scripts/gentest/src/main.rs
+++ b/scripts/gentest/src/main.rs
@@ -181,7 +181,7 @@ async fn test_root_element(client: Client, name: String, fixture_path: impl AsRe
     let description = loop {
         match client.execute("return getTestData()", vec![]).await {
             Ok(description) => break description,
-            Err(err) if attempts < 5 => {
+            Err(err) if attempts < 3 => {
                 attempts += 1;
                 warn!("getTestData() failed for {name} (attempt {attempts}): {err}");
                 tokio::time::sleep(std::time::Duration::from_millis(200)).await;

--- a/scripts/gentest/src/main.rs
+++ b/scripts/gentest/src/main.rs
@@ -175,7 +175,20 @@ async fn test_root_element(client: Client, name: String, fixture_path: impl AsRe
     let url = format!("file://{}", fixture_path.display());
 
     client.goto(&url).await.unwrap();
-    let description = client.execute("return getTestData()", vec![]).await.unwrap();
+
+    // Navigation can occasionally return before the document is fully loaded, so retry a few times
+    let mut attempts = 0;
+    let description = loop {
+        match client.execute("return getTestData()", vec![]).await {
+            Ok(description) => break description,
+            Err(err) if attempts < 5 => {
+                attempts += 1;
+                warn!("getTestData() failed for {name} (attempt {attempts}): {err}");
+                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            }
+            Err(err) => panic!("getTestData() failed for {}: {}", name, err),
+        }
+    };
     let description_string = description.as_str().unwrap();
     let description = serde_json::from_str(description_string).unwrap();
     (name.to_string(), fixture_path.to_path_buf(), description)

--- a/src/compute/grid/track_sizing.rs
+++ b/src/compute/grid/track_sizing.rs
@@ -1399,7 +1399,10 @@ fn distribute_space_up_to_limits(
             .iter()
             .filter(|track| track_affected_property(track) + track.item_incurred_increase < track_limit(track))
             .filter(|track| track_is_affected(track))
-            .map(|track| (track_limit(track) - track_affected_property(track)) / track_distribution_proportion(track))
+            .map(|track| {
+                (track_limit(track) - track_affected_property(track) - track.item_incurred_increase)
+                    / track_distribution_proportion(track)
+            })
             .min_by(|a, b| a.total_cmp(b))
             .unwrap(); // We will never pass an empty track list to this function
         let iteration_item_incurred_increase =
@@ -1407,7 +1410,10 @@ fn distribute_space_up_to_limits(
 
         for track in tracks.iter_mut().filter(|track| track_is_affected(track)) {
             let increase = iteration_item_incurred_increase * track_distribution_proportion(track);
-            if increase > 0.0 && track_affected_property(track) + increase <= track_limit(track) + THRESHOLD {
+            if increase > 0.0
+                && track_affected_property(track) + track.item_incurred_increase + increase
+                    <= track_limit(track) + THRESHOLD
+            {
                 track.item_incurred_increase += increase;
                 space_to_distribute -= increase;
             }

--- a/test_fixtures/grid/grid_definite_size_auto_tracks_asymmetric_max_content.html
+++ b/test_fixtures/grid/grid_definite_size_auto_tracks_asymmetric_max_content.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div class="viewport" style="width: 100px;">
+  <div id="test-root" style="display: grid; grid-template-columns: auto auto; width: 100px;">
+    <div>XX&ZeroWidthSpace;XX</div>
+    <div>XX&ZeroWidthSpace;XX&ZeroWidthSpace;XX&ZeroWidthSpace;XX</div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_definite_size_auto_tracks_asymmetric_max_content_issue_1000.html
+++ b/test_fixtures/grid/grid_definite_size_auto_tracks_asymmetric_max_content_issue_1000.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div class="viewport" style="width: 928px;">
+  <div id="test-root" style="display: grid; grid-template-columns: auto auto; width: 928px;">
+    <div>XXXXXX&ZeroWidthSpace;XXXXXX&ZeroWidthSpace;XXXXXX&ZeroWidthSpace;XXXXXX&ZeroWidthSpace;XXXXXX&ZeroWidthSpace;XXXXXX&ZeroWidthSpace;XXXX</div>
+    <div style="max-width: 674px;">XXXXXX&ZeroWidthSpace;XXXXXX&ZeroWidthSpace;XXXXXX&ZeroWidthSpace;XXXXXX&ZeroWidthSpace;XXXXXX&ZeroWidthSpace;XXXXXX&ZeroWidthSpace;XXXXXX&ZeroWidthSpace;XXXXXX&ZeroWidthSpace;XXXXXX&ZeroWidthSpace;XXXXXX&ZeroWidthSpace;XXXXXX&ZeroWidthSpace;XX</div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/hand_written/measure.rs
+++ b/tests/hand_written/measure.rs
@@ -368,4 +368,49 @@ mod measure {
         assert_eq!(taffy.layout(child).unwrap().size.width, 100.0);
         assert_eq!(taffy.layout(child).unwrap().size.height, 100.0);
     }
+
+    /// Test for https://github.com/DioxusLabs/taffy/issues/1000
+    /// Grid `auto` tracks must not grow past their growth limits (max-content contributions)
+    /// during the "maximise tracks" step, even when the tracks have asymmetric growth limits.
+    #[test]
+    fn grid_auto_tracks_no_grow_past_max_content() {
+        use taffy::{AvailableSpace, TaffyTree};
+
+        const MIN_CONTENT: f32 = 60.0;
+        const CONTAINER: f32 = 928.0;
+        let max_contents = [400.0f32, 674.0];
+
+        let mut tree: TaffyTree<f32> = TaffyTree::new();
+        let cells: Vec<NodeId> =
+            max_contents.iter().map(|mc| tree.new_leaf_with_context(Style::default(), *mc).unwrap()).collect();
+        let grid = tree
+            .new_with_children(
+                Style {
+                    display: Display::Grid,
+                    grid_template_columns: vec![auto(); max_contents.len()],
+                    size: Size { width: Dimension::from_length(CONTAINER), height: auto() },
+                    ..Default::default()
+                },
+                &cells,
+            )
+            .unwrap();
+        tree.compute_layout_with_measure(
+            grid,
+            Size { width: AvailableSpace::Definite(CONTAINER), height: AvailableSpace::MaxContent },
+            |known, available, _node, ctx, _style| {
+                let Some(&mut max_content) = ctx else { return Size::ZERO };
+                let width = known.width.unwrap_or(match available.width {
+                    AvailableSpace::Definite(w) => w.clamp(MIN_CONTENT, max_content),
+                    AvailableSpace::MaxContent => max_content,
+                    AvailableSpace::MinContent => MIN_CONTENT,
+                });
+                Size { width, height: 19.0 }
+            },
+        )
+        .unwrap();
+
+        // Track 0 freezes at its growth limit (400); the remainder goes to track 1.
+        assert_eq!(tree.layout(cells[0]).unwrap().size.width, 400.0);
+        assert_eq!(tree.layout(cells[1]).unwrap().size.width, 528.0);
+    }
 }

--- a/tests/hand_written/measure.rs
+++ b/tests/hand_written/measure.rs
@@ -368,49 +368,4 @@ mod measure {
         assert_eq!(taffy.layout(child).unwrap().size.width, 100.0);
         assert_eq!(taffy.layout(child).unwrap().size.height, 100.0);
     }
-
-    /// Test for https://github.com/DioxusLabs/taffy/issues/1000
-    /// Grid `auto` tracks must not grow past their growth limits (max-content contributions)
-    /// during the "maximise tracks" step, even when the tracks have asymmetric growth limits.
-    #[test]
-    fn grid_auto_tracks_no_grow_past_max_content() {
-        use taffy::{AvailableSpace, TaffyTree};
-
-        const MIN_CONTENT: f32 = 60.0;
-        const CONTAINER: f32 = 928.0;
-        let max_contents = [400.0f32, 674.0];
-
-        let mut tree: TaffyTree<f32> = TaffyTree::new();
-        let cells: Vec<NodeId> =
-            max_contents.iter().map(|mc| tree.new_leaf_with_context(Style::default(), *mc).unwrap()).collect();
-        let grid = tree
-            .new_with_children(
-                Style {
-                    display: Display::Grid,
-                    grid_template_columns: vec![auto(); max_contents.len()],
-                    size: Size { width: Dimension::from_length(CONTAINER), height: auto() },
-                    ..Default::default()
-                },
-                &cells,
-            )
-            .unwrap();
-        tree.compute_layout_with_measure(
-            grid,
-            Size { width: AvailableSpace::Definite(CONTAINER), height: AvailableSpace::MaxContent },
-            |known, available, _node, ctx, _style| {
-                let Some(&mut max_content) = ctx else { return Size::ZERO };
-                let width = known.width.unwrap_or(match available.width {
-                    AvailableSpace::Definite(w) => w.clamp(MIN_CONTENT, max_content),
-                    AvailableSpace::MaxContent => max_content,
-                    AvailableSpace::MinContent => MIN_CONTENT,
-                });
-                Size { width, height: 19.0 }
-            },
-        )
-        .unwrap();
-
-        // Track 0 freezes at its growth limit (400); the remainder goes to track 1.
-        assert_eq!(tree.layout(cells[0]).unwrap().size.width, 400.0);
-        assert_eq!(tree.layout(cells[1]).unwrap().size.width, 528.0);
-    }
 }

--- a/tests/xml/grid/grid_definite_size_auto_tracks_asymmetric_max_content__border_box_ltr.xml
+++ b/tests/xml/grid/grid_definite_size_auto_tracks_asymmetric_max_content__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_definite_size_auto_tracks_asymmetric_max_content__border_box_ltr" use-rounding="true">
+  <viewport width="100px" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="100px" grid-template-columns="auto auto">
+      <text direction="ltr">
+        XX​XX
+      </text>
+      <text direction="ltr">
+        XX​XX​XX​XX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="20">
+      <node x="0" y="0" width="40" height="20"/>
+      <node x="40" y="0" width="60" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_definite_size_auto_tracks_asymmetric_max_content__border_box_rtl.xml
+++ b/tests/xml/grid/grid_definite_size_auto_tracks_asymmetric_max_content__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_definite_size_auto_tracks_asymmetric_max_content__border_box_rtl" use-rounding="true">
+  <viewport width="100px" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="100px" grid-template-columns="auto auto">
+      <text direction="rtl">
+        XX​XX
+      </text>
+      <text direction="rtl">
+        XX​XX​XX​XX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="20">
+      <node x="60" y="0" width="40" height="20"/>
+      <node x="0" y="0" width="60" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_definite_size_auto_tracks_asymmetric_max_content__content_box_ltr.xml
+++ b/tests/xml/grid/grid_definite_size_auto_tracks_asymmetric_max_content__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_definite_size_auto_tracks_asymmetric_max_content__content_box_ltr" use-rounding="true">
+  <viewport width="100px" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="100px" grid-template-columns="auto auto">
+      <text box-sizing="content-box" direction="ltr">
+        XX​XX
+      </text>
+      <text box-sizing="content-box" direction="ltr">
+        XX​XX​XX​XX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="20">
+      <node x="0" y="0" width="40" height="20"/>
+      <node x="40" y="0" width="60" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_definite_size_auto_tracks_asymmetric_max_content__content_box_rtl.xml
+++ b/tests/xml/grid/grid_definite_size_auto_tracks_asymmetric_max_content__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_definite_size_auto_tracks_asymmetric_max_content__content_box_rtl" use-rounding="true">
+  <viewport width="100px" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="100px" grid-template-columns="auto auto">
+      <text box-sizing="content-box" direction="rtl">
+        XX​XX
+      </text>
+      <text box-sizing="content-box" direction="rtl">
+        XX​XX​XX​XX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="20">
+      <node x="60" y="0" width="40" height="20"/>
+      <node x="0" y="0" width="60" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_definite_size_auto_tracks_asymmetric_max_content_issue_1000__border_box_ltr.xml
+++ b/tests/xml/grid/grid_definite_size_auto_tracks_asymmetric_max_content_issue_1000__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_definite_size_auto_tracks_asymmetric_max_content_issue_1000__border_box_ltr" use-rounding="true">
+  <viewport width="928px" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="928px" grid-template-columns="auto auto">
+      <text direction="ltr">
+        XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXX
+      </text>
+      <text direction="ltr" max-width="674px">
+        XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXXXX​XX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="928" height="20">
+      <node x="0" y="0" width="400" height="20"/>
+      <node x="400" y="0" width="528" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_definite_size_auto_tracks_asymmetric_max_content_issue_1000__border_box_rtl.xml
+++ b/tests/xml/grid/grid_definite_size_auto_tracks_asymmetric_max_content_issue_1000__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_definite_size_auto_tracks_asymmetric_max_content_issue_1000__border_box_rtl" use-rounding="true">
+  <viewport width="928px" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="928px" grid-template-columns="auto auto">
+      <text direction="rtl">
+        XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXX
+      </text>
+      <text direction="rtl" max-width="674px">
+        XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXXXX​XX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="928" height="20">
+      <node x="528" y="0" width="400" height="20"/>
+      <node x="0" y="0" width="528" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_definite_size_auto_tracks_asymmetric_max_content_issue_1000__content_box_ltr.xml
+++ b/tests/xml/grid/grid_definite_size_auto_tracks_asymmetric_max_content_issue_1000__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_definite_size_auto_tracks_asymmetric_max_content_issue_1000__content_box_ltr" use-rounding="true">
+  <viewport width="928px" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="928px" grid-template-columns="auto auto">
+      <text box-sizing="content-box" direction="ltr">
+        XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXX
+      </text>
+      <text box-sizing="content-box" direction="ltr" max-width="674px">
+        XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXXXX​XX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="928" height="20">
+      <node x="0" y="0" width="400" height="20"/>
+      <node x="400" y="0" width="528" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_definite_size_auto_tracks_asymmetric_max_content_issue_1000__content_box_rtl.xml
+++ b/tests/xml/grid/grid_definite_size_auto_tracks_asymmetric_max_content_issue_1000__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_definite_size_auto_tracks_asymmetric_max_content_issue_1000__content_box_rtl" use-rounding="true">
+  <viewport width="928px" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="928px" grid-template-columns="auto auto">
+      <text box-sizing="content-box" direction="rtl">
+        XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXX
+      </text>
+      <text box-sizing="content-box" direction="rtl" max-width="674px">
+        XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXXXX​XXXXXX​XX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="928" height="20">
+      <node x="528" y="0" width="400" height="20"/>
+      <node x="0" y="0" width="528" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -18835,6 +18835,30 @@ mod grid {
 
     #[cfg(feature = "grid")]
     #[test]
+    fn grid_definite_size_auto_tracks_asymmetric_max_content__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_definite_size_auto_tracks_asymmetric_max_content__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_definite_size_auto_tracks_asymmetric_max_content__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_definite_size_auto_tracks_asymmetric_max_content__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_definite_size_auto_tracks_asymmetric_max_content__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_definite_size_auto_tracks_asymmetric_max_content__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_definite_size_auto_tracks_asymmetric_max_content__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_definite_size_auto_tracks_asymmetric_max_content__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
     fn grid_display_none_fixed_size__border_box_ltr() {
         crate::run_xml_test("grid", "grid_display_none_fixed_size__border_box_ltr");
     }

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -18859,6 +18859,36 @@ mod grid {
 
     #[cfg(feature = "grid")]
     #[test]
+    fn grid_definite_size_auto_tracks_asymmetric_max_content_issue_1000__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_definite_size_auto_tracks_asymmetric_max_content_issue_1000__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_definite_size_auto_tracks_asymmetric_max_content_issue_1000__content_box_ltr() {
+        crate::run_xml_test(
+            "grid",
+            "grid_definite_size_auto_tracks_asymmetric_max_content_issue_1000__content_box_ltr",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_definite_size_auto_tracks_asymmetric_max_content_issue_1000__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_definite_size_auto_tracks_asymmetric_max_content_issue_1000__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_definite_size_auto_tracks_asymmetric_max_content_issue_1000__content_box_rtl() {
+        crate::run_xml_test(
+            "grid",
+            "grid_definite_size_auto_tracks_asymmetric_max_content_issue_1000__content_box_rtl",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
     fn grid_display_none_fixed_size__border_box_ltr() {
         crate::run_xml_test("grid", "grid_display_none_fixed_size__border_box_ltr");
     }


### PR DESCRIPTION
# Objective

Fixes #1000

Grid `auto` tracks could grow past their growth limits (max-content contributions) and overflow a definite container, e.g. container `928` with track max-contents `[400, 674]` resolved to `[528, 528]` (sum 1056) instead of `[400, 528]`.

## Context

Root cause is in `distribute_space_up_to_limits`. Increases are accumulated in `track.item_incurred_increase` across loop iterations, but two places only compared the *base* property (`track_affected_property(track)`, which stays constant during distribution) against the limit, ignoring the increase accumulated so far:

```diff
 // per-iteration increase cap
-(track_limit(track) - track_affected_property(track)) / track_distribution_proportion(track)
+(track_limit(track) - track_affected_property(track) - track.item_incurred_increase)
+    / track_distribution_proportion(track)

 // application guard
-if increase > 0.0 && track_affected_property(track) + increase <= track_limit(track) + THRESHOLD
+if increase > 0.0
+    && track_affected_property(track) + track.item_incurred_increase + increase
+        <= track_limit(track) + THRESHOLD
```

Concretely for the repro (base sizes `[60, 60]`, limits `[400, 674]`, 808px free space): iteration 1 gives both tracks +340, freezing track 0 at its 400 limit. Iteration 2 correctly excludes track 0 from the proportion sum, but the application guard checked `60 + 128 <= 400` (ignoring the already-applied +340) and so gave the frozen track another +128, ending at 528 > 400.

This helper is shared by the §11.6 "maximise tracks" step and §11.5.1 base-size distribution, so both paths are fixed.

## Testing

Added a gentest fixture `grid_definite_size_auto_tracks_asymmetric_max_content` (definite 100px grid, two `auto` columns with max-contents 40/80 and min-contents 20/20); the generated tests (from Chrome 151) assert Chrome's `[40, 60]` track layout. An earlier hand-written version of this test was removed in favour of the generated one. The gentest harness also gained a small retry loop around `getTestData()` for flaky page loads. CHANGELOG updated.

Note: one pre-existing behavior changes as a side effect — for a container *larger* than the sum of max-contents (e.g. 1200 with `[400, 674]`), tracks now resolve to `[463, 737]` (maximise to limits, then §11.8 stretch distributes the remaining 126px *equally*) instead of the previous `[400, 800]`, matching browser behavior. All existing tests pass unchanged. A local WPT comparison (css-grid + css-flexbox, 1330 tests) between this branch and taffy main showed zero result changes from this fix.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/b4427fc29c124eda823ac3bce1fe8fed
Requested by: @nicoburns
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| 🟢 Reviewed | [`45e37bb`](https://github.com/dioxuslabs/taffy/pull/1001/commits/45e37bb5b5338f49ecff63b0743286413a7fa8db) |

<a href="https://dioxus.staging.devinenterprise.com/review/dioxuslabs/taffy/pull/1001" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->