### PR TITLE
Grid: speed up auto-placement search with per-track occupancy hulls

### DIFF
--- a/src/compute/grid/placement.rs
+++ b/src/compute/grid/placement.rs
@@ -328,16 +328,16 @@ fn place_definite_secondary_axis_item(
         let primary_axis_placement =
             resolve_indefinite_grid_span(position, primary_axis_span, primary_axis_is_reversed);
 
-        let does_fit = cell_occupancy_matrix.line_area_is_unoccupied(
+        let collision = cell_occupancy_matrix.line_area_collision_jump(
             primary_axis,
             primary_axis_placement,
             secondary_axis_placement,
+            primary_axis_is_reversed,
         );
 
-        if does_fit {
-            return (primary_axis_placement, secondary_axis_placement);
-        } else {
-            position = advance_position(position, primary_axis_is_reversed);
+        match collision {
+            None => return (primary_axis_placement, secondary_axis_placement),
+            Some(next_position) => position = next_position,
         }
     }
 }
@@ -370,10 +370,6 @@ fn place_indefinitely_positioned_item(
         search_start_line(primary_axis_grid_start_line, primary_axis_grid_end_line, primary_axis_is_reversed);
     let secondary_start_position =
         search_start_line(secondary_axis_grid_start_line, secondary_axis_grid_end_line, secondary_axis_is_reversed);
-
-    let line_area_is_occupied = |primary_span, secondary_span| {
-        !cell_occupancy_matrix.line_area_is_unoccupied(primary_axis, primary_span, secondary_span)
-    };
 
     let (mut primary_idx, mut secondary_idx) = grid_position;
 
@@ -409,9 +405,15 @@ fn place_indefinitely_positioned_item(
             let secondary_span =
                 resolve_indefinite_grid_span(secondary_idx, secondary_span, secondary_axis_is_reversed);
 
-            // If area is occupied, increment the index and try again
-            if line_area_is_occupied(primary_span, secondary_span) {
-                secondary_idx = advance_position(secondary_idx, secondary_axis_is_reversed);
+            // If area is occupied, jump the index past the collision and try again
+            let collision = cell_occupancy_matrix.line_area_collision_jump(
+                secondary_axis,
+                secondary_span,
+                primary_span,
+                secondary_axis_is_reversed,
+            );
+            if let Some(next_position) = collision {
+                secondary_idx = next_position;
                 continue;
             }
 
@@ -420,6 +422,10 @@ fn place_indefinitely_positioned_item(
         }
     } else {
         let primary_span = primary_placement_style.indefinite_span();
+
+        // Whether the item spans every track in the primary axis. Such an item can only be
+        // placed at the primary axis grid start, in a stripe of entirely unoccupied tracks.
+        let spans_all_primary_tracks = primary_span as usize >= cell_occupancy_matrix.track_counts(primary_axis).len();
 
         // Item does not have any fixed axis, so we search along the primary axis until we hit the end of the already
         // existent tracks, and then we reset the primary axis back to zero and increment the secondary axis index.
@@ -442,9 +448,33 @@ fn place_indefinitely_positioned_item(
                 continue;
             }
 
-            // If area is occupied, increment the primary index and try again
-            if line_area_is_occupied(primary_span, secondary_span) {
-                primary_idx = advance_position(primary_idx, primary_axis_is_reversed);
+            // If the item spans every primary axis track, it fits if and only if all of the
+            // secondary axis tracks it spans are entirely unoccupied. Jump the secondary index
+            // past any non-empty tracks in the spanned stripe.
+            if spans_all_primary_tracks {
+                match cell_occupancy_matrix.occupied_track_jump(
+                    secondary_axis,
+                    secondary_span,
+                    secondary_axis_is_reversed,
+                ) {
+                    Some(next_position) => {
+                        secondary_idx = next_position;
+                        primary_idx = primary_start_position;
+                        continue;
+                    }
+                    None => return (primary_span, secondary_span),
+                }
+            }
+
+            // If area is occupied, jump the primary index past the collision and try again
+            let collision = cell_occupancy_matrix.line_area_collision_jump(
+                primary_axis,
+                primary_span,
+                secondary_span,
+                primary_axis_is_reversed,
+            );
+            if let Some(next_position) = collision {
+                primary_idx = next_position;
                 continue;
             }
 

--- a/src/compute/grid/types/cell_occupancy.rs
+++ b/src/compute/grid/types/cell_occupancy.rs
@@ -3,8 +3,8 @@ use super::TrackCounts;
 use crate::compute::grid::OriginZeroLine;
 use crate::geometry::AbsoluteAxis;
 use crate::geometry::Line;
-use crate::util::sys::Vec;
-use core::cmp::max;
+use crate::util::sys::{new_vec_with_capacity, Vec};
+use core::cmp::{max, min};
 use core::fmt::Debug;
 use core::ops::Range;
 use grid::Grid;
@@ -21,6 +21,23 @@ pub(crate) enum CellOccupancyState {
     AutoPlaced,
 }
 
+/// The "hull" of the occupied cells within a single track of the `CellOccupancyMatrix`:
+/// the range from the first occupied cell to one past the last occupied cell (`None` if the
+/// track is entirely unoccupied). Cells at `start` and `end - 1` are always occupied, but
+/// cells in between may or may not be.
+type OccupiedHull = Option<Range<i16>>;
+
+/// Extends `hull` to cover `range`
+fn merge_hull(hull: &mut OccupiedHull, range: Range<i16>) {
+    if range.start >= range.end {
+        return;
+    }
+    *hull = match hull.take() {
+        Some(existing) => Some(min(existing.start, range.start)..max(existing.end, range.end)),
+        None => Some(range),
+    };
+}
+
 /// A dynamically sized matrix (2d grid) which tracks the occupancy of each grid cell during auto-placement
 /// It also keeps tabs on how many tracks there are and which tracks are implicit and which are explicit.
 pub(crate) struct CellOccupancyMatrix {
@@ -30,6 +47,10 @@ pub(crate) struct CellOccupancyMatrix {
     columns: TrackCounts,
     /// The counts of implicit and explicit rows
     rows: TrackCounts,
+    /// For each row: the hull of the occupied cells in that row (as column indices)
+    row_hulls: Vec<OccupiedHull>,
+    /// For each column: the hull of the occupied cells in that column (as row indices)
+    column_hulls: Vec<OccupiedHull>,
 }
 
 /// Debug impl that represents the matrix in a compact 2d text format
@@ -67,7 +88,11 @@ impl CellOccupancyMatrix {
     /// Create a CellOccupancyMatrix given a set of provisional track counts. The grid can expand as needed to fit more tracks,
     /// the provisional track counts represent a best effort attempt to avoid the extra allocations this requires.
     pub fn with_track_counts(columns: TrackCounts, rows: TrackCounts) -> Self {
-        Self { inner: Grid::new(rows.len(), columns.len()), rows, columns }
+        let mut row_hulls = new_vec_with_capacity(rows.len());
+        row_hulls.resize(rows.len(), None);
+        let mut column_hulls = new_vec_with_capacity(columns.len());
+        column_hulls.resize(columns.len(), None);
+        Self { inner: Grid::new(rows.len(), columns.len()), rows, columns, row_hulls, column_hulls }
     }
 
     /// Determines whether the specified area fits within the tracks currently represented by the matrix
@@ -130,6 +155,23 @@ impl CellOccupancyMatrix {
 
         // Update self with new data
         self.inner = Grid::from_vec(data, new_col_count);
+
+        // Shift the per-track occupied hulls to account for the newly inserted negative tracks
+        let mut row_hulls = new_vec_with_capacity(new_row_count);
+        row_hulls.resize(new_row_count, None);
+        for (index, hull) in self.row_hulls.drain(..).enumerate() {
+            row_hulls[index + req_negative_rows as usize] =
+                hull.map(|hull| (hull.start + req_negative_cols)..(hull.end + req_negative_cols));
+        }
+        self.row_hulls = row_hulls;
+        let mut column_hulls = new_vec_with_capacity(new_col_count);
+        column_hulls.resize(new_col_count, None);
+        for (index, hull) in self.column_hulls.drain(..).enumerate() {
+            column_hulls[index + req_negative_cols as usize] =
+                hull.map(|hull| (hull.start + req_negative_rows)..(hull.end + req_negative_rows));
+        }
+        self.column_hulls = column_hulls;
+
         self.rows.negative_implicit += req_negative_rows as u16;
         self.rows.positive_implicit += req_positive_rows as u16;
         self.columns.negative_implicit += req_negative_cols as u16;
@@ -161,66 +203,159 @@ impl CellOccupancyMatrix {
             row_range = self.rows.oz_line_range_to_track_range(row_span);
         }
 
-        for x in row_range {
+        for x in row_range.clone() {
+            merge_hull(&mut self.row_hulls[x as usize], col_range.clone());
             for y in col_range.clone() {
                 *self.inner.get_mut(x as usize, y as usize).unwrap() = value;
             }
         }
+        for y in col_range {
+            merge_hull(&mut self.column_hulls[y as usize], row_range.clone());
+        }
     }
 
-    /// Determines whether a grid area specified by the bounding grid lines in OriginZero coordinates
-    /// is entirely unnocupied. Returns true if all grid cells within the grid area are unnocupied, else false.
-    pub fn line_area_is_unoccupied(
-        &self,
-        primary_axis: AbsoluteAxis,
-        primary_span: Line<OriginZeroLine>,
-        secondary_span: Line<OriginZeroLine>,
-    ) -> bool {
-        let primary_range = self.track_counts(primary_axis).oz_line_range_to_track_range(primary_span);
-        let secondary_range = self.track_counts(primary_axis.other_axis()).oz_line_range_to_track_range(secondary_span);
-        self.track_area_is_unoccupied(primary_axis, primary_range, secondary_range)
+    /// Whether the cell at (`primary_index`, `secondary_index`) (indices into this matrix, with
+    /// `primary_index` indexing along `primary_axis`) is occupied. Out of bounds cells are unoccupied.
+    fn is_cell_occupied(&self, primary_axis: AbsoluteAxis, primary_index: i16, secondary_index: i16) -> bool {
+        let (row, col) = match primary_axis {
+            AbsoluteAxis::Horizontal => (secondary_index, primary_index),
+            AbsoluteAxis::Vertical => (primary_index, secondary_index),
+        };
+        !matches!(self.inner.get(row as usize, col as usize), None | Some(CellOccupancyState::Unoccupied))
     }
 
-    /// Determines whether a grid area specified by a range of indexes into this CellOccupancyMatrix
-    /// is entirely unnocupied. Returns true if all grid cells within the grid area are unnocupied, else false.
-    pub fn track_area_is_unoccupied(
+    /// Checks the specified area for occupied cells. Returns `None` if the area is entirely
+    /// unoccupied. Otherwise returns the index (into this matrix, along `primary_axis`) of an
+    /// occupied cell within the area such that every search position between the current one and
+    /// the position just past the returned cell would also collide with that cell. When searching
+    /// forwards (`reversed == false`) this is the maximum such index; when searching backwards it
+    /// is the minimum. This allows the auto-placement search cursor to jump past the collision
+    /// rather than advancing one track at a time.
+    ///
+    /// Uses the per-track occupied hulls so that fully-vacant and fully-occupied tracks are
+    /// handled in O(1) per track, only falling back to a dense cell scan when a track's hull
+    /// straddles the edge of the area being checked.
+    pub fn area_collision_extent(
         &self,
         primary_axis: AbsoluteAxis,
         primary_range: Range<i16>,
         secondary_range: Range<i16>,
-    ) -> bool {
-        let (row_range, col_range) = match primary_axis {
-            AbsoluteAxis::Horizontal => (secondary_range, primary_range),
-            AbsoluteAxis::Vertical => (primary_range, secondary_range),
+        reversed: bool,
+    ) -> Option<i16> {
+        let hulls: &[OccupiedHull] = match primary_axis {
+            AbsoluteAxis::Horizontal => &self.row_hulls,
+            AbsoluteAxis::Vertical => &self.column_hulls,
         };
 
-        // Search for occupied cells in the specified area. Out of bounds cells are considered unoccupied.
-        for x in row_range {
-            for y in col_range.clone() {
-                match self.inner.get(x as usize, y as usize) {
-                    None | Some(CellOccupancyState::Unoccupied) => continue,
-                    _ => return false,
+        // Out of bounds cells are considered unoccupied, so clamp the secondary range to the
+        // tracks which actually exist
+        let secondary_start = max(secondary_range.start, 0);
+        let secondary_end = min(secondary_range.end, hulls.len() as i16);
+
+        let mut extent: Option<i16> = None;
+        for secondary_index in secondary_start..secondary_end {
+            let Some(hull) = hulls[secondary_index as usize].clone() else { continue };
+            let overlap_start = max(hull.start, primary_range.start);
+            let overlap_end = min(hull.end, primary_range.end);
+            if overlap_start >= overlap_end {
+                continue;
+            }
+            let found = if !reversed {
+                if hull.end <= primary_range.end {
+                    // The last cell of the hull is always occupied and is within the area
+                    Some(hull.end - 1)
+                } else {
+                    (overlap_start..overlap_end)
+                        .rev()
+                        .find(|&index| self.is_cell_occupied(primary_axis, index, secondary_index))
                 }
+            } else if hull.start >= primary_range.start {
+                // The first cell of the hull is always occupied and is within the area
+                Some(hull.start)
+            } else {
+                (overlap_start..overlap_end).find(|&index| self.is_cell_occupied(primary_axis, index, secondary_index))
+            };
+            if let Some(index) = found {
+                extent = Some(match extent {
+                    None => index,
+                    Some(best) => {
+                        if reversed {
+                            min(best, index)
+                        } else {
+                            max(best, index)
+                        }
+                    }
+                });
             }
         }
+        extent
+    }
 
-        true
+    /// Like `area_collision_extent`, but takes bounding grid lines in OriginZero coordinates and
+    /// returns the next search position (also in OriginZero coordinates, along `primary_axis`)
+    /// that is not guaranteed to collide with the occupied cells found in the area.
+    /// Returns `None` if the area is entirely unoccupied.
+    pub fn line_area_collision_jump(
+        &self,
+        primary_axis: AbsoluteAxis,
+        primary_span: Line<OriginZeroLine>,
+        secondary_span: Line<OriginZeroLine>,
+        reversed: bool,
+    ) -> Option<OriginZeroLine> {
+        let primary_counts = self.track_counts(primary_axis);
+        let primary_range = primary_counts.oz_line_range_to_track_range(primary_span);
+        let secondary_range = self.track_counts(primary_axis.other_axis()).oz_line_range_to_track_range(secondary_span);
+        self.area_collision_extent(primary_axis, primary_range, secondary_range, reversed).map(|track_index| {
+            let line = primary_counts.track_to_prev_oz_line(track_index as u16);
+            if reversed {
+                OriginZeroLine(line.0 - 1)
+            } else {
+                line + 1
+            }
+        })
+    }
+
+    /// Given a span of tracks in `axis` (in OriginZero coordinates), returns the next search
+    /// position past all non-empty tracks within the span, or `None` if all tracks within the
+    /// span are entirely unoccupied. Used to place items which span every track in the other
+    /// axis (such items can only fit in a stripe of entirely unoccupied tracks).
+    pub fn occupied_track_jump(
+        &self,
+        axis: AbsoluteAxis,
+        span: Line<OriginZeroLine>,
+        reversed: bool,
+    ) -> Option<OriginZeroLine> {
+        let counts = self.track_counts(axis);
+        let hulls: &[OccupiedHull] = match axis {
+            AbsoluteAxis::Horizontal => &self.column_hulls,
+            AbsoluteAxis::Vertical => &self.row_hulls,
+        };
+        let range = counts.oz_line_range_to_track_range(span);
+        let start = max(range.start, 0);
+        let end = min(range.end, hulls.len() as i16);
+        let found = if !reversed {
+            (start..end).rev().find(|&index| hulls[index as usize].is_some())
+        } else {
+            (start..end).find(|&index| hulls[index as usize].is_some())
+        };
+        found.map(|track_index| {
+            let line = counts.track_to_prev_oz_line(track_index as u16);
+            if reversed {
+                OriginZeroLine(line.0 - 1)
+            } else {
+                line + 1
+            }
+        })
     }
 
     /// Determines whether the specified row contains any items
     pub fn row_is_occupied(&self, row_index: usize) -> bool {
-        if row_index >= self.inner.rows() {
-            return false;
-        }
-        self.inner.iter_row(row_index).any(|cell| !matches!(cell, CellOccupancyState::Unoccupied))
+        self.row_hulls.get(row_index).is_some_and(|hull| hull.is_some())
     }
 
     /// Determines whether the specified column contains any items
     pub fn column_is_occupied(&self, column_index: usize) -> bool {
-        if column_index >= self.inner.cols() {
-            return false;
-        }
-        self.inner.iter_col(column_index).any(|cell| !matches!(cell, CellOccupancyState::Unoccupied))
+        self.column_hulls.get(column_index).is_some_and(|hull| hull.is_some())
     }
 
     /// Returns the track counts of this CellOccunpancyMatrix in the relevant axis


### PR DESCRIPTION
# Objective

Fixes #1013

Grid auto-placement could take ~9 minutes for a single `compute_layout` call when a large-span item was auto-placed into a grid anchored near the positive track limit: the search cursor advanced one track at a time and each candidate position was checked with an O(span²) dense cell scan.

## Changes

`CellOccupancyMatrix` now maintains stateful per-track scanner state that persists across placement scans and is updated incrementally as items are recorded:

- `row_hulls` / `column_hulls`: for each track, the hull `Option<Range<i16>>` from the first to one-past-the-last occupied cell (i.e. the min/max range outside which all cells are known available). Maintained in `mark_area_as` and shifted in `expand_to_fit_range`.

On top of this state, the placement search implements the other two suggested fixes:

- **Jump past collisions instead of advancing by 1**: `line_area_is_unoccupied` is replaced by
  ```rust
  fn line_area_collision_jump(primary_axis, primary_span, secondary_span, reversed) -> Option<OriginZeroLine>
  ```
  which returns `None` if the area is free, or the next search position not guaranteed to collide (one past the max occupied cell in the area for forward search; min for reversed/RTL search). Every skipped position provably collides with the returned cell, so results are identical to the one-track-at-a-time search. Tracks whose hull is disjoint from the area are skipped in O(1), and a hull ending inside the area yields its boundary cell (always occupied) in O(1); a dense scan is only needed when a hull straddles the area's edge.
- **Special-case items whose span ≥ the axis track count**: such an item can only sit at the grid start, in a stripe of entirely-empty tracks. `occupied_track_jump` jumps the secondary cursor past all non-empty tracks in the spanned stripe using the hulls (a track is non-empty iff its hull is `Some`).

All three search loops (`place_definite_secondary_axis_item` and both branches of `place_indefinitely_positioned_item`) use the jumping search. `row_is_occupied` / `column_is_occupied` also become O(1) hull lookups.

With overflow checks on (release build), the issue's repro drops from ~540s to ~2.0s; the remaining time is dominated by the dense 20000×20000 cell matrix allocation/expansion itself, matching the previously-fast negative-anchor baseline (~1.6s), i.e. the placement search is no longer the bottleneck.

## Context

- No behavior change intended: placement results are identical to the previous linear search (all 4429 generated tests plus unit tests pass unchanged).
- The `anchor=32767` cases from the issue's table overflow `i16` in `OriginZeroLine + span` on `main` (with `-C overflow-checks=on`) both before and after this PR — that is the preexisting track-limit issue addressed by the clamping work in #986, not touched here.
- Internal-only change (no public API affected), so RELEASES.md is not updated.

## Feedback wanted

Whether the hull representation is sufficient as the "stateful scanner" state, or whether a full interval/bitset representation per track is wanted. The hull is a conservative over-approximation (cells inside it may be free), but the dense fallback only triggers when a hull straddles the candidate area's edge, which keeps the pathological cases fast while guaranteeing identical placement results.

Link to Devin session: https://app.devin.ai/sessions/ccd2776d73154ce3850c2fa28d33be78
Requested by: @nicoburns