### PR TITLE
More overlarge-grid gentests; clamp spans before RTL mirroring

### DIFF
--- a/src/compute/grid/placement.rs
+++ b/src/compute/grid/placement.rs
@@ -68,7 +68,9 @@ fn maybe_mirror_span(
     explicit_col_count: u16,
 ) -> Line<OriginZeroLine> {
     if axis == AbsoluteAxis::Horizontal && direction.is_rtl() {
-        mirror_horizontal_span(span, explicit_col_count)
+        // Clamp into the limited grid before mirroring so that placements outside of the limited
+        // grid mirror to the same tracks as their clamped equivalents
+        mirror_horizontal_span(clamp_span_to_limited_grid(span), explicit_col_count)
     } else {
         span
     }

--- a/src/compute/grid/types/cell_occupancy.rs
+++ b/src/compute/grid/types/cell_occupancy.rs
@@ -45,6 +45,10 @@ impl Debug for CellOccupancyMatrix {
             "Cols: neg_implicit={} explicit={} pos_implicit={}",
             self.columns.negative_implicit, self.columns.explicit, self.columns.positive_implicit
         )?;
+        if self.inner.rows() > 100 || self.inner.cols() > 100 {
+            writeln!(f, "State: (not printed: more than 100 tracks)")?;
+            return Ok(());
+        }
         writeln!(f, "State:")?;
 
         for row_idx in 0..self.inner.rows() {

--- a/test_fixtures/grid/grid_overlarge_auto_flow_after_max_row_item.html
+++ b/test_fixtures/grid/grid_overlarge_auto_flow_after_max_row_item.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Auto-placed items following an item on the maximum row line
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-auto-rows: 0px;">
+  <div style="background: #59c4f6; width: 20px; height: 20px; grid-row-start: 10000;"></div>
+  <div style="background: #63c466; width: 20px; height: 20px;"></div>
+  <div style="background: #feb43f; width: 20px; height: 20px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_overlarge_auto_flow_column_dense_extreme_row.html
+++ b/test_fixtures/grid/grid_overlarge_auto_flow_column_dense_extreme_row.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Dense column auto-flow with an item on an extreme negative row
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-auto-flow: column dense; grid-auto-rows: 0px; grid-auto-columns: 0px;">
+  <div style="background: #59c4f6; width: 20px; height: 20px; grid-row-start: -30000;"></div>
+  <div style="background: #63c466; width: 20px; height: 20px; grid-column-start: 5;"></div>
+  <div style="background: #feb43f; width: 20px; height: 20px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_overlarge_auto_flow_column_huge_row_span.html
+++ b/test_fixtures/grid/grid_overlarge_auto_flow_column_huge_row_span.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Column auto-flow with an auto-placed item spanning a huge number of rows
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-auto-flow: column; grid-auto-rows: 0px; grid-auto-columns: 0px;">
+  <div style="background: #59c4f6; width: 20px; height: 20px; grid-row: span 15000;"></div>
+  <div style="background: #63c466; width: 20px; height: 20px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_overlarge_auto_placed_huge_span.html
+++ b/test_fixtures/grid/grid_overlarge_auto_placed_huge_span.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Auto-placed item with a span greater than the track limit
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-auto-columns: 0px;">
+  <div style="background: #59c4f6; height: 20px; grid-column: span 15000;"></div>
+  <div style="background: #63c466; width: 20px; height: 20px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_overlarge_explicit_tracks_at_limit.html
+++ b/test_fixtures/grid/grid_overlarge_explicit_tracks_at_limit.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Exactly 10000 explicit zero-sized tracks with an item placed in the last track
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-columns: repeat(10000, 0px);">
+  <div style="background: #59c4f6; width: 20px; height: 20px; grid-column: 10000 / 10001;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_overlarge_explicit_tracks_just_over_limit.html
+++ b/test_fixtures/grid/grid_overlarge_explicit_tracks_just_over_limit.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    10001 explicit zero-sized tracks with an item placed in the last track
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-columns: repeat(10001, 0px);">
+  <div style="background: #59c4f6; width: 20px; height: 20px; grid-column: 10001 / 10002;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_overlarge_extreme_both_directions.html
+++ b/test_fixtures/grid/grid_overlarge_extreme_both_directions.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Item spanning from a large negative line to a large positive line
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-auto-columns: 0px;">
+  <div style="background: #59c4f6; height: 20px; grid-column: -15000 / 15000;"></div>
+  <div style="background: #63c466; width: 20px; height: 20px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_overlarge_negative_line_with_explicit_tracks.html
+++ b/test_fixtures/grid/grid_overlarge_negative_line_with_explicit_tracks.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Large negative line combined with a large explicit track count
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-columns: repeat(9000, 0px);">
+  <div style="background: #59c4f6; width: 20px; height: 20px; grid-column-start: -19005;"></div>
+  <div style="background: #63c466; width: 20px; height: 20px; grid-column-start: 9000;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_overlarge_negative_span_from_negative_line.html
+++ b/test_fixtures/grid/grid_overlarge_negative_span_from_negative_line.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Item spanning a large number of tracks from a large negative start line
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-auto-columns: 0px;">
+  <div style="background: #59c4f6; height: 20px; grid-column: -10001 / span 10000;"></div>
+  <div style="background: #63c466; width: 20px; height: 20px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_overlarge_negative_start_huge_span.html
+++ b/test_fixtures/grid/grid_overlarge_negative_start_huge_span.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Item with a negative start line and a span crossing both limits
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-auto-columns: 0px;">
+  <div style="background: #59c4f6; height: 20px; grid-column: -9990 / span 19990;"></div>
+  <div style="background: #63c466; width: 20px; height: 20px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_overlarge_placement_at_negative_limit.html
+++ b/test_fixtures/grid/grid_overlarge_placement_at_negative_limit.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Item placed just past the negative track limit in an implicit grid
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-auto-columns: 0px; grid-auto-rows: 0px;">
+  <div style="background: #59c4f6; width: 20px; height: 20px; grid-column-start: -10001; grid-row-start: -10001;"></div>
+  <div style="background: #63c466; width: 20px; height: 20px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_overlarge_placement_just_past_limit.html
+++ b/test_fixtures/grid/grid_overlarge_placement_just_past_limit.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Item placed just past the 10000 track limit in an implicit grid
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-auto-columns: 0px; grid-auto-rows: 0px;">
+  <div style="background: #59c4f6; width: 20px; height: 20px; grid-column-start: 10001; grid-row-start: 10001;"></div>
+  <div style="background: #63c466; width: 20px; height: 20px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_overlarge_row_span_overflows_positive_limit.html
+++ b/test_fixtures/grid/grid_overlarge_row_span_overflows_positive_limit.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Item whose row start is in range but whose row span crosses the positive limit
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-auto-rows: 0px;">
+  <div style="background: #59c4f6; width: 20px; height: 20px; grid-row: 9990 / span 50;"></div>
+  <div style="background: #63c466; width: 20px; height: 20px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_overlarge_span_crossing_max_line.html
+++ b/test_fixtures/grid/grid_overlarge_span_crossing_max_line.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Item whose span crosses the maximum track limit
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-auto-columns: 0px;">
+  <div style="background: #59c4f6; height: 20px; grid-column: 9995 / span 10;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_overlarge_span_over_limit.html
+++ b/test_fixtures/grid/grid_overlarge_span_over_limit.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Item with a span greater than the 10000 track limit
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-auto-columns: 0px;">
+  <div style="background: #59c4f6; height: 20px; grid-column: 1 / span 20000;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_overlarge_span_overflow_secondary_axis.html
+++ b/test_fixtures/grid/grid_overlarge_span_overflow_secondary_axis.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Definite column placement whose row span crosses the limit in the secondary axis
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-auto-rows: 0px; grid-auto-columns: 0px;">
+  <div style="background: #59c4f6; width: 20px; height: 20px; grid-column: 2; grid-row: 9995 / span 20;"></div>
+  <div style="background: #63c466; width: 20px; height: 20px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_overlarge_span_overflows_negative_limit.html
+++ b/test_fixtures/grid/grid_overlarge_span_overflows_negative_limit.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Item whose end line is in range but whose span crosses the negative track limit
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-auto-columns: 0px;">
+  <div style="background: #59c4f6; height: 20px; grid-column: span 50 / -9995;"></div>
+  <div style="background: #63c466; width: 20px; height: 20px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_overlarge_span_overflows_positive_limit.html
+++ b/test_fixtures/grid/grid_overlarge_span_overflows_positive_limit.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Item whose start line is in range but whose span crosses the positive track limit
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-auto-columns: 0px;">
+  <div style="background: #59c4f6; height: 20px; grid-column: 9990 / span 50;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_overlarge_span_to_negative_end.html
+++ b/test_fixtures/grid/grid_overlarge_span_to_negative_end.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Item with a large span ending at a negative line
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-columns: repeat(3, 10px);">
+  <div style="background: #59c4f6; height: 20px; grid-column: span 10000 / -1;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/grid/grid_overlarge_auto_flow_after_max_row_item__border_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_auto_flow_after_max_row_item__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_overlarge_auto_flow_after_max_row_item__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" grid-auto-rows="0px">
+      <div direction="ltr" width="20px" height="20px" grid-row-start="10000"/>
+      <div direction="ltr" width="20px" height="20px"/>
+      <div direction="ltr" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="0">
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_auto_flow_after_max_row_item__border_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_auto_flow_after_max_row_item__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_overlarge_auto_flow_after_max_row_item__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" grid-auto-rows="0px">
+      <div direction="rtl" width="20px" height="20px" grid-row-start="10000"/>
+      <div direction="rtl" width="20px" height="20px"/>
+      <div direction="rtl" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="0">
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_auto_flow_after_max_row_item__content_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_auto_flow_after_max_row_item__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_overlarge_auto_flow_after_max_row_item__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" grid-auto-rows="0px">
+      <div box-sizing="content-box" direction="ltr" width="20px" height="20px" grid-row-start="10000"/>
+      <div box-sizing="content-box" direction="ltr" width="20px" height="20px"/>
+      <div box-sizing="content-box" direction="ltr" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="0">
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_auto_flow_after_max_row_item__content_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_auto_flow_after_max_row_item__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_overlarge_auto_flow_after_max_row_item__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" grid-auto-rows="0px">
+      <div box-sizing="content-box" direction="rtl" width="20px" height="20px" grid-row-start="10000"/>
+      <div box-sizing="content-box" direction="rtl" width="20px" height="20px"/>
+      <div box-sizing="content-box" direction="rtl" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="0">
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_auto_flow_column_dense_extreme_row__border_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_auto_flow_column_dense_extreme_row__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_overlarge_auto_flow_column_dense_extreme_row__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" grid-auto-flow="column dense" grid-auto-rows="0px" grid-auto-columns="0px">
+      <div direction="ltr" width="20px" height="20px" grid-row-start="-30000"/>
+      <div direction="ltr" width="20px" height="20px" grid-column-start="5"/>
+      <div direction="ltr" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="0">
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_auto_flow_column_dense_extreme_row__border_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_auto_flow_column_dense_extreme_row__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_overlarge_auto_flow_column_dense_extreme_row__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" grid-auto-flow="column dense" grid-auto-rows="0px" grid-auto-columns="0px">
+      <div direction="rtl" width="20px" height="20px" grid-row-start="-30000"/>
+      <div direction="rtl" width="20px" height="20px" grid-column-start="5"/>
+      <div direction="rtl" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="0">
+      <node x="-20" y="0" width="20" height="20"/>
+      <node x="-20" y="0" width="20" height="20"/>
+      <node x="-20" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_auto_flow_column_dense_extreme_row__content_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_auto_flow_column_dense_extreme_row__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_overlarge_auto_flow_column_dense_extreme_row__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" grid-auto-flow="column dense" grid-auto-rows="0px" grid-auto-columns="0px">
+      <div box-sizing="content-box" direction="ltr" width="20px" height="20px" grid-row-start="-30000"/>
+      <div box-sizing="content-box" direction="ltr" width="20px" height="20px" grid-column-start="5"/>
+      <div box-sizing="content-box" direction="ltr" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="0">
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_auto_flow_column_dense_extreme_row__content_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_auto_flow_column_dense_extreme_row__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_overlarge_auto_flow_column_dense_extreme_row__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" grid-auto-flow="column dense" grid-auto-rows="0px" grid-auto-columns="0px">
+      <div box-sizing="content-box" direction="rtl" width="20px" height="20px" grid-row-start="-30000"/>
+      <div box-sizing="content-box" direction="rtl" width="20px" height="20px" grid-column-start="5"/>
+      <div box-sizing="content-box" direction="rtl" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="0">
+      <node x="-20" y="0" width="20" height="20"/>
+      <node x="-20" y="0" width="20" height="20"/>
+      <node x="-20" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_auto_flow_column_huge_row_span__border_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_auto_flow_column_huge_row_span__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_auto_flow_column_huge_row_span__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" grid-auto-flow="column" grid-auto-rows="0px" grid-auto-columns="0px">
+      <div direction="ltr" width="20px" height="20px" grid-row-start="span 15000"/>
+      <div direction="ltr" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="0">
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_auto_flow_column_huge_row_span__border_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_auto_flow_column_huge_row_span__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_auto_flow_column_huge_row_span__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" grid-auto-flow="column" grid-auto-rows="0px" grid-auto-columns="0px">
+      <div direction="rtl" width="20px" height="20px" grid-row-start="span 15000"/>
+      <div direction="rtl" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="0">
+      <node x="-20" y="0" width="20" height="20"/>
+      <node x="-20" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_auto_flow_column_huge_row_span__content_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_auto_flow_column_huge_row_span__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_auto_flow_column_huge_row_span__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" grid-auto-flow="column" grid-auto-rows="0px" grid-auto-columns="0px">
+      <div box-sizing="content-box" direction="ltr" width="20px" height="20px" grid-row-start="span 15000"/>
+      <div box-sizing="content-box" direction="ltr" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="0">
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_auto_flow_column_huge_row_span__content_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_auto_flow_column_huge_row_span__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_auto_flow_column_huge_row_span__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" grid-auto-flow="column" grid-auto-rows="0px" grid-auto-columns="0px">
+      <div box-sizing="content-box" direction="rtl" width="20px" height="20px" grid-row-start="span 15000"/>
+      <div box-sizing="content-box" direction="rtl" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="0">
+      <node x="-20" y="0" width="20" height="20"/>
+      <node x="-20" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_auto_placed_huge_span__border_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_auto_placed_huge_span__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_auto_placed_huge_span__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" grid-auto-columns="0px">
+      <div direction="ltr" height="20px" grid-column-start="span 15000"/>
+      <div direction="ltr" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="40">
+      <node x="0" y="0" width="0" height="20"/>
+      <node x="0" y="20" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_auto_placed_huge_span__border_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_auto_placed_huge_span__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_auto_placed_huge_span__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" grid-auto-columns="0px">
+      <div direction="rtl" height="20px" grid-column-start="span 15000"/>
+      <div direction="rtl" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="40">
+      <node x="0" y="0" width="0" height="20"/>
+      <node x="-20" y="20" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_auto_placed_huge_span__content_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_auto_placed_huge_span__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_auto_placed_huge_span__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" grid-auto-columns="0px">
+      <div box-sizing="content-box" direction="ltr" height="20px" grid-column-start="span 15000"/>
+      <div box-sizing="content-box" direction="ltr" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="40">
+      <node x="0" y="0" width="0" height="20"/>
+      <node x="0" y="20" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_auto_placed_huge_span__content_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_auto_placed_huge_span__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_auto_placed_huge_span__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" grid-auto-columns="0px">
+      <div box-sizing="content-box" direction="rtl" height="20px" grid-column-start="span 15000"/>
+      <div box-sizing="content-box" direction="rtl" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="40">
+      <node x="0" y="0" width="0" height="20"/>
+      <node x="-20" y="20" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_explicit_tracks_at_limit__border_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_explicit_tracks_at_limit__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_overlarge_explicit_tracks_at_limit__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" grid-template-columns="repeat(10000, 0px)">
+      <div direction="ltr" width="20px" height="20px" grid-column-start="10000" grid-column-end="10001"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="20">
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_explicit_tracks_at_limit__border_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_explicit_tracks_at_limit__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_overlarge_explicit_tracks_at_limit__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" grid-template-columns="repeat(10000, 0px)">
+      <div direction="rtl" width="20px" height="20px" grid-column-start="10000" grid-column-end="10001"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="20">
+      <node x="-20" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_explicit_tracks_at_limit__content_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_explicit_tracks_at_limit__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_overlarge_explicit_tracks_at_limit__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" grid-template-columns="repeat(10000, 0px)">
+      <div box-sizing="content-box" direction="ltr" width="20px" height="20px" grid-column-start="10000" grid-column-end="10001"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="20">
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_explicit_tracks_at_limit__content_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_explicit_tracks_at_limit__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_overlarge_explicit_tracks_at_limit__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" grid-template-columns="repeat(10000, 0px)">
+      <div box-sizing="content-box" direction="rtl" width="20px" height="20px" grid-column-start="10000" grid-column-end="10001"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="20">
+      <node x="-20" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_explicit_tracks_just_over_limit__border_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_explicit_tracks_just_over_limit__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_overlarge_explicit_tracks_just_over_limit__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" grid-template-columns="repeat(10001, 0px)">
+      <div direction="ltr" width="20px" height="20px" grid-column-start="10001" grid-column-end="10002"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="20">
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_explicit_tracks_just_over_limit__border_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_explicit_tracks_just_over_limit__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_overlarge_explicit_tracks_just_over_limit__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" grid-template-columns="repeat(10001, 0px)">
+      <div direction="rtl" width="20px" height="20px" grid-column-start="10001" grid-column-end="10002"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="20">
+      <node x="-20" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_explicit_tracks_just_over_limit__content_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_explicit_tracks_just_over_limit__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_overlarge_explicit_tracks_just_over_limit__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" grid-template-columns="repeat(10001, 0px)">
+      <div box-sizing="content-box" direction="ltr" width="20px" height="20px" grid-column-start="10001" grid-column-end="10002"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="20">
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_explicit_tracks_just_over_limit__content_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_explicit_tracks_just_over_limit__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_overlarge_explicit_tracks_just_over_limit__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" grid-template-columns="repeat(10001, 0px)">
+      <div box-sizing="content-box" direction="rtl" width="20px" height="20px" grid-column-start="10001" grid-column-end="10002"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="20">
+      <node x="-20" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_extreme_both_directions__border_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_extreme_both_directions__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_extreme_both_directions__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" grid-auto-columns="0px">
+      <div direction="ltr" height="20px" grid-column-start="-15000" grid-column-end="15000"/>
+      <div direction="ltr" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="40">
+      <node x="0" y="0" width="0" height="20"/>
+      <node x="0" y="20" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_extreme_both_directions__border_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_extreme_both_directions__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_extreme_both_directions__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" grid-auto-columns="0px">
+      <div direction="rtl" height="20px" grid-column-start="-15000" grid-column-end="15000"/>
+      <div direction="rtl" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="40">
+      <node x="0" y="0" width="0" height="20"/>
+      <node x="-20" y="20" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_extreme_both_directions__content_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_extreme_both_directions__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_extreme_both_directions__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" grid-auto-columns="0px">
+      <div box-sizing="content-box" direction="ltr" height="20px" grid-column-start="-15000" grid-column-end="15000"/>
+      <div box-sizing="content-box" direction="ltr" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="40">
+      <node x="0" y="0" width="0" height="20"/>
+      <node x="0" y="20" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_extreme_both_directions__content_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_extreme_both_directions__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_extreme_both_directions__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" grid-auto-columns="0px">
+      <div box-sizing="content-box" direction="rtl" height="20px" grid-column-start="-15000" grid-column-end="15000"/>
+      <div box-sizing="content-box" direction="rtl" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="40">
+      <node x="0" y="0" width="0" height="20"/>
+      <node x="-20" y="20" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_negative_line_with_explicit_tracks__border_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_negative_line_with_explicit_tracks__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_negative_line_with_explicit_tracks__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" grid-template-columns="repeat(9000, 0px)">
+      <div direction="ltr" width="20px" height="20px" grid-column-start="-19005"/>
+      <div direction="ltr" width="20px" height="20px" grid-column-start="9000"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="20">
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="20" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_negative_line_with_explicit_tracks__border_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_negative_line_with_explicit_tracks__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_negative_line_with_explicit_tracks__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" grid-template-columns="repeat(9000, 0px)">
+      <div direction="rtl" width="20px" height="20px" grid-column-start="-19005"/>
+      <div direction="rtl" width="20px" height="20px" grid-column-start="9000"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="20">
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="-20" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_negative_line_with_explicit_tracks__content_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_negative_line_with_explicit_tracks__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_negative_line_with_explicit_tracks__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" grid-template-columns="repeat(9000, 0px)">
+      <div box-sizing="content-box" direction="ltr" width="20px" height="20px" grid-column-start="-19005"/>
+      <div box-sizing="content-box" direction="ltr" width="20px" height="20px" grid-column-start="9000"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="20">
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="20" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_negative_line_with_explicit_tracks__content_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_negative_line_with_explicit_tracks__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_negative_line_with_explicit_tracks__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" grid-template-columns="repeat(9000, 0px)">
+      <div box-sizing="content-box" direction="rtl" width="20px" height="20px" grid-column-start="-19005"/>
+      <div box-sizing="content-box" direction="rtl" width="20px" height="20px" grid-column-start="9000"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="20">
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="-20" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_negative_span_from_negative_line__border_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_negative_span_from_negative_line__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_negative_span_from_negative_line__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" grid-auto-columns="0px">
+      <div direction="ltr" height="20px" grid-column-start="-10001" grid-column-end="span 10000"/>
+      <div direction="ltr" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="40">
+      <node x="0" y="0" width="0" height="20"/>
+      <node x="0" y="20" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_negative_span_from_negative_line__border_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_negative_span_from_negative_line__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_negative_span_from_negative_line__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" grid-auto-columns="0px">
+      <div direction="rtl" height="20px" grid-column-start="-10001" grid-column-end="span 10000"/>
+      <div direction="rtl" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="40">
+      <node x="0" y="0" width="0" height="20"/>
+      <node x="-20" y="20" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_negative_span_from_negative_line__content_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_negative_span_from_negative_line__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_negative_span_from_negative_line__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" grid-auto-columns="0px">
+      <div box-sizing="content-box" direction="ltr" height="20px" grid-column-start="-10001" grid-column-end="span 10000"/>
+      <div box-sizing="content-box" direction="ltr" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="40">
+      <node x="0" y="0" width="0" height="20"/>
+      <node x="0" y="20" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_negative_span_from_negative_line__content_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_negative_span_from_negative_line__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_negative_span_from_negative_line__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" grid-auto-columns="0px">
+      <div box-sizing="content-box" direction="rtl" height="20px" grid-column-start="-10001" grid-column-end="span 10000"/>
+      <div box-sizing="content-box" direction="rtl" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="40">
+      <node x="0" y="0" width="0" height="20"/>
+      <node x="-20" y="20" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_negative_start_huge_span__border_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_negative_start_huge_span__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_negative_start_huge_span__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" grid-auto-columns="0px">
+      <div direction="ltr" height="20px" grid-column-start="-9990" grid-column-end="span 19990"/>
+      <div direction="ltr" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="40">
+      <node x="0" y="0" width="0" height="20"/>
+      <node x="0" y="20" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_negative_start_huge_span__border_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_negative_start_huge_span__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_negative_start_huge_span__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" grid-auto-columns="0px">
+      <div direction="rtl" height="20px" grid-column-start="-9990" grid-column-end="span 19990"/>
+      <div direction="rtl" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="40">
+      <node x="0" y="0" width="0" height="20"/>
+      <node x="-20" y="20" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_negative_start_huge_span__content_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_negative_start_huge_span__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_negative_start_huge_span__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" grid-auto-columns="0px">
+      <div box-sizing="content-box" direction="ltr" height="20px" grid-column-start="-9990" grid-column-end="span 19990"/>
+      <div box-sizing="content-box" direction="ltr" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="40">
+      <node x="0" y="0" width="0" height="20"/>
+      <node x="0" y="20" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_negative_start_huge_span__content_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_negative_start_huge_span__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_negative_start_huge_span__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" grid-auto-columns="0px">
+      <div box-sizing="content-box" direction="rtl" height="20px" grid-column-start="-9990" grid-column-end="span 19990"/>
+      <div box-sizing="content-box" direction="rtl" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="40">
+      <node x="0" y="0" width="0" height="20"/>
+      <node x="-20" y="20" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_placement_at_negative_limit__border_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_placement_at_negative_limit__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_placement_at_negative_limit__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" grid-auto-rows="0px" grid-auto-columns="0px">
+      <div direction="ltr" width="20px" height="20px" grid-row-start="-10001" grid-column-start="-10001"/>
+      <div direction="ltr" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="0">
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_placement_at_negative_limit__border_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_placement_at_negative_limit__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_placement_at_negative_limit__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" grid-auto-rows="0px" grid-auto-columns="0px">
+      <div direction="rtl" width="20px" height="20px" grid-row-start="-10001" grid-column-start="-10001"/>
+      <div direction="rtl" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="0">
+      <node x="-20" y="0" width="20" height="20"/>
+      <node x="-20" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_placement_at_negative_limit__content_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_placement_at_negative_limit__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_placement_at_negative_limit__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" grid-auto-rows="0px" grid-auto-columns="0px">
+      <div box-sizing="content-box" direction="ltr" width="20px" height="20px" grid-row-start="-10001" grid-column-start="-10001"/>
+      <div box-sizing="content-box" direction="ltr" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="0">
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_placement_at_negative_limit__content_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_placement_at_negative_limit__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_placement_at_negative_limit__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" grid-auto-rows="0px" grid-auto-columns="0px">
+      <div box-sizing="content-box" direction="rtl" width="20px" height="20px" grid-row-start="-10001" grid-column-start="-10001"/>
+      <div box-sizing="content-box" direction="rtl" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="0">
+      <node x="-20" y="0" width="20" height="20"/>
+      <node x="-20" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_placement_just_past_limit__border_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_placement_just_past_limit__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_placement_just_past_limit__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" grid-auto-rows="0px" grid-auto-columns="0px">
+      <div direction="ltr" width="20px" height="20px" grid-row-start="10001" grid-column-start="10001"/>
+      <div direction="ltr" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="0">
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_placement_just_past_limit__border_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_placement_just_past_limit__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_placement_just_past_limit__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" grid-auto-rows="0px" grid-auto-columns="0px">
+      <div direction="rtl" width="20px" height="20px" grid-row-start="10001" grid-column-start="10001"/>
+      <div direction="rtl" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="0">
+      <node x="-20" y="0" width="20" height="20"/>
+      <node x="-20" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_placement_just_past_limit__content_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_placement_just_past_limit__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_placement_just_past_limit__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" grid-auto-rows="0px" grid-auto-columns="0px">
+      <div box-sizing="content-box" direction="ltr" width="20px" height="20px" grid-row-start="10001" grid-column-start="10001"/>
+      <div box-sizing="content-box" direction="ltr" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="0">
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_placement_just_past_limit__content_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_placement_just_past_limit__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_placement_just_past_limit__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" grid-auto-rows="0px" grid-auto-columns="0px">
+      <div box-sizing="content-box" direction="rtl" width="20px" height="20px" grid-row-start="10001" grid-column-start="10001"/>
+      <div box-sizing="content-box" direction="rtl" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="0">
+      <node x="-20" y="0" width="20" height="20"/>
+      <node x="-20" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_row_span_overflows_positive_limit__border_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_row_span_overflows_positive_limit__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_row_span_overflows_positive_limit__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" grid-auto-rows="0px">
+      <div direction="ltr" width="20px" height="20px" grid-row-start="9990" grid-row-end="span 50"/>
+      <div direction="ltr" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="0">
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_row_span_overflows_positive_limit__border_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_row_span_overflows_positive_limit__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_row_span_overflows_positive_limit__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" grid-auto-rows="0px">
+      <div direction="rtl" width="20px" height="20px" grid-row-start="9990" grid-row-end="span 50"/>
+      <div direction="rtl" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="0">
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_row_span_overflows_positive_limit__content_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_row_span_overflows_positive_limit__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_row_span_overflows_positive_limit__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" grid-auto-rows="0px">
+      <div box-sizing="content-box" direction="ltr" width="20px" height="20px" grid-row-start="9990" grid-row-end="span 50"/>
+      <div box-sizing="content-box" direction="ltr" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="0">
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_row_span_overflows_positive_limit__content_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_row_span_overflows_positive_limit__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_row_span_overflows_positive_limit__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" grid-auto-rows="0px">
+      <div box-sizing="content-box" direction="rtl" width="20px" height="20px" grid-row-start="9990" grid-row-end="span 50"/>
+      <div box-sizing="content-box" direction="rtl" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="0">
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_span_crossing_max_line__border_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_span_crossing_max_line__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_overlarge_span_crossing_max_line__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" grid-auto-columns="0px">
+      <div direction="ltr" height="20px" grid-column-start="9995" grid-column-end="span 10"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="20">
+      <node x="0" y="0" width="0" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_span_crossing_max_line__border_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_span_crossing_max_line__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_overlarge_span_crossing_max_line__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" grid-auto-columns="0px">
+      <div direction="rtl" height="20px" grid-column-start="9995" grid-column-end="span 10"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="20">
+      <node x="0" y="0" width="0" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_span_crossing_max_line__content_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_span_crossing_max_line__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_overlarge_span_crossing_max_line__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" grid-auto-columns="0px">
+      <div box-sizing="content-box" direction="ltr" height="20px" grid-column-start="9995" grid-column-end="span 10"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="20">
+      <node x="0" y="0" width="0" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_span_crossing_max_line__content_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_span_crossing_max_line__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_overlarge_span_crossing_max_line__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" grid-auto-columns="0px">
+      <div box-sizing="content-box" direction="rtl" height="20px" grid-column-start="9995" grid-column-end="span 10"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="20">
+      <node x="0" y="0" width="0" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_span_over_limit__border_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_span_over_limit__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_overlarge_span_over_limit__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" grid-auto-columns="0px">
+      <div direction="ltr" height="20px" grid-column-start="1" grid-column-end="span 20000"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="20">
+      <node x="0" y="0" width="0" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_span_over_limit__border_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_span_over_limit__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_overlarge_span_over_limit__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" grid-auto-columns="0px">
+      <div direction="rtl" height="20px" grid-column-start="1" grid-column-end="span 20000"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="20">
+      <node x="0" y="0" width="0" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_span_over_limit__content_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_span_over_limit__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_overlarge_span_over_limit__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" grid-auto-columns="0px">
+      <div box-sizing="content-box" direction="ltr" height="20px" grid-column-start="1" grid-column-end="span 20000"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="20">
+      <node x="0" y="0" width="0" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_span_over_limit__content_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_span_over_limit__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_overlarge_span_over_limit__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" grid-auto-columns="0px">
+      <div box-sizing="content-box" direction="rtl" height="20px" grid-column-start="1" grid-column-end="span 20000"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="20">
+      <node x="0" y="0" width="0" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_span_overflow_secondary_axis__border_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_span_overflow_secondary_axis__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_span_overflow_secondary_axis__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" grid-auto-rows="0px" grid-auto-columns="0px">
+      <div direction="ltr" width="20px" height="20px" grid-row-start="9995" grid-row-end="span 20" grid-column-start="2"/>
+      <div direction="ltr" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="0">
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_span_overflow_secondary_axis__border_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_span_overflow_secondary_axis__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_span_overflow_secondary_axis__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" grid-auto-rows="0px" grid-auto-columns="0px">
+      <div direction="rtl" width="20px" height="20px" grid-row-start="9995" grid-row-end="span 20" grid-column-start="2"/>
+      <div direction="rtl" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="0">
+      <node x="-20" y="0" width="20" height="20"/>
+      <node x="-20" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_span_overflow_secondary_axis__content_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_span_overflow_secondary_axis__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_span_overflow_secondary_axis__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" grid-auto-rows="0px" grid-auto-columns="0px">
+      <div box-sizing="content-box" direction="ltr" width="20px" height="20px" grid-row-start="9995" grid-row-end="span 20" grid-column-start="2"/>
+      <div box-sizing="content-box" direction="ltr" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="0">
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_span_overflow_secondary_axis__content_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_span_overflow_secondary_axis__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_span_overflow_secondary_axis__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" grid-auto-rows="0px" grid-auto-columns="0px">
+      <div box-sizing="content-box" direction="rtl" width="20px" height="20px" grid-row-start="9995" grid-row-end="span 20" grid-column-start="2"/>
+      <div box-sizing="content-box" direction="rtl" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="0">
+      <node x="-20" y="0" width="20" height="20"/>
+      <node x="-20" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_span_overflows_negative_limit__border_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_span_overflows_negative_limit__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_span_overflows_negative_limit__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" grid-auto-columns="0px">
+      <div direction="ltr" height="20px" grid-column-start="span 50" grid-column-end="-9995"/>
+      <div direction="ltr" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="20">
+      <node x="0" y="0" width="0" height="20"/>
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_span_overflows_negative_limit__border_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_span_overflows_negative_limit__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_span_overflows_negative_limit__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" grid-auto-columns="0px">
+      <div direction="rtl" height="20px" grid-column-start="span 50" grid-column-end="-9995"/>
+      <div direction="rtl" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="20">
+      <node x="0" y="0" width="0" height="20"/>
+      <node x="-20" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_span_overflows_negative_limit__content_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_span_overflows_negative_limit__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_span_overflows_negative_limit__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" grid-auto-columns="0px">
+      <div box-sizing="content-box" direction="ltr" height="20px" grid-column-start="span 50" grid-column-end="-9995"/>
+      <div box-sizing="content-box" direction="ltr" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="20">
+      <node x="0" y="0" width="0" height="20"/>
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_span_overflows_negative_limit__content_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_span_overflows_negative_limit__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_overlarge_span_overflows_negative_limit__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" grid-auto-columns="0px">
+      <div box-sizing="content-box" direction="rtl" height="20px" grid-column-start="span 50" grid-column-end="-9995"/>
+      <div box-sizing="content-box" direction="rtl" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="20">
+      <node x="0" y="0" width="0" height="20"/>
+      <node x="-20" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_span_overflows_positive_limit__border_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_span_overflows_positive_limit__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_overlarge_span_overflows_positive_limit__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" grid-auto-columns="0px">
+      <div direction="ltr" height="20px" grid-column-start="9990" grid-column-end="span 50"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="20">
+      <node x="0" y="0" width="0" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_span_overflows_positive_limit__border_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_span_overflows_positive_limit__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_overlarge_span_overflows_positive_limit__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" grid-auto-columns="0px">
+      <div direction="rtl" height="20px" grid-column-start="9990" grid-column-end="span 50"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="20">
+      <node x="0" y="0" width="0" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_span_overflows_positive_limit__content_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_span_overflows_positive_limit__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_overlarge_span_overflows_positive_limit__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" grid-auto-columns="0px">
+      <div box-sizing="content-box" direction="ltr" height="20px" grid-column-start="9990" grid-column-end="span 50"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="20">
+      <node x="0" y="0" width="0" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_span_overflows_positive_limit__content_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_span_overflows_positive_limit__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_overlarge_span_overflows_positive_limit__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" grid-auto-columns="0px">
+      <div box-sizing="content-box" direction="rtl" height="20px" grid-column-start="9990" grid-column-end="span 50"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="0" height="20">
+      <node x="0" y="0" width="0" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_span_to_negative_end__border_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_span_to_negative_end__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_overlarge_span_to_negative_end__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" grid-template-columns="repeat(3, 10px)">
+      <div direction="ltr" height="20px" grid-column-start="span 10000" grid-column-end="-1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="30" height="20">
+      <node x="0" y="0" width="30" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_span_to_negative_end__border_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_span_to_negative_end__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_overlarge_span_to_negative_end__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" grid-template-columns="repeat(3, 10px)">
+      <div direction="rtl" height="20px" grid-column-start="span 10000" grid-column-end="-1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="30" height="20">
+      <node x="0" y="0" width="30" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_span_to_negative_end__content_box_ltr.xml
+++ b/tests/xml/grid/grid_overlarge_span_to_negative_end__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_overlarge_span_to_negative_end__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" grid-template-columns="repeat(3, 10px)">
+      <div box-sizing="content-box" direction="ltr" height="20px" grid-column-start="span 10000" grid-column-end="-1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="30" height="20">
+      <node x="0" y="0" width="30" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overlarge_span_to_negative_end__content_box_rtl.xml
+++ b/tests/xml/grid/grid_overlarge_span_to_negative_end__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_overlarge_span_to_negative_end__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" grid-template-columns="repeat(3, 10px)">
+      <div box-sizing="content-box" direction="rtl" height="20px" grid-column-start="span 10000" grid-column-end="-1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="30" height="20">
+      <node x="0" y="0" width="30" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -21841,6 +21841,54 @@ mod grid {
 
     #[cfg(feature = "grid")]
     #[test]
+    fn grid_overlarge_auto_flow_after_max_row_item__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_auto_flow_after_max_row_item__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_auto_flow_after_max_row_item__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_auto_flow_after_max_row_item__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_auto_flow_after_max_row_item__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_auto_flow_after_max_row_item__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_auto_flow_after_max_row_item__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_auto_flow_after_max_row_item__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_auto_flow_column_dense_extreme_row__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_auto_flow_column_dense_extreme_row__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_auto_flow_column_dense_extreme_row__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_auto_flow_column_dense_extreme_row__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_auto_flow_column_dense_extreme_row__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_auto_flow_column_dense_extreme_row__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_auto_flow_column_dense_extreme_row__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_auto_flow_column_dense_extreme_row__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
     fn grid_overlarge_auto_flow_column_explicit_columns_large_negative_row_start__border_box_ltr() {
         crate::run_xml_test(
             "grid",
@@ -21901,6 +21949,78 @@ mod grid {
 
     #[cfg(feature = "grid")]
     #[test]
+    fn grid_overlarge_explicit_tracks_at_limit__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_explicit_tracks_at_limit__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_explicit_tracks_at_limit__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_explicit_tracks_at_limit__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_explicit_tracks_at_limit__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_explicit_tracks_at_limit__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_explicit_tracks_at_limit__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_explicit_tracks_at_limit__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_explicit_tracks_just_over_limit__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_explicit_tracks_just_over_limit__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_explicit_tracks_just_over_limit__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_explicit_tracks_just_over_limit__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_explicit_tracks_just_over_limit__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_explicit_tracks_just_over_limit__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_explicit_tracks_just_over_limit__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_explicit_tracks_just_over_limit__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_extreme_both_directions__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_extreme_both_directions__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_extreme_both_directions__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_extreme_both_directions__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_extreme_both_directions__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_extreme_both_directions__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_extreme_both_directions__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_extreme_both_directions__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
     fn grid_overlarge_extreme_line_numbers__border_box_ltr() {
         crate::run_xml_test("grid", "grid_overlarge_extreme_line_numbers__border_box_ltr");
     }
@@ -21949,6 +22069,102 @@ mod grid {
 
     #[cfg(feature = "grid")]
     #[test]
+    fn grid_overlarge_negative_line_with_explicit_tracks__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_negative_line_with_explicit_tracks__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_negative_line_with_explicit_tracks__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_negative_line_with_explicit_tracks__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_negative_line_with_explicit_tracks__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_negative_line_with_explicit_tracks__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_negative_line_with_explicit_tracks__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_negative_line_with_explicit_tracks__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_negative_span_from_negative_line__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_negative_span_from_negative_line__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_negative_span_from_negative_line__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_negative_span_from_negative_line__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_negative_span_from_negative_line__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_negative_span_from_negative_line__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_negative_span_from_negative_line__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_negative_span_from_negative_line__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_placement_at_negative_limit__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_placement_at_negative_limit__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_placement_at_negative_limit__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_placement_at_negative_limit__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_placement_at_negative_limit__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_placement_at_negative_limit__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_placement_at_negative_limit__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_placement_at_negative_limit__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_placement_just_past_limit__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_placement_just_past_limit__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_placement_just_past_limit__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_placement_just_past_limit__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_placement_just_past_limit__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_placement_just_past_limit__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_placement_just_past_limit__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_placement_just_past_limit__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
     fn grid_overlarge_repeat_track_count_product_overflow__border_box_ltr() {
         crate::run_xml_test("grid", "grid_overlarge_repeat_track_count_product_overflow__border_box_ltr");
     }
@@ -21969,6 +22185,78 @@ mod grid {
     #[test]
     fn grid_overlarge_repeat_track_count_product_overflow__content_box_rtl() {
         crate::run_xml_test("grid", "grid_overlarge_repeat_track_count_product_overflow__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_span_crossing_max_line__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_span_crossing_max_line__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_span_crossing_max_line__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_span_crossing_max_line__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_span_crossing_max_line__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_span_crossing_max_line__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_span_crossing_max_line__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_span_crossing_max_line__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_span_over_limit__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_span_over_limit__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_span_over_limit__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_span_over_limit__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_span_over_limit__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_span_over_limit__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_span_over_limit__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_span_over_limit__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_span_to_negative_end__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_span_to_negative_end__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_span_to_negative_end__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_span_to_negative_end__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_span_to_negative_end__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_span_to_negative_end__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_span_to_negative_end__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_span_to_negative_end__content_box_rtl");
     }
 
     #[cfg(feature = "grid")]

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -21925,6 +21925,30 @@ mod grid {
 
     #[cfg(feature = "grid")]
     #[test]
+    fn grid_overlarge_auto_flow_column_huge_row_span__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_auto_flow_column_huge_row_span__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_auto_flow_column_huge_row_span__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_auto_flow_column_huge_row_span__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_auto_flow_column_huge_row_span__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_auto_flow_column_huge_row_span__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_auto_flow_column_huge_row_span__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_auto_flow_column_huge_row_span__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
     fn grid_overlarge_auto_flow_column_large_negative_row_start__border_box_ltr() {
         crate::run_xml_test("grid", "grid_overlarge_auto_flow_column_large_negative_row_start__border_box_ltr");
     }
@@ -21945,6 +21969,30 @@ mod grid {
     #[test]
     fn grid_overlarge_auto_flow_column_large_negative_row_start__content_box_rtl() {
         crate::run_xml_test("grid", "grid_overlarge_auto_flow_column_large_negative_row_start__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_auto_placed_huge_span__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_auto_placed_huge_span__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_auto_placed_huge_span__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_auto_placed_huge_span__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_auto_placed_huge_span__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_auto_placed_huge_span__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_auto_placed_huge_span__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_auto_placed_huge_span__content_box_rtl");
     }
 
     #[cfg(feature = "grid")]
@@ -22117,6 +22165,30 @@ mod grid {
 
     #[cfg(feature = "grid")]
     #[test]
+    fn grid_overlarge_negative_start_huge_span__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_negative_start_huge_span__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_negative_start_huge_span__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_negative_start_huge_span__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_negative_start_huge_span__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_negative_start_huge_span__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_negative_start_huge_span__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_negative_start_huge_span__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
     fn grid_overlarge_placement_at_negative_limit__border_box_ltr() {
         crate::run_xml_test("grid", "grid_overlarge_placement_at_negative_limit__border_box_ltr");
     }
@@ -22189,6 +22261,30 @@ mod grid {
 
     #[cfg(feature = "grid")]
     #[test]
+    fn grid_overlarge_row_span_overflows_positive_limit__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_row_span_overflows_positive_limit__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_row_span_overflows_positive_limit__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_row_span_overflows_positive_limit__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_row_span_overflows_positive_limit__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_row_span_overflows_positive_limit__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_row_span_overflows_positive_limit__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_row_span_overflows_positive_limit__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
     fn grid_overlarge_span_crossing_max_line__border_box_ltr() {
         crate::run_xml_test("grid", "grid_overlarge_span_crossing_max_line__border_box_ltr");
     }
@@ -22233,6 +22329,78 @@ mod grid {
     #[test]
     fn grid_overlarge_span_over_limit__content_box_rtl() {
         crate::run_xml_test("grid", "grid_overlarge_span_over_limit__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_span_overflow_secondary_axis__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_span_overflow_secondary_axis__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_span_overflow_secondary_axis__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_span_overflow_secondary_axis__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_span_overflow_secondary_axis__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_span_overflow_secondary_axis__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_span_overflow_secondary_axis__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_span_overflow_secondary_axis__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_span_overflows_negative_limit__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_span_overflows_negative_limit__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_span_overflows_negative_limit__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_span_overflows_negative_limit__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_span_overflows_negative_limit__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_span_overflows_negative_limit__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_span_overflows_negative_limit__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_span_overflows_negative_limit__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_span_overflows_positive_limit__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_span_overflows_positive_limit__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_span_overflows_positive_limit__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_overlarge_span_overflows_positive_limit__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_span_overflows_positive_limit__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_span_overflows_positive_limit__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overlarge_span_overflows_positive_limit__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_overlarge_span_overflows_positive_limit__content_box_rtl");
     }
 
     #[cfg(feature = "grid")]


### PR DESCRIPTION
# Objective

Stress-test the grid track-limit clamping in #986 against Chrome by adding 19 new gentest fixtures covering placements near/past the ±10000 track limit:

- explicit track counts at/just over the limit (`repeat(10000, 0px)`, `repeat(10001, 0px)`)
- lines just past the positive/negative limit (`10001`, `-10001`)
- spans over the limit (`1 / span 20000`, `span 10000 / -1`, `-10001 / span 10000`, `span 15000` auto-placed)
- items whose start line is in range but whose non-1 span crosses a limit (`9990 / span 50`, `span 50 / -9995`, `9995 / span 10`, `-9990 / span 19990`, row-axis and secondary-axis variants)
- extreme both-direction placement (`-15000 / 15000`)
- large negative lines combined with a large explicit track count
- auto-flow interactions with extreme rows (including `column dense` and huge-span auto-placed items)

This found one genuine disagreement with Chrome, which this PR also fixes: `grid_overlarge_explicit_tracks_just_over_limit` failed in **RTL only**. With `grid-template-columns: repeat(10001, 0px)` (clamped to 10000 tracks) and an item at `grid-column: 10001 / 10002`, both lines clamp to OZ line 10000, resolving to the span `10000..10001` — one line past `MAX_OZ_LINE`. In LTR the clamp in `record_grid_placement` fixes this up to `9999..10000` (an explicit 0px track), but in RTL the span was mirrored *first*, mapping it to `-1..0` — a valid-looking implicit track that then gets auto-sized to 20px, so Taffy reported a 20px-wide container where Chrome reports 0px.

Fix: clamp spans into the limited grid before mirroring in `maybe_mirror_span`:

```rust
if axis == AbsoluteAxis::Horizontal && direction.is_rtl() {
    mirror_horizontal_span(clamp_span_to_limited_grid(span), explicit_col_count)
}
```

All other fixtures (including all span-overflow cases) agree with Chrome on this branch with no panics. `cargo test --workspace` passes (4533 xml tests).

Also: `CellOccupancyMatrix`'s `Debug` impl no longer prints the 2D occupancy state when the grid has more than 100 rows or columns.

## Context

Based on (and targeting) #986 per request — not taking that PR over. Test fixtures generated against Chrome-for-Testing 151.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/08dbe7c4e19641248f14fca5e1c96321
Requested by: @nicoburns