### PR TITLE
Port WPT grid-intrinsic-track-sizes-001; fix minimum contribution clamp and beyond-limits distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Fixed
 
+- Grid: an explicitly specified preferred or minimum size is no longer clamped by the spanned tracks' fixed max track sizing functions when computing an item's minimum contribution. That clamp only applies to the content-based (automatic) minimum size, per [CSS Grid §6.6](https://www.w3.org/TR/css-grid-1/#min-size-auto). Fixes e.g. an item with `min-width: 12px` in a `minmax(auto, 10px)` track sizing the track to `12px` rather than `10px`
+
+- Grid: when distributing a spanning item's intrinsic size contribution to its spanned tracks, space distributed "beyond limits" now ignores the tracks' growth limits (still capping growth at any `fit-content()` argument), per [CSS Grid §12.5.1](https://www.w3.org/TR/css-grid-1/#extra-space). Previously the growth limits were still enforced, so tracks such as `minmax(min-content, 10px)` could not expand beyond `10px` to accommodate an item's contribution
+
 - Grid: when distributing a spanning item's intrinsic size contribution to flexible tracks, the flex factor sum used to decide between flex-factor-proportional and equal distribution is now computed over only the spanned tracks eligible to receive the space (rather than all tracks in the axis), matching Chrome. Fixes track sizing when an item spans `0fr` tracks or a mix of intrinsic and non-intrinsic flexible tracks (e.g. `0fr minmax(0, 1fr)`)
 
 - Block: replaced elements (`item_is_replaced: true`) are no longer stretch-sized to the container width. An auto width now resolves to the intrinsic size, per [CSS 2 §10.3.4](https://www.w3.org/TR/CSS22/visudet.html#block-replaced-width)

--- a/src/compute/grid/track_sizing.rs
+++ b/src/compute/grid/track_sizing.rs
@@ -725,6 +725,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                         has_intrinsic_min_track_sizing_function,
                         fit_content_limit,
                         IntrinsicContributionType::Minimum,
+                        axis_inner_node_size,
                     );
                 } else {
                     distribute_item_space_to_base_size(
@@ -734,6 +735,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                         has_intrinsic_min_track_sizing_function,
                         |track| track.growth_limit,
                         IntrinsicContributionType::Minimum,
+                        axis_inner_node_size,
                     );
                 }
             }
@@ -759,6 +761,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                         has_min_or_max_content_min_track_sizing_function,
                         fit_content_limit,
                         IntrinsicContributionType::Minimum,
+                        axis_inner_node_size,
                     );
                 } else {
                     distribute_item_space_to_base_size(
@@ -768,6 +771,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                         has_min_or_max_content_min_track_sizing_function,
                         |track| track.growth_limit,
                         IntrinsicContributionType::Minimum,
+                        axis_inner_node_size,
                     );
                 }
             }
@@ -829,6 +833,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                             has_max_content_min_track_sizing_function,
                             |_| f32::INFINITY,
                             IntrinsicContributionType::Maximum,
+                            axis_inner_node_size,
                         );
                     } else {
                         let fit_content_limited_growth_limit =
@@ -840,6 +845,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                             has_auto_min_track_sizing_function,
                             fit_content_limited_growth_limit,
                             IntrinsicContributionType::Maximum,
+                            axis_inner_node_size,
                         );
                     }
                 }
@@ -863,6 +869,7 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                     has_max_content_min_track_sizing_function,
                     |track| track.growth_limit,
                     IntrinsicContributionType::Maximum,
+                    axis_inner_node_size,
                 );
             }
         }
@@ -942,6 +949,7 @@ fn distribute_item_space_to_base_size(
     track_is_affected: impl Fn(&GridTrack) -> bool,
     track_limit: impl Fn(&GridTrack) -> f32,
     intrinsic_contribution_type: IntrinsicContributionType,
+    axis_inner_node_size: Option<f32>,
 ) {
     if is_flex {
         let filter = |track: &GridTrack| track.is_flexible() && track_is_affected(track);
@@ -962,6 +970,7 @@ fn distribute_item_space_to_base_size(
                 |track| track.flex_factor(),
                 track_limit,
                 intrinsic_contribution_type,
+                axis_inner_node_size,
             )
         } else {
             distribute_item_space_to_base_size_inner(
@@ -971,6 +980,7 @@ fn distribute_item_space_to_base_size(
                 |_| 1.0,
                 track_limit,
                 intrinsic_contribution_type,
+                axis_inner_node_size,
             )
         }
     } else {
@@ -981,6 +991,7 @@ fn distribute_item_space_to_base_size(
             |_| 1.0,
             track_limit,
             intrinsic_contribution_type,
+            axis_inner_node_size,
         )
     }
 
@@ -993,6 +1004,7 @@ fn distribute_item_space_to_base_size(
         track_distribution_proportion: impl Fn(&GridTrack) -> f32,
         track_limit: impl Fn(&GridTrack) -> f32,
         intrinsic_contribution_type: IntrinsicContributionType,
+        axis_inner_node_size: Option<f32>,
     ) {
         // Skip this distribution if there is either
         //   - no space to distribute
@@ -1052,13 +1064,15 @@ fn distribute_item_space_to_base_size(
                 filter = (|_| true) as fn(&GridTrack) -> bool;
             }
 
+            // When distributing beyond limits, growth limits are ignored, but the argument
+            // to any fit-content() max track sizing function still caps growth.
             distribute_space_up_to_limits(
                 extra_space,
                 tracks,
-                filter,
+                |track| track_is_affected(track) && filter(track),
                 &track_distribution_proportion,
                 get_base_size,
-                &track_limit, // Should apply only fit-content limit here?
+                |track| track.fit_content_limit(axis_inner_node_size),
             );
         }
 

--- a/src/compute/grid/types/grid_item.rs
+++ b/src/compute/grid/types/grid_item.rs
@@ -523,8 +523,7 @@ impl GridItem {
         let padding_border_size = (padding + border).sum_axes();
         let box_sizing_adjustment =
             if self.box_sizing == BoxSizing::ContentBox { padding_border_size } else { Size::ZERO };
-        let size = self
-            .size
+        self.size
             .maybe_resolve(grid_area_size, |val, basis| tree.calc(val, basis))
             .maybe_apply_aspect_ratio(self.aspect_ratio)
             .maybe_add(box_sizing_adjustment)
@@ -575,19 +574,19 @@ impl GridItem {
                         minimum_contribution = minimum_contribution.maybe_min(size).maybe_min(max_size);
                     }
 
-                    minimum_contribution
+                    // The content-based minimum size is additionally clamped by the sum of any fixed max track sizing
+                    // functions of the tracks the item spans. Note that this clamp does not apply to explicitly specified
+                    // preferred or minimum sizes, and that the argument to fit-content() does not clamp the content-based
+                    // minimum size in the same way as a fixed max track sizing function.
+                    let limit =
+                        self.spanned_fixed_track_limit(axis, axis_tracks, inner_node_size.get(axis), &|val, basis| {
+                            tree.resolve_calc_value(val, basis)
+                        });
+                    minimum_contribution.maybe_min(limit)
                 } else {
                     0.0
                 }
-            });
-
-        // In all cases, the size suggestion is additionally clamped by the maximum size in the affected axis, if it’s definite.
-        // Note: The argument to fit-content() does not clamp the content-based minimum size in the same way as a fixed max track
-        // sizing function.
-        let limit = self.spanned_fixed_track_limit(axis, axis_tracks, inner_node_size.get(axis), &|val, basis| {
-            tree.resolve_calc_value(val, basis)
-        });
-        size.maybe_min(limit)
+            })
     }
 
     /// Retrieve the item's minimum contribution from the cache or compute it using the provided parameters

--- a/test_fixtures/grid/grid_intrinsic_track_sizes_001_span1_auto.html
+++ b/test_fixtures/grid/grid_intrinsic_track_sizes_001_span1_auto.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 120px; height: 120px; border: 3px solid black; grid-template-columns: auto; grid-template-rows: auto;">
+  <div style="min-width: 12px; min-height: 12px; grid-column: 1 / span 1; grid-row: 1 / span 1;">XXX&#8203;XX&#8203;X</div>
+  <div style="grid-column: 1; grid-row: 1;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_intrinsic_track_sizes_001_span1_max_content.html
+++ b/test_fixtures/grid/grid_intrinsic_track_sizes_001_span1_max_content.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 120px; height: 120px; border: 3px solid black; grid-template-columns: max-content; grid-template-rows: max-content;">
+  <div style="min-width: 12px; min-height: 12px; grid-column: 1 / span 1; grid-row: 1 / span 1;">XXX&#8203;XX&#8203;X</div>
+  <div style="grid-column: 1; grid-row: 1;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_intrinsic_track_sizes_001_span1_min_content.html
+++ b/test_fixtures/grid/grid_intrinsic_track_sizes_001_span1_min_content.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 120px; height: 120px; border: 3px solid black; grid-template-columns: min-content; grid-template-rows: min-content;">
+  <div style="min-width: 12px; min-height: 12px; grid-column: 1 / span 1; grid-row: 1 / span 1;">XXX&#8203;XX&#8203;X</div>
+  <div style="grid-column: 1; grid-row: 1;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_intrinsic_track_sizes_001_span1_minmax_0_auto.html
+++ b/test_fixtures/grid/grid_intrinsic_track_sizes_001_span1_minmax_0_auto.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 120px; height: 120px; border: 3px solid black; grid-template-columns: minmax(0, auto); grid-template-rows: minmax(0, auto);">
+  <div style="min-width: 12px; min-height: 12px; grid-column: 1 / span 1; grid-row: 1 / span 1;">XXX&#8203;XX&#8203;X</div>
+  <div style="grid-column: 1; grid-row: 1;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_intrinsic_track_sizes_001_span1_minmax_0_max_content.html
+++ b/test_fixtures/grid/grid_intrinsic_track_sizes_001_span1_minmax_0_max_content.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 120px; height: 120px; border: 3px solid black; grid-template-columns: minmax(0, max-content); grid-template-rows: minmax(0, max-content);">
+  <div style="min-width: 12px; min-height: 12px; grid-column: 1 / span 1; grid-row: 1 / span 1;">XXX&#8203;XX&#8203;X</div>
+  <div style="grid-column: 1; grid-row: 1;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_intrinsic_track_sizes_001_span1_minmax_0_min_content.html
+++ b/test_fixtures/grid/grid_intrinsic_track_sizes_001_span1_minmax_0_min_content.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 120px; height: 120px; border: 3px solid black; grid-template-columns: minmax(0, min-content); grid-template-rows: minmax(0, min-content);">
+  <div style="min-width: 12px; min-height: 12px; grid-column: 1 / span 1; grid-row: 1 / span 1;">XXX&#8203;XX&#8203;X</div>
+  <div style="grid-column: 1; grid-row: 1;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_intrinsic_track_sizes_001_span1_minmax_auto_10px.html
+++ b/test_fixtures/grid/grid_intrinsic_track_sizes_001_span1_minmax_auto_10px.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 120px; height: 120px; border: 3px solid black; grid-template-columns: minmax(auto, 10px); grid-template-rows: minmax(auto, 10px);">
+  <div style="min-width: 12px; min-height: 12px; grid-column: 1 / span 1; grid-row: 1 / span 1;">XXX&#8203;XX&#8203;X</div>
+  <div style="grid-column: 1; grid-row: 1;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_intrinsic_track_sizes_001_span1_minmax_max_content_10px.html
+++ b/test_fixtures/grid/grid_intrinsic_track_sizes_001_span1_minmax_max_content_10px.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 120px; height: 120px; border: 3px solid black; grid-template-columns: minmax(max-content, 10px); grid-template-rows: minmax(max-content, 10px);">
+  <div style="min-width: 12px; min-height: 12px; grid-column: 1 / span 1; grid-row: 1 / span 1;">XXX&#8203;XX&#8203;X</div>
+  <div style="grid-column: 1; grid-row: 1;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_intrinsic_track_sizes_001_span1_minmax_min_content_10px.html
+++ b/test_fixtures/grid/grid_intrinsic_track_sizes_001_span1_minmax_min_content_10px.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 120px; height: 120px; border: 3px solid black; grid-template-columns: minmax(min-content, 10px); grid-template-rows: minmax(min-content, 10px);">
+  <div style="min-width: 12px; min-height: 12px; grid-column: 1 / span 1; grid-row: 1 / span 1;">XXX&#8203;XX&#8203;X</div>
+  <div style="grid-column: 1; grid-row: 1;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_20px_auto.html
+++ b/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_20px_auto.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 120px; height: 120px; border: 3px solid black; grid-template-columns: 20px auto; grid-template-rows: 20px auto;">
+  <div style="min-width: 12px; min-height: 12px; grid-column: 1 / span 2; grid-row: 1 / span 2;">XXX&#8203;XX&#8203;X</div>
+  <div style="grid-column: 1; grid-row: 1;"></div>
+  <div style="grid-column: 2; grid-row: 2;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_20px_max_content.html
+++ b/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_20px_max_content.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 120px; height: 120px; border: 3px solid black; grid-template-columns: 20px max-content; grid-template-rows: 20px max-content;">
+  <div style="min-width: 12px; min-height: 12px; grid-column: 1 / span 2; grid-row: 1 / span 2;">XXX&#8203;XX&#8203;X</div>
+  <div style="grid-column: 1; grid-row: 1;"></div>
+  <div style="grid-column: 2; grid-row: 2;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_20px_min_content.html
+++ b/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_20px_min_content.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 120px; height: 120px; border: 3px solid black; grid-template-columns: 20px min-content; grid-template-rows: 20px min-content;">
+  <div style="min-width: 12px; min-height: 12px; grid-column: 1 / span 2; grid-row: 1 / span 2;">XXX&#8203;XX&#8203;X</div>
+  <div style="grid-column: 1; grid-row: 1;"></div>
+  <div style="grid-column: 2; grid-row: 2;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_0_auto.html
+++ b/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_0_auto.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 120px; height: 120px; border: 3px solid black; grid-template-columns: 20px minmax(0, auto); grid-template-rows: 20px minmax(0, auto);">
+  <div style="min-width: 12px; min-height: 12px; grid-column: 1 / span 2; grid-row: 1 / span 2;">XXX&#8203;XX&#8203;X</div>
+  <div style="grid-column: 1; grid-row: 1;"></div>
+  <div style="grid-column: 2; grid-row: 2;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_0_max_content.html
+++ b/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_0_max_content.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 120px; height: 120px; border: 3px solid black; grid-template-columns: 20px minmax(0, max-content); grid-template-rows: 20px minmax(0, max-content);">
+  <div style="min-width: 12px; min-height: 12px; grid-column: 1 / span 2; grid-row: 1 / span 2;">XXX&#8203;XX&#8203;X</div>
+  <div style="grid-column: 1; grid-row: 1;"></div>
+  <div style="grid-column: 2; grid-row: 2;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_0_min_content.html
+++ b/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_0_min_content.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 120px; height: 120px; border: 3px solid black; grid-template-columns: 20px minmax(0, min-content); grid-template-rows: 20px minmax(0, min-content);">
+  <div style="min-width: 12px; min-height: 12px; grid-column: 1 / span 2; grid-row: 1 / span 2;">XXX&#8203;XX&#8203;X</div>
+  <div style="grid-column: 1; grid-row: 1;"></div>
+  <div style="grid-column: 2; grid-row: 2;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_auto_30px.html
+++ b/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_auto_30px.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 120px; height: 120px; border: 3px solid black; grid-template-columns: 20px minmax(auto, 30px); grid-template-rows: 20px minmax(auto, 30px);">
+  <div style="min-width: 12px; min-height: 12px; grid-column: 1 / span 2; grid-row: 1 / span 2;">XXX&#8203;XX&#8203;X</div>
+  <div style="grid-column: 1; grid-row: 1;"></div>
+  <div style="grid-column: 2; grid-row: 2;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_30px.html
+++ b/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_30px.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 120px; height: 120px; border: 3px solid black; grid-template-columns: 20px minmax(max-content, 30px); grid-template-rows: 20px minmax(max-content, 30px);">
+  <div style="min-width: 12px; min-height: 12px; grid-column: 1 / span 2; grid-row: 1 / span 2;">XXX&#8203;XX&#8203;X</div>
+  <div style="grid-column: 1; grid-row: 1;"></div>
+  <div style="grid-column: 2; grid-row: 2;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_6px.html
+++ b/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_6px.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 120px; height: 120px; border: 3px solid black; grid-template-columns: 20px minmax(max-content, 6px); grid-template-rows: 20px minmax(max-content, 6px);">
+  <div style="min-width: 12px; min-height: 12px; grid-column: 1 / span 2; grid-row: 1 / span 2;">XXX&#8203;XX&#8203;X</div>
+  <div style="grid-column: 1; grid-row: 1;"></div>
+  <div style="grid-column: 2; grid-row: 2;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_40px.html
+++ b/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_40px.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 120px; height: 120px; border: 3px solid black; grid-template-columns: 20px minmax(min-content, 40px); grid-template-rows: 20px minmax(min-content, 40px);">
+  <div style="min-width: 12px; min-height: 12px; grid-column: 1 / span 2; grid-row: 1 / span 2;">XXX&#8203;XX&#8203;X</div>
+  <div style="grid-column: 1; grid-row: 1;"></div>
+  <div style="grid-column: 2; grid-row: 2;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_6px.html
+++ b/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_6px.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 120px; height: 120px; border: 3px solid black; grid-template-columns: 20px minmax(min-content, 6px); grid-template-rows: 20px minmax(min-content, 6px);">
+  <div style="min-width: 12px; min-height: 12px; grid-column: 1 / span 2; grid-row: 1 / span 2;">XXX&#8203;XX&#8203;X</div>
+  <div style="grid-column: 1; grid-row: 1;"></div>
+  <div style="grid-column: 2; grid-row: 2;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_auto_auto.html
+++ b/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_auto_auto.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 120px; height: 120px; border: 3px solid black; grid-template-columns: auto auto; grid-template-rows: auto auto;">
+  <div style="min-width: 12px; min-height: 12px; grid-column: 1 / span 2; grid-row: 1 / span 2;">XXX&#8203;XX&#8203;X</div>
+  <div style="grid-column: 1; grid-row: 1;"></div>
+  <div style="grid-column: 2; grid-row: 2;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_max_content_max_content.html
+++ b/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_max_content_max_content.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 120px; height: 120px; border: 3px solid black; grid-template-columns: max-content max-content; grid-template-rows: max-content max-content;">
+  <div style="min-width: 12px; min-height: 12px; grid-column: 1 / span 2; grid-row: 1 / span 2;">XXX&#8203;XX&#8203;X</div>
+  <div style="grid-column: 1; grid-row: 1;"></div>
+  <div style="grid-column: 2; grid-row: 2;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_max_content_min_content.html
+++ b/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_max_content_min_content.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 120px; height: 120px; border: 3px solid black; grid-template-columns: max-content min-content; grid-template-rows: max-content min-content;">
+  <div style="min-width: 12px; min-height: 12px; grid-column: 1 / span 2; grid-row: 1 / span 2;">XXX&#8203;XX&#8203;X</div>
+  <div style="grid-column: 1; grid-row: 1;"></div>
+  <div style="grid-column: 2; grid-row: 2;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_min_content_min_content.html
+++ b/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_min_content_min_content.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 120px; height: 120px; border: 3px solid black; grid-template-columns: min-content min-content; grid-template-rows: min-content min-content;">
+  <div style="min-width: 12px; min-height: 12px; grid-column: 1 / span 2; grid-row: 1 / span 2;">XXX&#8203;XX&#8203;X</div>
+  <div style="grid-column: 1; grid-row: 1;"></div>
+  <div style="grid-column: 2; grid-row: 2;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_minmax_0_auto_minmax_0_auto.html
+++ b/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_minmax_0_auto_minmax_0_auto.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 120px; height: 120px; border: 3px solid black; grid-template-columns: minmax(0, auto) minmax(0, auto); grid-template-rows: minmax(0, auto) minmax(0, auto);">
+  <div style="min-width: 12px; min-height: 12px; grid-column: 1 / span 2; grid-row: 1 / span 2;">XXX&#8203;XX&#8203;X</div>
+  <div style="grid-column: 1; grid-row: 1;"></div>
+  <div style="grid-column: 2; grid-row: 2;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_minmax_0_max_content_minmax_0_max_content.html
+++ b/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_minmax_0_max_content_minmax_0_max_content.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 120px; height: 120px; border: 3px solid black; grid-template-columns: minmax(0, max-content) minmax(0, max-content); grid-template-rows: minmax(0, max-content) minmax(0, max-content);">
+  <div style="min-width: 12px; min-height: 12px; grid-column: 1 / span 2; grid-row: 1 / span 2;">XXX&#8203;XX&#8203;X</div>
+  <div style="grid-column: 1; grid-row: 1;"></div>
+  <div style="grid-column: 2; grid-row: 2;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_minmax_0_min_content_minmax_0_min_content.html
+++ b/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_minmax_0_min_content_minmax_0_min_content.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 120px; height: 120px; border: 3px solid black; grid-template-columns: minmax(0, min-content) minmax(0, min-content); grid-template-rows: minmax(0, min-content) minmax(0, min-content);">
+  <div style="min-width: 12px; min-height: 12px; grid-column: 1 / span 2; grid-row: 1 / span 2;">XXX&#8203;XX&#8203;X</div>
+  <div style="grid-column: 1; grid-row: 1;"></div>
+  <div style="grid-column: 2; grid-row: 2;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_minmax_auto_10px_minmax_auto_10px.html
+++ b/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_minmax_auto_10px_minmax_auto_10px.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 120px; height: 120px; border: 3px solid black; grid-template-columns: minmax(auto, 10px) minmax(auto, 10px); grid-template-rows: minmax(auto, 10px) minmax(auto, 10px);">
+  <div style="min-width: 12px; min-height: 12px; grid-column: 1 / span 2; grid-row: 1 / span 2;">XXX&#8203;XX&#8203;X</div>
+  <div style="grid-column: 1; grid-row: 1;"></div>
+  <div style="grid-column: 2; grid-row: 2;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_minmax_auto_4px_minmax_auto_4px.html
+++ b/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_minmax_auto_4px_minmax_auto_4px.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 120px; height: 120px; border: 3px solid black; grid-template-columns: minmax(auto, 4px) minmax(auto, 4px); grid-template-rows: minmax(auto, 4px) minmax(auto, 4px);">
+  <div style="min-width: 12px; min-height: 12px; grid-column: 1 / span 2; grid-row: 1 / span 2;">XXX&#8203;XX&#8203;X</div>
+  <div style="grid-column: 1; grid-row: 1;"></div>
+  <div style="grid-column: 2; grid-row: 2;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_minmax_max_content_10px_minmax_max_content_10px.html
+++ b/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_minmax_max_content_10px_minmax_max_content_10px.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 120px; height: 120px; border: 3px solid black; grid-template-columns: minmax(max-content, 10px) minmax(max-content, 10px); grid-template-rows: minmax(max-content, 10px) minmax(max-content, 10px);">
+  <div style="min-width: 12px; min-height: 12px; grid-column: 1 / span 2; grid-row: 1 / span 2;">XXX&#8203;XX&#8203;X</div>
+  <div style="grid-column: 1; grid-row: 1;"></div>
+  <div style="grid-column: 2; grid-row: 2;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_minmax_min_content_10px_minmax_min_content_10px.html
+++ b/test_fixtures/grid/grid_intrinsic_track_sizes_001_span2_minmax_min_content_10px_minmax_min_content_10px.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 120px; height: 120px; border: 3px solid black; grid-template-columns: minmax(min-content, 10px) minmax(min-content, 10px); grid-template-rows: minmax(min-content, 10px) minmax(min-content, 10px);">
+  <div style="min-width: 12px; min-height: 12px; grid-column: 1 / span 2; grid-row: 1 / span 2;">XXX&#8203;XX&#8203;X</div>
+  <div style="grid-column: 1; grid-row: 1;"></div>
+  <div style="grid-column: 2; grid-row: 2;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_auto__border_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_auto__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_intrinsic_track_sizes_001_span1_auto__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="auto" grid-template-columns="auto">
+      <text direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 1" grid-column-start="1" grid-column-end="span 1">
+        XXX​XX​X
+      </text>
+      <div direction="ltr" grid-row-start="1" grid-column-start="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="114" height="114"/>
+      <node x="3" y="3" width="114" height="114"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_auto__border_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_auto__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_intrinsic_track_sizes_001_span1_auto__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="auto" grid-template-columns="auto">
+      <text direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 1" grid-column-start="1" grid-column-end="span 1">
+        XXX​XX​X
+      </text>
+      <div direction="rtl" grid-row-start="1" grid-column-start="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="114" height="114"/>
+      <node x="3" y="3" width="114" height="114"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_auto__content_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_auto__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_intrinsic_track_sizes_001_span1_auto__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="auto" grid-template-columns="auto">
+      <text box-sizing="content-box" direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 1" grid-column-start="1" grid-column-end="span 1">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="1" grid-column-start="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="120" height="120"/>
+      <node x="3" y="3" width="120" height="120"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_auto__content_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_auto__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_intrinsic_track_sizes_001_span1_auto__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="auto" grid-template-columns="auto">
+      <text box-sizing="content-box" direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 1" grid-column-start="1" grid-column-end="span 1">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="1" grid-column-start="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="120" height="120"/>
+      <node x="3" y="3" width="120" height="120"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_max_content__border_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_max_content__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_intrinsic_track_sizes_001_span1_max_content__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="max-content" grid-template-columns="max-content">
+      <text direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 1" grid-column-start="1" grid-column-end="span 1">
+        XXX​XX​X
+      </text>
+      <div direction="ltr" grid-row-start="1" grid-column-start="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="60" height="12"/>
+      <node x="3" y="3" width="60" height="12"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_max_content__border_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_max_content__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_intrinsic_track_sizes_001_span1_max_content__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="max-content" grid-template-columns="max-content">
+      <text direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 1" grid-column-start="1" grid-column-end="span 1">
+        XXX​XX​X
+      </text>
+      <div direction="rtl" grid-row-start="1" grid-column-start="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="57" y="3" width="60" height="12"/>
+      <node x="57" y="3" width="60" height="12"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_max_content__content_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_max_content__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_intrinsic_track_sizes_001_span1_max_content__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="max-content" grid-template-columns="max-content">
+      <text box-sizing="content-box" direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 1" grid-column-start="1" grid-column-end="span 1">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="1" grid-column-start="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="60" height="12"/>
+      <node x="3" y="3" width="60" height="12"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_max_content__content_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_max_content__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_intrinsic_track_sizes_001_span1_max_content__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="max-content" grid-template-columns="max-content">
+      <text box-sizing="content-box" direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 1" grid-column-start="1" grid-column-end="span 1">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="1" grid-column-start="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="63" y="3" width="60" height="12"/>
+      <node x="63" y="3" width="60" height="12"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_min_content__border_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_min_content__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_intrinsic_track_sizes_001_span1_min_content__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="min-content" grid-template-columns="min-content">
+      <text direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 1" grid-column-start="1" grid-column-end="span 1">
+        XXX​XX​X
+      </text>
+      <div direction="ltr" grid-row-start="1" grid-column-start="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="30" height="20"/>
+      <node x="3" y="3" width="30" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_min_content__border_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_min_content__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_intrinsic_track_sizes_001_span1_min_content__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="min-content" grid-template-columns="min-content">
+      <text direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 1" grid-column-start="1" grid-column-end="span 1">
+        XXX​XX​X
+      </text>
+      <div direction="rtl" grid-row-start="1" grid-column-start="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="87" y="3" width="30" height="20"/>
+      <node x="87" y="3" width="30" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_min_content__content_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_min_content__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_intrinsic_track_sizes_001_span1_min_content__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="min-content" grid-template-columns="min-content">
+      <text box-sizing="content-box" direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 1" grid-column-start="1" grid-column-end="span 1">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="1" grid-column-start="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="30" height="20"/>
+      <node x="3" y="3" width="30" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_min_content__content_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_min_content__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_intrinsic_track_sizes_001_span1_min_content__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="min-content" grid-template-columns="min-content">
+      <text box-sizing="content-box" direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 1" grid-column-start="1" grid-column-end="span 1">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="1" grid-column-start="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="93" y="3" width="30" height="20"/>
+      <node x="93" y="3" width="30" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_0_auto__border_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_0_auto__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_intrinsic_track_sizes_001_span1_minmax_0_auto__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(0px,auto)" grid-template-columns="minmax(0px,auto)">
+      <text direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 1" grid-column-start="1" grid-column-end="span 1">
+        XXX​XX​X
+      </text>
+      <div direction="ltr" grid-row-start="1" grid-column-start="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="114" height="114"/>
+      <node x="3" y="3" width="114" height="114"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_0_auto__border_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_0_auto__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_intrinsic_track_sizes_001_span1_minmax_0_auto__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(0px,auto)" grid-template-columns="minmax(0px,auto)">
+      <text direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 1" grid-column-start="1" grid-column-end="span 1">
+        XXX​XX​X
+      </text>
+      <div direction="rtl" grid-row-start="1" grid-column-start="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="114" height="114"/>
+      <node x="3" y="3" width="114" height="114"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_0_auto__content_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_0_auto__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_intrinsic_track_sizes_001_span1_minmax_0_auto__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(0px,auto)" grid-template-columns="minmax(0px,auto)">
+      <text box-sizing="content-box" direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 1" grid-column-start="1" grid-column-end="span 1">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="1" grid-column-start="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="120" height="120"/>
+      <node x="3" y="3" width="120" height="120"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_0_auto__content_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_0_auto__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_intrinsic_track_sizes_001_span1_minmax_0_auto__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(0px,auto)" grid-template-columns="minmax(0px,auto)">
+      <text box-sizing="content-box" direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 1" grid-column-start="1" grid-column-end="span 1">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="1" grid-column-start="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="120" height="120"/>
+      <node x="3" y="3" width="120" height="120"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_0_max_content__border_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_0_max_content__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_intrinsic_track_sizes_001_span1_minmax_0_max_content__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(0px,max-content)" grid-template-columns="minmax(0px,max-content)">
+      <text direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 1" grid-column-start="1" grid-column-end="span 1">
+        XXX​XX​X
+      </text>
+      <div direction="ltr" grid-row-start="1" grid-column-start="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="60" height="12"/>
+      <node x="3" y="3" width="60" height="12"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_0_max_content__border_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_0_max_content__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_intrinsic_track_sizes_001_span1_minmax_0_max_content__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(0px,max-content)" grid-template-columns="minmax(0px,max-content)">
+      <text direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 1" grid-column-start="1" grid-column-end="span 1">
+        XXX​XX​X
+      </text>
+      <div direction="rtl" grid-row-start="1" grid-column-start="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="57" y="3" width="60" height="12"/>
+      <node x="57" y="3" width="60" height="12"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_0_max_content__content_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_0_max_content__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_intrinsic_track_sizes_001_span1_minmax_0_max_content__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(0px,max-content)" grid-template-columns="minmax(0px,max-content)">
+      <text box-sizing="content-box" direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 1" grid-column-start="1" grid-column-end="span 1">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="1" grid-column-start="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="60" height="12"/>
+      <node x="3" y="3" width="60" height="12"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_0_max_content__content_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_0_max_content__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_intrinsic_track_sizes_001_span1_minmax_0_max_content__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(0px,max-content)" grid-template-columns="minmax(0px,max-content)">
+      <text box-sizing="content-box" direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 1" grid-column-start="1" grid-column-end="span 1">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="1" grid-column-start="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="63" y="3" width="60" height="12"/>
+      <node x="63" y="3" width="60" height="12"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_0_min_content__border_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_0_min_content__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_intrinsic_track_sizes_001_span1_minmax_0_min_content__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(0px,min-content)" grid-template-columns="minmax(0px,min-content)">
+      <text direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 1" grid-column-start="1" grid-column-end="span 1">
+        XXX​XX​X
+      </text>
+      <div direction="ltr" grid-row-start="1" grid-column-start="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="30" height="20"/>
+      <node x="3" y="3" width="30" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_0_min_content__border_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_0_min_content__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_intrinsic_track_sizes_001_span1_minmax_0_min_content__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(0px,min-content)" grid-template-columns="minmax(0px,min-content)">
+      <text direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 1" grid-column-start="1" grid-column-end="span 1">
+        XXX​XX​X
+      </text>
+      <div direction="rtl" grid-row-start="1" grid-column-start="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="87" y="3" width="30" height="20"/>
+      <node x="87" y="3" width="30" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_0_min_content__content_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_0_min_content__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_intrinsic_track_sizes_001_span1_minmax_0_min_content__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(0px,min-content)" grid-template-columns="minmax(0px,min-content)">
+      <text box-sizing="content-box" direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 1" grid-column-start="1" grid-column-end="span 1">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="1" grid-column-start="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="30" height="20"/>
+      <node x="3" y="3" width="30" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_0_min_content__content_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_0_min_content__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_intrinsic_track_sizes_001_span1_minmax_0_min_content__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(0px,min-content)" grid-template-columns="minmax(0px,min-content)">
+      <text box-sizing="content-box" direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 1" grid-column-start="1" grid-column-end="span 1">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="1" grid-column-start="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="93" y="3" width="30" height="20"/>
+      <node x="93" y="3" width="30" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_auto_10px__border_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_auto_10px__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_intrinsic_track_sizes_001_span1_minmax_auto_10px__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(auto,10px)" grid-template-columns="minmax(auto,10px)">
+      <text direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 1" grid-column-start="1" grid-column-end="span 1">
+        XXX​XX​X
+      </text>
+      <div direction="ltr" grid-row-start="1" grid-column-start="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="12" height="12"/>
+      <node x="3" y="3" width="12" height="12"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_auto_10px__border_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_auto_10px__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_intrinsic_track_sizes_001_span1_minmax_auto_10px__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(auto,10px)" grid-template-columns="minmax(auto,10px)">
+      <text direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 1" grid-column-start="1" grid-column-end="span 1">
+        XXX​XX​X
+      </text>
+      <div direction="rtl" grid-row-start="1" grid-column-start="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="105" y="3" width="12" height="12"/>
+      <node x="105" y="3" width="12" height="12"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_auto_10px__content_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_auto_10px__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_intrinsic_track_sizes_001_span1_minmax_auto_10px__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(auto,10px)" grid-template-columns="minmax(auto,10px)">
+      <text box-sizing="content-box" direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 1" grid-column-start="1" grid-column-end="span 1">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="1" grid-column-start="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="12" height="12"/>
+      <node x="3" y="3" width="12" height="12"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_auto_10px__content_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_auto_10px__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_intrinsic_track_sizes_001_span1_minmax_auto_10px__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(auto,10px)" grid-template-columns="minmax(auto,10px)">
+      <text box-sizing="content-box" direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 1" grid-column-start="1" grid-column-end="span 1">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="1" grid-column-start="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="111" y="3" width="12" height="12"/>
+      <node x="111" y="3" width="12" height="12"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_max_content_10px__border_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_max_content_10px__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_intrinsic_track_sizes_001_span1_minmax_max_content_10px__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(max-content,10px)" grid-template-columns="minmax(max-content,10px)">
+      <text direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 1" grid-column-start="1" grid-column-end="span 1">
+        XXX​XX​X
+      </text>
+      <div direction="ltr" grid-row-start="1" grid-column-start="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="60" height="12"/>
+      <node x="3" y="3" width="60" height="12"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_max_content_10px__border_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_max_content_10px__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_intrinsic_track_sizes_001_span1_minmax_max_content_10px__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(max-content,10px)" grid-template-columns="minmax(max-content,10px)">
+      <text direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 1" grid-column-start="1" grid-column-end="span 1">
+        XXX​XX​X
+      </text>
+      <div direction="rtl" grid-row-start="1" grid-column-start="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="57" y="3" width="60" height="12"/>
+      <node x="57" y="3" width="60" height="12"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_max_content_10px__content_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_max_content_10px__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_intrinsic_track_sizes_001_span1_minmax_max_content_10px__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(max-content,10px)" grid-template-columns="minmax(max-content,10px)">
+      <text box-sizing="content-box" direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 1" grid-column-start="1" grid-column-end="span 1">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="1" grid-column-start="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="60" height="12"/>
+      <node x="3" y="3" width="60" height="12"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_max_content_10px__content_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_max_content_10px__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_intrinsic_track_sizes_001_span1_minmax_max_content_10px__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(max-content,10px)" grid-template-columns="minmax(max-content,10px)">
+      <text box-sizing="content-box" direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 1" grid-column-start="1" grid-column-end="span 1">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="1" grid-column-start="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="63" y="3" width="60" height="12"/>
+      <node x="63" y="3" width="60" height="12"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_min_content_10px__border_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_min_content_10px__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_intrinsic_track_sizes_001_span1_minmax_min_content_10px__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(min-content,10px)" grid-template-columns="minmax(min-content,10px)">
+      <text direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 1" grid-column-start="1" grid-column-end="span 1">
+        XXX​XX​X
+      </text>
+      <div direction="ltr" grid-row-start="1" grid-column-start="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="30" height="20"/>
+      <node x="3" y="3" width="30" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_min_content_10px__border_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_min_content_10px__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_intrinsic_track_sizes_001_span1_minmax_min_content_10px__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(min-content,10px)" grid-template-columns="minmax(min-content,10px)">
+      <text direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 1" grid-column-start="1" grid-column-end="span 1">
+        XXX​XX​X
+      </text>
+      <div direction="rtl" grid-row-start="1" grid-column-start="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="87" y="3" width="30" height="20"/>
+      <node x="87" y="3" width="30" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_min_content_10px__content_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_min_content_10px__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_intrinsic_track_sizes_001_span1_minmax_min_content_10px__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(min-content,10px)" grid-template-columns="minmax(min-content,10px)">
+      <text box-sizing="content-box" direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 1" grid-column-start="1" grid-column-end="span 1">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="1" grid-column-start="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="30" height="20"/>
+      <node x="3" y="3" width="30" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_min_content_10px__content_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span1_minmax_min_content_10px__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_intrinsic_track_sizes_001_span1_minmax_min_content_10px__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(min-content,10px)" grid-template-columns="minmax(min-content,10px)">
+      <text box-sizing="content-box" direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 1" grid-column-start="1" grid-column-end="span 1">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="1" grid-column-start="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="93" y="3" width="30" height="20"/>
+      <node x="93" y="3" width="30" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_auto__border_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_auto__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_auto__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px auto" grid-template-columns="20px auto">
+      <text direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="114" height="114"/>
+      <node x="3" y="3" width="20" height="20"/>
+      <node x="23" y="23" width="94" height="94"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_auto__border_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_auto__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_auto__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px auto" grid-template-columns="20px auto">
+      <text direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="114" height="114"/>
+      <node x="97" y="3" width="20" height="20"/>
+      <node x="3" y="23" width="94" height="94"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_auto__content_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_auto__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_auto__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px auto" grid-template-columns="20px auto">
+      <text box-sizing="content-box" direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="120" height="120"/>
+      <node x="3" y="3" width="20" height="20"/>
+      <node x="23" y="23" width="100" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_auto__content_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_auto__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_auto__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px auto" grid-template-columns="20px auto">
+      <text box-sizing="content-box" direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="120" height="120"/>
+      <node x="103" y="3" width="20" height="20"/>
+      <node x="3" y="23" width="100" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_max_content__border_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_max_content__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_max_content__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px max-content" grid-template-columns="20px max-content">
+      <text direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="60" height="20"/>
+      <node x="3" y="3" width="20" height="20"/>
+      <node x="23" y="23" width="40" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_max_content__border_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_max_content__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_max_content__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px max-content" grid-template-columns="20px max-content">
+      <text direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="57" y="3" width="60" height="20"/>
+      <node x="97" y="3" width="20" height="20"/>
+      <node x="57" y="23" width="40" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_max_content__content_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_max_content__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_max_content__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px max-content" grid-template-columns="20px max-content">
+      <text box-sizing="content-box" direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="60" height="20"/>
+      <node x="3" y="3" width="20" height="20"/>
+      <node x="23" y="23" width="40" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_max_content__content_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_max_content__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_max_content__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px max-content" grid-template-columns="20px max-content">
+      <text box-sizing="content-box" direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="63" y="3" width="60" height="20"/>
+      <node x="103" y="3" width="20" height="20"/>
+      <node x="63" y="23" width="40" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_min_content__border_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_min_content__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_min_content__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px min-content" grid-template-columns="20px min-content">
+      <text direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="30" height="20"/>
+      <node x="3" y="3" width="20" height="20"/>
+      <node x="23" y="23" width="10" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_min_content__border_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_min_content__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_min_content__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px min-content" grid-template-columns="20px min-content">
+      <text direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="87" y="3" width="30" height="20"/>
+      <node x="97" y="3" width="20" height="20"/>
+      <node x="87" y="23" width="10" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_min_content__content_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_min_content__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_min_content__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px min-content" grid-template-columns="20px min-content">
+      <text box-sizing="content-box" direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="30" height="20"/>
+      <node x="3" y="3" width="20" height="20"/>
+      <node x="23" y="23" width="10" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_min_content__content_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_min_content__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_min_content__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px min-content" grid-template-columns="20px min-content">
+      <text box-sizing="content-box" direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="93" y="3" width="30" height="20"/>
+      <node x="103" y="3" width="20" height="20"/>
+      <node x="93" y="23" width="10" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_0_auto__border_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_0_auto__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_minmax_0_auto__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px minmax(0px,auto)" grid-template-columns="20px minmax(0px,auto)">
+      <text direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="114" height="114"/>
+      <node x="3" y="3" width="20" height="20"/>
+      <node x="23" y="23" width="94" height="94"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_0_auto__border_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_0_auto__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_minmax_0_auto__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px minmax(0px,auto)" grid-template-columns="20px minmax(0px,auto)">
+      <text direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="114" height="114"/>
+      <node x="97" y="3" width="20" height="20"/>
+      <node x="3" y="23" width="94" height="94"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_0_auto__content_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_0_auto__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_minmax_0_auto__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px minmax(0px,auto)" grid-template-columns="20px minmax(0px,auto)">
+      <text box-sizing="content-box" direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="120" height="120"/>
+      <node x="3" y="3" width="20" height="20"/>
+      <node x="23" y="23" width="100" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_0_auto__content_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_0_auto__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_minmax_0_auto__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px minmax(0px,auto)" grid-template-columns="20px minmax(0px,auto)">
+      <text box-sizing="content-box" direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="120" height="120"/>
+      <node x="103" y="3" width="20" height="20"/>
+      <node x="3" y="23" width="100" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_0_max_content__border_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_0_max_content__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_minmax_0_max_content__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px minmax(0px,max-content)" grid-template-columns="20px minmax(0px,max-content)">
+      <text direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="60" height="20"/>
+      <node x="3" y="3" width="20" height="20"/>
+      <node x="23" y="23" width="40" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_0_max_content__border_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_0_max_content__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_minmax_0_max_content__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px minmax(0px,max-content)" grid-template-columns="20px minmax(0px,max-content)">
+      <text direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="57" y="3" width="60" height="20"/>
+      <node x="97" y="3" width="20" height="20"/>
+      <node x="57" y="23" width="40" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_0_max_content__content_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_0_max_content__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_minmax_0_max_content__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px minmax(0px,max-content)" grid-template-columns="20px minmax(0px,max-content)">
+      <text box-sizing="content-box" direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="60" height="20"/>
+      <node x="3" y="3" width="20" height="20"/>
+      <node x="23" y="23" width="40" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_0_max_content__content_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_0_max_content__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_minmax_0_max_content__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px minmax(0px,max-content)" grid-template-columns="20px minmax(0px,max-content)">
+      <text box-sizing="content-box" direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="63" y="3" width="60" height="20"/>
+      <node x="103" y="3" width="20" height="20"/>
+      <node x="63" y="23" width="40" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_0_min_content__border_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_0_min_content__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_minmax_0_min_content__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px minmax(0px,min-content)" grid-template-columns="20px minmax(0px,min-content)">
+      <text direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="30" height="20"/>
+      <node x="3" y="3" width="20" height="20"/>
+      <node x="23" y="23" width="10" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_0_min_content__border_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_0_min_content__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_minmax_0_min_content__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px minmax(0px,min-content)" grid-template-columns="20px minmax(0px,min-content)">
+      <text direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="87" y="3" width="30" height="20"/>
+      <node x="97" y="3" width="20" height="20"/>
+      <node x="87" y="23" width="10" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_0_min_content__content_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_0_min_content__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_minmax_0_min_content__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px minmax(0px,min-content)" grid-template-columns="20px minmax(0px,min-content)">
+      <text box-sizing="content-box" direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="30" height="20"/>
+      <node x="3" y="3" width="20" height="20"/>
+      <node x="23" y="23" width="10" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_0_min_content__content_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_0_min_content__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_minmax_0_min_content__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px minmax(0px,min-content)" grid-template-columns="20px minmax(0px,min-content)">
+      <text box-sizing="content-box" direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="93" y="3" width="30" height="20"/>
+      <node x="103" y="3" width="20" height="20"/>
+      <node x="93" y="23" width="10" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_auto_30px__border_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_auto_30px__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_minmax_auto_30px__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px minmax(auto,30px)" grid-template-columns="20px minmax(auto,30px)">
+      <text direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="50" height="50"/>
+      <node x="3" y="3" width="20" height="20"/>
+      <node x="23" y="23" width="30" height="30"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_auto_30px__border_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_auto_30px__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_minmax_auto_30px__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px minmax(auto,30px)" grid-template-columns="20px minmax(auto,30px)">
+      <text direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="67" y="3" width="50" height="50"/>
+      <node x="97" y="3" width="20" height="20"/>
+      <node x="67" y="23" width="30" height="30"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_auto_30px__content_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_auto_30px__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_minmax_auto_30px__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px minmax(auto,30px)" grid-template-columns="20px minmax(auto,30px)">
+      <text box-sizing="content-box" direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="50" height="50"/>
+      <node x="3" y="3" width="20" height="20"/>
+      <node x="23" y="23" width="30" height="30"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_auto_30px__content_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_auto_30px__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_minmax_auto_30px__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px minmax(auto,30px)" grid-template-columns="20px minmax(auto,30px)">
+      <text box-sizing="content-box" direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="73" y="3" width="50" height="50"/>
+      <node x="103" y="3" width="20" height="20"/>
+      <node x="73" y="23" width="30" height="30"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_30px__border_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_30px__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_30px__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px minmax(max-content,30px)" grid-template-columns="20px minmax(max-content,30px)">
+      <text direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="60" height="50"/>
+      <node x="3" y="3" width="20" height="20"/>
+      <node x="23" y="23" width="40" height="30"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_30px__border_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_30px__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_30px__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px minmax(max-content,30px)" grid-template-columns="20px minmax(max-content,30px)">
+      <text direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="57" y="3" width="60" height="50"/>
+      <node x="97" y="3" width="20" height="20"/>
+      <node x="57" y="23" width="40" height="30"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_30px__content_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_30px__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_30px__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px minmax(max-content,30px)" grid-template-columns="20px minmax(max-content,30px)">
+      <text box-sizing="content-box" direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="60" height="50"/>
+      <node x="3" y="3" width="20" height="20"/>
+      <node x="23" y="23" width="40" height="30"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_30px__content_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_30px__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_30px__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px minmax(max-content,30px)" grid-template-columns="20px minmax(max-content,30px)">
+      <text box-sizing="content-box" direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="63" y="3" width="60" height="50"/>
+      <node x="103" y="3" width="20" height="20"/>
+      <node x="63" y="23" width="40" height="30"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_6px__border_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_6px__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_6px__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px minmax(max-content,6px)" grid-template-columns="20px minmax(max-content,6px)">
+      <text direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="60" height="26"/>
+      <node x="3" y="3" width="20" height="20"/>
+      <node x="23" y="23" width="40" height="6"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_6px__border_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_6px__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_6px__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px minmax(max-content,6px)" grid-template-columns="20px minmax(max-content,6px)">
+      <text direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="57" y="3" width="60" height="26"/>
+      <node x="97" y="3" width="20" height="20"/>
+      <node x="57" y="23" width="40" height="6"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_6px__content_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_6px__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_6px__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px minmax(max-content,6px)" grid-template-columns="20px minmax(max-content,6px)">
+      <text box-sizing="content-box" direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="60" height="26"/>
+      <node x="3" y="3" width="20" height="20"/>
+      <node x="23" y="23" width="40" height="6"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_6px__content_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_6px__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_6px__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px minmax(max-content,6px)" grid-template-columns="20px minmax(max-content,6px)">
+      <text box-sizing="content-box" direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="63" y="3" width="60" height="26"/>
+      <node x="103" y="3" width="20" height="20"/>
+      <node x="63" y="23" width="40" height="6"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_40px__border_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_40px__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_40px__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px minmax(min-content,40px)" grid-template-columns="20px minmax(min-content,40px)">
+      <text direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="60" height="60"/>
+      <node x="3" y="3" width="20" height="20"/>
+      <node x="23" y="23" width="40" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_40px__border_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_40px__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_40px__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px minmax(min-content,40px)" grid-template-columns="20px minmax(min-content,40px)">
+      <text direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="57" y="3" width="60" height="60"/>
+      <node x="97" y="3" width="20" height="20"/>
+      <node x="57" y="23" width="40" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_40px__content_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_40px__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_40px__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px minmax(min-content,40px)" grid-template-columns="20px minmax(min-content,40px)">
+      <text box-sizing="content-box" direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="60" height="60"/>
+      <node x="3" y="3" width="20" height="20"/>
+      <node x="23" y="23" width="40" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_40px__content_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_40px__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_40px__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px minmax(min-content,40px)" grid-template-columns="20px minmax(min-content,40px)">
+      <text box-sizing="content-box" direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="63" y="3" width="60" height="60"/>
+      <node x="103" y="3" width="20" height="20"/>
+      <node x="63" y="23" width="40" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_6px__border_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_6px__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_6px__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px minmax(min-content,6px)" grid-template-columns="20px minmax(min-content,6px)">
+      <text direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="30" height="26"/>
+      <node x="3" y="3" width="20" height="20"/>
+      <node x="23" y="23" width="10" height="6"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_6px__border_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_6px__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_6px__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px minmax(min-content,6px)" grid-template-columns="20px minmax(min-content,6px)">
+      <text direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="87" y="3" width="30" height="26"/>
+      <node x="97" y="3" width="20" height="20"/>
+      <node x="87" y="23" width="10" height="6"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_6px__content_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_6px__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_6px__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px minmax(min-content,6px)" grid-template-columns="20px minmax(min-content,6px)">
+      <text box-sizing="content-box" direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="30" height="26"/>
+      <node x="3" y="3" width="20" height="20"/>
+      <node x="23" y="23" width="10" height="6"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_6px__content_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_6px__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_6px__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="20px minmax(min-content,6px)" grid-template-columns="20px minmax(min-content,6px)">
+      <text box-sizing="content-box" direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="93" y="3" width="30" height="26"/>
+      <node x="103" y="3" width="20" height="20"/>
+      <node x="93" y="23" width="10" height="6"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_auto_auto__border_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_auto_auto__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_auto_auto__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="auto auto" grid-template-columns="auto auto">
+      <text direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="114" height="114"/>
+      <node x="3" y="3" width="57" height="57"/>
+      <node x="60" y="60" width="57" height="57"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_auto_auto__border_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_auto_auto__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_auto_auto__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="auto auto" grid-template-columns="auto auto">
+      <text direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="114" height="114"/>
+      <node x="60" y="3" width="57" height="57"/>
+      <node x="3" y="60" width="57" height="57"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_auto_auto__content_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_auto_auto__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_auto_auto__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="auto auto" grid-template-columns="auto auto">
+      <text box-sizing="content-box" direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="120" height="120"/>
+      <node x="3" y="3" width="60" height="60"/>
+      <node x="63" y="63" width="60" height="60"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_auto_auto__content_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_auto_auto__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_auto_auto__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="auto auto" grid-template-columns="auto auto">
+      <text box-sizing="content-box" direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="120" height="120"/>
+      <node x="63" y="3" width="60" height="60"/>
+      <node x="3" y="63" width="60" height="60"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_max_content_max_content__border_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_max_content_max_content__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_max_content_max_content__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="max-content max-content" grid-template-columns="max-content max-content">
+      <text direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="60" height="12"/>
+      <node x="3" y="3" width="30" height="6"/>
+      <node x="33" y="9" width="30" height="6"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_max_content_max_content__border_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_max_content_max_content__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_max_content_max_content__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="max-content max-content" grid-template-columns="max-content max-content">
+      <text direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="57" y="3" width="60" height="12"/>
+      <node x="87" y="3" width="30" height="6"/>
+      <node x="57" y="9" width="30" height="6"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_max_content_max_content__content_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_max_content_max_content__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_max_content_max_content__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="max-content max-content" grid-template-columns="max-content max-content">
+      <text box-sizing="content-box" direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="60" height="12"/>
+      <node x="3" y="3" width="30" height="6"/>
+      <node x="33" y="9" width="30" height="6"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_max_content_max_content__content_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_max_content_max_content__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_max_content_max_content__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="max-content max-content" grid-template-columns="max-content max-content">
+      <text box-sizing="content-box" direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="63" y="3" width="60" height="12"/>
+      <node x="93" y="3" width="30" height="6"/>
+      <node x="63" y="9" width="30" height="6"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_max_content_min_content__border_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_max_content_min_content__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_max_content_min_content__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="max-content min-content" grid-template-columns="max-content min-content">
+      <text direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="60" height="12"/>
+      <node x="3" y="3" width="45" height="6"/>
+      <node x="48" y="9" width="15" height="6"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_max_content_min_content__border_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_max_content_min_content__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_max_content_min_content__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="max-content min-content" grid-template-columns="max-content min-content">
+      <text direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="57" y="3" width="60" height="12"/>
+      <node x="72" y="3" width="45" height="6"/>
+      <node x="57" y="9" width="15" height="6"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_max_content_min_content__content_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_max_content_min_content__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_max_content_min_content__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="max-content min-content" grid-template-columns="max-content min-content">
+      <text box-sizing="content-box" direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="60" height="12"/>
+      <node x="3" y="3" width="45" height="6"/>
+      <node x="48" y="9" width="15" height="6"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_max_content_min_content__content_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_max_content_min_content__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_max_content_min_content__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="max-content min-content" grid-template-columns="max-content min-content">
+      <text box-sizing="content-box" direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="63" y="3" width="60" height="12"/>
+      <node x="78" y="3" width="45" height="6"/>
+      <node x="63" y="9" width="15" height="6"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_min_content_min_content__border_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_min_content_min_content__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_min_content_min_content__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="min-content min-content" grid-template-columns="min-content min-content">
+      <text direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="30" height="20"/>
+      <node x="3" y="3" width="15" height="10"/>
+      <node x="18" y="13" width="15" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_min_content_min_content__border_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_min_content_min_content__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_min_content_min_content__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="min-content min-content" grid-template-columns="min-content min-content">
+      <text direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="87" y="3" width="30" height="20"/>
+      <node x="102" y="3" width="15" height="10"/>
+      <node x="87" y="13" width="15" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_min_content_min_content__content_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_min_content_min_content__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_min_content_min_content__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="min-content min-content" grid-template-columns="min-content min-content">
+      <text box-sizing="content-box" direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="30" height="20"/>
+      <node x="3" y="3" width="15" height="10"/>
+      <node x="18" y="13" width="15" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_min_content_min_content__content_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_min_content_min_content__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_min_content_min_content__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="min-content min-content" grid-template-columns="min-content min-content">
+      <text box-sizing="content-box" direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="93" y="3" width="30" height="20"/>
+      <node x="108" y="3" width="15" height="10"/>
+      <node x="93" y="13" width="15" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_0_auto_minmax_0_auto__border_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_0_auto_minmax_0_auto__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_minmax_0_auto_minmax_0_auto__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(0px,auto) minmax(0px,auto)" grid-template-columns="minmax(0px,auto) minmax(0px,auto)">
+      <text direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="114" height="114"/>
+      <node x="3" y="3" width="57" height="57"/>
+      <node x="60" y="60" width="57" height="57"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_0_auto_minmax_0_auto__border_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_0_auto_minmax_0_auto__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_minmax_0_auto_minmax_0_auto__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(0px,auto) minmax(0px,auto)" grid-template-columns="minmax(0px,auto) minmax(0px,auto)">
+      <text direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="114" height="114"/>
+      <node x="60" y="3" width="57" height="57"/>
+      <node x="3" y="60" width="57" height="57"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_0_auto_minmax_0_auto__content_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_0_auto_minmax_0_auto__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_minmax_0_auto_minmax_0_auto__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(0px,auto) minmax(0px,auto)" grid-template-columns="minmax(0px,auto) minmax(0px,auto)">
+      <text box-sizing="content-box" direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="120" height="120"/>
+      <node x="3" y="3" width="60" height="60"/>
+      <node x="63" y="63" width="60" height="60"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_0_auto_minmax_0_auto__content_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_0_auto_minmax_0_auto__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_minmax_0_auto_minmax_0_auto__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(0px,auto) minmax(0px,auto)" grid-template-columns="minmax(0px,auto) minmax(0px,auto)">
+      <text box-sizing="content-box" direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="120" height="120"/>
+      <node x="63" y="3" width="60" height="60"/>
+      <node x="3" y="63" width="60" height="60"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_0_max_content_minmax_0_max_content__border_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_0_max_content_minmax_0_max_content__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_minmax_0_max_content_minmax_0_max_content__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(0px,max-content) minmax(0px,max-content)" grid-template-columns="minmax(0px,max-content) minmax(0px,max-content)">
+      <text direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="60" height="12"/>
+      <node x="3" y="3" width="30" height="6"/>
+      <node x="33" y="9" width="30" height="6"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_0_max_content_minmax_0_max_content__border_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_0_max_content_minmax_0_max_content__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_minmax_0_max_content_minmax_0_max_content__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(0px,max-content) minmax(0px,max-content)" grid-template-columns="minmax(0px,max-content) minmax(0px,max-content)">
+      <text direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="57" y="3" width="60" height="12"/>
+      <node x="87" y="3" width="30" height="6"/>
+      <node x="57" y="9" width="30" height="6"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_0_max_content_minmax_0_max_content__content_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_0_max_content_minmax_0_max_content__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_minmax_0_max_content_minmax_0_max_content__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(0px,max-content) minmax(0px,max-content)" grid-template-columns="minmax(0px,max-content) minmax(0px,max-content)">
+      <text box-sizing="content-box" direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="60" height="12"/>
+      <node x="3" y="3" width="30" height="6"/>
+      <node x="33" y="9" width="30" height="6"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_0_max_content_minmax_0_max_content__content_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_0_max_content_minmax_0_max_content__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_minmax_0_max_content_minmax_0_max_content__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(0px,max-content) minmax(0px,max-content)" grid-template-columns="minmax(0px,max-content) minmax(0px,max-content)">
+      <text box-sizing="content-box" direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="63" y="3" width="60" height="12"/>
+      <node x="93" y="3" width="30" height="6"/>
+      <node x="63" y="9" width="30" height="6"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_0_min_content_minmax_0_min_content__border_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_0_min_content_minmax_0_min_content__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_minmax_0_min_content_minmax_0_min_content__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(0px,min-content) minmax(0px,min-content)" grid-template-columns="minmax(0px,min-content) minmax(0px,min-content)">
+      <text direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="30" height="20"/>
+      <node x="3" y="3" width="15" height="10"/>
+      <node x="18" y="13" width="15" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_0_min_content_minmax_0_min_content__border_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_0_min_content_minmax_0_min_content__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_minmax_0_min_content_minmax_0_min_content__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(0px,min-content) minmax(0px,min-content)" grid-template-columns="minmax(0px,min-content) minmax(0px,min-content)">
+      <text direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="87" y="3" width="30" height="20"/>
+      <node x="102" y="3" width="15" height="10"/>
+      <node x="87" y="13" width="15" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_0_min_content_minmax_0_min_content__content_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_0_min_content_minmax_0_min_content__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_minmax_0_min_content_minmax_0_min_content__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(0px,min-content) minmax(0px,min-content)" grid-template-columns="minmax(0px,min-content) minmax(0px,min-content)">
+      <text box-sizing="content-box" direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="30" height="20"/>
+      <node x="3" y="3" width="15" height="10"/>
+      <node x="18" y="13" width="15" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_0_min_content_minmax_0_min_content__content_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_0_min_content_minmax_0_min_content__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_minmax_0_min_content_minmax_0_min_content__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(0px,min-content) minmax(0px,min-content)" grid-template-columns="minmax(0px,min-content) minmax(0px,min-content)">
+      <text box-sizing="content-box" direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="93" y="3" width="30" height="20"/>
+      <node x="108" y="3" width="15" height="10"/>
+      <node x="93" y="13" width="15" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_auto_10px_minmax_auto_10px__border_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_auto_10px_minmax_auto_10px__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_minmax_auto_10px_minmax_auto_10px__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(auto,10px) minmax(auto,10px)" grid-template-columns="minmax(auto,10px) minmax(auto,10px)">
+      <text direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="20" height="20"/>
+      <node x="3" y="3" width="10" height="10"/>
+      <node x="13" y="13" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_auto_10px_minmax_auto_10px__border_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_auto_10px_minmax_auto_10px__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_minmax_auto_10px_minmax_auto_10px__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(auto,10px) minmax(auto,10px)" grid-template-columns="minmax(auto,10px) minmax(auto,10px)">
+      <text direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="97" y="3" width="20" height="20"/>
+      <node x="107" y="3" width="10" height="10"/>
+      <node x="97" y="13" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_auto_10px_minmax_auto_10px__content_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_auto_10px_minmax_auto_10px__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_minmax_auto_10px_minmax_auto_10px__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(auto,10px) minmax(auto,10px)" grid-template-columns="minmax(auto,10px) minmax(auto,10px)">
+      <text box-sizing="content-box" direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="20" height="20"/>
+      <node x="3" y="3" width="10" height="10"/>
+      <node x="13" y="13" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_auto_10px_minmax_auto_10px__content_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_auto_10px_minmax_auto_10px__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_minmax_auto_10px_minmax_auto_10px__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(auto,10px) minmax(auto,10px)" grid-template-columns="minmax(auto,10px) minmax(auto,10px)">
+      <text box-sizing="content-box" direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="103" y="3" width="20" height="20"/>
+      <node x="113" y="3" width="10" height="10"/>
+      <node x="103" y="13" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_auto_4px_minmax_auto_4px__border_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_auto_4px_minmax_auto_4px__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_minmax_auto_4px_minmax_auto_4px__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(auto,4px) minmax(auto,4px)" grid-template-columns="minmax(auto,4px) minmax(auto,4px)">
+      <text direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="12" height="12"/>
+      <node x="3" y="3" width="6" height="6"/>
+      <node x="9" y="9" width="6" height="6"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_auto_4px_minmax_auto_4px__border_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_auto_4px_minmax_auto_4px__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_minmax_auto_4px_minmax_auto_4px__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(auto,4px) minmax(auto,4px)" grid-template-columns="minmax(auto,4px) minmax(auto,4px)">
+      <text direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="105" y="3" width="12" height="12"/>
+      <node x="111" y="3" width="6" height="6"/>
+      <node x="105" y="9" width="6" height="6"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_auto_4px_minmax_auto_4px__content_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_auto_4px_minmax_auto_4px__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_minmax_auto_4px_minmax_auto_4px__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(auto,4px) minmax(auto,4px)" grid-template-columns="minmax(auto,4px) minmax(auto,4px)">
+      <text box-sizing="content-box" direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="12" height="12"/>
+      <node x="3" y="3" width="6" height="6"/>
+      <node x="9" y="9" width="6" height="6"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_auto_4px_minmax_auto_4px__content_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_auto_4px_minmax_auto_4px__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_minmax_auto_4px_minmax_auto_4px__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(auto,4px) minmax(auto,4px)" grid-template-columns="minmax(auto,4px) minmax(auto,4px)">
+      <text box-sizing="content-box" direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="111" y="3" width="12" height="12"/>
+      <node x="117" y="3" width="6" height="6"/>
+      <node x="111" y="9" width="6" height="6"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_max_content_10px_minmax_max_content_10px__border_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_max_content_10px_minmax_max_content_10px__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_minmax_max_content_10px_minmax_max_content_10px__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(max-content,10px) minmax(max-content,10px)" grid-template-columns="minmax(max-content,10px) minmax(max-content,10px)">
+      <text direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="60" height="20"/>
+      <node x="3" y="3" width="30" height="10"/>
+      <node x="33" y="13" width="30" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_max_content_10px_minmax_max_content_10px__border_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_max_content_10px_minmax_max_content_10px__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_minmax_max_content_10px_minmax_max_content_10px__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(max-content,10px) minmax(max-content,10px)" grid-template-columns="minmax(max-content,10px) minmax(max-content,10px)">
+      <text direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="57" y="3" width="60" height="20"/>
+      <node x="87" y="3" width="30" height="10"/>
+      <node x="57" y="13" width="30" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_max_content_10px_minmax_max_content_10px__content_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_max_content_10px_minmax_max_content_10px__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_minmax_max_content_10px_minmax_max_content_10px__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(max-content,10px) minmax(max-content,10px)" grid-template-columns="minmax(max-content,10px) minmax(max-content,10px)">
+      <text box-sizing="content-box" direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="60" height="20"/>
+      <node x="3" y="3" width="30" height="10"/>
+      <node x="33" y="13" width="30" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_max_content_10px_minmax_max_content_10px__content_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_max_content_10px_minmax_max_content_10px__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_minmax_max_content_10px_minmax_max_content_10px__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(max-content,10px) minmax(max-content,10px)" grid-template-columns="minmax(max-content,10px) minmax(max-content,10px)">
+      <text box-sizing="content-box" direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="63" y="3" width="60" height="20"/>
+      <node x="93" y="3" width="30" height="10"/>
+      <node x="63" y="13" width="30" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_min_content_10px_minmax_min_content_10px__border_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_min_content_10px_minmax_min_content_10px__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_minmax_min_content_10px_minmax_min_content_10px__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(min-content,10px) minmax(min-content,10px)" grid-template-columns="minmax(min-content,10px) minmax(min-content,10px)">
+      <text direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="3" y="3" width="30" height="20"/>
+      <node x="3" y="3" width="15" height="10"/>
+      <node x="18" y="13" width="15" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_min_content_10px_minmax_min_content_10px__border_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_min_content_10px_minmax_min_content_10px__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_minmax_min_content_10px_minmax_min_content_10px__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(min-content,10px) minmax(min-content,10px)" grid-template-columns="minmax(min-content,10px) minmax(min-content,10px)">
+      <text direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="87" y="3" width="30" height="20"/>
+      <node x="102" y="3" width="15" height="10"/>
+      <node x="87" y="13" width="15" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_min_content_10px_minmax_min_content_10px__content_box_ltr.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_min_content_10px_minmax_min_content_10px__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_minmax_min_content_10px_minmax_min_content_10px__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(min-content,10px) minmax(min-content,10px)" grid-template-columns="minmax(min-content,10px) minmax(min-content,10px)">
+      <text box-sizing="content-box" direction="ltr" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="3" y="3" width="30" height="20"/>
+      <node x="3" y="3" width="15" height="10"/>
+      <node x="18" y="13" width="15" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_min_content_10px_minmax_min_content_10px__content_box_rtl.xml
+++ b/tests/xml/grid/grid_intrinsic_track_sizes_001_span2_minmax_min_content_10px_minmax_min_content_10px__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_intrinsic_track_sizes_001_span2_minmax_min_content_10px_minmax_min_content_10px__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px" grid-template-rows="minmax(min-content,10px) minmax(min-content,10px)" grid-template-columns="minmax(min-content,10px) minmax(min-content,10px)">
+      <text box-sizing="content-box" direction="rtl" min-width="12px" min-height="12px" grid-row-start="1" grid-row-end="span 2" grid-column-start="1" grid-column-end="span 2">
+        XXX​XX​X
+      </text>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="126" height="126">
+      <node x="93" y="3" width="30" height="20"/>
+      <node x="108" y="3" width="15" height="10"/>
+      <node x="93" y="13" width="15" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -23651,6 +23651,864 @@ mod grid {
 
     #[cfg(feature = "grid")]
     #[test]
+    fn grid_intrinsic_track_sizes_001_span1_auto__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span1_auto__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span1_auto__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span1_auto__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span1_auto__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span1_auto__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span1_auto__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span1_auto__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span1_max_content__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span1_max_content__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span1_max_content__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span1_max_content__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span1_max_content__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span1_max_content__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span1_max_content__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span1_max_content__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span1_min_content__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span1_min_content__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span1_min_content__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span1_min_content__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span1_min_content__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span1_min_content__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span1_min_content__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span1_min_content__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span1_minmax_0_auto__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span1_minmax_0_auto__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span1_minmax_0_auto__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span1_minmax_0_auto__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span1_minmax_0_auto__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span1_minmax_0_auto__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span1_minmax_0_auto__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span1_minmax_0_auto__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span1_minmax_0_max_content__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span1_minmax_0_max_content__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span1_minmax_0_max_content__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span1_minmax_0_max_content__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span1_minmax_0_max_content__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span1_minmax_0_max_content__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span1_minmax_0_max_content__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span1_minmax_0_max_content__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span1_minmax_0_min_content__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span1_minmax_0_min_content__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span1_minmax_0_min_content__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span1_minmax_0_min_content__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span1_minmax_0_min_content__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span1_minmax_0_min_content__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span1_minmax_0_min_content__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span1_minmax_0_min_content__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span1_minmax_auto_10px__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span1_minmax_auto_10px__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span1_minmax_auto_10px__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span1_minmax_auto_10px__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span1_minmax_auto_10px__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span1_minmax_auto_10px__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span1_minmax_auto_10px__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span1_minmax_auto_10px__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span1_minmax_max_content_10px__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span1_minmax_max_content_10px__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span1_minmax_max_content_10px__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span1_minmax_max_content_10px__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span1_minmax_max_content_10px__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span1_minmax_max_content_10px__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span1_minmax_max_content_10px__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span1_minmax_max_content_10px__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span1_minmax_min_content_10px__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span1_minmax_min_content_10px__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span1_minmax_min_content_10px__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span1_minmax_min_content_10px__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span1_minmax_min_content_10px__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span1_minmax_min_content_10px__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span1_minmax_min_content_10px__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span1_minmax_min_content_10px__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_auto__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_20px_auto__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_auto__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_20px_auto__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_auto__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_20px_auto__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_auto__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_20px_auto__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_max_content__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_20px_max_content__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_max_content__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_20px_max_content__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_max_content__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_20px_max_content__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_max_content__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_20px_max_content__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_min_content__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_20px_min_content__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_min_content__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_20px_min_content__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_min_content__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_20px_min_content__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_min_content__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_20px_min_content__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_minmax_0_auto__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_20px_minmax_0_auto__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_minmax_0_auto__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_20px_minmax_0_auto__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_minmax_0_auto__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_20px_minmax_0_auto__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_minmax_0_auto__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_20px_minmax_0_auto__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_minmax_0_max_content__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_20px_minmax_0_max_content__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_minmax_0_max_content__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_20px_minmax_0_max_content__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_minmax_0_max_content__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_20px_minmax_0_max_content__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_minmax_0_max_content__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_20px_minmax_0_max_content__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_minmax_0_min_content__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_20px_minmax_0_min_content__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_minmax_0_min_content__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_20px_minmax_0_min_content__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_minmax_0_min_content__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_20px_minmax_0_min_content__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_minmax_0_min_content__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_20px_minmax_0_min_content__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_minmax_auto_30px__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_20px_minmax_auto_30px__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_minmax_auto_30px__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_20px_minmax_auto_30px__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_minmax_auto_30px__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_20px_minmax_auto_30px__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_minmax_auto_30px__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_20px_minmax_auto_30px__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_30px__border_box_ltr() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_30px__border_box_ltr",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_30px__content_box_ltr() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_30px__content_box_ltr",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_30px__border_box_rtl() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_30px__border_box_rtl",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_30px__content_box_rtl() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_30px__content_box_rtl",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_6px__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_6px__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_6px__content_box_ltr() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_6px__content_box_ltr",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_6px__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_6px__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_6px__content_box_rtl() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_20px_minmax_max_content_6px__content_box_rtl",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_40px__border_box_ltr() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_40px__border_box_ltr",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_40px__content_box_ltr() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_40px__content_box_ltr",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_40px__border_box_rtl() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_40px__border_box_rtl",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_40px__content_box_rtl() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_40px__content_box_rtl",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_6px__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_6px__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_6px__content_box_ltr() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_6px__content_box_ltr",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_6px__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_6px__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_6px__content_box_rtl() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_20px_minmax_min_content_6px__content_box_rtl",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_auto_auto__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_auto_auto__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_auto_auto__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_auto_auto__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_auto_auto__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_auto_auto__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_auto_auto__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_auto_auto__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_max_content_max_content__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_max_content_max_content__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_max_content_max_content__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_max_content_max_content__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_max_content_max_content__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_max_content_max_content__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_max_content_max_content__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_max_content_max_content__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_max_content_min_content__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_max_content_min_content__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_max_content_min_content__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_max_content_min_content__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_max_content_min_content__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_max_content_min_content__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_max_content_min_content__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_max_content_min_content__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_min_content_min_content__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_min_content_min_content__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_min_content_min_content__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_min_content_min_content__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_min_content_min_content__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_min_content_min_content__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_min_content_min_content__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_min_content_min_content__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_minmax_0_auto_minmax_0_auto__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_minmax_0_auto_minmax_0_auto__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_minmax_0_auto_minmax_0_auto__content_box_ltr() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_minmax_0_auto_minmax_0_auto__content_box_ltr",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_minmax_0_auto_minmax_0_auto__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_intrinsic_track_sizes_001_span2_minmax_0_auto_minmax_0_auto__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_minmax_0_auto_minmax_0_auto__content_box_rtl() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_minmax_0_auto_minmax_0_auto__content_box_rtl",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_minmax_0_max_content_minmax_0_max_content__border_box_ltr() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_minmax_0_max_content_minmax_0_max_content__border_box_ltr",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_minmax_0_max_content_minmax_0_max_content__content_box_ltr() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_minmax_0_max_content_minmax_0_max_content__content_box_ltr",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_minmax_0_max_content_minmax_0_max_content__border_box_rtl() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_minmax_0_max_content_minmax_0_max_content__border_box_rtl",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_minmax_0_max_content_minmax_0_max_content__content_box_rtl() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_minmax_0_max_content_minmax_0_max_content__content_box_rtl",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_minmax_0_min_content_minmax_0_min_content__border_box_ltr() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_minmax_0_min_content_minmax_0_min_content__border_box_ltr",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_minmax_0_min_content_minmax_0_min_content__content_box_ltr() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_minmax_0_min_content_minmax_0_min_content__content_box_ltr",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_minmax_0_min_content_minmax_0_min_content__border_box_rtl() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_minmax_0_min_content_minmax_0_min_content__border_box_rtl",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_minmax_0_min_content_minmax_0_min_content__content_box_rtl() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_minmax_0_min_content_minmax_0_min_content__content_box_rtl",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_minmax_auto_10px_minmax_auto_10px__border_box_ltr() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_minmax_auto_10px_minmax_auto_10px__border_box_ltr",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_minmax_auto_10px_minmax_auto_10px__content_box_ltr() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_minmax_auto_10px_minmax_auto_10px__content_box_ltr",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_minmax_auto_10px_minmax_auto_10px__border_box_rtl() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_minmax_auto_10px_minmax_auto_10px__border_box_rtl",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_minmax_auto_10px_minmax_auto_10px__content_box_rtl() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_minmax_auto_10px_minmax_auto_10px__content_box_rtl",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_minmax_auto_4px_minmax_auto_4px__border_box_ltr() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_minmax_auto_4px_minmax_auto_4px__border_box_ltr",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_minmax_auto_4px_minmax_auto_4px__content_box_ltr() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_minmax_auto_4px_minmax_auto_4px__content_box_ltr",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_minmax_auto_4px_minmax_auto_4px__border_box_rtl() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_minmax_auto_4px_minmax_auto_4px__border_box_rtl",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_minmax_auto_4px_minmax_auto_4px__content_box_rtl() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_minmax_auto_4px_minmax_auto_4px__content_box_rtl",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_minmax_max_content_10px_minmax_max_content_10px__border_box_ltr() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_minmax_max_content_10px_minmax_max_content_10px__border_box_ltr",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_minmax_max_content_10px_minmax_max_content_10px__content_box_ltr() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_minmax_max_content_10px_minmax_max_content_10px__content_box_ltr",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_minmax_max_content_10px_minmax_max_content_10px__border_box_rtl() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_minmax_max_content_10px_minmax_max_content_10px__border_box_rtl",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_minmax_max_content_10px_minmax_max_content_10px__content_box_rtl() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_minmax_max_content_10px_minmax_max_content_10px__content_box_rtl",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_minmax_min_content_10px_minmax_min_content_10px__border_box_ltr() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_minmax_min_content_10px_minmax_min_content_10px__border_box_ltr",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_minmax_min_content_10px_minmax_min_content_10px__content_box_ltr() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_minmax_min_content_10px_minmax_min_content_10px__content_box_ltr",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_minmax_min_content_10px_minmax_min_content_10px__border_box_rtl() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_minmax_min_content_10px_minmax_min_content_10px__border_box_rtl",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_intrinsic_track_sizes_001_span2_minmax_min_content_10px_minmax_min_content_10px__content_box_rtl() {
+        crate::run_xml_test(
+            "grid",
+            "grid_intrinsic_track_sizes_001_span2_minmax_min_content_10px_minmax_min_content_10px__content_box_rtl",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
     fn grid_justify_content_center__border_box_ltr() {
         crate::run_xml_test("grid", "grid_justify_content_center__border_box_ltr");
     }


### PR DESCRIPTION
# Objective

Port the WPT test [grid-intrinsic-track-sizes-001](https://wpt.live/css/css-grid/layout-algorithm/grid-intrinsic-track-sizes-001.html) to Taffy's generated test suite, and fix the two grid track sizing bugs it exposed. Follows the same process as #1019.

## Context

### Test fixtures

31 gentest fixtures (one per `checkTrackSizes` case in the WPT test) in `test_fixtures/grid/grid_intrinsic_track_sizes_001_*.html`. Each is a 120x120 grid with a single small item (`min-width: 12px; min-height: 12px`, Ahem text) spanning 1 or 2 tracks, plus empty diagonal "probe" elements (one per track at column i / row i) so the generated expectations expose each resolved track size.

Substitution: the WPT item text is `XXX XX<br>XX<br>XX`, but hard line breaks (`<br>`) aren't expressible in gentest's Ahem text-measure model (which wraps only at zero-width spaces). The fixtures use `XXX&#8203;XX&#8203;X` instead, which preserves the key inline sizes (min-content 30px, max-content 60px, both larger than the 12px minimum) while being representable. Row-axis expected values therefore differ from the WPT assertions, but all expectations are captured from Chrome rendering the actual fixtures; column-axis probe sizes were verified against the WPT-asserted track sizes.

### Bug fix 1: minimum contribution clamped explicit min-width by fixed max track sizing functions

`GridItem::minimum_contribution` clamped the result by the spanned tracks' fixed max track sizing functions in all cases. Per [CSS Grid §6.6](https://www.w3.org/TR/css-grid-1/#min-size-auto) that clamp applies only to the content-based (automatic) minimum size, not to an explicitly specified preferred/minimum size:

```diff
 fn minimum_contribution(...) -> f32 {
-    let size = size.or(min_size).or(...).unwrap_or_else(|| content_based_minimum);
-    size.maybe_min(spanned_fixed_track_limit)   // clamp applied unconditionally
+    size.or(min_size).or(...).unwrap_or_else(|| {
+        content_based_minimum.maybe_min(spanned_fixed_track_limit)  // clamp only the automatic minimum
+    })
 }
```

e.g. `minmax(auto, 10px)` track containing an item with `min-width: 12px` now resolves to 12px (was 10px), matching Chrome and the WPT assertion.

### Bug fix 2: "distribute space beyond limits" still enforced growth limits

In `distribute_item_space_to_base_size`, step 3 (distributing an item's remaining contribution *beyond limits*, [§12.5.1](https://www.w3.org/TR/css-grid-1/#extra-space)) passed the same `track_limit` (growth limit) used in step 2, so no space could ever be distributed beyond limits to tracks with fixed max sizing functions. It now ignores growth limits, capping growth only at any `fit-content()` argument. This resolved a pre-existing `// Should apply only fit-content limit here?` comment at that call site. The beyond-limits track filter is also now composed with `track_is_affected` so that space cannot leak into gutter tracks (which were previously protected by their zero growth limit).

e.g. two `minmax(min-content, 10px)` tracks spanned by an item with min-content contribution 30px now resolve to 15px each (was 10px each), matching Chrome and the WPT assertion.

Fixed failing cases: `minmax(auto, 10px)`, `minmax(auto, 4px) x2`, `minmax(min-content, 10px) x2`, `minmax(max-content, 10px) x2`, `20px minmax(min-content, 6px)`, `20px minmax(max-content, 6px)`, `20px minmax(max-content, 30px)`. All 5000+ generated tests pass; CHANGELOG.md updated under Unreleased.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/509f10813b6745119aa867aa26d722da
Requested by: @nicoburns