### PR TITLE
Force scrollbar size in gentests

### DIFF
--- a/scripts/gentest/src/main.rs
+++ b/scripts/gentest/src/main.rs
@@ -150,7 +150,7 @@ async fn main() {
 
 async fn asserts_non_zero_width_scrollbars(client: Client) {
     // Load minimal test page defined in the string
-    const TEST_PAGE: &str = r#"data:text/html;charset=utf-8,<html><body><div style="overflow:scroll" /></body></html>"#;
+    const TEST_PAGE: &str = r#"data:text/html;charset=utf-8,<html><style>::-webkit-scrollbar{ width: 15px; height: 15px; }</style><body><div style="overflow:scroll" /></body></html>"#;
     client.goto(TEST_PAGE).await.unwrap();
 
     // Determine the width of the scrollbar

--- a/scripts/gentest/test_base_style.css
+++ b/scripts/gentest/test_base_style.css
@@ -12,6 +12,13 @@
     font-style: normal;
 }
 
+/* Force Chrome to use space-taking scrollbars.
+   The exact width (15px) must match the width assumed in the test runner */
+::-webkit-scrollbar {
+  width: 15px;
+  height: 15px;
+}
+
 body {
   padding: 0;
   margin: 0;


### PR DESCRIPTION
# Objective

Split commit cdec5303 out of #1004 as a standalone PR.

Force Chrome to use space-taking 15px scrollbars during test generation via a `::-webkit-scrollbar { width: 15px; height: 15px; }` rule (in `test_base_style.css` and in the scrollbar-width sanity-check page in `scripts/gentest/src/main.rs`), instead of relying on OS scrollbar settings. This makes gentest output reproducible across machines; 15px matches the width already assumed by the test runner.

## Context

Cherry-picked from #1004 (originally cdec530348439ac9e983c7351df679a26b9fae65). Tests were regenerated after this change and produced no diffs.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/06c8ca00413649e2bf7f6f115ee33652
Requested by: @nicoburns