### PR TITLE
Block: don't stretch-size replaced elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Block: replaced elements (`item_is_replaced: true`) are no longer stretch-sized to the container width. An auto width now resolves to the intrinsic size, per [CSS 2 §10.3.4](https://www.w3.org/TR/CSS22/visudet.html#block-replaced-width)
+
 - Grid: tracks no longer grow past their growth limits when distributing free space to multiple tracks with asymmetric limits (in the "maximise tracks" step and when distributing item contributions to base sizes). Previously a track could be assigned space beyond its limit in later distribution iterations, causing `auto` tracks to overflow a definite container (#1000)
 
 - Flexbox: min/max sizes transferred through the aspect ratio now clamp the flex base size, the automatic minimum size, and the hypothetical main/cross sizes of flex items, instead of being baked into the item's used min/max sizes. This matches browser behaviour for replaced elements and items with `aspect-ratio` combined with min/max constraints in the opposite axis ([w3c/csswg-drafts#10997](https://github.com/w3c/csswg-drafts/issues/10997))

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -938,12 +938,11 @@ fn perform_final_layout_on_in_flow_children(
                 }
             };
 
-            let known_dimensions = if item.is_table {
+            // Tables and replaced elements are not stretch-sized: they resolve their own
+            // size (for replaced elements an auto width resolves to the intrinsic size
+            // <https://www.w3.org/TR/CSS22/visudet.html#block-replaced-width>)
+            let known_dimensions = if item.is_table || item.is_replaced {
                 Size::NONE
-            } else if item.is_replaced {
-                // Replaced elements are not stretch-sized: an auto width resolves to the
-                // intrinsic size <https://www.w3.org/TR/CSS22/visudet.html#block-replaced-width>
-                item.size.maybe_clamp(item.min_size, item.max_size)
             } else {
                 item.size
                     .map_width(|width| {

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -197,6 +197,11 @@ struct BlockItem {
     /// Items that are tables don't have stretch sizing applied to them
     is_table: bool,
 
+    /// Items that are replaced elements resolve an auto width to their intrinsic size
+    /// rather than being stretch-sized
+    /// <https://www.w3.org/TR/CSS22/visudet.html#block-replaced-width>
+    is_replaced: bool,
+
     /// Whether the child is a non-independent block or inline node
     is_in_same_bfc: bool,
 
@@ -653,6 +658,7 @@ fn generate_item_list(
 
             let is_block = child_style.is_block();
             let is_table = child_style.is_table();
+            let is_replaced = child_style.is_compressible_replaced();
             let is_scroll_container = overflow.x.is_scroll_container() || overflow.y.is_scroll_container();
 
             let is_in_same_bfc: bool =
@@ -662,6 +668,7 @@ fn generate_item_list(
                 node_id: child_node_id,
                 order: order as u32,
                 is_table,
+                is_replaced,
                 is_in_same_bfc,
                 #[cfg(feature = "float_layout")]
                 float,
@@ -933,11 +940,13 @@ fn perform_final_layout_on_in_flow_children(
 
             let known_dimensions = if item.is_table {
                 Size::NONE
+            } else if item.is_replaced {
+                // Replaced elements are not stretch-sized: an auto width resolves to the
+                // intrinsic size <https://www.w3.org/TR/CSS22/visudet.html#block-replaced-width>
+                item.size.maybe_clamp(item.min_size, item.max_size)
             } else {
                 item.size
                     .map_width(|width| {
-                        // TODO: Allow stretch-sizing to be conditional, as there are exceptions.
-                        // e.g. Table children of blocks do not stretch fit
                         Some(width.unwrap_or(stretch_width).maybe_clamp(item.min_size.width, item.max_size.width))
                     })
                     .maybe_clamp(item.min_size, item.max_size)
@@ -961,9 +970,9 @@ fn perform_final_layout_on_in_flow_children(
             let clear_pos = f32::NEG_INFINITY;
 
             let item_layout = if item.is_in_same_bfc {
-                let width = known_dimensions
-                    .width
-                    .expect("Same-bfc child will always have defined width due to stretch sizing");
+                // Replaced elements may not have a known width (they are sized by their
+                // measure function rather than stretch-sized)
+                let width = known_dimensions.width.unwrap_or(stretch_width);
 
                 // TODO: account for auto margins
                 let inset_left = item_non_auto_margin.left + content_box_inset.left;

--- a/tests/hand_written.rs
+++ b/tests/hand_written.rs
@@ -1,4 +1,5 @@
 mod hand_written {
+    mod block_replaced;
     mod border_and_padding;
     mod caching;
     mod floats;

--- a/tests/hand_written/block_replaced.rs
+++ b/tests/hand_written/block_replaced.rs
@@ -1,0 +1,115 @@
+//! Sizing of replaced (`item_is_replaced: true`) children of block containers.
+//!
+//! Block layout stretch-sizes in-flow children to the container width, but block-level
+//! replaced elements are exempt: with `width: auto` they use their intrinsic size
+//! (<https://www.w3.org/TR/CSS22/visudet.html#block-replaced-width>).
+#[cfg(test)]
+mod block_replaced {
+    use taffy::prelude::*;
+    use taffy::TaffyTree;
+    use taffy_test_helpers::{new_test_tree, test_measure_function, TestNodeContext};
+
+    // A 142x20 badge-like image (height = width * 20/142)
+    const BADGE: TestNodeContext = TestNodeContext::aspect_ratio(142.0, 20.0 / 142.0);
+
+    fn block_container(width: f32) -> Style {
+        Style { display: Display::Block, size: Size { width: length(width), height: auto() }, ..Default::default() }
+    }
+
+    fn layout(taffy: &mut TaffyTree<TestNodeContext>, root: NodeId) {
+        taffy.compute_layout_with_measure(root, Size::MAX_CONTENT, test_measure_function).unwrap();
+    }
+
+    #[test]
+    fn auto_width_uses_intrinsic_size() {
+        let mut taffy = new_test_tree();
+        let child = taffy
+            .new_leaf_with_context(
+                Style { display: Display::Block, item_is_replaced: true, ..Default::default() },
+                BADGE,
+            )
+            .unwrap();
+        let root = taffy.new_with_children(block_container(600.0), &[child]).unwrap();
+        layout(&mut taffy, root);
+
+        let child_layout = taffy.layout(child).unwrap();
+        assert_eq!(child_layout.size.width, 142.0);
+        assert_eq!(child_layout.size.height, 20.0);
+    }
+
+    #[test]
+    fn non_replaced_child_is_stretch_sized() {
+        let mut taffy = new_test_tree();
+        let child =
+            taffy.new_leaf_with_context(Style { display: Display::Block, ..Default::default() }, BADGE).unwrap();
+        let root = taffy.new_with_children(block_container(600.0), &[child]).unwrap();
+        layout(&mut taffy, root);
+
+        assert_eq!(taffy.layout(child).unwrap().size.width, 600.0);
+    }
+
+    #[test]
+    fn explicit_width_is_used() {
+        let mut taffy = new_test_tree();
+        let child = taffy
+            .new_leaf_with_context(
+                Style {
+                    display: Display::Block,
+                    item_is_replaced: true,
+                    size: Size { width: length(300.0), height: length(50.0) },
+                    ..Default::default()
+                },
+                BADGE,
+            )
+            .unwrap();
+        let root = taffy.new_with_children(block_container(600.0), &[child]).unwrap();
+        layout(&mut taffy, root);
+
+        let child_layout = taffy.layout(child).unwrap();
+        assert_eq!(child_layout.size.width, 300.0);
+        assert_eq!(child_layout.size.height, 50.0);
+    }
+
+    #[test]
+    fn max_width_clamps_intrinsic_size() {
+        let mut taffy = new_test_tree();
+        let child = taffy
+            .new_leaf_with_context(
+                Style {
+                    display: Display::Block,
+                    item_is_replaced: true,
+                    max_size: Size { width: percent(1.0), height: auto() },
+                    ..Default::default()
+                },
+                BADGE,
+            )
+            .unwrap();
+        let root = taffy.new_with_children(block_container(100.0), &[child]).unwrap();
+        layout(&mut taffy, root);
+
+        let child_layout = taffy.layout(child).unwrap();
+        assert_eq!(child_layout.size.width, 100.0);
+    }
+
+    #[test]
+    fn auto_margins_center_replaced_child() {
+        let mut taffy = new_test_tree();
+        let child = taffy
+            .new_leaf_with_context(
+                Style {
+                    display: Display::Block,
+                    item_is_replaced: true,
+                    margin: Rect { left: auto(), right: auto(), top: zero(), bottom: zero() },
+                    ..Default::default()
+                },
+                BADGE,
+            )
+            .unwrap();
+        let root = taffy.new_with_children(block_container(600.0), &[child]).unwrap();
+        layout(&mut taffy, root);
+
+        let child_layout = taffy.layout(child).unwrap();
+        assert_eq!(child_layout.size.width, 142.0);
+        assert_eq!(child_layout.location.x, (600.0 - 142.0) / 2.0);
+    }
+}


### PR DESCRIPTION
# Objective

Block layout stretch-sizes all in-flow children to the container width, passing the stretched width down as a known dimension. Block-level replaced elements are exempt from this per [CSS 2 §10.3.4](https://www.w3.org/TR/CSS22/visudet.html#block-replaced-width): an auto width resolves to the intrinsic size. The stretched known width was overriding intrinsic sizing in consumers' measure functions — in Blitz this made every `img { display: block }` (e.g. GitHub README badges/logos) stretch to the full container width, with height scaled up by the aspect ratio (DioxusLabs/blitz#553).

This PR skips stretch-sizing for items where `style.is_compressible_replaced()` returns true, using the same `item_is_replaced` hook that grid already consults, treating them identically to tables:

```rust
// Tables and replaced elements are not stretch-sized: they resolve their own size
let known_dimensions = if item.is_table || item.is_replaced {
    Size::NONE
} else {
    /* stretch-size as before */
};
```

The replaced element's own sizing algorithm (leaf algorithm / measure function) then resolves everything itself: explicit widths, aspect ratio, and min/max constraints — including the replaced-specific min/max rules that block layout's generic clamp wouldn't get right. Auto margins still center against the stretch width, and flex/grid behaviour is unchanged. The same-bfc `known_dimensions.width.expect(...)` becomes `unwrap_or(stretch_width)` since replaced children now have no known width.

## Context

- Follows the precedent of #807 (grid `is_compressible_replaced` special-casing) and the existing `is_table` exemption in block layout (the `TODO: Allow stretch-sizing to be conditional` addressed here).
- Blitz-side verification: DioxusLabs/blitz#553 sets `item_is_replaced: true` for replaced elements against this branch and drops its temporary workaround; blitz test suites pass and local WPT runs improve (`absolute-replaced-width-*` 23→26, `normal-flow/block-replaced-*` 0→2, `c43-rpl-bbx-002` newly passing).
- Added hand-written tests in `tests/hand_written/block_replaced.rs` covering intrinsic sizing, stretch-sizing of non-replaced siblings, explicit width, `max-width` clamping, and auto-margin centering.
- CHANGELOG.md updated (no RELEASES.md in this repo).

## Feedback wanted

- Replaced items keep `is_in_same_bfc: true` (unlike tables, which are excluded). This only affects the float-context insets computed from the now-unknown width; since replaced elements are leaves this seemed harmless, but flagging in case you'd rather exempt them like tables.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/18463052d16041d18e4475332d34f5e6
Requested by: @nicoburns