### PR TITLE
Cache fixes: Axis correctness fix. Clock eviction. Don't cache margin-collapsing measures.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@ Why did you make this PR?
 If you're fixing a specific issue, say "Fixes #X" and the linked issue will be automatically closed when this PR is merged.
 If it's not obvious, describe how this changes made addressed the objectives.
 
-**Changes that will affect external library users must update RELEASES.md before they will be merged.**
+**Changes that will affect external library users must update CHANGELOG.md before they will be merged.**
 
 ## Context
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,13 @@
 
 - Flexbox/Block: absolutely positioned children are no longer measured when both of their dimensions are already known (e.g. from explicit sizes or insets), matching the existing grid behaviour
 
+- `CacheTree::cache_get` (and `Cache::get`) now take `&mut self`. The measure cache now uses second-chance (clock) eviction across its entries instead of a fixed slot-assignment scheme, which requires recently-used bookkeeping on reads. Implementors of `CacheTree` must update their `cache_get` implementations to take `&mut self`
+
 ### Fixed
+
+- Cache: a node's size measured for one axis is no longer returned from the cache when the other axis is queried. The cache key now records which axis (or both) a measure result was computed for, and only serves entries valid for the requested axis. Previously e.g. a width-only measure of a block container (which computes no height) could later be served for a height query, returning a garbage height
+
+- Cache: measure results whose `LayoutOutput` carries margin-collapse metadata (`margins_can_collapse_through`, or non-zero `top_margin`/`bottom_margin`) are no longer cached, as measure cache entries only store the size and cache hits would return that metadata zeroed, breaking margin collapsing in block layout
 
 - Flexbox: intrinsic main sizing now applies negative main-axis margins as lengths for non-shrinking items, and zero-basis items no longer collapse the intrinsic container size (#1151)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Cache: measure results computed for a single axis are no longer returned for queries in the other axis. Algorithms may return a garbage size in the non-requested axis (e.g. the block algorithm short-circuits width-only measures with a height of `0.0`), which could cause grid items in intrinsically-sized rows to collapse to zero height and overlap when an intrinsic column-sizing pass measured the items' widths before the row-sizing pass
+
 - Grid: tracks no longer grow past their growth limits when distributing free space to multiple tracks with asymmetric limits (in the "maximise tracks" step and when distributing item contributions to base sizes). Previously a track could be assigned space beyond its limit in later distribution iterations, causing `auto` tracks to overflow a definite container (#1000)
 
 - Flexbox: min/max sizes transferred through the aspect ratio now clamp the flex base size, the automatic minimum size, and the hypothetical main/cross sizes of flex items, instead of being baked into the item's used min/max sizes. This matches browser behaviour for replaced elements and items with `aspect-ratio` combined with min/max constraints in the opposite axis ([w3c/csswg-drafts#10997](https://github.com/w3c/csswg-drafts/issues/10997))

--- a/examples/custom_tree_owned_partial.rs
+++ b/examples/custom_tree_owned_partial.rs
@@ -187,8 +187,8 @@ impl taffy::LayoutPartialTree for Node {
 }
 
 impl CacheTree for Node {
-    fn cache_get(&self, node_id: NodeId, inputs: &taffy::LayoutInput) -> Option<taffy::LayoutOutput> {
-        self.node_from_id(node_id).cache.get(inputs)
+    fn cache_get(&mut self, node_id: NodeId, inputs: &taffy::LayoutInput) -> Option<taffy::LayoutOutput> {
+        self.node_from_id_mut(node_id).cache.get(inputs)
     }
 
     fn cache_store(&mut self, node_id: NodeId, inputs: &taffy::LayoutInput, layout_output: taffy::LayoutOutput) {

--- a/examples/custom_tree_owned_unsafe.rs
+++ b/examples/custom_tree_owned_unsafe.rs
@@ -185,8 +185,8 @@ impl LayoutPartialTree for StatelessLayoutTree {
 }
 
 impl CacheTree for StatelessLayoutTree {
-    fn cache_get(&self, node_id: NodeId, inputs: &taffy::LayoutInput) -> Option<taffy::LayoutOutput> {
-        unsafe { node_from_id(node_id) }.cache.get(inputs)
+    fn cache_get(&mut self, node_id: NodeId, inputs: &taffy::LayoutInput) -> Option<taffy::LayoutOutput> {
+        unsafe { node_from_id_mut(node_id) }.cache.get(inputs)
     }
 
     fn cache_store(&mut self, node_id: NodeId, inputs: &taffy::LayoutInput, layout_output: taffy::LayoutOutput) {

--- a/examples/custom_tree_vec.rs
+++ b/examples/custom_tree_vec.rs
@@ -193,8 +193,8 @@ impl taffy::LayoutPartialTree for Tree {
 }
 
 impl CacheTree for Tree {
-    fn cache_get(&self, node_id: NodeId, inputs: &taffy::LayoutInput) -> Option<taffy::LayoutOutput> {
-        self.node_from_id(node_id).cache.get(inputs)
+    fn cache_get(&mut self, node_id: NodeId, inputs: &taffy::LayoutInput) -> Option<taffy::LayoutOutput> {
+        self.node_from_id_mut(node_id).cache.get(inputs)
     }
 
     fn cache_store(&mut self, node_id: NodeId, inputs: &taffy::LayoutInput, layout_output: taffy::LayoutOutput) {

--- a/src/tree/cache.rs
+++ b/src/tree/cache.rs
@@ -104,6 +104,19 @@ impl CacheKey {
     fn x_axis_parent_size(&self) -> u64 {
         self.parent_size & (X_AXIS_VALUE_MASK & NON_SIGN_BITS_MASK)
     }
+
+    /// Return the bits that encode the requested axis
+    fn requested_axis_bits(&self) -> u64 {
+        self.parent_size & BOTH_SIGN_BITS_MASK
+    }
+
+    /// Whether a cached entry with this key contains a valid size for the axis requested by `other`.
+    /// Sizes computed for a single axis may contain garbage values in the other axis, so an entry
+    /// is only usable if it was computed for the same axis (or for both axes).
+    fn size_is_valid_for(&self, other: &CacheKey) -> bool {
+        let entry_axis = self.requested_axis_bits();
+        entry_axis == BOTH_SIGN_BITS_MASK || entry_axis == other.requested_axis_bits()
+    }
 }
 
 impl From<&LayoutInput> for CacheKey {
@@ -230,6 +243,7 @@ impl Cache {
                 for entry in self.measure_entries.iter().flatten() {
                     if entry.key.kd_available_space == key.kd_available_space
                         && (entry.key.x_axis_parent_size() == key.x_axis_parent_size())
+                        && entry.key.size_is_valid_for(&key)
                     {
                         return Some(LayoutOutput::from_outer_size(entry.content));
                     }

--- a/src/tree/cache.rs
+++ b/src/tree/cache.rs
@@ -4,7 +4,7 @@
 
 use crate::geometry::Size;
 use crate::style::AvailableSpace;
-use crate::tree::{LayoutInput, LayoutOutput, RunMode};
+use crate::tree::{CollapsibleMarginSet, LayoutInput, LayoutOutput, RunMode};
 use crate::RequestedAxis;
 
 /// The number of cache entries for each node in the tree
@@ -219,6 +219,16 @@ impl Cache {
                 self.final_layout_entry = Some(CacheEntry { key, content: layout_output })
             }
             RunMode::ComputeSize => {
+                // Measure entries only store the size, and cache hits are reconstructed with
+                // `LayoutOutput::from_outer_size`, which resets the margin-collapse metadata
+                // (`top_margin`, `bottom_margin`, `margins_can_collapse_through`). Results that
+                // carry such metadata cannot be reconstructed from their size, so don't cache them.
+                if layout_output.margins_can_collapse_through
+                    || layout_output.top_margin != CollapsibleMarginSet::ZERO
+                    || layout_output.bottom_margin != CollapsibleMarginSet::ZERO
+                {
+                    return;
+                }
                 self.is_empty = false;
                 if let Some(index) =
                     self.measure_entries.iter().position(|entry| entry.is_some_and(|entry| entry.key == key))
@@ -320,6 +330,21 @@ mod tests {
 
         assert_eq!(cache.measure_entries.iter().flatten().count(), 2);
         assert_eq!(cache.get(&input(1.0)), Some(output(3.0)));
+    }
+
+    #[test]
+    fn measurements_with_margin_collapse_metadata_are_not_cached() {
+        let mut cache = Cache::new();
+
+        let mut collapse_through = output(1.0);
+        collapse_through.margins_can_collapse_through = true;
+        cache.store(&input(1.0), collapse_through);
+        assert_eq!(cache.get(&input(1.0)), None);
+
+        let mut carried_margin = output(2.0);
+        carried_margin.top_margin = CollapsibleMarginSet::from_margin(10.0);
+        cache.store(&input(2.0), carried_margin);
+        assert_eq!(cache.get(&input(2.0)), None);
     }
 
     #[test]

--- a/src/tree/cache.rs
+++ b/src/tree/cache.rs
@@ -107,6 +107,19 @@ impl CacheKey {
     fn x_axis_parent_size(&self) -> u64 {
         self.parent_size & (X_AXIS_VALUE_MASK & NON_SIGN_BITS_MASK)
     }
+
+    /// Return the bits that encode the requested axis
+    fn requested_axis_bits(&self) -> u64 {
+        self.parent_size & BOTH_SIGN_BITS_MASK
+    }
+
+    /// Whether a cached entry with this key contains a valid size for the axis requested by `other`.
+    /// Sizes computed for a single axis may contain garbage values in the other axis, so an entry
+    /// is only usable if it was computed for the same axis (or for both axes).
+    fn size_is_valid_for(&self, other: &CacheKey) -> bool {
+        let entry_axis = self.requested_axis_bits();
+        entry_axis == BOTH_SIGN_BITS_MASK || entry_axis == other.requested_axis_bits()
+    }
 }
 
 impl From<&LayoutInput> for CacheKey {
@@ -237,6 +250,7 @@ impl Cache {
                     if entry.key.kd_available_space == key.kd_available_space
                         && entry.key.known_dimensions_are_definite == key.known_dimensions_are_definite
                         && (entry.key.x_axis_parent_size() == key.x_axis_parent_size())
+                        && entry.key.size_is_valid_for(&key)
                     {
                         return Some(LayoutOutput::from_outer_size(entry.content));
                     }

--- a/src/tree/cache.rs
+++ b/src/tree/cache.rs
@@ -159,6 +159,8 @@ pub struct Cache {
     final_layout_entry: Option<CacheEntry<LayoutOutput>>,
     /// The cache entries for the node's preliminary size measurements
     measure_entries: [Option<CacheEntry<Size<f32>>>; CACHE_SIZE],
+    /// The indices of the measure entries, ordered from most to least recently used
+    measure_entry_order: [u8; CACHE_SIZE],
     /// Tracks if all cache entries are empty
     is_empty: bool,
 }
@@ -172,91 +174,33 @@ impl Default for Cache {
 impl Cache {
     /// Create a new empty cache
     pub const fn new() -> Self {
-        Self { final_layout_entry: None, measure_entries: [None; CACHE_SIZE], is_empty: true }
-    }
-
-    /// Return the cache slot to cache the current computed result in
-    ///
-    /// ## Caching Strategy
-    ///
-    /// We need multiple cache slots, because a node's size is often queried by it's parent multiple times in the course of the layout
-    /// process, and we don't want later results to clobber earlier ones.
-    ///
-    /// The two variables that we care about when determining cache slot are:
-    ///
-    ///   - How many "known_dimensions" are set. In the worst case, a node may be called first with neither dimension known, then with one
-    ///     dimension known (either width of height - which doesn't matter for our purposes here), and then with both dimensions known.
-    ///   - Whether unknown dimensions are being sized under a min-content or a max-content available space constraint (definite available space
-    ///     shares a cache slot with max-content because a node will generally be sized under one or the other but not both).
-    ///
-    /// ## Cache slots:
-    ///
-    /// - Slot 0: Both known_dimensions were set
-    /// - Slots 1-4: 1 of 2 known_dimensions were set and:
-    ///   - Slot 1: width but not height known_dimension was set and the other dimension was either a MaxContent or Definite available space constraintraint
-    ///   - Slot 2: width but not height known_dimension was set and the other dimension was a MinContent constraint
-    ///   - Slot 3: height but not width known_dimension was set and the other dimension was either a MaxContent or Definite available space constraintable space constraint
-    ///   - Slot 4: height but not width known_dimension was set and the other dimension was a MinContent constraint
-    /// - Slots 5-8: Neither known_dimensions were set and:
-    ///   - Slot 5: x-axis available space is MaxContent or Definite and y-axis available space is MaxContent or Definite
-    ///   - Slot 6: x-axis available space is MaxContent or Definite and y-axis available space is MinContent
-    ///   - Slot 7: x-axis available space is MinContent and y-axis available space is MaxContent or Definite
-    ///   - Slot 8: x-axis available space is MinContent and y-axis available space is MinContent
-    #[inline]
-    fn compute_cache_slot(known_dimensions: Size<Option<f32>>, available_space: Size<AvailableSpace>) -> usize {
-        use AvailableSpace::{Definite, MaxContent, MinContent};
-
-        let has_known_width = known_dimensions.width.is_some();
-        let has_known_height = known_dimensions.height.is_some();
-
-        // Slot 0: Both known_dimensions were set
-        if has_known_width && has_known_height {
-            return 0;
-        }
-
-        // Slot 1: width but not height known_dimension was set and the other dimension was either a MaxContent or Definite available space constraint
-        // Slot 2: width but not height known_dimension was set and the other dimension was a MinContent constraint
-        if has_known_width && !has_known_height {
-            return 1 + (available_space.height == MinContent) as usize;
-        }
-
-        // Slot 3: height but not width known_dimension was set and the other dimension was either a MaxContent or Definite available space constraint
-        // Slot 4: height but not width known_dimension was set and the other dimension was a MinContent constraint
-        if has_known_height && !has_known_width {
-            return 3 + (available_space.width == MinContent) as usize;
-        }
-
-        // Slots 5-8: Neither known_dimensions were set and:
-        match (available_space.width, available_space.height) {
-            // Slot 5: x-axis available space is MaxContent or Definite and y-axis available space is MaxContent or Definite
-            (MaxContent | Definite(_), MaxContent | Definite(_)) => 5,
-            // Slot 6: x-axis available space is MaxContent or Definite and y-axis available space is MinContent
-            (MaxContent | Definite(_), MinContent) => 6,
-            // Slot 7: x-axis available space is MinContent and y-axis available space is MaxContent or Definite
-            (MinContent, MaxContent | Definite(_)) => 7,
-            // Slot 8: x-axis available space is MinContent and y-axis available space is MinContent
-            (MinContent, MinContent) => 8,
+        Self {
+            final_layout_entry: None,
+            measure_entries: [None; CACHE_SIZE],
+            measure_entry_order: [0, 1, 2, 3, 4, 5, 6, 7, 8],
+            is_empty: true,
         }
     }
 
     /// Try to retrieve a cached result from the cache
     #[inline]
-    pub fn get(&self, input: &LayoutInput) -> Option<LayoutOutput> {
+    pub fn get(&mut self, input: &LayoutInput) -> Option<LayoutOutput> {
         let key = CacheKey::from(input);
         match input.run_mode {
             RunMode::PerformLayout => self.final_layout_entry.filter(|entry| entry.key == key).map(|e| e.content),
             RunMode::ComputeSize => {
-                for entry in self.measure_entries.iter().flatten() {
-                    if entry.key.kd_available_space == key.kd_available_space
-                        && entry.key.known_dimensions_are_definite == key.known_dimensions_are_definite
-                        && (entry.key.x_axis_parent_size() == key.x_axis_parent_size())
-                        && entry.key.size_is_valid_for(&key)
-                    {
-                        return Some(LayoutOutput::from_outer_size(entry.content));
-                    }
-                }
-
-                None
+                let order_index = self.measure_entry_order.iter().position(|&entry_index| {
+                    self.measure_entries[entry_index as usize].is_some_and(|entry| {
+                        entry.key.kd_available_space == key.kd_available_space
+                            && entry.key.known_dimensions_are_definite == key.known_dimensions_are_definite
+                            && (entry.key.x_axis_parent_size() == key.x_axis_parent_size())
+                            && entry.key.size_is_valid_for(&key)
+                    })
+                })?;
+                let entry_index = self.measure_entry_order[order_index] as usize;
+                let content = self.measure_entries[entry_index].unwrap().content;
+                self.measure_entry_order[..=order_index].rotate_right(1);
+                Some(LayoutOutput::from_outer_size(content))
             }
             RunMode::PerformHiddenLayout => None,
         }
@@ -272,8 +216,16 @@ impl Cache {
             }
             RunMode::ComputeSize => {
                 self.is_empty = false;
-                let cache_slot = Self::compute_cache_slot(input.known_dimensions, input.available_space);
-                self.measure_entries[cache_slot] = Some(CacheEntry { key, content: layout_output.size });
+                let order_index = self
+                    .measure_entry_order
+                    .iter()
+                    .position(|&entry_index| {
+                        self.measure_entries[entry_index as usize].is_some_and(|entry| entry.key == key)
+                    })
+                    .unwrap_or(CACHE_SIZE - 1);
+                let entry_index = self.measure_entry_order[order_index] as usize;
+                self.measure_entry_order[..=order_index].rotate_right(1);
+                self.measure_entries[entry_index] = Some(CacheEntry { key, content: layout_output.size });
             }
             RunMode::PerformHiddenLayout => {}
         }
@@ -287,6 +239,7 @@ impl Cache {
         self.is_empty = true;
         self.final_layout_entry = None;
         self.measure_entries = [None; CACHE_SIZE];
+        self.measure_entry_order = [0, 1, 2, 3, 4, 5, 6, 7, 8];
         ClearState::Cleared
     }
 
@@ -302,4 +255,66 @@ pub enum ClearState {
     Cleared,
     /// Everything was already cleared
     AlreadyEmpty,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::geometry::Line;
+    use crate::tree::SizingMode;
+
+    fn input(width: f32) -> LayoutInput {
+        LayoutInput {
+            run_mode: RunMode::ComputeSize,
+            sizing_mode: SizingMode::InherentSize,
+            axis: RequestedAxis::Both,
+            known_dimensions: Size { width: Some(width), height: None },
+            known_dimensions_are_definite: Size { width: true, height: true },
+            parent_size: Size::NONE,
+            available_space: Size { width: AvailableSpace::MaxContent, height: AvailableSpace::MaxContent },
+            vertical_margins_are_collapsible: Line::FALSE,
+        }
+    }
+
+    fn output(width: f32) -> LayoutOutput {
+        LayoutOutput::from_outer_size(Size { width, height: width })
+    }
+
+    #[test]
+    fn measure_entries_are_evicted_in_least_recently_used_order() {
+        let mut cache = Cache::new();
+        for width in 0..CACHE_SIZE {
+            cache.store(&input(width as f32), output(width as f32));
+        }
+
+        assert_eq!(cache.get(&input(0.0)), Some(output(0.0)));
+        cache.store(&input(CACHE_SIZE as f32), output(CACHE_SIZE as f32));
+
+        assert_eq!(cache.get(&input(1.0)), None);
+        assert_eq!(cache.get(&input(0.0)), Some(output(0.0)));
+    }
+
+    #[test]
+    fn storing_an_existing_measurement_updates_and_promotes_it() {
+        let mut cache = Cache::new();
+        cache.store(&input(1.0), output(1.0));
+        cache.store(&input(2.0), output(2.0));
+        cache.store(&input(1.0), output(3.0));
+
+        assert_eq!(cache.measure_entries.iter().flatten().count(), 2);
+        assert_eq!(cache.get(&input(1.0)), Some(output(3.0)));
+    }
+
+    #[test]
+    fn retrieving_a_measurement_only_reorders_slot_indices() {
+        let mut cache = Cache::new();
+        cache.store(&input(1.0), output(1.0));
+        cache.store(&input(2.0), output(2.0));
+        let entries = cache.measure_entries;
+        let order = cache.measure_entry_order;
+
+        assert_eq!(cache.get(&input(1.0)), Some(output(1.0)));
+        assert_eq!(cache.measure_entries, entries);
+        assert_ne!(cache.measure_entry_order, order);
+    }
 }

--- a/src/tree/cache.rs
+++ b/src/tree/cache.rs
@@ -159,8 +159,10 @@ pub struct Cache {
     final_layout_entry: Option<CacheEntry<LayoutOutput>>,
     /// The cache entries for the node's preliminary size measurements
     measure_entries: [Option<CacheEntry<Size<f32>>>; CACHE_SIZE],
-    /// The indices of the measure entries, ordered from most to least recently used
-    measure_entry_order: [u8; CACHE_SIZE],
+    /// Tracks which measure entries have been used since the eviction cursor last passed them
+    recently_used_entries: u16,
+    /// The next measure entry to consider replacing
+    next_measure_entry: u8,
     /// Tracks if all cache entries are empty
     is_empty: bool,
 }
@@ -177,7 +179,8 @@ impl Cache {
         Self {
             final_layout_entry: None,
             measure_entries: [None; CACHE_SIZE],
-            measure_entry_order: [0, 1, 2, 3, 4, 5, 6, 7, 8],
+            recently_used_entries: 0,
+            next_measure_entry: 0,
             is_empty: true,
         }
     }
@@ -189,18 +192,19 @@ impl Cache {
         match input.run_mode {
             RunMode::PerformLayout => self.final_layout_entry.filter(|entry| entry.key == key).map(|e| e.content),
             RunMode::ComputeSize => {
-                let order_index = self.measure_entry_order.iter().position(|&entry_index| {
-                    self.measure_entries[entry_index as usize].is_some_and(|entry| {
-                        entry.key.kd_available_space == key.kd_available_space
-                            && entry.key.known_dimensions_are_definite == key.known_dimensions_are_definite
-                            && (entry.key.x_axis_parent_size() == key.x_axis_parent_size())
-                            && entry.key.size_is_valid_for(&key)
-                    })
-                })?;
-                let entry_index = self.measure_entry_order[order_index] as usize;
-                let content = self.measure_entries[entry_index].unwrap().content;
-                self.measure_entry_order[..=order_index].rotate_right(1);
-                Some(LayoutOutput::from_outer_size(content))
+                for (index, entry) in self.measure_entries.iter().enumerate() {
+                    let Some(entry) = entry else { continue };
+                    if entry.key.kd_available_space == key.kd_available_space
+                        && entry.key.known_dimensions_are_definite == key.known_dimensions_are_definite
+                        && (entry.key.x_axis_parent_size() == key.x_axis_parent_size())
+                        && entry.key.size_is_valid_for(&key)
+                    {
+                        self.recently_used_entries |= 1 << index;
+                        return Some(LayoutOutput::from_outer_size(entry.content));
+                    }
+                }
+
+                None
             }
             RunMode::PerformHiddenLayout => None,
         }
@@ -216,16 +220,27 @@ impl Cache {
             }
             RunMode::ComputeSize => {
                 self.is_empty = false;
-                let order_index = self
-                    .measure_entry_order
-                    .iter()
-                    .position(|&entry_index| {
-                        self.measure_entries[entry_index as usize].is_some_and(|entry| entry.key == key)
-                    })
-                    .unwrap_or(CACHE_SIZE - 1);
-                let entry_index = self.measure_entry_order[order_index] as usize;
-                self.measure_entry_order[..=order_index].rotate_right(1);
+                if let Some(index) =
+                    self.measure_entries.iter().position(|entry| entry.is_some_and(|entry| entry.key == key))
+                {
+                    self.measure_entries[index].as_mut().unwrap().content = layout_output.size;
+                    self.recently_used_entries |= 1 << index;
+                    return;
+                }
+                while self.recently_used_entries & (1 << self.next_measure_entry) != 0 {
+                    self.recently_used_entries &= !(1 << self.next_measure_entry);
+                    self.next_measure_entry += 1;
+                    if self.next_measure_entry == CACHE_SIZE as u8 {
+                        self.next_measure_entry = 0;
+                    }
+                }
+                let entry_index = self.next_measure_entry as usize;
                 self.measure_entries[entry_index] = Some(CacheEntry { key, content: layout_output.size });
+                self.recently_used_entries |= 1 << entry_index;
+                self.next_measure_entry += 1;
+                if self.next_measure_entry == CACHE_SIZE as u8 {
+                    self.next_measure_entry = 0;
+                }
             }
             RunMode::PerformHiddenLayout => {}
         }
@@ -239,7 +254,8 @@ impl Cache {
         self.is_empty = true;
         self.final_layout_entry = None;
         self.measure_entries = [None; CACHE_SIZE];
-        self.measure_entry_order = [0, 1, 2, 3, 4, 5, 6, 7, 8];
+        self.recently_used_entries = 0;
+        self.next_measure_entry = 0;
         ClearState::Cleared
     }
 
@@ -281,21 +297,22 @@ mod tests {
     }
 
     #[test]
-    fn measure_entries_are_evicted_in_least_recently_used_order() {
+    fn recently_used_measure_entries_get_a_second_chance() {
         let mut cache = Cache::new();
         for width in 0..CACHE_SIZE {
             cache.store(&input(width as f32), output(width as f32));
         }
-
-        assert_eq!(cache.get(&input(0.0)), Some(output(0.0)));
         cache.store(&input(CACHE_SIZE as f32), output(CACHE_SIZE as f32));
 
-        assert_eq!(cache.get(&input(1.0)), None);
-        assert_eq!(cache.get(&input(0.0)), Some(output(0.0)));
+        assert_eq!(cache.get(&input(1.0)), Some(output(1.0)));
+        cache.store(&input((CACHE_SIZE + 1) as f32), output((CACHE_SIZE + 1) as f32));
+
+        assert_eq!(cache.get(&input(1.0)), Some(output(1.0)));
+        assert_eq!(cache.get(&input(2.0)), None);
     }
 
     #[test]
-    fn storing_an_existing_measurement_updates_and_promotes_it() {
+    fn storing_an_existing_measurement_updates_it_in_place() {
         let mut cache = Cache::new();
         cache.store(&input(1.0), output(1.0));
         cache.store(&input(2.0), output(2.0));
@@ -306,15 +323,15 @@ mod tests {
     }
 
     #[test]
-    fn retrieving_a_measurement_only_reorders_slot_indices() {
+    fn retrieving_a_measurement_only_marks_its_slot_as_used() {
         let mut cache = Cache::new();
         cache.store(&input(1.0), output(1.0));
         cache.store(&input(2.0), output(2.0));
+        cache.recently_used_entries = 0;
         let entries = cache.measure_entries;
-        let order = cache.measure_entry_order;
 
         assert_eq!(cache.get(&input(1.0)), Some(output(1.0)));
         assert_eq!(cache.measure_entries, entries);
-        assert_ne!(cache.measure_entry_order, order);
+        assert_ne!(cache.recently_used_entries, 0);
     }
 }

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -210,7 +210,7 @@ impl<NodeContext> TraverseTree for TaffyTree<NodeContext> {}
 
 // CacheTree impl for TaffyTree
 impl<NodeContext> CacheTree for TaffyTree<NodeContext> {
-    fn cache_get(&self, node_id: NodeId, input: &LayoutInput) -> Option<LayoutOutput> {
+    fn cache_get(&mut self, node_id: NodeId, input: &LayoutInput) -> Option<LayoutOutput> {
         self.nodes[node_id.into()].cache.get(input)
     }
 
@@ -403,7 +403,7 @@ impl<NodeContext, MeasureFunction> CacheTree for TaffyView<'_, NodeContext, Meas
 where
     MeasureFunction: FnMut(LayoutInput, NodeId, Option<&mut NodeContext>, &Style) -> LayoutOutput,
 {
-    fn cache_get(&self, node_id: NodeId, input: &LayoutInput) -> Option<LayoutOutput> {
+    fn cache_get(&mut self, node_id: NodeId, input: &LayoutInput) -> Option<LayoutOutput> {
         self.taffy.nodes[node_id.into()].cache.get(input)
     }
 

--- a/src/tree/traits.rs
+++ b/src/tree/traits.rs
@@ -205,7 +205,7 @@ pub trait LayoutPartialTree: TraversePartialTree {
 /// The `Cache` struct implements a per-node cache that is compatible with this trait.
 pub trait CacheTree {
     /// Try to retrieve a cached result from the cache
-    fn cache_get(&self, node_id: NodeId, input: &LayoutInput) -> Option<LayoutOutput>;
+    fn cache_get(&mut self, node_id: NodeId, input: &LayoutInput) -> Option<LayoutOutput>;
 
     /// Store a computed size in the cache
     fn cache_store(&mut self, node_id: NodeId, input: &LayoutInput, layout_output: LayoutOutput);

--- a/tests/hand_written/caching.rs
+++ b/tests/hand_written/caching.rs
@@ -37,4 +37,58 @@ mod caching {
         taffy.compute_layout_with_measure(node, Size::MAX_CONTENT, test_measure_function).unwrap();
         assert_eq!(taffy.get_node_context_mut(leaf).unwrap().count, 7);
     }
+
+    /// A node's size measured for one axis must not be returned from the cache when the other
+    /// axis is queried, as the size in the non-requested axis is not guaranteed to be valid.
+    #[test]
+    #[cfg(all(feature = "grid", feature = "block_layout"))]
+    fn grid_block_item_height_not_polluted_by_width_measure() {
+        let mut taffy = new_test_tree();
+
+        let item_style = |row: i16| Style {
+            display: Display::Block,
+            grid_row: taffy::geometry::Line { start: line(row), end: line(row + 1) },
+            grid_column: taffy::geometry::Line { start: line(1), end: line(2) },
+            ..Default::default()
+        };
+
+        // Each grid item is a block container wrapping a measured leaf. The block layout
+        // algorithm short-circuits width-only measures without computing a height, so a
+        // subsequent height query must not reuse that cached result.
+        let mut make_item = |row: i16| {
+            let leaf = taffy.new_leaf_with_context(Style::default(), TestNodeContext::fixed(100.0, 19.0)).unwrap();
+            taffy.new_with_children(item_style(row), &[leaf]).unwrap()
+        };
+        let a = make_item(1);
+        let b = make_item(2);
+        let c = make_item(3);
+
+        let container = taffy
+            .new_with_children(
+                Style {
+                    display: Display::Grid,
+                    // The `auto` column is required to trigger intrinsic (width) sizing of the
+                    // items before the row-sizing (height) pass.
+                    grid_template_columns: vec![percent(0.6), auto()],
+                    size: Size { width: length(1000.0), height: auto() },
+                    ..Default::default()
+                },
+                &[a, b, c],
+            )
+            .unwrap();
+
+        taffy
+            .compute_layout_with_measure(
+                container,
+                Size { width: AvailableSpace::Definite(1000.0), height: AvailableSpace::Definite(1000.0) },
+                test_measure_function,
+            )
+            .unwrap();
+
+        for (index, node) in [a, b, c].into_iter().enumerate() {
+            let layout = taffy.layout(node).unwrap();
+            assert_eq!(layout.size.height, 19.0);
+            assert_eq!(layout.location.y, 19.0 * index as f32);
+        }
+    }
 }


### PR DESCRIPTION
# Objective

Fix the measure cache returning results computed for one axis in response to queries for the other axis, and stop caching measure results whose margin-collapse metadata cannot be reconstructed on a cache hit.

The block layout algorithm short-circuits width-only measures without computing a height. Previously such an entry could later be served for a height query, returning a garbage height (observed as broken grid/block item heights in Blitz).

## Changes (vs `main`)

**Axis-validity guard**: `CacheKey` now encodes the `RequestedAxis` of the request (packed into the spare sign bits of the `parent_size` key). A measure entry is only served if it was computed for both axes or for the same axis as the query (`CacheKey::size_is_valid_for`).

**Second-chance (clock) eviction replaces fixed slot assignment**: `compute_cache_slot` is removed. Measure entries are now stored in the first evictable slot chosen by a clock algorithm: a `recently_used_entries` bitmask marks entries that hit (or were re-stored) since the eviction cursor (`next_measure_entry`) last passed them; the cursor skips-and-clears recently-used slots and evicts the first cold one. Storing an entry with an identical key updates it in place. This keeps hot entries alive now that entries are differentiated by requested axis rather than by a fixed slot scheme. As a consequence `Cache::get` (and `CacheTree::cache_get`) now take `&mut self`.

**Don't cache measure results that carry margin-collapse metadata**: measure entries only store `Size<f32>`, and hits are reconstructed with `LayoutOutput::from_outer_size`, which zeroes `top_margin`/`bottom_margin` and `margins_can_collapse_through`. With the axis guard in place, such reconstructed results started being consumed by block layout (previously masked by cross-axis hits), regressing WPT `margin-collapse-113.xht`/`115.xht` in Blitz (empty blocks stopped collapsing through, adding a spurious 100px). Results carrying that metadata are now simply not stored:

```rust
RunMode::ComputeSize => {
    if layout_output.margins_can_collapse_through
        || layout_output.top_margin != CollapsibleMarginSet::ZERO
        || layout_output.bottom_margin != CollapsibleMarginSet::ZERO
    {
        return;
    }
    // ... store size-only entry
}
```

## Breaking change

`CacheTree::cache_get` now takes `&mut self` (needed for LRU bookkeeping on read). Implementors must update their impls (examples updated in this PR).

## Context

Verified against Blitz (DioxusLabs/blitz#776): the previously-regressed `margin-collapse-113.xht`/`115.xht` now pass, and `css/CSS2/margin-padding-clear` plus the flexbox/grid WPT suites score one test higher than Blitz `main` with no regressions. Full Taffy test suite passes; hand-written tests cover the axis guard, eviction behaviour, and the metadata no-store rule (cache-behaviour tests can't be expressed as gentests).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/7dfa80b22d3b4a8eaa88cc617fa69e11
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/7dfa80b22d3b4a8eaa88cc617fa69e11?variant=devin-insiders
Requested by: @nicoburns