### PR TITLE
Batch test fixture collection into a few in-browser script calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /yoga_test_fixtures
 /yoga_test_fixtures_grouped
 /test_fixtures/_scratch
+/.chrome-for-testing
 
 **/*.rs.bk
 Cargo.lock

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,18 +26,9 @@ If you do you not want to install `just` then you can peak into the `justfile` i
 Flexbox layouts are tested by validating that layouts written in this crate perform the same as in Chrome.
 This is done by rendering an equivalent layout in HTML and then generating a Rust test case which asserts that the resulting layout is the same when run through our layout engine.
 
-You can run these tests without setting up a webdriver environment but if you are looking to add any test case you will need to install [chromedriver](http://chromedriver.chromium.org) and [Chrome](https://www.google.com/chrome/).
-If you are developing on macOS this is easy to do through brew.
+You can run these tests without setting up a webdriver environment. And if you are looking to add a test case then no manual setup is required either: the test generation script downloads a matching pair of [Chrome for Testing](https://developer.chrome.com/blog/chrome-for-testing) and ChromeDriver builds into the `.chrome-for-testing` directory in the root of the repo (using the `scripts/getchrome` crate) and uses those. The download only happens once per version: subsequent runs reuse the already downloaded build. You can also trigger the download on its own by running `just getchrome`.
 
-```bash
-brew install chromedriver
-```
-
-If you are Ubuntu, you will have to install `openssl` first,
-and then can follow [these instructions](https://tecadmin.net/setup-selenium-chromedriver-on-ubuntu/).
-Be sure that your Chrome version matches the downloaded `chromedriver` version!
-
-Once you have chromedriver installed and available in `PATH` you can re-generate all tests by running `just gentest`. You should not manually update the tests in `tests/generated`. Instead, fix the script in `scripts/gentest/` and re-generate them. This can happen after a refactor. It can be helpful to commit the updated tests in a dedicated commit so that they can be easier to ignore during review.
+You can re-generate all tests by running `just gentest`. You should not manually update the tests in `tests/generated`. Instead, fix the script in `scripts/gentest/` and re-generate them. This can happen after a refactor. It can be helpful to commit the updated tests in a dedicated commit so that they can be easier to ignore during review.
 
 To add a new test case add another HTML file to `/test_fixtures` following the current tests as a template for new tests.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ doc-scrape-examples = true
 [workspace]
 members = [
     "scripts/gentest",
+    "scripts/getchrome",
     "scripts/format-fixtures",
     "scripts/import-yoga-tests",
     "tests/common",

--- a/justfile
+++ b/justfile
@@ -1,6 +1,9 @@
 gentest:
   cargo run --release --package gentest --
 
+getchrome:
+  cargo run --release --package getchrome --
+
 import-yoga-tests:
   cargo run --package import-yoga-tests --
 

--- a/scripts/gentest/Cargo.toml
+++ b/scripts/gentest/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 env_logger = "0.11.10"
 fantoccini = "0.22.0"
+getchrome = { path = "../getchrome" }
 log = "0.4"
 serde_json = "1"
 tokio = { version = "1.18", features = ["full"] }

--- a/scripts/gentest/batch_runner.html
+++ b/scripts/gentest/batch_runner.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Taffy test fixture batch runner</title>
+  <style>
+    html, body { margin: 0; padding: 0; overflow: hidden; }
+    iframe { display: block; width: 100vw; height: 100vh; border: none; }
+  </style>
+  <script>
+    // Load each fixture URL into the iframe in turn and collect the output of the
+    // fixture's own getTestData() function (defined by test_helper.js).
+    //
+    // The iframe fills the entire viewport so that fixtures lay out exactly as they
+    // would when loaded as the top-level document.
+    async function collectTestData(urls) {
+      const iframe = document.getElementById('runner');
+      const results = [];
+      for (const url of urls) {
+        const loaded = new Promise((resolve, reject) => {
+          iframe.onload = resolve;
+          iframe.onerror = () => reject(new Error(`failed to load ${url}`));
+        });
+        iframe.src = url;
+        await loaded;
+        const win = iframe.contentWindow;
+        if (!win || typeof win.getTestData !== 'function') {
+          throw new Error(`getTestData() is not defined in ${url}`);
+        }
+        try {
+          results.push(win.getTestData());
+        } catch (err) {
+          throw new Error(`getTestData() failed for ${url}: ${err}`);
+        }
+      }
+      return results;
+    }
+  </script>
+</head>
+<body>
+  <iframe id="runner"></iframe>
+</body>
+</html>

--- a/scripts/gentest/src/main.rs
+++ b/scripts/gentest/src/main.rs
@@ -35,18 +35,23 @@ async fn main() {
         .collect();
     fixtures.sort_unstable_by_key(|f| f.1.clone());
 
+    info!("obtaining chrome-for-testing");
+    let chrome = getchrome::download_default().expect("failed to download chrome-for-testing");
+    info!("using chrome-for-testing {}", chrome.version);
+
     info!("starting webdriver instance");
     let webdriver_url = "http://localhost:4444";
-    let mut webdriver_handle = Command::new("chromedriver")
-        .arg("--port=4444")
-        .spawn()
-        .expect("ChromeDriver not found: Make sure you have it installed and added to your PATH.");
+    let mut webdriver_handle =
+        Command::new(&chrome.chromedriver).arg("--port=4444").spawn().expect("failed to start ChromeDriver");
 
     // this is silly, but it works
     std::thread::sleep(std::time::Duration::from_secs(1));
 
     let mut caps = serde_json::map::Map::new();
-    let chrome_opts = serde_json::json!({ "args": ["--headless", "--disable-gpu"] });
+    let chrome_opts = serde_json::json!({
+        "binary": chrome.chrome,
+        "args": ["--headless", "--disable-gpu"],
+    });
     caps.insert("goog:chromeOptions".to_string(), chrome_opts.clone());
 
     info!("spawning webdriver client and collecting test descriptions");

--- a/scripts/gentest/src/main.rs
+++ b/scripts/gentest/src/main.rs
@@ -22,6 +22,18 @@ use xmlwriter::{Indent, Options, XmlWriter};
 /// the browser. All of these normally take well under a second.
 const TIMEOUT: Duration = Duration::from_secs(10);
 
+/// How many fixtures to collect test data for in a single script call
+///
+/// Fixtures are loaded into an iframe and measured by a script running inside the browser, which
+/// is much faster than a WebDriver navigation per fixture. Collecting in batches (rather than all
+/// at once) bounds how much work is lost to a hung browser and allows progress to be reported.
+const BATCH_SIZE: usize = 100;
+
+/// How long to wait for a single batch of fixtures before giving up
+///
+/// A fixture normally takes a few milliseconds, so this is very generous.
+const BATCH_TIMEOUT: Duration = Duration::from_secs(60);
+
 #[tokio::main]
 async fn main() {
     env_logger::init();
@@ -55,7 +67,8 @@ async fn main() {
     // afterwards regardless of whether doing so succeeded.
     let result = match webdriver.new_session(&chrome.chrome).await {
         Ok(client) => {
-            let result = collect_test_descs(&client, &fixtures).await;
+            let harness_path = root_dir.join("batch_runner.html");
+            let result = collect_test_descs(&client, &harness_path, &fixtures).await;
             webdriver.close_session(client).await;
             result
         }
@@ -232,7 +245,14 @@ impl WebDriver {
         let mut caps = serde_json::map::Map::new();
         let chrome_opts = serde_json::json!({
             "binary": chrome_path,
-            "args": ["--headless", "--disable-gpu", format!("--user-data-dir={}", self.profile_dir.display())],
+            // --allow-file-access-from-files lets the file:// batch runner page read the
+            // file:// fixture documents that it loads into its iframe
+            "args": [
+                "--headless",
+                "--disable-gpu",
+                "--allow-file-access-from-files",
+                format!("--user-data-dir={}", self.profile_dir.display()),
+            ],
         });
         caps.insert("goog:chromeOptions".to_string(), chrome_opts);
 
@@ -253,7 +273,7 @@ impl WebDriver {
 
         // Bound how long the browser itself will spend on a single navigation or script, so that a
         // problematic test fixture results in an error rather than a hang.
-        let timeouts = TimeoutConfiguration::new(Some(TIMEOUT), Some(TIMEOUT), Some(Duration::ZERO));
+        let timeouts = TimeoutConfiguration::new(Some(BATCH_TIMEOUT), Some(TIMEOUT), Some(Duration::ZERO));
         client.update_timeouts(timeouts).await.map_err(|err| format!("could not set WebDriver timeouts: {err}"))?;
 
         Ok(client)
@@ -344,21 +364,88 @@ fn free_port() -> std::io::Result<u16> {
 }
 
 /// Collect the layout of every test fixture from the browser
+///
+/// The fixtures are loaded into an iframe of the batch runner page at `harness_path` in batches
+/// of [`BATCH_SIZE`], so that collecting the test data requires one WebDriver script call per
+/// batch rather than a navigation and a script call per fixture.
 async fn collect_test_descs(
     client: &Client,
+    harness_path: &Path,
     fixtures: &[(String, PathBuf)],
 ) -> Result<Vec<(String, PathBuf, Value)>, String> {
     asserts_non_zero_width_scrollbars(client).await?;
 
+    let harness_url = format!("file://{}", harness_path.display());
+    timeout(TIMEOUT, client.goto(&harness_url))
+        .await
+        .map_err(|_| format!("timed out loading the batch runner page ({harness_url})"))?
+        .map_err(|err| format!("could not load the batch runner page ({harness_url}): {err}"))?;
+
     info!("collecting test descriptions");
     let progress = Progress::new(fixtures.len());
     let mut test_descs = Vec::with_capacity(fixtures.len());
-    for (index, (name, fixture_path)) in fixtures.iter().enumerate() {
-        progress.step(index, name);
-        test_descs.push(test_root_element(client, name, fixture_path).await?);
+    for batch in fixtures.chunks(BATCH_SIZE) {
+        let (first, last) = (&batch[0].0, &batch[batch.len() - 1].0);
+        progress.step(test_descs.len() + batch.len() - 1, &format!("{first} .. {last}"));
+        test_descs.extend(collect_batch(client, batch).await?);
     }
     progress.finish(&format!("collected {} test descriptions", test_descs.len()));
     Ok(test_descs)
+}
+
+/// Glue script that runs the batch runner page's `collectTestData()` for a batch of fixture URLs
+///
+/// An async WebDriver script reports completion by calling the callback that is appended to its
+/// arguments, and an exception thrown by the promise would not propagate to that callback, so
+/// success and failure are reported explicitly as `{ok: ...}` / `{error: ...}`.
+const COLLECT_BATCH_SCRIPT: &str = "
+    const [urls, done] = arguments;
+    collectTestData(urls).then(
+        (results) => done({ ok: results }),
+        (err) => done({ error: String(err) }),
+    );
+";
+
+/// Collect the layout of a batch of test fixtures from the browser
+async fn collect_batch(client: &Client, batch: &[(String, PathBuf)]) -> Result<Vec<(String, PathBuf, Value)>, String> {
+    let first = &batch[0].0;
+    let urls: Vec<Value> = batch.iter().map(|(_, path)| Value::String(format!("file://{}", path.display()))).collect();
+
+    // The browser occasionally stops responding to a command entirely, so time each command out
+    // rather than waiting forever. The browser's own script timeout ([`BATCH_TIMEOUT`]) normally
+    // triggers first, turning a problematic fixture into an error naming the batch.
+    let grace_period = Duration::from_secs(5);
+    let result = timeout(BATCH_TIMEOUT + grace_period, client.execute_async(COLLECT_BATCH_SCRIPT, vec![urls.into()]))
+        .await
+        .map_err(|_| format!("timed out collecting test data for the batch starting with {first}"))?
+        .map_err(|err| format!("could not collect test data for the batch starting with {first}: {err}"))?;
+
+    if let Some(error) = result.get("error").and_then(Value::as_str) {
+        return Err(format!("could not collect test data: {error}"));
+    }
+    let results = result
+        .get("ok")
+        .and_then(Value::as_array)
+        .ok_or_else(|| format!("unexpected test data for the batch starting with {first}: {result}"))?;
+    if results.len() != batch.len() {
+        return Err(format!(
+            "expected test data for {} fixtures in the batch starting with {first}, but got {}",
+            batch.len(),
+            results.len()
+        ));
+    }
+
+    batch
+        .iter()
+        .zip(results)
+        .map(|((name, fixture_path), description)| {
+            let description_string =
+                description.as_str().ok_or_else(|| format!("unexpected test data for {name}: {description}"))?;
+            let description = serde_json::from_str(description_string)
+                .map_err(|err| format!("invalid test data for {name}: {err}"))?;
+            Ok((name.clone(), fixture_path.clone(), description))
+        })
+        .collect()
 }
 
 /// The width of the terminal in characters, defaulting to 80 if it cannot be determined
@@ -432,43 +519,6 @@ async fn asserts_non_zero_width_scrollbars(client: &Client) -> Result<(), String
     }
 
     Ok(())
-}
-
-async fn test_root_element(
-    client: &Client,
-    name: &str,
-    fixture_path: &Path,
-) -> Result<(String, PathBuf, Value), String> {
-    let url = format!("file://{}", fixture_path.display());
-
-    // The browser occasionally stops responding to a command entirely, so time each command out
-    // rather than waiting forever. A fixture normally takes a few milliseconds.
-    timeout(TIMEOUT, client.goto(&url))
-        .await
-        .map_err(|_| format!("timed out loading the test fixture {name} ({})", fixture_path.display()))?
-        .map_err(|err| format!("could not load the test fixture {name}: {err}"))?;
-
-    // Navigation can occasionally return before the document is fully loaded, so retry a few times
-    let mut attempts = 0;
-    let description = loop {
-        let result = timeout(TIMEOUT, client.execute("return getTestData()", vec![]))
-            .await
-            .map_err(|_| format!("timed out running getTestData() for {name}"))?;
-        match result {
-            Ok(description) => break description,
-            Err(err) if attempts < 3 => {
-                attempts += 1;
-                warn!("getTestData() failed for {name} (attempt {attempts}): {err}");
-                tokio::time::sleep(Duration::from_millis(200)).await;
-            }
-            Err(err) => return Err(format!("getTestData() failed for {name}: {err}")),
-        }
-    };
-    let description_string =
-        description.as_str().ok_or_else(|| format!("unexpected test data for {name}: {description}"))?;
-    let description =
-        serde_json::from_str(description_string).map_err(|err| format!("invalid test data for {name}: {err}"))?;
-    Ok((name.to_string(), fixture_path.to_path_buf(), description))
 }
 
 fn generate_test(name: impl AsRef<str>, description: &Value) -> String {

--- a/scripts/gentest/src/main.rs
+++ b/scripts/gentest/src/main.rs
@@ -2,15 +2,25 @@ use std::borrow::Cow;
 use std::ffi::{OsStr, OsString};
 use std::fmt::Display;
 use std::fs::{self, OpenOptions};
-use std::io::Write as _;
+use std::io::{IsTerminal, Write as _};
+use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
 use std::path::{Component, Path, PathBuf};
-use std::process::Command;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
 
+use fantoccini::wd::TimeoutConfiguration;
 use fantoccini::{Client, ClientBuilder};
 use log::*;
 use serde_json::Value;
+use tokio::time::timeout;
 use walkdir::WalkDir;
 use xmlwriter::{Indent, Options, XmlWriter};
+
+/// How long to wait for any single step of test generation before giving up
+///
+/// This bounds starting ChromeDriver, starting and quitting the browser, and each command sent to
+/// the browser. All of these normally take well under a second.
+const TIMEOUT: Duration = Duration::from_secs(10);
 
 #[tokio::main]
 async fn main() {
@@ -36,37 +46,23 @@ async fn main() {
     fixtures.sort_unstable_by_key(|f| f.1.clone());
 
     info!("obtaining chrome-for-testing");
-    let chrome = getchrome::download_default().expect("failed to download chrome-for-testing");
+    let chrome = getchrome::download_default().unwrap_or_else(|err| fatal(&err.to_string()));
     info!("using chrome-for-testing {}", chrome.version);
 
-    info!("starting webdriver instance");
-    let webdriver_url = "http://localhost:4444";
-    let mut webdriver_handle =
-        Command::new(&chrome.chromedriver).arg("--port=4444").spawn().expect("failed to start ChromeDriver");
+    let mut webdriver = WebDriver::start(&chrome.chromedriver).unwrap_or_else(|err| fatal(&err));
 
-    // this is silly, but it works
-    std::thread::sleep(std::time::Duration::from_secs(1));
-
-    let mut caps = serde_json::map::Map::new();
-    let chrome_opts = serde_json::json!({
-        "binary": chrome.chrome,
-        "args": ["--headless", "--disable-gpu"],
-    });
-    caps.insert("goog:chromeOptions".to_string(), chrome_opts.clone());
-
-    info!("spawning webdriver client and collecting test descriptions");
-    let client = ClientBuilder::native().capabilities(caps.clone()).connect(webdriver_url).await.unwrap();
-
-    asserts_non_zero_width_scrollbars(client.clone()).await;
-
-    let mut test_descs = vec![];
-    for (name, fixture_path) in fixtures.iter() {
-        test_descs.push(test_root_element(client.clone(), name.clone(), fixture_path).await);
-    }
-
-    info!("killing webdriver instance...");
-    webdriver_handle.kill().unwrap();
-    webdriver_handle.wait().unwrap();
+    // Collect the test descriptions, making sure that the browser and webdriver are shut down
+    // afterwards regardless of whether doing so succeeded.
+    let result = match webdriver.new_session(&chrome.chrome).await {
+        Ok(client) => {
+            let result = collect_test_descs(&client, &fixtures).await;
+            webdriver.close_session(client).await;
+            result
+        }
+        Err(err) => Err(err),
+    };
+    webdriver.shutdown();
+    let test_descs = result.unwrap_or_else(|err| fatal(&err));
 
     info!("generating test sources and concatenating...");
 
@@ -150,53 +146,329 @@ async fn main() {
     }
 
     info!("formatting the source directory");
-    Command::new("cargo").arg("fmt").current_dir(repo_root).status().unwrap();
+    // The tests have already been written at this point, so a formatting failure is not fatal
+    match Command::new("cargo").arg("fmt").current_dir(repo_root).status() {
+        Ok(status) if !status.success() => warn!("`cargo fmt` failed ({status})"),
+        Err(err) => warn!("could not run `cargo fmt`: {err}"),
+        Ok(_) => {}
+    }
 }
 
-async fn asserts_non_zero_width_scrollbars(client: Client) {
+/// Report a fatal error and exit without generating any tests
+///
+/// Aborting rather than continuing means that an incomplete run cannot delete existing tests
+/// (test generation removes and re-creates the whole generated tests directory).
+fn fatal(message: &str) -> ! {
+    error!("{message}");
+    eprintln!("\nError: {message}\n\nNo tests have been generated.");
+    std::process::exit(1);
+}
+
+/// A running ChromeDriver process, along with the URL that it is listening on
+struct WebDriver {
+    process: Child,
+    url: String,
+    /// The profile directory that the browser is told to use
+    ///
+    /// Passing our own directory (rather than letting ChromeDriver pick a temporary one) makes it
+    /// possible to identify the browser processes belonging to this run, so that they can be
+    /// cleaned up even when ChromeDriver fails to do so.
+    profile_dir: PathBuf,
+}
+
+impl WebDriver {
+    /// Start ChromeDriver on a free port and wait for it to start accepting connections
+    fn start(chromedriver_path: &Path) -> Result<Self, String> {
+        // Rather than a fixed port, use a free port chosen by the OS. This prevents us from
+        // interfering with (or being confused by) any other WebDriver server on the machine,
+        // including a ChromeDriver left behind by a previous run of this script.
+        let port = free_port().map_err(|err| format!("could not find a free port for ChromeDriver: {err}"))?;
+
+        info!("starting webdriver instance on port {port}");
+        let process = Command::new(chromedriver_path)
+            .arg(format!("--port={port}"))
+            .spawn()
+            .map_err(|err| format!("could not start ChromeDriver ({}): {err}", chromedriver_path.display()))?;
+
+        let profile_dir = std::env::temp_dir().join(format!("taffy-gentest-{}", std::process::id()));
+        let mut webdriver = WebDriver { process, url: format!("http://127.0.0.1:{port}"), profile_dir };
+        webdriver.wait_until_listening(port)?;
+        Ok(webdriver)
+    }
+
+    /// Wait for ChromeDriver to start accepting connections on `port`
+    ///
+    /// ChromeDriver only binds its port once it is ready to serve requests, so this avoids sending
+    /// requests to a server that is not up yet (and avoids waiting for a fixed amount of time).
+    fn wait_until_listening(&mut self, port: u16) -> Result<(), String> {
+        let addr = SocketAddr::from(([127, 0, 0, 1], port));
+        let start = Instant::now();
+        loop {
+            // Detect ChromeDriver failing to start (e.g. because the port is already in use)
+            // rather than waiting for it to accept a connection that will never come.
+            match self.process.try_wait() {
+                Ok(Some(status)) => return Err(format!("ChromeDriver exited during startup ({status})")),
+                Err(err) => return Err(format!("could not determine whether ChromeDriver is running: {err}")),
+                Ok(None) => {}
+            }
+
+            if TcpStream::connect_timeout(&addr, Duration::from_secs(1)).is_ok() {
+                return Ok(());
+            }
+
+            if start.elapsed() > TIMEOUT {
+                return Err(format!(
+                    "ChromeDriver did not start listening on port {port} within {} seconds",
+                    TIMEOUT.as_secs()
+                ));
+            }
+
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+
+    /// Create a WebDriver session that runs the browser at `chrome_path`
+    async fn new_session(&self, chrome_path: &Path) -> Result<Client, String> {
+        let mut caps = serde_json::map::Map::new();
+        let chrome_opts = serde_json::json!({
+            "binary": chrome_path,
+            "args": ["--headless", "--disable-gpu", format!("--user-data-dir={}", self.profile_dir.display())],
+        });
+        caps.insert("goog:chromeOptions".to_string(), chrome_opts);
+
+        info!("spawning webdriver client");
+        // Creating the session launches the browser, which can hang indefinitely (for example if
+        // the browser cannot start), so give up rather than hanging forever.
+        let mut builder = ClientBuilder::native();
+        builder.capabilities(caps);
+        let client = timeout(TIMEOUT, builder.connect(&self.url))
+            .await
+            .map_err(|_| {
+                format!(
+                    "the browser did not start within {} seconds. Check the ChromeDriver output above for details.",
+                    TIMEOUT.as_secs()
+                )
+            })?
+            .map_err(|err| format!("could not create a WebDriver session: {err}"))?;
+
+        // Bound how long the browser itself will spend on a single navigation or script, so that a
+        // problematic test fixture results in an error rather than a hang.
+        let timeouts = TimeoutConfiguration::new(Some(TIMEOUT), Some(TIMEOUT), Some(Duration::ZERO));
+        client.update_timeouts(timeouts).await.map_err(|err| format!("could not set WebDriver timeouts: {err}"))?;
+
+        Ok(client)
+    }
+
+    /// Close the WebDriver session, which quits the browser that it launched
+    async fn close_session(&self, client: Client) {
+        info!("closing webdriver session...");
+        // If the session is not closed then the browser is left running as an orphan process when
+        // ChromeDriver is killed, so log loudly if this fails.
+        match timeout(TIMEOUT, client.close()).await {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => warn!("could not close the webdriver session (the browser may still be running): {err}"),
+            Err(_) => warn!("closing the webdriver session timed out (the browser may still be running)"),
+        }
+    }
+
+    /// Shut the ChromeDriver process down and clean up after the browser it launched
+    fn shutdown(&mut self) {
+        self.stop_process();
+        self.kill_leftover_browsers();
+        let _ = fs::remove_dir_all(&self.profile_dir);
+    }
+
+    /// Kill any browser process that is still using our profile directory
+    ///
+    /// A browser that has stopped responding is not shut down by ChromeDriver, and would otherwise
+    /// be left behind as an orphan process holding on to a lot of memory.
+    #[cfg(unix)]
+    fn kill_leftover_browsers(&self) {
+        if !self.profile_dir.exists() {
+            return;
+        }
+        // Only processes launched with our profile directory match this pattern
+        let pattern = format!("--user-data-dir={}", self.profile_dir.display());
+        // The `--` is required because the pattern itself starts with dashes
+        let killed = Command::new("pkill").args(["-9", "-f", "--"]).arg(&pattern).status();
+        if matches!(killed, Ok(status) if status.success()) {
+            warn!("killed browser processes that did not shut down cleanly");
+        }
+    }
+
+    #[cfg(not(unix))]
+    fn kill_leftover_browsers(&self) {}
+
+    /// Stop the ChromeDriver process
+    fn stop_process(&mut self) {
+        if matches!(self.process.try_wait(), Ok(Some(_))) {
+            return;
+        }
+
+        info!("stopping webdriver instance...");
+
+        // Ask ChromeDriver to shut down gracefully so that it gets the chance to quit any browser
+        // that it is still responsible for. `Child::kill` sends SIGKILL, which would leave such a
+        // browser running as an orphan process.
+        #[cfg(unix)]
+        {
+            let _ = Command::new("kill").arg(self.process.id().to_string()).status();
+            let start = Instant::now();
+            while start.elapsed() < TIMEOUT {
+                if matches!(self.process.try_wait(), Ok(Some(_))) {
+                    return;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            warn!("ChromeDriver did not shut down gracefully. Killing it.");
+        }
+
+        let _ = self.process.kill();
+        let _ = self.process.wait();
+    }
+}
+
+impl Drop for WebDriver {
+    fn drop(&mut self) {
+        // Backstop for exit paths that do not shut the webdriver down explicitly (such as a panic)
+        self.shutdown();
+    }
+}
+
+/// Ask the OS for a free TCP port
+fn free_port() -> std::io::Result<u16> {
+    // The port is free when the listener is dropped at the end of this function. This is racy in
+    // theory, but in practice the port is bound again immediately, and ChromeDriver failing to
+    // bind it is detected and reported.
+    Ok(TcpListener::bind((Ipv4Addr::LOCALHOST, 0))?.local_addr()?.port())
+}
+
+/// Collect the layout of every test fixture from the browser
+async fn collect_test_descs(
+    client: &Client,
+    fixtures: &[(String, PathBuf)],
+) -> Result<Vec<(String, PathBuf, Value)>, String> {
+    asserts_non_zero_width_scrollbars(client).await?;
+
+    info!("collecting test descriptions");
+    let progress = Progress::new(fixtures.len());
+    let mut test_descs = Vec::with_capacity(fixtures.len());
+    for (index, (name, fixture_path)) in fixtures.iter().enumerate() {
+        progress.step(index, name);
+        test_descs.push(test_root_element(client, name, fixture_path).await?);
+    }
+    progress.finish(&format!("collected {} test descriptions", test_descs.len()));
+    Ok(test_descs)
+}
+
+/// The width of the terminal in characters, defaulting to 80 if it cannot be determined
+fn terminal_width() -> usize {
+    let from_tput = || {
+        let output = Command::new("tput").arg("cols").stderr(Stdio::null()).output().ok()?;
+        String::from_utf8_lossy(&output.stdout).trim().parse().ok()
+    };
+    std::env::var("COLUMNS").ok().and_then(|columns| columns.parse().ok()).or_else(from_tput).unwrap_or(80)
+}
+
+/// Reports the progress of a long running sequence of steps
+///
+/// When stderr is a terminal a single line is updated in place. Otherwise (when the output is being
+/// piped to a file or a CI log) one line is logged per step.
+struct Progress {
+    total: usize,
+    in_place: bool,
+    /// The width of the terminal, which progress lines are truncated to so that they do not wrap
+    terminal_width: usize,
+}
+
+impl Progress {
+    fn new(total: usize) -> Self {
+        Progress { total, in_place: std::io::stderr().is_terminal(), terminal_width: terminal_width() }
+    }
+
+    /// Report that the (zero-based) step `index`, described by `label`, is about to start
+    fn step(&self, index: usize, label: &str) {
+        let (count, total) = (index + 1, self.total);
+        if self.in_place {
+            // A line that is exactly as wide as the terminal already wraps, hence the -1
+            let width = self.terminal_width.saturating_sub(1);
+            let line: String = format!("[{count}/{total}] {label}").chars().take(width).collect();
+            // `\r` moves back to the start of the line and `\x1b[K` clears the rest of it
+            eprint!("\r\x1b[K{line}");
+            let _ = std::io::stderr().flush();
+        } else {
+            info!("[{count}/{total}] {label}");
+        }
+    }
+
+    /// Replace the progress line with a final message
+    fn finish(&self, label: &str) {
+        if self.in_place {
+            eprintln!("\r\x1b[K{label}");
+        } else {
+            info!("{label}");
+        }
+    }
+}
+
+async fn asserts_non_zero_width_scrollbars(client: &Client) -> Result<(), String> {
     // Load minimal test page defined in the string
     const TEST_PAGE: &str = r#"data:text/html;charset=utf-8,<html><body><div style="overflow:scroll" /></body></html>"#;
-    client.goto(TEST_PAGE).await.unwrap();
+    client.goto(TEST_PAGE).await.map_err(|err| format!("could not load the scrollbar test page: {err}"))?;
 
     // Determine the width of the scrollbar
     let scrollbar_width = client
         .execute("return document.body.firstChild.clientWidth - document.body.firstChild.offsetWidth;", vec![])
         .await
-        .unwrap();
-    let Value::Number(scrollbar_width) = scrollbar_width else { panic!("Error retrieving scrollbar_width") };
-    let scrollbar_width = scrollbar_width.as_f64().unwrap();
+        .map_err(|err| format!("could not determine the width of scrollbars: {err}"))?;
+    let scrollbar_width =
+        scrollbar_width.as_f64().ok_or_else(|| format!("unexpected scrollbar width: {scrollbar_width}"))?;
 
     if scrollbar_width == 0.0 {
-        panic!(concat!(
-            "\n\n    Error: Scrollbar width of zero detected. This test generation script must be run with scrollbars set to take up space.\n",
-            "    On macOS this can be done by setting Show Scrollbars to 'always' in the Appearance section of the System Settings app.\n\n"
-        ))
+        return Err(concat!(
+            "Scrollbar width of zero detected. This test generation script must be run with scrollbars set to take up space.\n",
+            "    On macOS this can be done by setting Show Scrollbars to 'always' in the Appearance section of the System Settings app."
+        ).to_string());
     }
+
+    Ok(())
 }
 
-async fn test_root_element(client: Client, name: String, fixture_path: impl AsRef<Path>) -> (String, PathBuf, Value) {
-    let fixture_path = fixture_path.as_ref();
-
+async fn test_root_element(
+    client: &Client,
+    name: &str,
+    fixture_path: &Path,
+) -> Result<(String, PathBuf, Value), String> {
     let url = format!("file://{}", fixture_path.display());
 
-    client.goto(&url).await.unwrap();
+    // The browser occasionally stops responding to a command entirely, so time each command out
+    // rather than waiting forever. A fixture normally takes a few milliseconds.
+    timeout(TIMEOUT, client.goto(&url))
+        .await
+        .map_err(|_| format!("timed out loading the test fixture {name} ({})", fixture_path.display()))?
+        .map_err(|err| format!("could not load the test fixture {name}: {err}"))?;
 
     // Navigation can occasionally return before the document is fully loaded, so retry a few times
     let mut attempts = 0;
     let description = loop {
-        match client.execute("return getTestData()", vec![]).await {
+        let result = timeout(TIMEOUT, client.execute("return getTestData()", vec![]))
+            .await
+            .map_err(|_| format!("timed out running getTestData() for {name}"))?;
+        match result {
             Ok(description) => break description,
             Err(err) if attempts < 3 => {
                 attempts += 1;
                 warn!("getTestData() failed for {name} (attempt {attempts}): {err}");
-                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                tokio::time::sleep(Duration::from_millis(200)).await;
             }
-            Err(err) => panic!("getTestData() failed for {}: {}", name, err),
+            Err(err) => return Err(format!("getTestData() failed for {name}: {err}")),
         }
     };
-    let description_string = description.as_str().unwrap();
-    let description = serde_json::from_str(description_string).unwrap();
-    (name.to_string(), fixture_path.to_path_buf(), description)
+    let description_string =
+        description.as_str().ok_or_else(|| format!("unexpected test data for {name}: {description}"))?;
+    let description =
+        serde_json::from_str(description_string).map_err(|err| format!("invalid test data for {name}: {err}"))?;
+    Ok((name.to_string(), fixture_path.to_path_buf(), description))
 }
 
 fn generate_test(name: impl AsRef<str>, description: &Value) -> String {

--- a/scripts/getchrome/Cargo.toml
+++ b/scripts/getchrome/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "getchrome"
+version = "0.1.0"
+authors = ["Nico Burns"]
+edition = "2021"
+
+[dependencies]
+env_logger = "0.11.10"
+log = "0.4"
+serde_json = "1"
+
+[dependencies.ureq]
+version = "3.3.0"
+default-features = false
+features = ["rustls"]
+
+[dependencies.zip]
+version = "8.6.0"
+default-features = false
+features = ["deflate"]

--- a/scripts/getchrome/src/lib.rs
+++ b/scripts/getchrome/src/lib.rs
@@ -5,8 +5,9 @@
 //! install directory then nothing is downloaded.
 
 use std::fs::{self, File};
-use std::io;
+use std::io::{self, IsTerminal, Write as _};
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
 use log::*;
 
@@ -16,6 +17,17 @@ const VERSIONS_URL: &str =
 
 /// The release channel that we download builds from
 const CHANNEL: &str = "Stable";
+
+/// How long to wait for a server to respond before giving up
+const TIMEOUT: Duration = Duration::from_secs(10);
+
+/// An HTTP agent that gives up rather than hanging indefinitely if a server stops responding
+///
+/// No timeout is applied to reading the response body, as the browser archives are large enough
+/// that any limit which is safe on a slow connection would be too long to be useful.
+fn agent() -> ureq::Agent {
+    ureq::Agent::config_builder().timeout_connect(Some(TIMEOUT)).timeout_recv_response(Some(TIMEOUT)).build().into()
+}
 
 /// Paths to the binaries of a downloaded Chrome for Testing build
 #[derive(Debug, Clone)]
@@ -123,7 +135,7 @@ fn download_url(downloads: &serde_json::Value, platform: &str) -> Option<String>
 }
 
 fn get_json(url: &str) -> io::Result<serde_json::Value> {
-    let body = ureq::get(url).call().map_err(http_error)?.into_body();
+    let body = agent().get(url).call().map_err(http_error)?.into_body();
     serde_json::from_reader(body.into_reader()).map_err(Into::into)
 }
 
@@ -133,21 +145,89 @@ fn get_json(url: &str) -> io::Result<serde_json::Value> {
 /// `dest_dir` containing one directory per extracted archive.
 fn download_and_unzip(url: String, dest_dir: &Path) -> io::Result<()> {
     debug!("downloading {url}");
-    let mut body = ureq::get(&url).call().map_err(http_error)?.into_body();
+    let response = agent().get(&url).call().map_err(http_error)?;
+    let total_bytes = response
+        .headers()
+        .get("content-length")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok());
+    let mut body = response.into_body();
+
+    let name = url.rsplit('/').next().unwrap_or(&url).to_string();
 
     // Stream the archive to a temporary file rather than buffering it in memory (the browser
     // archives are hundreds of megabytes) as reading a zip archive requires random access.
     let zip_path = dest_dir.join(".download.zip");
     let mut zip_file = File::create(&zip_path)?;
-    io::copy(&mut body.as_reader(), &mut zip_file)?;
+    copy_with_progress(&mut body.as_reader(), &mut zip_file, &name, total_bytes)?;
     drop(zip_file);
 
-    debug!("extracting {url}");
+    progress(&format!("extracting {name}"));
     let mut archive = zip::ZipArchive::new(File::open(&zip_path)?)?;
     archive.extract(dest_dir)?;
     fs::remove_file(&zip_path)?;
+    clear_progress();
 
     Ok(())
+}
+
+/// Copy `reader` to `writer`, reporting how much has been copied as it goes
+fn copy_with_progress(
+    reader: &mut impl io::Read,
+    writer: &mut impl io::Write,
+    name: &str,
+    total_bytes: Option<u64>,
+) -> io::Result<()> {
+    const MIB: f64 = (1024 * 1024) as f64;
+
+    let mut buffer = vec![0; 128 * 1024];
+    let mut copied: u64 = 0;
+    let mut last_report = Instant::now();
+    loop {
+        let count = reader.read(&mut buffer)?;
+        if count == 0 {
+            break;
+        }
+        writer.write_all(&buffer[..count])?;
+        copied += count as u64;
+
+        // Rate limit the reporting so that it does not dominate the time spent downloading
+        if last_report.elapsed() >= Duration::from_millis(100) {
+            last_report = Instant::now();
+            match total_bytes {
+                Some(total) => progress(&format!(
+                    "downloading {name} ({:.0}%, {:.0}MiB of {:.0}MiB)",
+                    (copied as f64 / total as f64) * 100.0,
+                    copied as f64 / MIB,
+                    total as f64 / MIB
+                )),
+                None => progress(&format!("downloading {name} ({:.0}MiB)", copied as f64 / MIB)),
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Report progress on a single line of the terminal, replacing whatever was reported before it
+///
+/// Nothing is printed when stderr is not a terminal (the messages are logged instead), as the
+/// in place updates would just fill up a log file.
+fn progress(message: &str) {
+    if std::io::stderr().is_terminal() {
+        // `\r` moves back to the start of the line and `\x1b[K` clears the rest of it
+        eprint!("\r\x1b[K{message}");
+        let _ = std::io::stderr().flush();
+    } else {
+        debug!("{message}");
+    }
+}
+
+/// Remove the line last written by [`progress`]
+fn clear_progress() {
+    if std::io::stderr().is_terminal() {
+        eprint!("\r\x1b[K");
+        let _ = std::io::stderr().flush();
+    }
 }
 
 fn http_error(error: ureq::Error) -> io::Error {

--- a/scripts/getchrome/src/lib.rs
+++ b/scripts/getchrome/src/lib.rs
@@ -1,0 +1,159 @@
+//! Downloads a [Chrome for Testing](https://developer.chrome.com/blog/chrome-for-testing) build
+//! (both the browser and the matching ChromeDriver) into a local directory.
+//!
+//! The downloaded binaries are cached: if the requested version is already present in the
+//! install directory then nothing is downloaded.
+
+use std::fs::{self, File};
+use std::io;
+use std::path::{Path, PathBuf};
+
+use log::*;
+
+/// The endpoint listing the latest Chrome for Testing build of each release channel
+const VERSIONS_URL: &str =
+    "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json";
+
+/// The release channel that we download builds from
+const CHANNEL: &str = "Stable";
+
+/// Paths to the binaries of a downloaded Chrome for Testing build
+#[derive(Debug, Clone)]
+pub struct ChromeForTesting {
+    /// The Chrome for Testing version that was downloaded (e.g. "131.0.6778.85")
+    pub version: String,
+    /// Path to the Chrome for Testing browser binary
+    pub chrome: PathBuf,
+    /// Path to the ChromeDriver binary matching `chrome`
+    pub chromedriver: PathBuf,
+}
+
+/// The directory that Chrome for Testing builds are downloaded into by default:
+/// the `.chrome-for-testing` directory in the root of the repository.
+pub fn default_install_dir() -> PathBuf {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let repo_root = manifest_dir.parent().and_then(Path::parent).unwrap();
+    repo_root.join(".chrome-for-testing")
+}
+
+/// Download the latest stable Chrome for Testing build into [`default_install_dir`]
+pub fn download_default() -> io::Result<ChromeForTesting> {
+    download(&default_install_dir())
+}
+
+/// Download the latest stable Chrome for Testing build into `install_dir` (unless it is already
+/// present there), returning the paths of the downloaded binaries.
+///
+/// Each version is downloaded into its own `<install_dir>/<version>` subdirectory, so multiple
+/// versions can coexist.
+pub fn download(install_dir: &Path) -> io::Result<ChromeForTesting> {
+    let platform = platform()?;
+
+    info!("querying the latest {CHANNEL} chrome-for-testing version");
+    let versions = get_json(VERSIONS_URL)?;
+    let channel = &versions["channels"][CHANNEL];
+    let version = channel["version"]
+        .as_str()
+        .ok_or_else(|| invalid_data(format!("no {CHANNEL} version listed at {VERSIONS_URL}")))?
+        .to_string();
+
+    let version_dir = install_dir.join(&version);
+    let paths = ChromeForTesting {
+        chrome: version_dir.join(chrome_binary_subpath(platform)),
+        chromedriver: version_dir.join(chromedriver_binary_subpath(platform)),
+        version,
+    };
+
+    // The marker file is only written once both archives have been fully extracted, so that a
+    // download that is interrupted part way through is not mistaken for a complete one.
+    let marker_path = version_dir.join(".complete");
+    if marker_path.exists() {
+        info!("chrome-for-testing {} ({platform}) is already downloaded", paths.version);
+        return Ok(paths);
+    }
+
+    info!("downloading chrome-for-testing {} ({platform}) to {}", paths.version, version_dir.display());
+    let _ = fs::remove_dir_all(&version_dir);
+    fs::create_dir_all(&version_dir)?;
+    for binary in ["chrome", "chromedriver"] {
+        let url = download_url(&channel["downloads"][binary], platform)
+            .ok_or_else(|| invalid_data(format!("no {binary} download listed for platform {platform}")))?;
+        download_and_unzip(url, &version_dir)?;
+    }
+    File::create(&marker_path)?;
+
+    Ok(paths)
+}
+
+/// The chrome-for-testing platform identifier for the platform we are running on
+fn platform() -> io::Result<&'static str> {
+    Ok(match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("linux", "x86_64") => "linux64",
+        ("macos", "aarch64") => "mac-arm64",
+        ("macos", "x86_64") => "mac-x64",
+        ("windows", "x86_64") => "win64",
+        ("windows", "x86") => "win32",
+        (os, arch) => return Err(invalid_data(format!("chrome-for-testing does not provide builds for {os} {arch}"))),
+    })
+}
+
+/// The path of the browser binary relative to the root of the extracted archives
+fn chrome_binary_subpath(platform: &str) -> PathBuf {
+    let dir = PathBuf::from(format!("chrome-{platform}"));
+    if platform.starts_with("mac") {
+        dir.join("Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing")
+    } else if platform.starts_with("win") {
+        dir.join("chrome.exe")
+    } else {
+        dir.join("chrome")
+    }
+}
+
+/// The path of the ChromeDriver binary relative to the root of the extracted archives
+fn chromedriver_binary_subpath(platform: &str) -> PathBuf {
+    let file = if platform.starts_with("win") { "chromedriver.exe" } else { "chromedriver" };
+    PathBuf::from(format!("chromedriver-{platform}")).join(file)
+}
+
+/// Find the download URL for `platform` in a chrome-for-testing list of downloads
+fn download_url(downloads: &serde_json::Value, platform: &str) -> Option<String> {
+    downloads.as_array()?.iter().find(|download| download["platform"].as_str() == Some(platform))?["url"]
+        .as_str()
+        .map(str::to_string)
+}
+
+fn get_json(url: &str) -> io::Result<serde_json::Value> {
+    let body = ureq::get(url).call().map_err(http_error)?.into_body();
+    serde_json::from_reader(body.into_reader()).map_err(Into::into)
+}
+
+/// Download the zip archive at `url` and extract it into `dest_dir`
+///
+/// The chrome-for-testing archives each contain a single top-level directory, so this results in
+/// `dest_dir` containing one directory per extracted archive.
+fn download_and_unzip(url: String, dest_dir: &Path) -> io::Result<()> {
+    debug!("downloading {url}");
+    let mut body = ureq::get(&url).call().map_err(http_error)?.into_body();
+
+    // Stream the archive to a temporary file rather than buffering it in memory (the browser
+    // archives are hundreds of megabytes) as reading a zip archive requires random access.
+    let zip_path = dest_dir.join(".download.zip");
+    let mut zip_file = File::create(&zip_path)?;
+    io::copy(&mut body.as_reader(), &mut zip_file)?;
+    drop(zip_file);
+
+    debug!("extracting {url}");
+    let mut archive = zip::ZipArchive::new(File::open(&zip_path)?)?;
+    archive.extract(dest_dir)?;
+    fs::remove_file(&zip_path)?;
+
+    Ok(())
+}
+
+fn http_error(error: ureq::Error) -> io::Error {
+    io::Error::other(error)
+}
+
+fn invalid_data(message: String) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message)
+}

--- a/scripts/getchrome/src/main.rs
+++ b/scripts/getchrome/src/main.rs
@@ -1,0 +1,17 @@
+//! Downloads a Chrome for Testing build (browser + matching ChromeDriver) to a local directory.
+//!
+//! The download directory can be passed as the first argument, and defaults to the
+//! `.chrome-for-testing` directory in the root of the repository.
+
+use std::path::PathBuf;
+
+fn main() {
+    env_logger::init();
+
+    let install_dir = std::env::args_os().nth(1).map(PathBuf::from).unwrap_or_else(getchrome::default_install_dir);
+    let chrome = getchrome::download(&install_dir).expect("failed to download chrome-for-testing");
+
+    println!("chrome-for-testing {}", chrome.version);
+    println!("chrome:       {}", chrome.chrome.display());
+    println!("chromedriver: {}", chrome.chromedriver.display());
+}


### PR DESCRIPTION
# Objective

Speed up test generation by eliminating the per-fixture WebDriver round trips (a `goto` + `execute` per fixture, ~1100 fixtures). Fixture data collection now takes ~10 seconds total on a dev machine.

## Context

Stacked on top of #1004 (its two commits are included here because the `getchrome` branch lives on a fork and can't be used as a base). Only the last commit is new.

Instead of navigating the browser to each fixture, the generator navigates once to a new `scripts/gentest/batch_runner.html` harness page, then issues one async WebDriver script call per batch of 100 fixtures. JavaScript inside the page iterates the fixture URLs, loading each into a viewport-sized iframe and calling the fixture's own `getTestData()` (from `test_helper.js`) on its `contentWindow`:

```js
async function collectTestData(urls) {
  for (const url of urls) {
    iframe.src = url; await loaded;
    results.push(iframe.contentWindow.getTestData());
  }
  return results;
}
```

Details:
- Chrome is launched with `--allow-file-access-from-files` so the `file://` harness page can access the `file://` fixture documents in its iframe.
- The iframe is styled to `100vw`/`100vh` with no margins/scrollbars on the harness page, so fixtures lay out identically to being the top-level document — regenerated output is byte-for-byte identical to the current generated tests.
- Batches of 100 (rather than one call for everything) bound how much work a hung browser loses and preserve progress reporting; the browser-side script timeout is raised to 60s per batch.
- The per-fixture `test_root_element` (with its load-race retry loop) is removed; the iframe `onload` await makes the retry unnecessary.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/83219dcb3e984055b5df7323d727e4be
Requested by: @nicoburns