### PR TITLE
Make scroll_width/scroll_height symmetric in border

### DIFF
--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -1959,6 +1959,7 @@ fn calculate_flex_item(
     total_offset_cross: f32,
     line_offset_cross: f32,
     #[cfg(feature = "content_size")] total_content_size: &mut Size<f32>,
+    #[cfg(feature = "content_size")] border: Rect<f32>,
     container_size: Size<f32>,
     node_inner_size: Size<Option<f32>>,
     direction: FlexDirection,
@@ -2060,9 +2061,9 @@ fn calculate_flex_item(
     #[cfg(feature = "content_size")]
     {
         let contribution_location = if layout_direction.is_rtl() {
-            Point { x: container_size.width - (location.x + size.width), y: location.y }
+            Point { x: container_size.width - (location.x + size.width) - border.right, y: location.y - border.top }
         } else {
-            location
+            Point { x: location.x - border.left, y: location.y - border.top }
         };
         *total_content_size = total_content_size.f32_max(compute_content_size_contribution(
             contribution_location,
@@ -2080,6 +2081,7 @@ fn calculate_layout_line(
     line: &mut FlexLine,
     total_offset_cross: &mut f32,
     #[cfg(feature = "content_size")] content_size: &mut Size<f32>,
+    #[cfg(feature = "content_size")] border: Rect<f32>,
     container_size: Size<f32>,
     node_inner_size: Size<Option<f32>>,
     padding_border: Rect<f32>,
@@ -2108,6 +2110,8 @@ fn calculate_layout_line(
                 line_offset_cross,
                 #[cfg(feature = "content_size")]
                 content_size,
+                #[cfg(feature = "content_size")]
+                border,
                 container_size,
                 node_inner_size,
                 direction,
@@ -2124,6 +2128,8 @@ fn calculate_layout_line(
                 line_offset_cross,
                 #[cfg(feature = "content_size")]
                 content_size,
+                #[cfg(feature = "content_size")]
+                border,
                 container_size,
                 node_inner_size,
                 direction,
@@ -2161,6 +2167,8 @@ fn final_layout_pass(
                 &mut total_offset_cross,
                 #[cfg(feature = "content_size")]
                 &mut content_size,
+                #[cfg(feature = "content_size")]
+                constants.border,
                 constants.container_size,
                 constants.node_inner_size,
                 constants.content_box_inset,
@@ -2176,6 +2184,8 @@ fn final_layout_pass(
                 &mut total_offset_cross,
                 #[cfg(feature = "content_size")]
                 &mut content_size,
+                #[cfg(feature = "content_size")]
+                constants.border,
                 constants.container_size,
                 constants.node_inner_size,
                 constants.content_box_inset,

--- a/src/tree/layout.rs
+++ b/src/tree/layout.rs
@@ -324,22 +324,24 @@ impl Layout {
 
 #[cfg(feature = "content_size")]
 impl Layout {
-    /// Return the scroll width of the node.
-    /// The scroll width is the difference between the width and the content width, floored at zero
+    /// Return the maximum horizontal scroll offset of the node.
+    /// This is the content width less the width of the padding box, floored at zero.
     pub fn scroll_width(&self) -> f32 {
         f32_max(
             0.0,
             self.content_size.width + f32_min(self.scrollbar_size.width, self.size.width) - self.size.width
+                + self.border.left
                 + self.border.right,
         )
     }
 
-    /// Return the scroll height of the node.
-    /// The scroll height is the difference between the height and the content height, floored at zero
+    /// Return the maximum vertical scroll offset of the node.
+    /// This is the content height less the height of the padding box, floored at zero.
     pub fn scroll_height(&self) -> f32 {
         f32_max(
             0.0,
             self.content_size.height + f32_min(self.scrollbar_size.height, self.size.height) - self.size.height
+                + self.border.top
                 + self.border.bottom,
         )
     }

--- a/tests/hand_written.rs
+++ b/tests/hand_written.rs
@@ -8,5 +8,6 @@ mod hand_written {
     mod root_constraints;
     mod rounding;
     mod safe_alignment;
+    mod scroll_size;
     mod serde;
 }

--- a/tests/hand_written/scroll_size.rs
+++ b/tests/hand_written/scroll_size.rs
@@ -1,0 +1,83 @@
+//! The maximum scroll offset is the content size less the size of the padding
+//! box, so it must not depend on which side a border sits on, and must agree
+//! across the layout algorithms.
+
+use taffy::geometry::Point;
+use taffy::prelude::*;
+use taffy::style::{BoxSizing, Display, Overflow};
+use taffy_test_helpers::new_test_tree;
+
+const CONTENT: f32 = 1000.0;
+const CONTAINER: f32 = 200.0;
+const BORDER: f32 = 20.0;
+
+fn scroller(display: Display, border: Rect<LengthPercentage>) -> Layout {
+    let mut tree = new_test_tree();
+    let child = tree
+        .new_leaf(Style { size: Size { width: length(100.0), height: length(CONTENT) }, ..Default::default() })
+        .unwrap();
+    let node = tree
+        .new_with_children(
+            Style {
+                display,
+                box_sizing: BoxSizing::BorderBox,
+                size: Size { width: length(300.0), height: length(CONTAINER) },
+                border,
+                overflow: Point { x: Overflow::Scroll, y: Overflow::Scroll },
+                ..Default::default()
+            },
+            &[child],
+        )
+        .unwrap();
+
+    tree.compute_layout(node, Size::MAX_CONTENT).unwrap();
+    *tree.layout(node).unwrap()
+}
+
+fn edge(top: f32, bottom: f32) -> Rect<LengthPercentage> {
+    Rect {
+        left: LengthPercentage::from_length(0.0),
+        right: LengthPercentage::from_length(0.0),
+        top: LengthPercentage::from_length(top),
+        bottom: LengthPercentage::from_length(bottom),
+    }
+}
+
+#[test]
+fn scroll_height_does_not_depend_on_which_edge_the_border_is_on() {
+    for display in [Display::Block, Display::Flex, Display::Grid] {
+        let top = scroller(display, edge(BORDER, 0.0));
+        let bottom = scroller(display, edge(0.0, BORDER));
+
+        assert_eq!(
+            top.scroll_height(),
+            bottom.scroll_height(),
+            "{display:?}: border-top gave {} and border-bottom gave {}",
+            top.scroll_height(),
+            bottom.scroll_height(),
+        );
+    }
+}
+
+#[test]
+fn scroll_height_is_the_content_beyond_the_padding_box() {
+    for display in [Display::Block, Display::Flex, Display::Grid] {
+        for (top, bottom) in [(BORDER, 0.0), (0.0, BORDER), (BORDER, BORDER), (0.0, 0.0)] {
+            let layout = scroller(display, edge(top, bottom));
+            let padding_box = CONTAINER - top - bottom;
+
+            assert_eq!(layout.scroll_height(), CONTENT - padding_box, "{display:?} with border {top}/{bottom}",);
+        }
+    }
+}
+
+#[test]
+fn content_size_excludes_the_containers_own_border() {
+    for display in [Display::Block, Display::Flex, Display::Grid] {
+        for (top, bottom) in [(BORDER, 0.0), (0.0, BORDER), (BORDER, BORDER), (0.0, 0.0)] {
+            let layout = scroller(display, edge(top, bottom));
+
+            assert_eq!(layout.content_size.height, CONTENT, "{display:?} with border {top}/{bottom}");
+        }
+    }
+}


### PR DESCRIPTION
Closes #1006. Fixes #871.

The maximum scroll offset is the content size less the size of the padding box, so it should not depend on which edge a border sits on. `scroll_height()` added back `border.bottom` but not `border.top` (and `scroll_width()` `border.right` but not `border.left`), so a container with a leading border stopped one border-width short of its content.

**Flexbox did not show this, because it was cancelling against a second bug.** Its `content_size` contributions are measured from the container's *border* box rather than its padding box, so `content_size` came back inflated by the leading border — exactly the term the scroll functions omitted. Block and grid measure from the content box, so they had nothing to cancel with and returned the wrong answer.

For a 200px tall `box-sizing: border-box` scroller holding 1000px of content, where the correct maximum is `1000 - (200 - 20) = 820`:

| display | `content_size.height` | `scroll_height()` before | after |
|---|---|---|---|
| `Block` | 1000 | **800** | 820 |
| `Grid` | 1000 | **800** | 820 |
| `Flex` | **1020** | 820 | 820 |

`border-bottom: 20px` already returned 820 everywhere, so block and grid were asymmetric in exactly `border.top`. Chrome reports the same maximum whichever edge carries the border.

**That coupling is why both halves are in one PR.** Correcting either alone moves flexbox off the right answer: fixing `content_size` without the scroll functions drops flex to 800, and fixing the scroll functions without `content_size` pushes flex to 840. Together, all three algorithms agree.

## Changes

- Flexbox `content_size` contributions subtract the container's border, matching block and grid. This is the #871 half; I checked block and grid and neither includes the container's border, so flexbox was the only algorithm affected.
- `scroll_width`/`scroll_height` add both borders, and their doc comments now say what they return — "the difference between the width and the content width" did not describe the `+ border` term.

## Tests

`tests/hand_written/scroll_size.rs` covers all three algorithms:

- `scroll_height_does_not_depend_on_which_edge_the_border_is_on`
- `scroll_height_is_the_content_beyond_the_padding_box`
- `content_size_excludes_the_containers_own_border`

All three fail on `main` — 800 vs 820, 800 vs 820, and 1020 vs 1000 respectively — and each names a distinct symptom, so the flexbox and scroll halves cannot silently re-cancel.

The existing suite is unchanged: 4429 generated tests, the hand-written suite and doctests all pass on both the default and `--all-features` sets, and `--no-default-features` still builds. Worth noting that nothing in the generated suite covers `content_size` or `scroll_*` for bordered scroll containers, which is why flexbox's inflated value went unnoticed.

Found via [Blitz](https://github.com/DioxusLabs/blitz), which uses block layout, where a bordered scroll container stops one border-width short of the bottom.