### PR TITLE
Flexbox: don't floor item intrinsic contributions by container padding/border

### DIFF
--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -1117,12 +1117,9 @@ fn determine_container_main_size(
                                 // Ultimately, this was not found by reading the spec, but by trial and error fixing tests to align with Webkit/Firefox output.
                                 // (see the `flex_basis_unconstraint_row` and `flex_basis_uncontraint_column` generated tests which demonstrate this)
                                 if constants.is_row {
-                                    content_main_size.maybe_clamp(style_min, style_max).max(main_content_box_inset)
+                                    content_main_size.maybe_clamp(style_min, style_max)
                                 } else {
-                                    content_main_size
-                                        .max(item.flex_basis)
-                                        .maybe_clamp(style_min, style_max)
-                                        .max(main_content_box_inset)
+                                    content_main_size.max(item.flex_basis).maybe_clamp(style_min, style_max)
                                 }
                             }
                         };

--- a/test_fixtures/flex/flex_grow_padding_auto_size_column.html
+++ b/test_fixtures/flex/flex_grow_padding_auto_size_column.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; flex-direction: column; padding: 100px;">
+  <div style="flex-grow: 1; width: 50px; height: 10px;"></div>
+  <div style="width: 50px; height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/flex_grow_padding_auto_size_row.html
+++ b/test_fixtures/flex/flex_grow_padding_auto_size_row.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; flex-direction: row; padding: 100px;">
+  <div style="flex-grow: 1; width: 10px; height: 50px;"></div>
+  <div style="width: 10px; height: 50px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/flex/flex_grow_padding_auto_size_column__border_box_ltr.xml
+++ b/tests/xml/flex/flex_grow_padding_auto_size_column__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="flex_grow_padding_auto_size_column__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" flex-direction="column" padding-top="100px" padding-left="100px" padding-bottom="100px" padding-right="100px">
+      <div direction="ltr" flex-grow="1" width="50px" height="10px"/>
+      <div direction="ltr" width="50px" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="250" height="220">
+      <node x="100" y="100" width="50" height="10"/>
+      <node x="100" y="110" width="50" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_grow_padding_auto_size_column__border_box_rtl.xml
+++ b/tests/xml/flex/flex_grow_padding_auto_size_column__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="flex_grow_padding_auto_size_column__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" flex-direction="column" padding-top="100px" padding-left="100px" padding-bottom="100px" padding-right="100px">
+      <div direction="rtl" flex-grow="1" width="50px" height="10px"/>
+      <div direction="rtl" width="50px" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="250" height="220">
+      <node x="100" y="100" width="50" height="10"/>
+      <node x="100" y="110" width="50" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_grow_padding_auto_size_column__content_box_ltr.xml
+++ b/tests/xml/flex/flex_grow_padding_auto_size_column__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="flex_grow_padding_auto_size_column__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" flex-direction="column" padding-top="100px" padding-left="100px" padding-bottom="100px" padding-right="100px">
+      <div box-sizing="content-box" direction="ltr" flex-grow="1" width="50px" height="10px"/>
+      <div box-sizing="content-box" direction="ltr" width="50px" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="250" height="220">
+      <node x="100" y="100" width="50" height="10"/>
+      <node x="100" y="110" width="50" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_grow_padding_auto_size_column__content_box_rtl.xml
+++ b/tests/xml/flex/flex_grow_padding_auto_size_column__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="flex_grow_padding_auto_size_column__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" flex-direction="column" padding-top="100px" padding-left="100px" padding-bottom="100px" padding-right="100px">
+      <div box-sizing="content-box" direction="rtl" flex-grow="1" width="50px" height="10px"/>
+      <div box-sizing="content-box" direction="rtl" width="50px" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="250" height="220">
+      <node x="100" y="100" width="50" height="10"/>
+      <node x="100" y="110" width="50" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_grow_padding_auto_size_row__border_box_ltr.xml
+++ b/tests/xml/flex/flex_grow_padding_auto_size_row__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="flex_grow_padding_auto_size_row__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" padding-top="100px" padding-left="100px" padding-bottom="100px" padding-right="100px">
+      <div direction="ltr" flex-grow="1" width="10px" height="50px"/>
+      <div direction="ltr" width="10px" height="50px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="220" height="250">
+      <node x="100" y="100" width="10" height="50"/>
+      <node x="110" y="100" width="10" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_grow_padding_auto_size_row__border_box_rtl.xml
+++ b/tests/xml/flex/flex_grow_padding_auto_size_row__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="flex_grow_padding_auto_size_row__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" padding-top="100px" padding-left="100px" padding-bottom="100px" padding-right="100px">
+      <div direction="rtl" flex-grow="1" width="10px" height="50px"/>
+      <div direction="rtl" width="10px" height="50px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="220" height="250">
+      <node x="110" y="100" width="10" height="50"/>
+      <node x="100" y="100" width="10" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_grow_padding_auto_size_row__content_box_ltr.xml
+++ b/tests/xml/flex/flex_grow_padding_auto_size_row__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="flex_grow_padding_auto_size_row__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" padding-top="100px" padding-left="100px" padding-bottom="100px" padding-right="100px">
+      <div box-sizing="content-box" direction="ltr" flex-grow="1" width="10px" height="50px"/>
+      <div box-sizing="content-box" direction="ltr" width="10px" height="50px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="220" height="250">
+      <node x="100" y="100" width="10" height="50"/>
+      <node x="110" y="100" width="10" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_grow_padding_auto_size_row__content_box_rtl.xml
+++ b/tests/xml/flex/flex_grow_padding_auto_size_row__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="flex_grow_padding_auto_size_row__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" padding-top="100px" padding-left="100px" padding-bottom="100px" padding-right="100px">
+      <div box-sizing="content-box" direction="rtl" flex-grow="1" width="10px" height="50px"/>
+      <div box-sizing="content-box" direction="rtl" width="10px" height="50px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="220" height="250">
+      <node x="110" y="100" width="10" height="50"/>
+      <node x="100" y="100" width="10" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -10302,6 +10302,46 @@ mod flex {
     }
 
     #[test]
+    fn flex_grow_padding_auto_size_column__border_box_ltr() {
+        crate::run_xml_test("flex", "flex_grow_padding_auto_size_column__border_box_ltr");
+    }
+
+    #[test]
+    fn flex_grow_padding_auto_size_column__content_box_ltr() {
+        crate::run_xml_test("flex", "flex_grow_padding_auto_size_column__content_box_ltr");
+    }
+
+    #[test]
+    fn flex_grow_padding_auto_size_column__border_box_rtl() {
+        crate::run_xml_test("flex", "flex_grow_padding_auto_size_column__border_box_rtl");
+    }
+
+    #[test]
+    fn flex_grow_padding_auto_size_column__content_box_rtl() {
+        crate::run_xml_test("flex", "flex_grow_padding_auto_size_column__content_box_rtl");
+    }
+
+    #[test]
+    fn flex_grow_padding_auto_size_row__border_box_ltr() {
+        crate::run_xml_test("flex", "flex_grow_padding_auto_size_row__border_box_ltr");
+    }
+
+    #[test]
+    fn flex_grow_padding_auto_size_row__content_box_ltr() {
+        crate::run_xml_test("flex", "flex_grow_padding_auto_size_row__content_box_ltr");
+    }
+
+    #[test]
+    fn flex_grow_padding_auto_size_row__border_box_rtl() {
+        crate::run_xml_test("flex", "flex_grow_padding_auto_size_row__border_box_rtl");
+    }
+
+    #[test]
+    fn flex_grow_padding_auto_size_row__content_box_rtl() {
+        crate::run_xml_test("flex", "flex_grow_padding_auto_size_row__content_box_rtl");
+    }
+
+    #[test]
     fn flex_grow_root_minimized__border_box_ltr() {
         crate::run_xml_test("flex", "flex_grow_root_minimized__border_box_ltr");
     }


### PR DESCRIPTION
# Objective

Fixes #909.

When a flex container with padding/border has an auto main size, items with `flex_grow > 0` incorrectly grew to fill the container's padding+border space. E.g. a column with `padding: 100px` and two 10px-tall children gave the `flex_grow: 1` child a height of 200px (container 410px) where Chrome gives 10px (container 220px).

## Context

In `determine_container_main_size` (min-/max-content branch), each item's intrinsic content contribution was floored by `main_content_box_inset` — the *container's* padding+border sum:

```rust
content_main_size.max(item.flex_basis).maybe_clamp(style_min, style_max).max(main_content_box_inset)
```

This inflated `content_flex_fraction` for growable items (`diff = 200 - flex_basis`), causing them to grow by the container's inset. The inset is already added once to the container size afterwards (`main_size + main_content_box_inset`) and the container-level floor is applied separately after clamping, so the per-item floor is removed.

New gentests `flex_grow_padding_auto_size_column`/`_row` (Chrome-generated expectations) cover the issue's repro. Full test suite passes and no other gentest expectations changed.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/ce1f4bf119b24d2c8f6391f6e8205eea
Requested by: @nicoburns