### PR TITLE
Add Position::Static and Position::Fixed with deferred containing-block layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Added
+
+- `Position::Static` and `Position::Fixed` variants. `Static` behaves like `Relative` in-flow but ignores inset properties and does not act as a containing block for absolutely positioned descendants. `Fixed` behaves like `Absolute` but is always deferred to the tree implementation to be positioned against its fixed containing block (normally the viewport). `Relative` remains the default, so existing users are unaffected.
+- `LayoutPartialTree::defer_absolute_child`: a new optional trait method (default: no-op) which layout algorithms call for absolutely positioned children whose containing block is not the container being laid out (i.e. `Fixed` children and `Absolute` children of `Static` containers), passing the child's static position. `TaffyTree` implements this and positions deferred children against their actual containing block in a post-layout pass.
+- `compute_absolute_child_layout`: the absolutely-positioned-child layout algorithm (previously private to the block algorithm) is now public so tree implementations can lay out deferred children against arbitrary containing blocks.
+- `Direction::is_rtl` is now public.
+
 ### Fixed
 
 - Grid: tracks no longer grow past their growth limits when distributing free space to multiple tracks with asymmetric limits (in the "maximise tracks" step and when distributing item contributions to base sizes). Previously a track could be assigned space beyond its limit in later distribution iterations, causing `auto` tracks to overflow a definite container (#1000)

--- a/benches/src/taffy_03_helpers.rs
+++ b/benches/src/taffy_03_helpers.rs
@@ -159,8 +159,8 @@ fn convert_display(input: taffy::style::Display) -> taffy_03::style::Display {
 
 fn convert_position(input: taffy::style::Position) -> taffy_03::style::Position {
     match input {
-        taffy::style::Position::Relative => taffy_03::style::Position::Relative,
-        taffy::style::Position::Absolute => taffy_03::style::Position::Absolute,
+        taffy::style::Position::Relative | taffy::style::Position::Static => taffy_03::style::Position::Relative,
+        taffy::style::Position::Absolute | taffy::style::Position::Fixed => taffy_03::style::Position::Absolute,
     }
 }
 

--- a/benches/src/yoga_helpers.rs
+++ b/benches/src/yoga_helpers.rs
@@ -199,7 +199,8 @@ fn apply_taffy_style(node: &mut yg::Node, style: &tf::Style) {
     // position
     node.set_position_type(match style.position {
         tf::Position::Relative => yg::PositionType::Relative,
-        tf::Position::Absolute => yg::PositionType::Absolute,
+        tf::Position::Static => yg::PositionType::Static,
+        tf::Position::Absolute | tf::Position::Fixed => yg::PositionType::Absolute,
     });
     // inset
     node.set_position(yg::Edge::Left, into_yg_units(style.inset.left));

--- a/src/compute/absolute.rs
+++ b/src/compute/absolute.rs
@@ -157,38 +157,55 @@ pub fn compute_absolute_child_layout(
             height: absolute_auto_margin_space.y - final_size.height - non_auto_margin.vertical_axis_sum(),
         };
 
-        let auto_margin_size = Size {
-            width: {
-                let auto_margin_count = margin.left.is_none() as u8 + margin.right.is_none() as u8;
-                if auto_margin_count == 2
-                    && (style_size.width.is_none() || style_size.width.unwrap() >= free_space.width)
-                {
-                    0.0
-                } else if auto_margin_count > 0 {
-                    free_space.width / auto_margin_count as f32
+        // https://www.w3.org/TR/CSS22/visudet.html#abs-non-replaced-width
+        // If both margin-left and margin-right are auto, solve the equation under the extra
+        // constraint that the two margins get equal values, unless this would make them negative,
+        // in which case when direction of the containing block is ltr (rtl), set margin-left
+        // (margin-right) to zero and solve for margin-right (margin-left).
+        // Auto margins in an axis only resolve to non-zero values when both insets in that
+        // axis are set; otherwise they resolve to zero.
+        let (auto_margin_left, auto_margin_right) = {
+            let auto_margin_count = if left.is_some() && right.is_some() {
+                margin.left.is_none() as u8 + margin.right.is_none() as u8
+            } else {
+                0
+            };
+            if auto_margin_count == 2 && free_space.width < 0.0 {
+                if direction.is_rtl() {
+                    (free_space.width, 0.0)
                 } else {
-                    0.0
+                    (0.0, free_space.width)
                 }
-            },
-            height: {
-                let auto_margin_count = margin.top.is_none() as u8 + margin.bottom.is_none() as u8;
-                if auto_margin_count == 2
-                    && (style_size.height.is_none() || style_size.height.unwrap() >= free_space.height)
-                {
-                    0.0
-                } else if auto_margin_count > 0 {
-                    free_space.height / auto_margin_count as f32
-                } else {
-                    0.0
-                }
-            },
+            } else if auto_margin_count > 0 {
+                let share = free_space.width / auto_margin_count as f32;
+                (share, share)
+            } else {
+                (0.0, 0.0)
+            }
+        };
+
+        // https://www.w3.org/TR/CSS22/visudet.html#abs-non-replaced-height
+        // If both margin-top and margin-bottom are auto, solve the equation under the extra
+        // constraint that the two margins get equal values (no non-negativity constraint
+        // applies in the vertical axis).
+        let auto_margin_height = {
+            let auto_margin_count = if top.is_some() && bottom.is_some() {
+                margin.top.is_none() as u8 + margin.bottom.is_none() as u8
+            } else {
+                0
+            };
+            if auto_margin_count > 0 {
+                free_space.height / auto_margin_count as f32
+            } else {
+                0.0
+            }
         };
 
         Rect {
-            left: margin.left.map(|_| 0.0).unwrap_or(auto_margin_size.width),
-            right: margin.right.map(|_| 0.0).unwrap_or(auto_margin_size.width),
-            top: margin.top.map(|_| 0.0).unwrap_or(auto_margin_size.height),
-            bottom: margin.bottom.map(|_| 0.0).unwrap_or(auto_margin_size.height),
+            left: margin.left.map(|_| 0.0).unwrap_or(auto_margin_left),
+            right: margin.right.map(|_| 0.0).unwrap_or(auto_margin_right),
+            top: margin.top.map(|_| 0.0).unwrap_or(auto_margin_height),
+            bottom: margin.bottom.map(|_| 0.0).unwrap_or(auto_margin_height),
         }
     };
 

--- a/src/compute/absolute.rs
+++ b/src/compute/absolute.rs
@@ -31,11 +31,13 @@ pub struct AbsoluteChildLayout {
 /// - `area_offset` is the offset of the positioning area from the containing block's border box
 ///   origin (i.e. border + scrollbar gutter on the start sides).
 /// - `static_position` is the child's static position, relative to the containing block's
-///   border box origin.
+///   border box origin. If `static_position_direction` is [`Direction::Rtl`] then its `x`
+///   coordinate is the static position of the child's *right* edge, otherwise its left edge.
 /// - `direction` is the `direction` style (LTR/RTL) of the containing block.
 ///
 /// The child's unrounded layout is written to the tree with a location relative to the
 /// containing block's border box, and also returned.
+#[allow(clippy::too_many_arguments)]
 pub fn compute_absolute_child_layout(
     tree: &mut impl LayoutPartialTree,
     child_id: NodeId,
@@ -43,6 +45,7 @@ pub fn compute_absolute_child_layout(
     area_size: Size<f32>,
     area_offset: Point<f32>,
     static_position: Point<f32>,
+    static_position_direction: Direction,
     direction: Direction,
 ) -> AbsoluteChildLayout {
     let area_width = area_size.width;
@@ -207,7 +210,7 @@ pub fn compute_absolute_child_layout(
         (Some(left), None) => left + resolved_margin.left,
         (None, Some(right)) => area_size.width - final_size.width - right - resolved_margin.right,
         (None, None) => {
-            if direction.is_rtl() {
+            if static_position_direction.is_rtl() {
                 static_position.x - final_size.width - resolved_margin.right - area_offset.x
             } else {
                 static_position.x + resolved_margin.left - area_offset.x

--- a/src/compute/absolute.rs
+++ b/src/compute/absolute.rs
@@ -1,0 +1,258 @@
+//! Layout of a single absolutely positioned child against its containing block.
+//!
+//! This is the CSS2 "absolutely positioned, non-replaced elements" sizing/positioning
+//! algorithm as used by block containers. It is exposed publicly so that tree implementations
+//! can lay out children which were deferred via
+//! [`LayoutPartialTree::defer_absolute_child`](crate::LayoutPartialTree::defer_absolute_child)
+//! against their actual containing block.
+use crate::geometry::Line;
+use crate::geometry::{Point, Rect, Size};
+use crate::style::{AvailableSpace, BoxSizing, CoreStyle, Direction, Overflow, Position};
+use crate::tree::{Layout, LayoutPartialTree, LayoutPartialTreeExt, NodeId, SizingMode};
+use crate::util::sys::f32_max;
+use crate::util::MaybeMath;
+use crate::util::MaybeResolve;
+use crate::util::ResolveOrZero;
+
+/// The result of [`compute_absolute_child_layout`]
+pub struct AbsoluteChildLayout {
+    /// The layout that was set on the child (location is relative to the containing block's border box)
+    pub layout: Layout,
+    /// The child's content size (for scrollable overflow computation)
+    pub content_size: Size<f32>,
+    /// The child's overflow style
+    pub overflow: Point<Overflow>,
+}
+
+/// Size and position a single absolutely positioned child against a containing block.
+///
+/// - `area_size` is the size of the containing block's positioning area (the padding box,
+///   i.e. border box minus borders and scrollbar gutters).
+/// - `area_offset` is the offset of the positioning area from the containing block's border box
+///   origin (i.e. border + scrollbar gutter on the start sides).
+/// - `static_position` is the child's static position, relative to the containing block's
+///   border box origin.
+/// - `direction` is the `direction` style (LTR/RTL) of the containing block.
+///
+/// The child's unrounded layout is written to the tree with a location relative to the
+/// containing block's border box, and also returned.
+pub fn compute_absolute_child_layout(
+    tree: &mut impl LayoutPartialTree,
+    child_id: NodeId,
+    order: u32,
+    area_size: Size<f32>,
+    area_offset: Point<f32>,
+    static_position: Point<f32>,
+    direction: Direction,
+) -> AbsoluteChildLayout {
+    let area_width = area_size.width;
+    let area_height = area_size.height;
+
+    let child_style = tree.get_core_container_style(child_id);
+
+    let aspect_ratio = child_style.aspect_ratio();
+    let overflow = child_style.overflow();
+    let scrollbar_width = child_style.scrollbar_width();
+    let margin =
+        child_style.margin().map(|margin| margin.resolve_to_option(area_width, |val, basis| tree.calc(val, basis)));
+    let padding = child_style.padding().resolve_or_zero(Some(area_width), |val, basis| tree.calc(val, basis));
+    let border = child_style.border().resolve_or_zero(Some(area_width), |val, basis| tree.calc(val, basis));
+    let padding_border_sum = (padding + border).sum_axes();
+    let box_sizing_adjustment =
+        if child_style.box_sizing() == BoxSizing::ContentBox { padding_border_sum } else { Size::ZERO };
+
+    // Resolve inset
+    let left = child_style.inset().left.maybe_resolve(area_width, |val, basis| tree.calc(val, basis));
+    let right = child_style.inset().right.maybe_resolve(area_width, |val, basis| tree.calc(val, basis));
+    let top = child_style.inset().top.maybe_resolve(area_height, |val, basis| tree.calc(val, basis));
+    let bottom = child_style.inset().bottom.maybe_resolve(area_height, |val, basis| tree.calc(val, basis));
+
+    // Compute known dimensions from min/max/inherent size styles
+    let style_size = child_style
+        .size()
+        .maybe_resolve(area_size, |val, basis| tree.calc(val, basis))
+        .maybe_apply_aspect_ratio(aspect_ratio)
+        .maybe_add(box_sizing_adjustment);
+    let min_size = child_style
+        .min_size()
+        .maybe_resolve(area_size, |val, basis| tree.calc(val, basis))
+        .maybe_apply_aspect_ratio(aspect_ratio)
+        .maybe_add(box_sizing_adjustment)
+        .or(padding_border_sum.map(Some))
+        .maybe_max(padding_border_sum);
+    let max_size = child_style
+        .max_size()
+        .maybe_resolve(area_size, |val, basis| tree.calc(val, basis))
+        .maybe_apply_aspect_ratio(aspect_ratio)
+        .maybe_add(box_sizing_adjustment);
+    let mut known_dimensions = style_size.maybe_clamp(min_size, max_size);
+
+    drop(child_style);
+
+    // Fill in width from left/right and reapply aspect ratio if:
+    //   - Width is not already known
+    //   - Item has both left and right inset properties set
+    if let (None, Some(left), Some(right)) = (known_dimensions.width, left, right) {
+        let new_width_raw = area_width.maybe_sub(margin.left).maybe_sub(margin.right) - left - right;
+        known_dimensions.width = Some(f32_max(new_width_raw, 0.0));
+        known_dimensions = known_dimensions.maybe_apply_aspect_ratio(aspect_ratio).maybe_clamp(min_size, max_size);
+    }
+
+    // Fill in height from top/bottom and reapply aspect ratio if:
+    //   - Height is not already known
+    //   - Item has both top and bottom inset properties set
+    if let (None, Some(top), Some(bottom)) = (known_dimensions.height, top, bottom) {
+        let new_height_raw = area_height.maybe_sub(margin.top).maybe_sub(margin.bottom) - top - bottom;
+        known_dimensions.height = Some(f32_max(new_height_raw, 0.0));
+        known_dimensions = known_dimensions.maybe_apply_aspect_ratio(aspect_ratio).maybe_clamp(min_size, max_size);
+    }
+
+    let measured_size = tree.measure_child_size_both(
+        child_id,
+        known_dimensions,
+        area_size.map(Some),
+        Size {
+            width: AvailableSpace::Definite(area_width.maybe_clamp(min_size.width, max_size.width)),
+            height: AvailableSpace::Definite(area_height.maybe_clamp(min_size.height, max_size.height)),
+        },
+        SizingMode::ContentSize,
+        Line::FALSE,
+    );
+
+    let final_size = known_dimensions.unwrap_or(measured_size).maybe_clamp(min_size, max_size);
+
+    let layout_output = tree.perform_child_layout(
+        child_id,
+        final_size.map(Some),
+        area_size.map(Some),
+        Size {
+            width: AvailableSpace::Definite(area_width.maybe_clamp(min_size.width, max_size.width)),
+            height: AvailableSpace::Definite(area_height.maybe_clamp(min_size.height, max_size.height)),
+        },
+        SizingMode::ContentSize,
+        Line::FALSE,
+    );
+
+    let non_auto_margin = Rect {
+        left: if left.is_some() { margin.left.unwrap_or(0.0) } else { 0.0 },
+        right: if right.is_some() { margin.right.unwrap_or(0.0) } else { 0.0 },
+        top: if top.is_some() { margin.top.unwrap_or(0.0) } else { 0.0 },
+        bottom: if bottom.is_some() { margin.bottom.unwrap_or(0.0) } else { 0.0 },
+    };
+
+    // Expand auto margins to fill available space
+    // https://www.w3.org/TR/CSS21/visudet.html#abs-non-replaced-width
+    let auto_margin = {
+        // Auto margins for absolutely positioned elements in block containers only resolve
+        // if inset is set. Otherwise they resolve to 0.
+        let absolute_auto_margin_space = Point {
+            x: right.map(|right| area_size.width - right - left.unwrap_or(0.0)).unwrap_or(final_size.width),
+            y: bottom.map(|bottom| area_size.height - bottom - top.unwrap_or(0.0)).unwrap_or(final_size.height),
+        };
+        let free_space = Size {
+            width: absolute_auto_margin_space.x - final_size.width - non_auto_margin.horizontal_axis_sum(),
+            height: absolute_auto_margin_space.y - final_size.height - non_auto_margin.vertical_axis_sum(),
+        };
+
+        let auto_margin_size = Size {
+            width: {
+                let auto_margin_count = margin.left.is_none() as u8 + margin.right.is_none() as u8;
+                if auto_margin_count == 2
+                    && (style_size.width.is_none() || style_size.width.unwrap() >= free_space.width)
+                {
+                    0.0
+                } else if auto_margin_count > 0 {
+                    free_space.width / auto_margin_count as f32
+                } else {
+                    0.0
+                }
+            },
+            height: {
+                let auto_margin_count = margin.top.is_none() as u8 + margin.bottom.is_none() as u8;
+                if auto_margin_count == 2
+                    && (style_size.height.is_none() || style_size.height.unwrap() >= free_space.height)
+                {
+                    0.0
+                } else if auto_margin_count > 0 {
+                    free_space.height / auto_margin_count as f32
+                } else {
+                    0.0
+                }
+            },
+        };
+
+        Rect {
+            left: margin.left.map(|_| 0.0).unwrap_or(auto_margin_size.width),
+            right: margin.right.map(|_| 0.0).unwrap_or(auto_margin_size.width),
+            top: margin.top.map(|_| 0.0).unwrap_or(auto_margin_size.height),
+            bottom: margin.bottom.map(|_| 0.0).unwrap_or(auto_margin_size.height),
+        }
+    };
+
+    let resolved_margin = Rect {
+        left: margin.left.unwrap_or(auto_margin.left),
+        right: margin.right.unwrap_or(auto_margin.right),
+        top: margin.top.unwrap_or(auto_margin.top),
+        bottom: margin.bottom.unwrap_or(auto_margin.bottom),
+    };
+
+    let x_offset = match (left, right) {
+        (Some(left), Some(right)) => {
+            if direction.is_rtl() {
+                area_size.width - final_size.width - right - resolved_margin.right
+            } else {
+                left + resolved_margin.left
+            }
+        }
+        (Some(left), None) => left + resolved_margin.left,
+        (None, Some(right)) => area_size.width - final_size.width - right - resolved_margin.right,
+        (None, None) => {
+            if direction.is_rtl() {
+                static_position.x - final_size.width - resolved_margin.right - area_offset.x
+            } else {
+                static_position.x + resolved_margin.left - area_offset.x
+            }
+        }
+    };
+    let location = Point {
+        x: x_offset + area_offset.x,
+        y: top
+            .map(|top| top + resolved_margin.top)
+            .or(bottom.map(|bottom| area_size.height - final_size.height - bottom - resolved_margin.bottom))
+            .maybe_add(area_offset.y)
+            .unwrap_or(static_position.y + resolved_margin.top),
+    };
+    // Note: axis intentionally switched here as scrollbars take up space in the opposite axis
+    // to the axis in which scrolling is enabled.
+    let scrollbar_size = Size {
+        width: if overflow.y == Overflow::Scroll { scrollbar_width } else { 0.0 },
+        height: if overflow.x == Overflow::Scroll { scrollbar_width } else { 0.0 },
+    };
+
+    let layout = Layout {
+        order,
+        size: final_size,
+        #[cfg(feature = "content_size")]
+        content_size: layout_output.content_size,
+        scrollbar_size,
+        location,
+        padding,
+        border,
+        margin: resolved_margin,
+    };
+    tree.set_unrounded_layout(child_id, &layout);
+
+    #[cfg(feature = "content_size")]
+    let content_size = layout_output.content_size;
+    #[cfg(not(feature = "content_size"))]
+    let content_size = Size::ZERO;
+
+    AbsoluteChildLayout { layout, content_size, overflow }
+}
+
+/// Whether `Position::Absolute` children of a container with the given position style should be
+/// deferred to the tree implementation (rather than laid out by the container itself).
+#[inline(always)]
+pub(crate) fn should_defer_absolute_child(child_position: Position, container_position: Position) -> bool {
+    child_position == Position::Fixed || container_position == Position::Static
+}

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -181,6 +181,7 @@ impl BlockContext<'_> {
     }
 }
 
+use super::absolute::{compute_absolute_child_layout, should_defer_absolute_child};
 use super::common::alignment::{apply_alignment_fallback, compute_alignment_offset};
 #[cfg(feature = "content_size")]
 use super::common::content_size::compute_content_size_contribution;
@@ -413,12 +414,12 @@ fn compute_inner(
     let own_margins_collapse_with_children = Line {
         start: vertical_margins_are_collapsible.start
             && !is_scroll_container
-            && style.position() == Position::Relative
+            && style.position().is_inflow()
             && padding.top == 0.0
             && border.top == 0.0,
         end: vertical_margins_are_collapsible.end
             && !is_scroll_container
-            && style.position() == Position::Relative
+            && style.position().is_inflow()
             && padding.bottom == 0.0
             && border.bottom == 0.0
             && size.height.is_none(),
@@ -426,7 +427,7 @@ fn compute_inner(
     let has_styles_preventing_being_collapsed_through = !style.is_block()
         || block_ctx.is_bfc_root()
         || is_scroll_container
-        || style.position() == Position::Absolute
+        || style.position().is_absolutely_positioned()
         || padding.top > 0.0
         || padding.bottom > 0.0
         || border.top > 0.0
@@ -436,6 +437,7 @@ fn compute_inner(
 
     let text_align = style.text_align();
     let align_content = style.align_content();
+    let container_position = style.position();
     drop(style);
 
     // 1. Generate items
@@ -542,7 +544,7 @@ fn compute_inner(
 
     // Determine whether this node can be collapsed through
     let all_in_flow_children_can_be_collapsed_through =
-        items.iter().all(|item| item.position == Position::Absolute || item.can_be_collapsed_through);
+        items.iter().all(|item| item.position.is_absolutely_positioned() || item.can_be_collapsed_through);
     let can_be_collapsed_through =
         !has_styles_preventing_being_collapsed_through && all_in_flow_children_can_be_collapsed_through;
 
@@ -589,6 +591,7 @@ fn compute_inner(
     let absolute_content_size = perform_absolute_layout_on_absolute_children(
         tree,
         &items,
+        container_position,
         absolute_position_area,
         absolute_position_offset,
         direction,
@@ -656,7 +659,7 @@ fn generate_item_list(
             let is_scroll_container = overflow.x.is_scroll_container() || overflow.y.is_scroll_container();
 
             let is_in_same_bfc: bool =
-                is_block && !is_table && position != Position::Absolute && is_not_floated && !is_scroll_container;
+                is_block && !is_table && position.is_inflow() && is_not_floated && !is_scroll_container;
 
             BlockItem {
                 node_id: child_node_id,
@@ -685,7 +688,7 @@ fn generate_item_list(
                 overflow,
                 scrollbar_width: child_style.scrollbar_width(),
                 position,
-                inset: child_style.inset(),
+                inset: if position == Position::Static { Rect::auto() } else { child_style.inset() },
                 margin: child_style.margin(),
                 padding,
                 border,
@@ -713,7 +716,7 @@ fn determine_content_based_container_width(
     let mut max_child_width = 0.0;
     #[cfg(feature = "float_layout")]
     let mut float_contribution = FloatIntrinsicWidthCalculator::new(available_width);
-    for item in items.iter().filter(|item| item.position != Position::Absolute) {
+    for item in items.iter().filter(|item| item.position.is_inflow()) {
         let known_dimensions = item.size.maybe_clamp(item.min_size, item.max_size);
 
         let item_x_margin_sum = item
@@ -806,7 +809,7 @@ fn perform_final_layout_on_in_flow_children(
     let mut y_offset_for_float = resolved_content_box_inset.top;
 
     for item in items.iter_mut() {
-        if item.position == Position::Absolute {
+        if item.position.is_absolutely_positioned() {
             let x = match direction {
                 Direction::Ltr => resolved_content_box_inset.left,
                 Direction::Rtl => container_outer_width - resolved_content_box_inset.right,
@@ -1183,236 +1186,54 @@ fn perform_final_layout_on_in_flow_children(
 fn perform_absolute_layout_on_absolute_children(
     tree: &mut impl LayoutBlockContainer,
     items: &[BlockItem],
+    container_position: Position,
     area_size: Size<f32>,
     area_offset: Point<f32>,
     direction: Direction,
 ) -> Size<f32> {
-    let area_width = area_size.width;
-    let area_height = area_size.height;
-
     #[cfg_attr(not(feature = "content_size"), allow(unused_mut))]
     let mut absolute_content_size = Size::ZERO;
 
-    for item in items.iter().filter(|item| item.position == Position::Absolute) {
+    for item in items.iter().filter(|item| item.position.is_absolutely_positioned()) {
         let child_style = tree.get_block_child_style(item.node_id);
 
-        // Skip items that are display:none or are not position:absolute
-        if child_style.box_generation_mode() == BoxGenerationMode::None || child_style.position() != Position::Absolute
-        {
+        // Skip items that are display:none or are not absolutely positioned
+        let child_position = child_style.position();
+        if child_style.box_generation_mode() == BoxGenerationMode::None || !child_position.is_absolutely_positioned() {
+            continue;
+        }
+        drop(child_style);
+
+        // If this container is not the child's containing block then hand the child back to the
+        // tree implementation to be laid out against its actual containing block.
+        if should_defer_absolute_child(child_position, container_position) {
+            tree.defer_absolute_child(item.node_id, item.order, item.static_position);
             continue;
         }
 
-        let aspect_ratio = child_style.aspect_ratio();
-        let margin =
-            child_style.margin().map(|margin| margin.resolve_to_option(area_width, |val, basis| tree.calc(val, basis)));
-        let padding = child_style.padding().resolve_or_zero(Some(area_width), |val, basis| tree.calc(val, basis));
-        let border = child_style.border().resolve_or_zero(Some(area_width), |val, basis| tree.calc(val, basis));
-        let padding_border_sum = (padding + border).sum_axes();
-        let box_sizing_adjustment =
-            if child_style.box_sizing() == BoxSizing::ContentBox { padding_border_sum } else { Size::ZERO };
-
-        // Resolve inset
-        let left = child_style.inset().left.maybe_resolve(area_width, |val, basis| tree.calc(val, basis));
-        let right = child_style.inset().right.maybe_resolve(area_width, |val, basis| tree.calc(val, basis));
-        let top = child_style.inset().top.maybe_resolve(area_height, |val, basis| tree.calc(val, basis));
-        let bottom = child_style.inset().bottom.maybe_resolve(area_height, |val, basis| tree.calc(val, basis));
-
-        // Compute known dimensions from min/max/inherent size styles
-        let style_size = child_style
-            .size()
-            .maybe_resolve(area_size, |val, basis| tree.calc(val, basis))
-            .maybe_apply_aspect_ratio(aspect_ratio)
-            .maybe_add(box_sizing_adjustment);
-        let min_size = child_style
-            .min_size()
-            .maybe_resolve(area_size, |val, basis| tree.calc(val, basis))
-            .maybe_apply_aspect_ratio(aspect_ratio)
-            .maybe_add(box_sizing_adjustment)
-            .or(padding_border_sum.map(Some))
-            .maybe_max(padding_border_sum);
-        let max_size = child_style
-            .max_size()
-            .maybe_resolve(area_size, |val, basis| tree.calc(val, basis))
-            .maybe_apply_aspect_ratio(aspect_ratio)
-            .maybe_add(box_sizing_adjustment);
-        let mut known_dimensions = style_size.maybe_clamp(min_size, max_size);
-
-        drop(child_style);
-
-        // Fill in width from left/right and reapply aspect ratio if:
-        //   - Width is not already known
-        //   - Item has both left and right inset properties set
-        if let (None, Some(left), Some(right)) = (known_dimensions.width, left, right) {
-            let new_width_raw = area_width.maybe_sub(margin.left).maybe_sub(margin.right) - left - right;
-            known_dimensions.width = Some(f32_max(new_width_raw, 0.0));
-            known_dimensions = known_dimensions.maybe_apply_aspect_ratio(aspect_ratio).maybe_clamp(min_size, max_size);
-        }
-
-        // Fill in height from top/bottom and reapply aspect ratio if:
-        //   - Height is not already known
-        //   - Item has both top and bottom inset properties set
-        if let (None, Some(top), Some(bottom)) = (known_dimensions.height, top, bottom) {
-            let new_height_raw = area_height.maybe_sub(margin.top).maybe_sub(margin.bottom) - top - bottom;
-            known_dimensions.height = Some(f32_max(new_height_raw, 0.0));
-            known_dimensions = known_dimensions.maybe_apply_aspect_ratio(aspect_ratio).maybe_clamp(min_size, max_size);
-        }
-
-        let measured_size = tree.measure_child_size_both(
+        let result = compute_absolute_child_layout(
+            tree,
             item.node_id,
-            known_dimensions,
-            area_size.map(Some),
-            Size {
-                width: AvailableSpace::Definite(area_width.maybe_clamp(min_size.width, max_size.width)),
-                height: AvailableSpace::Definite(area_height.maybe_clamp(min_size.height, max_size.height)),
-            },
-            SizingMode::ContentSize,
-            Line::FALSE,
-        );
-
-        let final_size = known_dimensions.unwrap_or(measured_size).maybe_clamp(min_size, max_size);
-
-        let layout_output = tree.perform_child_layout(
-            item.node_id,
-            final_size.map(Some),
-            area_size.map(Some),
-            Size {
-                width: AvailableSpace::Definite(area_width.maybe_clamp(min_size.width, max_size.width)),
-                height: AvailableSpace::Definite(area_height.maybe_clamp(min_size.height, max_size.height)),
-            },
-            SizingMode::ContentSize,
-            Line::FALSE,
-        );
-
-        let non_auto_margin = Rect {
-            left: if left.is_some() { margin.left.unwrap_or(0.0) } else { 0.0 },
-            right: if right.is_some() { margin.right.unwrap_or(0.0) } else { 0.0 },
-            top: if top.is_some() { margin.top.unwrap_or(0.0) } else { 0.0 },
-            bottom: if bottom.is_some() { margin.bottom.unwrap_or(0.0) } else { 0.0 },
-        };
-
-        // Expand auto margins to fill available space
-        // https://www.w3.org/TR/CSS21/visudet.html#abs-non-replaced-width
-        let auto_margin = {
-            // Auto margins for absolutely positioned elements in block containers only resolve
-            // if inset is set. Otherwise they resolve to 0.
-            let absolute_auto_margin_space = Point {
-                x: right.map(|right| area_size.width - right - left.unwrap_or(0.0)).unwrap_or(final_size.width),
-                y: bottom.map(|bottom| area_size.height - bottom - top.unwrap_or(0.0)).unwrap_or(final_size.height),
-            };
-            let free_space = Size {
-                width: absolute_auto_margin_space.x - final_size.width - non_auto_margin.horizontal_axis_sum(),
-                height: absolute_auto_margin_space.y - final_size.height - non_auto_margin.vertical_axis_sum(),
-            };
-
-            let auto_margin_size = Size {
-                // If all three of 'left', 'width', and 'right' are 'auto': First set any 'auto' values for 'margin-left' and 'margin-right' to 0.
-                // Then, if the 'direction' property of the element establishing the static-position containing block is 'ltr' set 'left' to the
-                // static position and apply rule number three below; otherwise, set 'right' to the static position and apply rule number one below.
-                //
-                // If none of the three is 'auto': If both 'margin-left' and 'margin-right' are 'auto', solve the equation under the extra constraint
-                // that the two margins get equal values, unless this would make them negative, in which case when direction of the containing block is
-                // 'ltr' ('rtl'), set 'margin-left' ('margin-right') to zero and solve for 'margin-right' ('margin-left'). If one of 'margin-left' or
-                // 'margin-right' is 'auto', solve the equation for that value. If the values are over-constrained, ignore the value for 'left' (in case
-                // the 'direction' property of the containing block is 'rtl') or 'right' (in case 'direction' is 'ltr') and solve for that value.
-                width: {
-                    let auto_margin_count = margin.left.is_none() as u8 + margin.right.is_none() as u8;
-                    if auto_margin_count == 2
-                        && (style_size.width.is_none() || style_size.width.unwrap() >= free_space.width)
-                    {
-                        0.0
-                    } else if auto_margin_count > 0 {
-                        free_space.width / auto_margin_count as f32
-                    } else {
-                        0.0
-                    }
-                },
-                height: {
-                    let auto_margin_count = margin.top.is_none() as u8 + margin.bottom.is_none() as u8;
-                    if auto_margin_count == 2
-                        && (style_size.height.is_none() || style_size.height.unwrap() >= free_space.height)
-                    {
-                        0.0
-                    } else if auto_margin_count > 0 {
-                        free_space.height / auto_margin_count as f32
-                    } else {
-                        0.0
-                    }
-                },
-            };
-
-            Rect {
-                left: margin.left.map(|_| 0.0).unwrap_or(auto_margin_size.width),
-                right: margin.right.map(|_| 0.0).unwrap_or(auto_margin_size.width),
-                top: margin.top.map(|_| 0.0).unwrap_or(auto_margin_size.height),
-                bottom: margin.bottom.map(|_| 0.0).unwrap_or(auto_margin_size.height),
-            }
-        };
-
-        let resolved_margin = Rect {
-            left: margin.left.unwrap_or(auto_margin.left),
-            right: margin.right.unwrap_or(auto_margin.right),
-            top: margin.top.unwrap_or(auto_margin.top),
-            bottom: margin.bottom.unwrap_or(auto_margin.bottom),
-        };
-
-        let x_offset = match (left, right) {
-            (Some(left), Some(right)) => {
-                if direction.is_rtl() {
-                    area_size.width - final_size.width - right - resolved_margin.right
-                } else {
-                    left + resolved_margin.left
-                }
-            }
-            (Some(left), None) => left + resolved_margin.left,
-            (None, Some(right)) => area_size.width - final_size.width - right - resolved_margin.right,
-            (None, None) => {
-                if direction.is_rtl() {
-                    item.static_position.x - final_size.width - resolved_margin.right - area_offset.x
-                } else {
-                    item.static_position.x + resolved_margin.left - area_offset.x
-                }
-            }
-        };
-        let location = Point {
-            x: x_offset + area_offset.x,
-            y: top
-                .map(|top| top + resolved_margin.top)
-                .or(bottom.map(|bottom| area_size.height - final_size.height - bottom - resolved_margin.bottom))
-                .maybe_add(area_offset.y)
-                .unwrap_or(item.static_position.y + resolved_margin.top),
-        };
-        // Note: axis intentionally switched here as scrollbars take up space in the opposite axis
-        // to the axis in which scrolling is enabled.
-        let scrollbar_size = Size {
-            width: if item.overflow.y == Overflow::Scroll { item.scrollbar_width } else { 0.0 },
-            height: if item.overflow.x == Overflow::Scroll { item.scrollbar_width } else { 0.0 },
-        };
-
-        tree.set_unrounded_layout(
-            item.node_id,
-            &Layout {
-                order: item.order,
-                size: final_size,
-                #[cfg(feature = "content_size")]
-                content_size: layout_output.content_size,
-                scrollbar_size,
-                location,
-                padding,
-                border,
-                margin: resolved_margin,
-            },
+            item.order,
+            area_size,
+            area_offset,
+            item.static_position,
+            direction,
         );
 
         #[cfg(feature = "content_size")]
         {
+            let location = result.layout.location;
             let relative_location = Point { x: location.x - area_offset.x, y: location.y - area_offset.y };
             absolute_content_size = absolute_content_size.f32_max(compute_content_size_contribution(
                 relative_location,
-                final_size,
-                layout_output.content_size,
+                result.layout.size,
+                result.content_size,
                 item.overflow,
             ));
         }
+        #[cfg(not(feature = "content_size"))]
+        let _ = result;
     }
 
     absolute_content_size

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -198,6 +198,11 @@ struct BlockItem {
     /// Items that are tables don't have stretch sizing applied to them
     is_table: bool,
 
+    /// Items that are replaced elements don't have stretch sizing applied to them
+    /// (CSS 2.1 §10.3.4: a block-level replaced element with `width: auto` uses its
+    /// intrinsic width)
+    is_replaced: bool,
+
     /// Whether the child is a non-independent block or inline node
     is_in_same_bfc: bool,
 
@@ -656,6 +661,7 @@ fn generate_item_list(
 
             let is_block = child_style.is_block();
             let is_table = child_style.is_table();
+            let is_replaced = child_style.is_compressible_replaced();
             let is_scroll_container = overflow.x.is_scroll_container() || overflow.y.is_scroll_container();
 
             let is_in_same_bfc: bool =
@@ -665,6 +671,7 @@ fn generate_item_list(
                 node_id: child_node_id,
                 order: order as u32,
                 is_table,
+                is_replaced,
                 is_in_same_bfc,
                 #[cfg(feature = "float_layout")]
                 float,
@@ -936,6 +943,10 @@ fn perform_final_layout_on_in_flow_children(
 
             let known_dimensions = if item.is_table {
                 Size::NONE
+            } else if item.is_replaced {
+                // Block-level replaced elements with `width: auto` use their intrinsic
+                // width rather than being stretched to fill the container
+                item.size.maybe_clamp(item.min_size, item.max_size)
             } else {
                 item.size
                     .map_width(|width| {
@@ -964,9 +975,20 @@ fn perform_final_layout_on_in_flow_children(
             let clear_pos = f32::NEG_INFINITY;
 
             let item_layout = if item.is_in_same_bfc {
-                let width = known_dimensions
+                let width = known_dimensions.width.unwrap_or_else(|| {
+                    // Replaced elements with `width: auto` size to their intrinsic width
+                    // rather than being stretched: measure to determine it
+                    tree.compute_child_layout(
+                        item.node_id,
+                        LayoutInput {
+                            run_mode: RunMode::ComputeSize,
+                            axis: RequestedAxis::Horizontal,
+                            ..inputs
+                        },
+                    )
+                    .size
                     .width
-                    .expect("Same-bfc child will always have defined width due to stretch sizing");
+                });
 
                 // TODO: account for auto margins
                 let inset_left = item_non_auto_margin.left + content_box_inset.left;

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -980,11 +980,7 @@ fn perform_final_layout_on_in_flow_children(
                     // rather than being stretched: measure to determine it
                     tree.compute_child_layout(
                         item.node_id,
-                        LayoutInput {
-                            run_mode: RunMode::ComputeSize,
-                            axis: RequestedAxis::Horizontal,
-                            ..inputs
-                        },
+                        LayoutInput { run_mode: RunMode::ComputeSize, axis: RequestedAxis::Horizontal, ..inputs },
                     )
                     .size
                     .width

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -1207,7 +1207,7 @@ fn perform_absolute_layout_on_absolute_children(
         // If this container is not the child's containing block then hand the child back to the
         // tree implementation to be laid out against its actual containing block.
         if should_defer_absolute_child(child_position, container_position) {
-            tree.defer_absolute_child(item.node_id, item.order, item.static_position);
+            tree.defer_absolute_child(item.node_id, item.order, item.static_position, direction);
             continue;
         }
 
@@ -1218,6 +1218,7 @@ fn perform_absolute_layout_on_absolute_children(
             area_size,
             area_offset,
             item.static_position,
+            direction,
             direction,
         );
 

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -15,6 +15,7 @@ use crate::util::MaybeMath;
 use crate::util::{MaybeResolve, ResolveOrZero};
 use crate::{BoxGenerationMode, BoxSizing, Direction, RequestedAxis};
 
+use super::absolute::should_defer_absolute_child;
 use super::common::alignment::apply_alignment_fallback;
 #[cfg(feature = "content_size")]
 use super::common::content_size::compute_content_size_contribution;
@@ -526,7 +527,7 @@ fn generate_anonymous_flex_items(
     tree.child_ids(node)
         .enumerate()
         .map(|(index, child)| (index, child, tree.get_flexbox_child_style(child)))
-        .filter(|(_, _, style)| style.position() != Position::Absolute)
+        .filter(|(_, _, style)| style.position().is_inflow())
         .filter(|(_, _, style)| style.box_generation_mode() != BoxGenerationMode::None)
         .map(|(index, child, child_style)| {
             let aspect_ratio = child_style.aspect_ratio();
@@ -557,9 +558,13 @@ fn generate_anonymous_flex_items(
                     .maybe_add(box_sizing_adjustment),
                 aspect_ratio,
 
-                inset: child_style
-                    .inset()
-                    .zip_size(constants.node_inner_size, |p, s| p.maybe_resolve(s, |val, basis| tree.calc(val, basis))),
+                inset: if child_style.position() == Position::Static {
+                    Rect { left: None, right: None, top: None, bottom: None }
+                } else {
+                    child_style.inset().zip_size(constants.node_inner_size, |p, s| {
+                        p.maybe_resolve(s, |val, basis| tree.calc(val, basis))
+                    })
+                },
                 margin: child_style
                     .margin()
                     .resolve_or_zero(constants.node_inner_size.width, |val, basis| tree.calc(val, basis)),
@@ -2217,6 +2222,8 @@ fn perform_absolute_layout_on_absolute_children(
     let inset_relative_size =
         constants.container_size - constants.border.sum_axes() - constants.scrollbar_gutter.into();
 
+    let container_position = tree.get_flexbox_container_style(node).position();
+
     #[cfg_attr(not(feature = "content_size"), allow(unused_mut))]
     let mut content_size = Size::ZERO;
 
@@ -2224,9 +2231,25 @@ fn perform_absolute_layout_on_absolute_children(
         let child = tree.get_child_id(node, order);
         let child_style = tree.get_flexbox_child_style(child);
 
-        // Skip items that are display:none or are not position:absolute
-        if child_style.box_generation_mode() == BoxGenerationMode::None || child_style.position() != Position::Absolute
-        {
+        // Skip items that are display:none or are not absolutely positioned
+        let child_position = child_style.position();
+        if child_style.box_generation_mode() == BoxGenerationMode::None || !child_position.is_absolutely_positioned() {
+            continue;
+        }
+
+        // If this container is not the child's containing block then hand the child back to the
+        // tree implementation to be laid out against its actual containing block.
+        if should_defer_absolute_child(child_position, container_position) {
+            drop(child_style);
+            let static_position = Point {
+                x: if constants.layout_direction.is_rtl() {
+                    constants.container_size.width - constants.content_box_inset.right
+                } else {
+                    constants.content_box_inset.left
+                },
+                y: constants.content_box_inset.top,
+            };
+            tree.defer_absolute_child(child, order as u32, static_position);
             continue;
         }
 

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -2237,21 +2237,12 @@ fn perform_absolute_layout_on_absolute_children(
             continue;
         }
 
-        // If this container is not the child's containing block then hand the child back to the
-        // tree implementation to be laid out against its actual containing block.
-        if should_defer_absolute_child(child_position, container_position) {
-            drop(child_style);
-            let static_position = Point {
-                x: if constants.layout_direction.is_rtl() {
-                    constants.container_size.width - constants.content_box_inset.right
-                } else {
-                    constants.content_box_inset.left
-                },
-                y: constants.content_box_inset.top,
-            };
-            tree.defer_absolute_child(child, order as u32, static_position);
-            continue;
-        }
+        // If this container is not the child's containing block then the child is handed back
+        // to the tree implementation (at the bottom of this loop) to be laid out against its
+        // actual containing block. Its static position is still determined by this container
+        // (justify-content/align-items etc.), but with insets treated as auto since insets
+        // resolve against the actual containing block instead.
+        let defer_child = should_defer_absolute_child(child_position, container_position);
 
         let overflow = child_style.overflow();
         let scrollbar_width = child_style.scrollbar_width();
@@ -2277,6 +2268,8 @@ fn perform_absolute_layout_on_absolute_children(
         let top = child_style.inset().top.maybe_resolve(inset_relative_size.height, |val, basis| tree.calc(val, basis));
         let bottom =
             child_style.inset().bottom.maybe_resolve(inset_relative_size.height, |val, basis| tree.calc(val, basis));
+        let (left, right, top, bottom) =
+            if defer_child { (None, None, None, None) } else { (left, right, top, bottom) };
 
         // Compute known dimensions from min/max/inherent size styles
         let style_size = child_style
@@ -2554,6 +2547,17 @@ fn perform_absolute_layout_on_absolute_children(
             true => Point { x: offset_main, y: offset_cross },
             false => Point { x: offset_cross, y: offset_main },
         };
+
+        if defer_child {
+            // The static position excludes the margins, since `compute_absolute_child_layout`
+            // applies margins relative to the static position.
+            let static_position = Point { x: location.x - resolved_margin.left, y: location.y - resolved_margin.top };
+            // The static position is a fully-resolved top-left position, so it is always
+            // recorded with LTR semantics.
+            tree.defer_absolute_child(child, order as u32, static_position, Direction::Ltr);
+            continue;
+        }
+
         let scrollbar_size = Size {
             width: if overflow.y == Overflow::Scroll { scrollbar_width } else { 0.0 },
             height: if overflow.x == Overflow::Scroll { scrollbar_width } else { 0.0 },

--- a/src/compute/grid/alignment.rs
+++ b/src/compute/grid/alignment.rs
@@ -67,6 +67,7 @@ pub(super) fn align_tracks(
 }
 
 /// Align and size a grid item into it's final position
+#[allow(clippy::too_many_arguments)]
 pub(super) fn align_and_position_item(
     tree: &mut impl LayoutGridContainer,
     node: NodeId,
@@ -75,7 +76,8 @@ pub(super) fn align_and_position_item(
     container_alignment_styles: InBothAbsAxis<Option<AlignItems>>,
     baseline_shim: f32,
     direction: Direction,
-) -> (Size<f32>, f32, f32) {
+    ignore_insets: bool,
+) -> (Size<f32>, Point<f32>, f32) {
     let grid_area_size = Size { width: grid_area.right - grid_area.left, height: grid_area.bottom - grid_area.top };
 
     let style = tree.get_grid_child_style(node);
@@ -87,14 +89,22 @@ pub(super) fn align_and_position_item(
     let align_self = style.align_self();
 
     let position = style.position();
-    let inset_horizontal = style
-        .inset()
-        .horizontal_components()
-        .map(|size| size.resolve_to_option(grid_area_size.width, |val, basis| tree.calc(val, basis)));
-    let inset_vertical = style
-        .inset()
-        .vertical_components()
-        .map(|size| size.resolve_to_option(grid_area_size.height, |val, basis| tree.calc(val, basis)));
+    let inset_horizontal = if ignore_insets {
+        Line { start: None, end: None }
+    } else {
+        style
+            .inset()
+            .horizontal_components()
+            .map(|size| size.resolve_to_option(grid_area_size.width, |val, basis| tree.calc(val, basis)))
+    };
+    let inset_vertical = if ignore_insets {
+        Line { start: None, end: None }
+    } else {
+        style
+            .inset()
+            .vertical_components()
+            .map(|size| size.resolve_to_option(grid_area_size.height, |val, basis| tree.calc(val, basis)))
+    };
     let padding =
         style.padding().map(|p| p.resolve_or_zero(Some(grid_area_size.width), |val, basis| tree.calc(val, basis)));
     let border =
@@ -291,7 +301,11 @@ pub(super) fn align_and_position_item(
     #[cfg(not(feature = "content_size"))]
     let contribution = Size::ZERO;
 
-    (contribution, y, height)
+    // In static-position mode (`ignore_insets`) the returned position excludes the margins,
+    // since `compute_absolute_child_layout` applies margins relative to the static position.
+    let returned_location =
+        if ignore_insets { Point { x: x - resolved_margin.left, y: y - resolved_margin.top } } else { Point { x, y } };
+    (contribution, returned_location, height)
 }
 
 /// Align and size a grid item along a single axis

--- a/src/compute/grid/alignment.rs
+++ b/src/compute/grid/alignment.rs
@@ -158,7 +158,7 @@ pub(super) fn align_and_position_item(
     let width = inherent_size.width.or_else(|| {
         // Apply width derived from both the left and right properties of an absolutely
         // positioned element being set
-        if position == Position::Absolute {
+        if position.is_absolutely_positioned() {
             if let (Some(left), Some(right)) = (inset_horizontal.start, inset_horizontal.end) {
                 return Some(f32_max(grid_area_minus_item_margins_size.width - left - right, 0.0));
             }
@@ -171,7 +171,7 @@ pub(super) fn align_and_position_item(
         if margin.left.is_some()
             && margin.right.is_some()
             && alignment_styles.horizontal == AlignSelf::STRETCH
-            && position != Position::Absolute
+            && !position.is_absolutely_positioned()
         {
             return Some(grid_area_minus_item_margins_size.width);
         }
@@ -183,7 +183,7 @@ pub(super) fn align_and_position_item(
     let Size { width, height } = Size { width, height: inherent_size.height }.maybe_apply_aspect_ratio(aspect_ratio);
 
     let height = height.or_else(|| {
-        if position == Position::Absolute {
+        if position.is_absolutely_positioned() {
             if let (Some(top), Some(bottom)) = (inset_vertical.start, inset_vertical.end) {
                 return Some(f32_max(grid_area_minus_item_margins_size.height - top - bottom, 0.0));
             }
@@ -196,7 +196,7 @@ pub(super) fn align_and_position_item(
         if margin.top.is_some()
             && margin.bottom.is_some()
             && alignment_styles.vertical == AlignSelf::STRETCH
-            && position != Position::Absolute
+            && !position.is_absolutely_positioned()
         {
             return Some(grid_area_minus_item_margins_size.height);
         }
@@ -212,7 +212,7 @@ pub(super) fn align_and_position_item(
     // Layout node
     drop(style);
 
-    let size = if position == Position::Absolute && (width.is_none() || height.is_none()) {
+    let size = if position.is_absolutely_positioned() && (width.is_none() || height.is_none()) {
         tree.measure_child_size_both(
             node,
             Size { width, height },
@@ -347,7 +347,7 @@ pub(super) fn align_item_within_area(
         }
     };
 
-    let offset_within_area = if position == Position::Absolute {
+    let offset_within_area = if position.is_absolutely_positioned() {
         match (inset.start, inset.end) {
             (Some(start), Some(end)) => {
                 if direction.is_rtl() {

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -591,7 +591,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
             right: columns[item.column_indexes.end as usize].offset,
         };
         #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
-        let (content_size_contribution, y_position, height) = align_and_position_item(
+        let (content_size_contribution, location, height) = align_and_position_item(
             tree,
             item.node,
             index as u32,
@@ -599,8 +599,9 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
             container_alignment_styles,
             item.baseline_shim,
             direction,
+            false,
         );
-        item.y_position = y_position;
+        item.y_position = location.y;
         item.height = height;
 
         #[cfg(feature = "content_size")]
@@ -635,20 +636,40 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
         let child_position = child_style.position();
         if child_position.is_absolutely_positioned() {
             // If this container is not the child's containing block then hand the child back to
-            // the tree implementation to be laid out against its actual containing block. The
-            // static position of an absolutely positioned child of a grid container is the
-            // content edge of the grid container.
+            // the tree implementation to be laid out against its actual containing block.
+            //
+            // The child's static position is determined as if it were the sole grid item in a
+            // grid area whose edges coincide with the content edges of the grid container
+            // (honoring the container's/item's alignment properties, with insets treated as
+            // auto since they resolve against the actual containing block instead).
             if should_defer_absolute_child(child_position, container_position) {
                 drop(child_style);
-                let static_position = Point {
-                    x: if direction.is_rtl() {
-                        container_border_box.width - border.right - padding.right - scrollbar_gutter.x
+                let content_box_grid_area = Rect {
+                    top: border.top + padding.top,
+                    bottom: container_border_box.height - border.bottom - padding.bottom - scrollbar_gutter.y,
+                    left: if direction.is_rtl() {
+                        border.left + padding.left + scrollbar_gutter.x
                     } else {
                         border.left + padding.left
                     },
-                    y: border.top + padding.top,
+                    right: container_border_box.width
+                        - border.right
+                        - padding.right
+                        - if direction.is_rtl() { 0.0 } else { scrollbar_gutter.x },
                 };
-                tree.defer_absolute_child(child, order, static_position);
+                let (_, static_position, _) = align_and_position_item(
+                    tree,
+                    child,
+                    order,
+                    content_box_grid_area,
+                    container_alignment_styles,
+                    0.0,
+                    direction,
+                    true,
+                );
+                // The static position is a fully-resolved top-left position, so it is always
+                // recorded with LTR semantics.
+                tree.defer_absolute_child(child, order, static_position, Direction::Ltr);
                 order += 1;
                 return;
             }
@@ -710,8 +731,16 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
 
             // TODO: Baseline alignment support for absolutely positioned items (should check if is actually specified)
             #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
-            let (content_size_contribution, _, _) =
-                align_and_position_item(tree, child, order, grid_area, container_alignment_styles, 0.0, direction);
+            let (content_size_contribution, _, _) = align_and_position_item(
+                tree,
+                child,
+                order,
+                grid_area,
+                container_alignment_styles,
+                0.0,
+                direction,
+                false,
+            );
             #[cfg(feature = "content_size")]
             {
                 item_content_size_contribution = item_content_size_contribution.f32_max(content_size_contribution);

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -1,8 +1,9 @@
 //! This module is a partial implementation of the CSS Grid Level 1 specification
 //! <https://www.w3.org/TR/css-grid-1>
+use crate::compute::absolute::should_defer_absolute_child;
 use crate::geometry::{AbsoluteAxis, AbstractAxis, InBothAbsAxis};
 use crate::geometry::{Line, Point, Rect, Size};
-use crate::style::{AlignItems, AlignSelf, AvailableSpace, Overflow, Position};
+use crate::style::{AlignItems, AlignSelf, AvailableSpace, Overflow};
 use crate::tree::{Layout, LayoutInput, LayoutOutput, LayoutPartialTreeExt, NodeId, RunMode, SizingMode};
 use crate::util::debug::debug_log;
 use crate::util::sys::{f32_max, f32_min, GridTrackVec, Vec};
@@ -49,6 +50,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
 
     let style = tree.get_grid_container_style(node);
     let direction = style.direction();
+    let container_position = style.position();
 
     // 1. Compute "available grid space"
     // https://www.w3.org/TR/css-grid-1/#available-grid-space
@@ -216,7 +218,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
             .enumerate()
             .map(|(index, child_node)| (index, child_node, tree.get_grid_child_style(child_node)))
             .filter(|(_, _, style)| {
-                style.box_generation_mode() != BoxGenerationMode::None && style.position() != Position::Absolute
+                style.box_generation_mode() != BoxGenerationMode::None && style.position().is_inflow()
             })
     };
     place_grid_items(
@@ -630,7 +632,27 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
         }
 
         // Position absolutely positioned child
-        if child_style.position() == Position::Absolute {
+        let child_position = child_style.position();
+        if child_position.is_absolutely_positioned() {
+            // If this container is not the child's containing block then hand the child back to
+            // the tree implementation to be laid out against its actual containing block. The
+            // static position of an absolutely positioned child of a grid container is the
+            // content edge of the grid container.
+            if should_defer_absolute_child(child_position, container_position) {
+                drop(child_style);
+                let static_position = Point {
+                    x: if direction.is_rtl() {
+                        container_border_box.width - border.right - padding.right - scrollbar_gutter.x
+                    } else {
+                        border.left + padding.left
+                    },
+                    y: border.top + padding.top,
+                };
+                tree.defer_absolute_child(child, order, static_position);
+                order += 1;
+                return;
+            }
+
             // Convert grid-col-{start/end} into Option's of indexes into the columns vector
             // The Option is None if the style property is Auto and an unresolvable Span
             let maybe_col_indexes = name_resolver

--- a/src/compute/leaf.rs
+++ b/src/compute/leaf.rs
@@ -1,7 +1,7 @@
 //! Computes size using styles and measure functions
 
 use crate::geometry::{Point, Size};
-use crate::style::{AvailableSpace, Overflow, Position};
+use crate::style::{AvailableSpace, Overflow};
 use crate::tree::{CollapsibleMarginSet, RunMode};
 use crate::tree::{LayoutInput, LayoutOutput, SizingMode};
 use crate::util::debug::debug_log;
@@ -76,7 +76,7 @@ where
     let has_styles_preventing_being_collapsed_through = !style.is_block()
         || style.overflow().x.is_scroll_container()
         || style.overflow().y.is_scroll_container()
-        || style.position() == Position::Absolute
+        || style.position().is_absolutely_positioned()
         || padding.top > 0.0
         || padding.bottom > 0.0
         || border.top > 0.0

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -21,6 +21,7 @@
 //! | [`round_layout`]                  | [`RoundTree`]                                                                                                                                                                                      | Round a tree of float-valued layouts to integer pixels               |
 //! | [`print_tree`](crate::print_tree) | [`PrintTree`](crate::PrintTree)                                                                                                                                                                    | Print a debug representation of a node tree and it's computed layout |
 //!
+pub(crate) mod absolute;
 pub(crate) mod common;
 pub(crate) mod leaf;
 
@@ -36,6 +37,7 @@ pub(crate) mod flexbox;
 #[cfg(feature = "grid")]
 pub(crate) mod grid;
 
+pub use absolute::{compute_absolute_child_layout, AbsoluteChildLayout};
 pub use leaf::compute_leaf_layout;
 
 #[cfg(feature = "block_layout")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,8 @@ pub use crate::compute::compute_grid_layout;
 pub use crate::compute::detailed_info::*;
 #[doc(inline)]
 pub use crate::compute::{
-    compute_cached_layout, compute_hidden_layout, compute_leaf_layout, compute_root_layout, round_layout,
+    compute_absolute_child_layout, compute_cached_layout, compute_hidden_layout, compute_leaf_layout,
+    compute_root_layout, round_layout, AbsoluteChildLayout,
 };
 #[doc(inline)]
 pub use crate::style::Style;

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -282,18 +282,48 @@ pub enum Position {
     /// Offsets do not affect the position of any other items; they are effectively a correction factor applied at the end.
     #[default]
     Relative,
+    /// The item participates in normal flow exactly like [`Position::Relative`], except that
+    /// [`Style::inset`] is ignored and the item does *not* act as the containing block for
+    /// absolutely positioned descendants. Absolutely positioned children of a `Static`
+    /// container are handed back to the tree implementation via
+    /// [`LayoutPartialTree::defer_absolute_child`](crate::LayoutPartialTree::defer_absolute_child)
+    /// to be positioned against an ancestor containing block.
+    Static,
     /// The offset is computed relative to this item's closest positioned ancestor, if any.
     /// Otherwise, it is placed relative to the origin.
     /// No space is created for the item in the page layout, and its size will not be altered.
     ///
     /// WARNING: to opt-out of layouting entirely, you must use [`Display::None`] instead on your [`Style`] object.
     Absolute,
+    /// Behaves like [`Position::Absolute`], except that the item is *always* handed back to the
+    /// tree implementation via
+    /// [`LayoutPartialTree::defer_absolute_child`](crate::LayoutPartialTree::defer_absolute_child),
+    /// allowing it to be positioned against the tree's fixed-position containing block
+    /// (typically the viewport or root node).
+    Fixed,
+}
+
+impl Position {
+    /// Whether the item participates in the normal flow of its parent's layout algorithm
+    /// (i.e. is not absolutely positioned)
+    #[inline(always)]
+    pub fn is_inflow(self) -> bool {
+        matches!(self, Position::Relative | Position::Static)
+    }
+
+    /// Whether the item is absolutely positioned (taken out of normal flow)
+    #[inline(always)]
+    pub fn is_absolutely_positioned(self) -> bool {
+        matches!(self, Position::Absolute | Position::Fixed)
+    }
 }
 
 #[cfg(feature = "parse")]
 crate::util::parse::impl_parse_for_keyword_enum!(Position,
     "relative" => Relative,
+    "static" => Static,
     "absolute" => Absolute,
+    "fixed" => Fixed,
 );
 
 /// Specifies whether size styles for this node are assigned to the node's "content box" or "border box"

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -432,7 +432,7 @@ pub enum Direction {
 impl Direction {
     /// Returns true if the direction is right-to-left
     #[inline]
-    pub(crate) fn is_rtl(&self) -> bool {
+    pub fn is_rtl(&self) -> bool {
         matches!(self, Direction::Rtl)
     }
 }

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -7,8 +7,8 @@ use slotmap::{DefaultKey, SlotMap};
 
 #[cfg(feature = "block_layout")]
 use crate::block::BlockContext;
-use crate::geometry::Size;
-use crate::style::{AvailableSpace, Display, Style};
+use crate::geometry::{Point, Size};
+use crate::style::{AvailableSpace, Display, Position, Style};
 use crate::sys::DefaultCheapStr;
 use crate::tree::{
     Cache, ClearState, Layout, LayoutInput, LayoutOutput, LayoutPartialTree, NodeId, PrintTree, RoundTree, RunMode,
@@ -18,7 +18,8 @@ use crate::util::debug::{debug_log, debug_log_node};
 use crate::util::sys::{new_vec_with_capacity, ChildrenVec, Vec};
 
 use crate::compute::{
-    compute_cached_layout, compute_hidden_layout, compute_leaf_layout, compute_root_layout, round_layout,
+    compute_absolute_child_layout, compute_cached_layout, compute_hidden_layout, compute_leaf_layout,
+    compute_root_layout, round_layout,
 };
 use crate::CacheTree;
 
@@ -88,6 +89,16 @@ impl Default for TaffyConfig {
     }
 }
 
+/// The static position of a node which was deferred by its parent during layout because the
+/// parent was not its containing block
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct DeferredPosition {
+    /// The source order of the node within its parent
+    order: u32,
+    /// The static position of the node, relative to its parent's border box
+    static_position: Point<f32>,
+}
+
 /// Layout information for a given [`Node`](crate::node::Node)
 ///
 /// Stored in a [`TaffyTree`].
@@ -107,6 +118,11 @@ struct NodeData {
     /// Whether the node has context data associated with it or not
     pub(crate) has_context: bool,
 
+    /// The static position recorded when this node was deferred by its parent during layout
+    /// (because the parent was not its containing block). See
+    /// [`LayoutPartialTree::defer_absolute_child`].
+    pub(crate) deferred_position: Option<DeferredPosition>,
+
     /// The cached results of the layout computation
     pub(crate) cache: Cache,
 
@@ -125,6 +141,7 @@ impl NodeData {
             unrounded_layout: Layout::new(),
             final_layout: Layout::new(),
             has_context: false,
+            deferred_position: None,
             #[cfg(feature = "detailed_layout_info")]
             detailed_layout_info: DetailedLayoutInfo::None,
         }
@@ -400,6 +417,11 @@ where
             #[cfg(feature = "block_layout")]
             None,
         )
+    }
+
+    #[inline(always)]
+    fn defer_absolute_child(&mut self, child_id: NodeId, order: u32, static_position: Point<f32>) {
+        self.taffy.nodes[child_id.into()].deferred_position = Some(DeferredPosition { order, static_position });
     }
 }
 
@@ -915,6 +937,7 @@ impl<NodeContext> TaffyTree<NodeContext> {
         let use_rounding = self.config.use_rounding;
         let mut taffy_view = TaffyView { taffy: self, measure_function };
         compute_root_layout(&mut taffy_view, node_id, available_space);
+        position_deferred_children(&mut taffy_view, node_id);
         if use_rounding {
             round_layout(&mut taffy_view, node_id);
         }
@@ -936,6 +959,134 @@ impl<NodeContext> TaffyTree<NodeContext> {
     #[cfg(test)]
     pub(crate) fn as_layout_tree(&mut self) -> impl LayoutPartialTree + CacheTree + '_ {
         TaffyView { taffy: self, measure_function: |_, _, _, _, _| Size::ZERO }
+    }
+}
+
+/// The containing block established by a positioned node, described relative to that node's
+/// border box
+#[derive(Copy, Clone)]
+struct ContainingBlock {
+    /// The node establishing the containing block
+    node: NodeId,
+    /// The size of the positioning area (border box minus borders and scrollbar gutters)
+    area_size: Size<f32>,
+    /// The offset of the positioning area from the node's border box origin
+    area_offset: Point<f32>,
+}
+
+impl ContainingBlock {
+    /// Compute the containing block established by a node from its unrounded layout
+    fn from_layout(node: NodeId, layout: &Layout, is_rtl: bool) -> Self {
+        let area_size = Size {
+            width: layout.size.width - layout.border.horizontal_axis_sum() - layout.scrollbar_size.width,
+            height: layout.size.height - layout.border.vertical_axis_sum() - layout.scrollbar_size.height,
+        };
+        let area_offset = Point {
+            x: if is_rtl { layout.border.left + layout.scrollbar_size.width } else { layout.border.left },
+            y: layout.border.top,
+        };
+        Self { node, area_size, area_offset }
+    }
+}
+
+/// Lay out children which were deferred during the main layout pass (via
+/// [`LayoutPartialTree::defer_absolute_child`]) against their actual containing block.
+///
+/// - `Position::Absolute` children of `Position::Static` containers are positioned against their
+///   nearest positioned (non-`Static`) ancestor, falling back to the root node.
+/// - `Position::Fixed` children are positioned against the root node.
+fn position_deferred_children<NodeContext, MeasureFunction>(
+    view: &mut TaffyView<'_, NodeContext, MeasureFunction>,
+    root: NodeId,
+) where
+    MeasureFunction:
+        FnMut(Size<Option<f32>>, Size<AvailableSpace>, NodeId, Option<&mut NodeContext>, &Style) -> Size<f32>,
+{
+    let root_is_rtl = view.taffy.nodes[root.into()].style.direction.is_rtl();
+    let root_layout = view.taffy.nodes[root.into()].unrounded_layout;
+    let root_cb = ContainingBlock::from_layout(root, &root_layout, root_is_rtl);
+    recurse(view, root, root_cb, root_cb, Point::ZERO, Point::ZERO);
+
+    /// Recursively walk the tree positioning deferred children.
+    ///
+    /// - `root_cb` is the containing block for `Position::Fixed` descendants (the root node)
+    /// - `abs_cb` is the containing block for `Position::Absolute` descendants
+    /// - `node_offset_from_cb` is the offset of `node`'s border box from `abs_cb`'s border box
+    /// - `node_offset_from_root` is the offset of `node`'s border box from the root's border box
+    fn recurse<NodeContext, MeasureFunction>(
+        view: &mut TaffyView<'_, NodeContext, MeasureFunction>,
+        node: NodeId,
+        root_cb: ContainingBlock,
+        abs_cb: ContainingBlock,
+        node_offset_from_cb: Point<f32>,
+        node_offset_from_root: Point<f32>,
+    ) where
+        MeasureFunction:
+            FnMut(Size<Option<f32>>, Size<AvailableSpace>, NodeId, Option<&mut NodeContext>, &Style) -> Size<f32>,
+    {
+        let node_position = view.taffy.nodes[node.into()].style.position;
+        let child_count = view.taffy.children[node.into()].len();
+        for index in 0..child_count {
+            let child = view.taffy.children[node.into()][index];
+            let child_data = &view.taffy.nodes[child.into()];
+            let child_position = child_data.style.position;
+            let deferred = child_data.deferred_position;
+
+            let is_deferred = child_position == Position::Fixed
+                || (child_position == Position::Absolute && node_position == Position::Static);
+
+            if is_deferred {
+                if let Some(DeferredPosition { order, static_position }) = deferred {
+                    // Fixed children are positioned against the root; absolute children against
+                    // the nearest positioned ancestor (`abs_cb`)
+                    let (cb, parent_offset) = if child_position == Position::Fixed {
+                        (root_cb, node_offset_from_root)
+                    } else {
+                        (abs_cb, node_offset_from_cb)
+                    };
+
+                    let direction = view.taffy.nodes[cb.node.into()].style.direction;
+                    let static_position_in_cb =
+                        Point { x: static_position.x + parent_offset.x, y: static_position.y + parent_offset.y };
+                    let result = compute_absolute_child_layout(
+                        view,
+                        child,
+                        order,
+                        cb.area_size,
+                        cb.area_offset,
+                        static_position_in_cb,
+                        direction,
+                    );
+                    // `compute_absolute_child_layout` writes a location relative to the containing
+                    // block's border box. Convert it to be relative to the parent's border box
+                    // (which is the coordinate space the rest of Taffy expects).
+                    let mut layout = result.layout;
+                    layout.location =
+                        Point { x: layout.location.x - parent_offset.x, y: layout.location.y - parent_offset.y };
+                    view.taffy.nodes[child.into()].unrounded_layout = layout;
+                }
+            }
+
+            // Recurse into the child's subtree
+            let child_layout = view.taffy.nodes[child.into()].unrounded_layout;
+            let child_offset_from_root = Point {
+                x: node_offset_from_root.x + child_layout.location.x,
+                y: node_offset_from_root.y + child_layout.location.y,
+            };
+            let (child_abs_cb, child_offset_from_cb) = if child_position == Position::Static {
+                (
+                    abs_cb,
+                    Point {
+                        x: node_offset_from_cb.x + child_layout.location.x,
+                        y: node_offset_from_cb.y + child_layout.location.y,
+                    },
+                )
+            } else {
+                let is_rtl = view.taffy.nodes[child.into()].style.direction.is_rtl();
+                (ContainingBlock::from_layout(child, &child_layout, is_rtl), Point::ZERO)
+            };
+            recurse(view, child, root_cb, child_abs_cb, child_offset_from_cb, child_offset_from_root);
+        }
     }
 }
 

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -8,7 +8,7 @@ use slotmap::{DefaultKey, SlotMap};
 #[cfg(feature = "block_layout")]
 use crate::block::BlockContext;
 use crate::geometry::{Point, Size};
-use crate::style::{AvailableSpace, Display, Position, Style};
+use crate::style::{AvailableSpace, Direction, Display, Position, Style};
 use crate::sys::DefaultCheapStr;
 use crate::tree::{
     Cache, ClearState, Layout, LayoutInput, LayoutOutput, LayoutPartialTree, NodeId, PrintTree, RoundTree, RunMode,
@@ -97,6 +97,8 @@ struct DeferredPosition {
     order: u32,
     /// The static position of the node, relative to its parent's border box
     static_position: Point<f32>,
+    /// The direction the static position was recorded in (RTL means `x` is the right edge)
+    static_position_direction: Direction,
 }
 
 /// Layout information for a given [`Node`](crate::node::Node)
@@ -420,8 +422,15 @@ where
     }
 
     #[inline(always)]
-    fn defer_absolute_child(&mut self, child_id: NodeId, order: u32, static_position: Point<f32>) {
-        self.taffy.nodes[child_id.into()].deferred_position = Some(DeferredPosition { order, static_position });
+    fn defer_absolute_child(
+        &mut self,
+        child_id: NodeId,
+        order: u32,
+        static_position: Point<f32>,
+        static_position_direction: Direction,
+    ) {
+        self.taffy.nodes[child_id.into()].deferred_position =
+            Some(DeferredPosition { order, static_position, static_position_direction });
     }
 }
 
@@ -1036,7 +1045,7 @@ fn position_deferred_children<NodeContext, MeasureFunction>(
                 || (child_position == Position::Absolute && node_position == Position::Static);
 
             if is_deferred {
-                if let Some(DeferredPosition { order, static_position }) = deferred {
+                if let Some(DeferredPosition { order, static_position, static_position_direction }) = deferred {
                     // Fixed children are positioned against the root; absolute children against
                     // the nearest positioned ancestor (`abs_cb`)
                     let (cb, parent_offset) = if child_position == Position::Fixed {
@@ -1055,6 +1064,7 @@ fn position_deferred_children<NodeContext, MeasureFunction>(
                         cb.area_size,
                         cb.area_offset,
                         static_position_in_cb,
+                        static_position_direction,
                         direction,
                     );
                     // `compute_absolute_child_layout` writes a location relative to the containing

--- a/src/tree/traits.rs
+++ b/src/tree/traits.rs
@@ -130,7 +130,7 @@ use super::{Layout, LayoutInput, LayoutOutput, NodeId, RequestedAxis, RunMode, S
 #[cfg(feature = "detailed_layout_info")]
 use crate::debug::debug_log;
 use crate::geometry::{AbsoluteAxis, Line, Point, Size};
-use crate::style::{AvailableSpace, CoreStyle};
+use crate::style::{AvailableSpace, CoreStyle, Direction};
 #[cfg(feature = "flexbox")]
 use crate::style::{FlexboxContainerStyle, FlexboxItemStyle};
 #[cfg(feature = "grid")]
@@ -221,10 +221,17 @@ pub trait LayoutPartialTree: TraversePartialTree {
     /// `Static` containers (and all `Fixed` children) are simply not laid out unless the tree
     /// implementation overrides this method.
     #[inline(always)]
-    fn defer_absolute_child(&mut self, child_id: NodeId, order: u32, static_position: Point<f32>) {
+    fn defer_absolute_child(
+        &mut self,
+        child_id: NodeId,
+        order: u32,
+        static_position: Point<f32>,
+        static_position_direction: Direction,
+    ) {
         let _ = child_id;
         let _ = order;
         let _ = static_position;
+        let _ = static_position_direction;
     }
 }
 

--- a/src/tree/traits.rs
+++ b/src/tree/traits.rs
@@ -129,7 +129,7 @@
 use super::{Layout, LayoutInput, LayoutOutput, NodeId, RequestedAxis, RunMode, SizingMode};
 #[cfg(feature = "detailed_layout_info")]
 use crate::debug::debug_log;
-use crate::geometry::{AbsoluteAxis, Line, Size};
+use crate::geometry::{AbsoluteAxis, Line, Point, Size};
 use crate::style::{AvailableSpace, CoreStyle};
 #[cfg(feature = "flexbox")]
 use crate::style::{FlexboxContainerStyle, FlexboxItemStyle};
@@ -198,6 +198,34 @@ pub trait LayoutPartialTree: TraversePartialTree {
 
     /// Compute the specified node's size or full layout given the specified constraints
     fn compute_child_layout(&mut self, node_id: NodeId, inputs: LayoutInput) -> LayoutOutput;
+
+    /// Called (during a `PerformLayout` pass) for each absolutely positioned child which the
+    /// container being laid out does not establish the containing block for. This is the case for:
+    ///
+    ///   - [`Position::Absolute`](crate::Position::Absolute) children of a
+    ///     [`Position::Static`](crate::Position::Static) container
+    ///   - [`Position::Fixed`](crate::Position::Fixed) children of any container
+    ///
+    /// The container does *not* lay such children out. Instead it computes their static position
+    /// (the position the child would occupy if its insets were all `auto`, relative to the
+    /// container's border box) and passes it to this method. The tree implementation is expected
+    /// to record this information and lay out the child against its actual containing block
+    /// after the main layout pass has completed (e.g. using
+    /// [`compute_absolute_child_layout`](crate::compute_absolute_child_layout)).
+    ///
+    /// Note that this method is only called when the container actually performs layout. If a
+    /// cached layout result is reused then it will not be re-called, so recorded static positions
+    /// should be stored durably (they only change when the container re-performs layout).
+    ///
+    /// The default implementation is a no-op, which means absolutely positioned children of
+    /// `Static` containers (and all `Fixed` children) are simply not laid out unless the tree
+    /// implementation overrides this method.
+    #[inline(always)]
+    fn defer_absolute_child(&mut self, child_id: NodeId, order: u32, static_position: Point<f32>) {
+        let _ = child_id;
+        let _ = order;
+        let _ = static_position;
+    }
 }
 
 /// Trait used by the `compute_cached_layout` method which allows cached layout results to be stored and retrieved.

--- a/test_fixtures/block/block_absolute_in_static_parent_static_position_fallback.html
+++ b/test_fixtures/block/block_absolute_in_static_parent_static_position_fallback.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; position: relative; height: 200px; width: 200px; padding: 10px;">
+  <div style="display: block; position: static; width: 150px; height: 150px; margin-left: 20px; margin-top: 20px; padding: 5px;">
+    <div style="display: block; width: 50px; height: 30px;"></div>
+    <div style="display: block; position: absolute; width: 60px; height: 40px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/block/block_absolute_in_static_parent_with_relative_grandparent.html
+++ b/test_fixtures/block/block_absolute_in_static_parent_with_relative_grandparent.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; position: relative; height: 200px; width: 200px; padding: 10px; border-width: 5px;">
+  <div style="display: block; position: static; width: 150px; height: 150px; margin-left: 20px; margin-top: 20px; padding: 5px;">
+    <div style="display: block; position: absolute; top: 10px; left: 15px; width: 60px; height: 40px;"></div>
+    <div style="display: block; position: absolute; bottom: 10px; right: 15px; width: 60px; height: 40px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/block/block_fixed_child_of_relative_parent.html
+++ b/test_fixtures/block/block_fixed_child_of_relative_parent.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; height: 200px; width: 200px;">
+  <div style="display: block; position: relative; width: 150px; height: 150px; margin-left: 40px; margin-top: 40px;">
+    <div style="display: block; position: fixed; top: 25px; left: 35px; width: 60px; height: 40px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/block/block_fixed_child_with_insets.html
+++ b/test_fixtures/block/block_fixed_child_with_insets.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; height: 200px; width: 200px;">
+  <div style="display: block; position: static; width: 150px; height: 150px; margin-left: 20px; margin-top: 20px;">
+    <div style="display: block; position: fixed; top: 25px; left: 35px; width: 60px; height: 40px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/block/block_static_ignores_inset.html
+++ b/test_fixtures/block/block_static_ignores_inset.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; height: 100px; width: 110px;">
+  <div style="display: block; position: static; top: 20px; left: 30px; width: 60px; height: 40px;"></div>
+  <div style="display: block; width: 60px; height: 40px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/absolute_child_of_static_flex_container.html
+++ b/test_fixtures/flex/absolute_child_of_static_flex_container.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; position: relative; height: 200px; width: 200px; padding: 10px;">
+  <div style="display: flex; position: static; width: 150px; height: 150px; margin-left: 20px; margin-top: 20px;">
+    <div style="width: 50px; height: 30px;"></div>
+    <div style="position: absolute; top: 10px; left: 15px; width: 60px; height: 40px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_absolute_child_of_static_grid_container.html
+++ b/test_fixtures/grid/grid_absolute_child_of_static_grid_container.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; position: relative; height: 200px; width: 200px; padding: 10px;">
+  <div style="display: grid; position: static; grid-template-columns: 50px 50px; grid-template-rows: 50px 50px; width: 150px; height: 150px; margin-left: 20px; margin-top: 20px;">
+    <div></div>
+    <div style="position: absolute; top: 10px; left: 15px; width: 60px; height: 40px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/block/block_absolute_in_static_parent_static_position_fallback__border_box_ltr.xml
+++ b/tests/xml/block/block_absolute_in_static_parent_static_position_fallback__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="block_absolute_in_static_parent_static_position_fallback__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="200px" height="200px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px">
+      <div display="block" direction="ltr" position="static" width="150px" height="150px" margin-top="20px" margin-left="20px" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px">
+        <div display="block" direction="ltr" width="50px" height="30px"/>
+        <div display="block" direction="ltr" position="absolute" width="60px" height="40px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="30" y="30" width="150" height="150">
+        <node x="5" y="5" width="50" height="30"/>
+        <node x="5" y="35" width="60" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_absolute_in_static_parent_static_position_fallback__border_box_rtl.xml
+++ b/tests/xml/block/block_absolute_in_static_parent_static_position_fallback__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="block_absolute_in_static_parent_static_position_fallback__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="200px" height="200px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px">
+      <div display="block" direction="rtl" position="static" width="150px" height="150px" margin-top="20px" margin-left="20px" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px">
+        <div display="block" direction="rtl" width="50px" height="30px"/>
+        <div display="block" direction="rtl" position="absolute" width="60px" height="40px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="40" y="30" width="150" height="150">
+        <node x="95" y="5" width="50" height="30"/>
+        <node x="85" y="35" width="60" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_absolute_in_static_parent_static_position_fallback__content_box_ltr.xml
+++ b/tests/xml/block/block_absolute_in_static_parent_static_position_fallback__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="block_absolute_in_static_parent_static_position_fallback__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="200px" height="200px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px">
+      <div display="block" box-sizing="content-box" direction="ltr" position="static" width="150px" height="150px" margin-top="20px" margin-left="20px" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px">
+        <div display="block" box-sizing="content-box" direction="ltr" width="50px" height="30px"/>
+        <div display="block" box-sizing="content-box" direction="ltr" position="absolute" width="60px" height="40px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="220" height="220">
+      <node x="30" y="30" width="160" height="160">
+        <node x="5" y="5" width="50" height="30"/>
+        <node x="5" y="35" width="60" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_absolute_in_static_parent_static_position_fallback__content_box_rtl.xml
+++ b/tests/xml/block/block_absolute_in_static_parent_static_position_fallback__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="block_absolute_in_static_parent_static_position_fallback__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="200px" height="200px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px">
+      <div display="block" box-sizing="content-box" direction="rtl" position="static" width="150px" height="150px" margin-top="20px" margin-left="20px" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px">
+        <div display="block" box-sizing="content-box" direction="rtl" width="50px" height="30px"/>
+        <div display="block" box-sizing="content-box" direction="rtl" position="absolute" width="60px" height="40px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="220" height="220">
+      <node x="50" y="30" width="160" height="160">
+        <node x="105" y="5" width="50" height="30"/>
+        <node x="95" y="35" width="60" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_absolute_in_static_parent_with_relative_grandparent__border_box_ltr.xml
+++ b/tests/xml/block/block_absolute_in_static_parent_with_relative_grandparent__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="block_absolute_in_static_parent_with_relative_grandparent__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="200px" height="200px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" border-top="5px" border-left="5px" border-bottom="5px" border-right="5px">
+      <div display="block" direction="ltr" position="static" width="150px" height="150px" margin-top="20px" margin-left="20px" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px">
+        <div display="block" direction="ltr" position="absolute" width="60px" height="40px" top="10px" left="15px"/>
+        <div display="block" direction="ltr" position="absolute" width="60px" height="40px" bottom="10px" right="15px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="35" y="35" width="150" height="150">
+        <node x="-15" y="-20" width="60" height="40"/>
+        <node x="85" y="110" width="60" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_absolute_in_static_parent_with_relative_grandparent__border_box_rtl.xml
+++ b/tests/xml/block/block_absolute_in_static_parent_with_relative_grandparent__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="block_absolute_in_static_parent_with_relative_grandparent__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="200px" height="200px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" border-top="5px" border-left="5px" border-bottom="5px" border-right="5px">
+      <div display="block" direction="rtl" position="static" width="150px" height="150px" margin-top="20px" margin-left="20px" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px">
+        <div display="block" direction="rtl" position="absolute" width="60px" height="40px" top="10px" left="15px"/>
+        <div display="block" direction="rtl" position="absolute" width="60px" height="40px" bottom="10px" right="15px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="35" y="35" width="150" height="150">
+        <node x="-15" y="-20" width="60" height="40"/>
+        <node x="85" y="110" width="60" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_absolute_in_static_parent_with_relative_grandparent__content_box_ltr.xml
+++ b/tests/xml/block/block_absolute_in_static_parent_with_relative_grandparent__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="block_absolute_in_static_parent_with_relative_grandparent__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="200px" height="200px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" border-top="5px" border-left="5px" border-bottom="5px" border-right="5px">
+      <div display="block" box-sizing="content-box" direction="ltr" position="static" width="150px" height="150px" margin-top="20px" margin-left="20px" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px">
+        <div display="block" box-sizing="content-box" direction="ltr" position="absolute" width="60px" height="40px" top="10px" left="15px"/>
+        <div display="block" box-sizing="content-box" direction="ltr" position="absolute" width="60px" height="40px" bottom="10px" right="15px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="230" height="230">
+      <node x="35" y="35" width="160" height="160">
+        <node x="-15" y="-20" width="60" height="40"/>
+        <node x="115" y="140" width="60" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_absolute_in_static_parent_with_relative_grandparent__content_box_rtl.xml
+++ b/tests/xml/block/block_absolute_in_static_parent_with_relative_grandparent__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="block_absolute_in_static_parent_with_relative_grandparent__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="200px" height="200px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" border-top="5px" border-left="5px" border-bottom="5px" border-right="5px">
+      <div display="block" box-sizing="content-box" direction="rtl" position="static" width="150px" height="150px" margin-top="20px" margin-left="20px" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px">
+        <div display="block" box-sizing="content-box" direction="rtl" position="absolute" width="60px" height="40px" top="10px" left="15px"/>
+        <div display="block" box-sizing="content-box" direction="rtl" position="absolute" width="60px" height="40px" bottom="10px" right="15px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="230" height="230">
+      <node x="55" y="35" width="160" height="160">
+        <node x="-35" y="-20" width="60" height="40"/>
+        <node x="95" y="140" width="60" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_fixed_child_of_relative_parent__border_box_ltr.xml
+++ b/tests/xml/block/block_fixed_child_of_relative_parent__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="block_fixed_child_of_relative_parent__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="200px" height="200px">
+      <div display="block" direction="ltr" width="150px" height="150px" margin-top="40px" margin-left="40px">
+        <div display="block" direction="ltr" position="fixed" width="60px" height="40px" top="25px" left="35px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="40" y="40" width="150" height="150">
+        <node x="-5" y="-15" width="60" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_fixed_child_of_relative_parent__border_box_rtl.xml
+++ b/tests/xml/block/block_fixed_child_of_relative_parent__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="block_fixed_child_of_relative_parent__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="200px" height="200px">
+      <div display="block" direction="rtl" width="150px" height="150px" margin-top="40px" margin-left="40px">
+        <div display="block" direction="rtl" position="fixed" width="60px" height="40px" top="25px" left="35px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="50" y="40" width="150" height="150">
+        <node x="-15" y="-15" width="60" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_fixed_child_of_relative_parent__content_box_ltr.xml
+++ b/tests/xml/block/block_fixed_child_of_relative_parent__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="block_fixed_child_of_relative_parent__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="200px" height="200px">
+      <div display="block" box-sizing="content-box" direction="ltr" width="150px" height="150px" margin-top="40px" margin-left="40px">
+        <div display="block" box-sizing="content-box" direction="ltr" position="fixed" width="60px" height="40px" top="25px" left="35px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="40" y="40" width="150" height="150">
+        <node x="-5" y="-15" width="60" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_fixed_child_of_relative_parent__content_box_rtl.xml
+++ b/tests/xml/block/block_fixed_child_of_relative_parent__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="block_fixed_child_of_relative_parent__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="200px" height="200px">
+      <div display="block" box-sizing="content-box" direction="rtl" width="150px" height="150px" margin-top="40px" margin-left="40px">
+        <div display="block" box-sizing="content-box" direction="rtl" position="fixed" width="60px" height="40px" top="25px" left="35px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="50" y="40" width="150" height="150">
+        <node x="-15" y="-15" width="60" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_fixed_child_with_insets__border_box_ltr.xml
+++ b/tests/xml/block/block_fixed_child_with_insets__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="block_fixed_child_with_insets__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="200px" height="200px">
+      <div display="block" direction="ltr" position="static" width="150px" height="150px" margin-top="20px" margin-left="20px">
+        <div display="block" direction="ltr" position="fixed" width="60px" height="40px" top="25px" left="35px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="20" y="20" width="150" height="150">
+        <node x="15" y="5" width="60" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_fixed_child_with_insets__border_box_rtl.xml
+++ b/tests/xml/block/block_fixed_child_with_insets__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="block_fixed_child_with_insets__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="200px" height="200px">
+      <div display="block" direction="rtl" position="static" width="150px" height="150px" margin-top="20px" margin-left="20px">
+        <div display="block" direction="rtl" position="fixed" width="60px" height="40px" top="25px" left="35px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="50" y="20" width="150" height="150">
+        <node x="-15" y="5" width="60" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_fixed_child_with_insets__content_box_ltr.xml
+++ b/tests/xml/block/block_fixed_child_with_insets__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="block_fixed_child_with_insets__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="200px" height="200px">
+      <div display="block" box-sizing="content-box" direction="ltr" position="static" width="150px" height="150px" margin-top="20px" margin-left="20px">
+        <div display="block" box-sizing="content-box" direction="ltr" position="fixed" width="60px" height="40px" top="25px" left="35px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="20" y="20" width="150" height="150">
+        <node x="15" y="5" width="60" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_fixed_child_with_insets__content_box_rtl.xml
+++ b/tests/xml/block/block_fixed_child_with_insets__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="block_fixed_child_with_insets__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="200px" height="200px">
+      <div display="block" box-sizing="content-box" direction="rtl" position="static" width="150px" height="150px" margin-top="20px" margin-left="20px">
+        <div display="block" box-sizing="content-box" direction="rtl" position="fixed" width="60px" height="40px" top="25px" left="35px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="50" y="20" width="150" height="150">
+        <node x="-15" y="5" width="60" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_static_ignores_inset__border_box_ltr.xml
+++ b/tests/xml/block/block_static_ignores_inset__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="block_static_ignores_inset__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="110px" height="100px">
+      <div display="block" direction="ltr" position="static" width="60px" height="40px" top="20px" left="30px"/>
+      <div display="block" direction="ltr" width="60px" height="40px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="110" height="100">
+      <node x="0" y="0" width="60" height="40"/>
+      <node x="0" y="40" width="60" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_static_ignores_inset__border_box_rtl.xml
+++ b/tests/xml/block/block_static_ignores_inset__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="block_static_ignores_inset__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="110px" height="100px">
+      <div display="block" direction="rtl" position="static" width="60px" height="40px" top="20px" left="30px"/>
+      <div display="block" direction="rtl" width="60px" height="40px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="110" height="100">
+      <node x="50" y="0" width="60" height="40"/>
+      <node x="50" y="40" width="60" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_static_ignores_inset__content_box_ltr.xml
+++ b/tests/xml/block/block_static_ignores_inset__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="block_static_ignores_inset__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="110px" height="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" position="static" width="60px" height="40px" top="20px" left="30px"/>
+      <div display="block" box-sizing="content-box" direction="ltr" width="60px" height="40px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="110" height="100">
+      <node x="0" y="0" width="60" height="40"/>
+      <node x="0" y="40" width="60" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_static_ignores_inset__content_box_rtl.xml
+++ b/tests/xml/block/block_static_ignores_inset__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="block_static_ignores_inset__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="110px" height="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" position="static" width="60px" height="40px" top="20px" left="30px"/>
+      <div display="block" box-sizing="content-box" direction="rtl" width="60px" height="40px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="110" height="100">
+      <node x="50" y="0" width="60" height="40"/>
+      <node x="50" y="40" width="60" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_child_of_static_flex_container__border_box_ltr.xml
+++ b/tests/xml/flex/absolute_child_of_static_flex_container__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="absolute_child_of_static_flex_container__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="200px" height="200px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px">
+      <div display="flex" direction="ltr" position="static" width="150px" height="150px" margin-top="20px" margin-left="20px">
+        <div direction="ltr" width="50px" height="30px"/>
+        <div direction="ltr" position="absolute" width="60px" height="40px" top="10px" left="15px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="30" y="30" width="150" height="150">
+        <node x="0" y="0" width="50" height="30"/>
+        <node x="-15" y="-20" width="60" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_child_of_static_flex_container__border_box_rtl.xml
+++ b/tests/xml/flex/absolute_child_of_static_flex_container__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="absolute_child_of_static_flex_container__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="200px" height="200px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px">
+      <div display="flex" direction="rtl" position="static" width="150px" height="150px" margin-top="20px" margin-left="20px">
+        <div direction="rtl" width="50px" height="30px"/>
+        <div direction="rtl" position="absolute" width="60px" height="40px" top="10px" left="15px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="40" y="30" width="150" height="150">
+        <node x="100" y="0" width="50" height="30"/>
+        <node x="-25" y="-20" width="60" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_child_of_static_flex_container__content_box_ltr.xml
+++ b/tests/xml/flex/absolute_child_of_static_flex_container__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="absolute_child_of_static_flex_container__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="200px" height="200px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px">
+      <div display="flex" box-sizing="content-box" direction="ltr" position="static" width="150px" height="150px" margin-top="20px" margin-left="20px">
+        <div box-sizing="content-box" direction="ltr" width="50px" height="30px"/>
+        <div box-sizing="content-box" direction="ltr" position="absolute" width="60px" height="40px" top="10px" left="15px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="220" height="220">
+      <node x="30" y="30" width="150" height="150">
+        <node x="0" y="0" width="50" height="30"/>
+        <node x="-15" y="-20" width="60" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_child_of_static_flex_container__content_box_rtl.xml
+++ b/tests/xml/flex/absolute_child_of_static_flex_container__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="absolute_child_of_static_flex_container__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="200px" height="200px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px">
+      <div display="flex" box-sizing="content-box" direction="rtl" position="static" width="150px" height="150px" margin-top="20px" margin-left="20px">
+        <div box-sizing="content-box" direction="rtl" width="50px" height="30px"/>
+        <div box-sizing="content-box" direction="rtl" position="absolute" width="60px" height="40px" top="10px" left="15px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="220" height="220">
+      <node x="60" y="30" width="150" height="150">
+        <node x="100" y="0" width="50" height="30"/>
+        <node x="-45" y="-20" width="60" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_child_of_static_grid_container__border_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_child_of_static_grid_container__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_absolute_child_of_static_grid_container__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="200px" height="200px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px">
+      <div display="grid" direction="ltr" position="static" width="150px" height="150px" margin-top="20px" margin-left="20px" grid-template-rows="50px 50px" grid-template-columns="50px 50px">
+        <div direction="ltr"/>
+        <div direction="ltr" position="absolute" width="60px" height="40px" top="10px" left="15px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="30" y="30" width="150" height="150">
+        <node x="0" y="0" width="50" height="50"/>
+        <node x="-15" y="-20" width="60" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_child_of_static_grid_container__border_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_child_of_static_grid_container__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_absolute_child_of_static_grid_container__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="200px" height="200px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px">
+      <div display="grid" direction="rtl" position="static" width="150px" height="150px" margin-top="20px" margin-left="20px" grid-template-rows="50px 50px" grid-template-columns="50px 50px">
+        <div direction="rtl"/>
+        <div direction="rtl" position="absolute" width="60px" height="40px" top="10px" left="15px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="40" y="30" width="150" height="150">
+        <node x="100" y="0" width="50" height="50"/>
+        <node x="-25" y="-20" width="60" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_child_of_static_grid_container__content_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_child_of_static_grid_container__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_absolute_child_of_static_grid_container__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="200px" height="200px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px">
+      <div display="grid" box-sizing="content-box" direction="ltr" position="static" width="150px" height="150px" margin-top="20px" margin-left="20px" grid-template-rows="50px 50px" grid-template-columns="50px 50px">
+        <div box-sizing="content-box" direction="ltr"/>
+        <div box-sizing="content-box" direction="ltr" position="absolute" width="60px" height="40px" top="10px" left="15px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="220" height="220">
+      <node x="30" y="30" width="150" height="150">
+        <node x="0" y="0" width="50" height="50"/>
+        <node x="-15" y="-20" width="60" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_child_of_static_grid_container__content_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_child_of_static_grid_container__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_absolute_child_of_static_grid_container__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="200px" height="200px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px">
+      <div display="grid" box-sizing="content-box" direction="rtl" position="static" width="150px" height="150px" margin-top="20px" margin-left="20px" grid-template-rows="50px 50px" grid-template-columns="50px 50px">
+        <div box-sizing="content-box" direction="rtl"/>
+        <div box-sizing="content-box" direction="rtl" position="absolute" width="60px" height="40px" top="10px" left="15px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="220" height="220">
+      <node x="60" y="30" width="150" height="150">
+        <node x="100" y="0" width="50" height="50"/>
+        <node x="-45" y="-20" width="60" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -314,6 +314,46 @@ mod block {
     }
 
     #[test]
+    fn block_absolute_in_static_parent_static_position_fallback__border_box_ltr() {
+        crate::run_xml_test("block", "block_absolute_in_static_parent_static_position_fallback__border_box_ltr");
+    }
+
+    #[test]
+    fn block_absolute_in_static_parent_static_position_fallback__content_box_ltr() {
+        crate::run_xml_test("block", "block_absolute_in_static_parent_static_position_fallback__content_box_ltr");
+    }
+
+    #[test]
+    fn block_absolute_in_static_parent_static_position_fallback__border_box_rtl() {
+        crate::run_xml_test("block", "block_absolute_in_static_parent_static_position_fallback__border_box_rtl");
+    }
+
+    #[test]
+    fn block_absolute_in_static_parent_static_position_fallback__content_box_rtl() {
+        crate::run_xml_test("block", "block_absolute_in_static_parent_static_position_fallback__content_box_rtl");
+    }
+
+    #[test]
+    fn block_absolute_in_static_parent_with_relative_grandparent__border_box_ltr() {
+        crate::run_xml_test("block", "block_absolute_in_static_parent_with_relative_grandparent__border_box_ltr");
+    }
+
+    #[test]
+    fn block_absolute_in_static_parent_with_relative_grandparent__content_box_ltr() {
+        crate::run_xml_test("block", "block_absolute_in_static_parent_with_relative_grandparent__content_box_ltr");
+    }
+
+    #[test]
+    fn block_absolute_in_static_parent_with_relative_grandparent__border_box_rtl() {
+        crate::run_xml_test("block", "block_absolute_in_static_parent_with_relative_grandparent__border_box_rtl");
+    }
+
+    #[test]
+    fn block_absolute_in_static_parent_with_relative_grandparent__content_box_rtl() {
+        crate::run_xml_test("block", "block_absolute_in_static_parent_with_relative_grandparent__content_box_rtl");
+    }
+
+    #[test]
     fn block_absolute_layout_child_order__border_box_ltr() {
         crate::run_xml_test("block", "block_absolute_layout_child_order__border_box_ltr");
     }
@@ -1943,6 +1983,46 @@ mod block {
     #[test]
     fn block_display_none_with_position_absolute__content_box_rtl() {
         crate::run_xml_test("block", "block_display_none_with_position_absolute__content_box_rtl");
+    }
+
+    #[test]
+    fn block_fixed_child_of_relative_parent__border_box_ltr() {
+        crate::run_xml_test("block", "block_fixed_child_of_relative_parent__border_box_ltr");
+    }
+
+    #[test]
+    fn block_fixed_child_of_relative_parent__content_box_ltr() {
+        crate::run_xml_test("block", "block_fixed_child_of_relative_parent__content_box_ltr");
+    }
+
+    #[test]
+    fn block_fixed_child_of_relative_parent__border_box_rtl() {
+        crate::run_xml_test("block", "block_fixed_child_of_relative_parent__border_box_rtl");
+    }
+
+    #[test]
+    fn block_fixed_child_of_relative_parent__content_box_rtl() {
+        crate::run_xml_test("block", "block_fixed_child_of_relative_parent__content_box_rtl");
+    }
+
+    #[test]
+    fn block_fixed_child_with_insets__border_box_ltr() {
+        crate::run_xml_test("block", "block_fixed_child_with_insets__border_box_ltr");
+    }
+
+    #[test]
+    fn block_fixed_child_with_insets__content_box_ltr() {
+        crate::run_xml_test("block", "block_fixed_child_with_insets__content_box_ltr");
+    }
+
+    #[test]
+    fn block_fixed_child_with_insets__border_box_rtl() {
+        crate::run_xml_test("block", "block_fixed_child_with_insets__border_box_rtl");
+    }
+
+    #[test]
+    fn block_fixed_child_with_insets__content_box_rtl() {
+        crate::run_xml_test("block", "block_fixed_child_with_insets__content_box_rtl");
     }
 
     #[test]
@@ -4538,6 +4618,26 @@ mod block {
     }
 
     #[test]
+    fn block_static_ignores_inset__border_box_ltr() {
+        crate::run_xml_test("block", "block_static_ignores_inset__border_box_ltr");
+    }
+
+    #[test]
+    fn block_static_ignores_inset__content_box_ltr() {
+        crate::run_xml_test("block", "block_static_ignores_inset__content_box_ltr");
+    }
+
+    #[test]
+    fn block_static_ignores_inset__border_box_rtl() {
+        crate::run_xml_test("block", "block_static_ignores_inset__border_box_rtl");
+    }
+
+    #[test]
+    fn block_static_ignores_inset__content_box_rtl() {
+        crate::run_xml_test("block", "block_static_ignores_inset__content_box_rtl");
+    }
+
+    #[test]
     fn block_text_align_center_rtl__border_box_ltr() {
         crate::run_xml_test("block", "block_text_align_center_rtl__border_box_ltr");
     }
@@ -5213,6 +5313,26 @@ mod flex {
     #[test]
     fn absolute_aspect_ratio_width_overrides_inset__content_box_rtl() {
         crate::run_xml_test("flex", "absolute_aspect_ratio_width_overrides_inset__content_box_rtl");
+    }
+
+    #[test]
+    fn absolute_child_of_static_flex_container__border_box_ltr() {
+        crate::run_xml_test("flex", "absolute_child_of_static_flex_container__border_box_ltr");
+    }
+
+    #[test]
+    fn absolute_child_of_static_flex_container__content_box_ltr() {
+        crate::run_xml_test("flex", "absolute_child_of_static_flex_container__content_box_ltr");
+    }
+
+    #[test]
+    fn absolute_child_of_static_flex_container__border_box_rtl() {
+        crate::run_xml_test("flex", "absolute_child_of_static_flex_container__border_box_rtl");
+    }
+
+    #[test]
+    fn absolute_child_of_static_flex_container__content_box_rtl() {
+        crate::run_xml_test("flex", "absolute_child_of_static_flex_container__content_box_rtl");
     }
 
     #[test]
@@ -16503,6 +16623,30 @@ mod grid {
     #[test]
     fn grid_absolute_align_self_sized_all__content_box_rtl() {
         crate::run_xml_test("grid", "grid_absolute_align_self_sized_all__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_child_of_static_grid_container__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_child_of_static_grid_container__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_child_of_static_grid_container__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_child_of_static_grid_container__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_child_of_static_grid_container__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_child_of_static_grid_container__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_child_of_static_grid_container__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_child_of_static_grid_container__content_box_rtl");
     }
 
     #[cfg(feature = "grid")]


### PR DESCRIPTION
# Objective

Add `Position::Static` and `Position::Fixed` so that absolutely positioned nodes can be positioned relative to a non-direct-parent containing block, and fixed nodes relative to the viewport/initial containing block (implemented in Blitz in DioxusLabs/blitz#578).

- `Position::Static`: in flow like `Relative`, but ignores insets and (crucially) does *not* establish a containing block for absolute descendants.
- `Position::Fixed`: laid out like `Absolute`; the distinction lets the embedding tree resolve it against a fixed containing block (viewport or transformed ancestor).
- New `LayoutPartialTree::defer_absolute_child(child_id, order, static_position, static_position_direction)` hook (default: no-op). Block/flex/grid/inline call it — instead of laying the child out — when an absolute child's containing block is not the current node (i.e. the container's position is `Static`), passing the alignment-aware static position. Deferred children don't contribute to the non-containing parent's content size.
- The absolute child layout routine is extracted as a public shared helper `compute::absolute::compute_absolute_child_layout(...) -> AbsoluteChildLayout`, so embedders (Blitz's post-layout positioning pass) can lay deferred children out against their real containing block with identical inset/margin/min-max/static-fallback semantics.

Also includes two behaviour fixes found while testing against WPT:
- Auto margins on absolutely positioned boxes now only resolve when both insets in the axis are set, centre whenever there is free space, and follow the CSS2 §10.3.7 negative-free-space direction rule.
- Block-level replaced elements (`is_compressible_replaced()`) with `width: auto` are no longer stretched to the container width; they use their intrinsic width (CSS 2.1 §10.3.4), with the in-flow layout path measuring the child when its width is not otherwise known.

Defaults are unchanged (`Position::Relative` remains default; `defer_absolute_child` defaults to no-op), so existing `TaffyTree` users are unaffected. RELEASES.md/CHANGELOG updated.

## Context

Designed alongside DioxusLabs/blitz#578, which maps stylo `static`/`fixed` to the new variants and adds a post-layout pass that lays out deferred children against their real containing block using `compute_absolute_child_layout`. Verified against the WPT `css/CSS2/positioning`, `css/css-position`, `css/css-grid/abspos` and `css/css-flexbox/abspos` suites (net +90 passes across those suites with the Blitz PR, no regressions).

## Feedback wanted

- The shape of the `defer_absolute_child` hook (in particular passing the static-position direction separately so distant RTL containing blocks resolve the correct edge).
- The replaced-element non-stretch path measures the child an extra time when its width is auto; caching makes this cheap but the structure could be nicer.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/222d77e67e0947fcb4cec72499eed49c
Requested by: @nicoburns