### PR TITLE
Grid: convert min/max size to content-box before track sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Grid: the container's min/max size is now converted to a content-box size (by subtracting padding, border and scrollbar gutters) before being used in the track sizing algorithm ("stretch auto tracks" and "expand flexible tracks" steps and the percentage basis fallback). Previously the border-box min/max size was used directly, causing tracks in a grid with padding/border and a `min-width`/`min-height` (but no definite size) to be sized too large by the padding+border amount ([WPT: grid-box-sizing-001](https://wpt.live/css/css-grid/grid-model/grid-box-sizing-001.html))
+
 - Grid: when distributing a spanning item's intrinsic size contribution to flexible tracks, the flex factor sum used to decide between flex-factor-proportional and equal distribution is now computed over only the spanned tracks eligible to receive the space (rather than all tracks in the axis), matching Chrome. Fixes track sizing when an item spans `0fr` tracks or a mix of intrinsic and non-intrinsic flexible tracks (e.g. `0fr minmax(0, 1fr)`)
 
 - Block: replaced elements (`item_is_replaced: true`) are no longer stretch-sized to the container width. An auto width now resolves to the intrinsic size, per [CSS 2 §10.3.4](https://www.w3.org/TR/CSS22/visudet.html#block-replaced-width)

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -125,6 +125,11 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
 
     let outer_node_size =
         known_dimensions.or(preferred_size).maybe_clamp(min_size, max_size).maybe_max(padding_border_size);
+
+    // The track sizing algorithm operates on the grid container's content box, so the min/max sizes
+    // (which are border-box sizes) need converting to content-box sizes before being passed to it
+    let inner_min_size = min_size.maybe_sub(content_box_inset.sum_axes());
+    let inner_max_size = max_size.maybe_sub(content_box_inset.sum_axes());
     let mut inner_node_size = Size {
         width: outer_node_size.width.map(|space| space - content_box_inset.horizontal_axis_sum()),
         height: outer_node_size.height.map(|space| space - content_box_inset.vertical_axis_sum()),
@@ -288,8 +293,8 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
     track_sizing_algorithm(
         tree,
         AbstractAxis::Inline,
-        min_size.get(AbstractAxis::Inline),
-        max_size.get(AbstractAxis::Inline),
+        inner_min_size.get(AbstractAxis::Inline),
+        inner_max_size.get(AbstractAxis::Inline),
         justify_content,
         align_content,
         available_grid_space,
@@ -311,8 +316,8 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
     track_sizing_algorithm(
         tree,
         AbstractAxis::Block,
-        min_size.get(AbstractAxis::Block),
-        max_size.get(AbstractAxis::Block),
+        inner_min_size.get(AbstractAxis::Block),
+        inner_max_size.get(AbstractAxis::Block),
         align_content,
         justify_content,
         available_grid_space,
@@ -435,8 +440,8 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
         track_sizing_algorithm(
             tree,
             AbstractAxis::Inline,
-            min_size.get(AbstractAxis::Inline),
-            max_size.get(AbstractAxis::Inline),
+            inner_min_size.get(AbstractAxis::Inline),
+            inner_max_size.get(AbstractAxis::Inline),
             justify_content,
             align_content,
             available_grid_space,
@@ -497,8 +502,8 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
             track_sizing_algorithm(
                 tree,
                 AbstractAxis::Block,
-                min_size.get(AbstractAxis::Block),
-                max_size.get(AbstractAxis::Block),
+                inner_min_size.get(AbstractAxis::Block),
+                inner_max_size.get(AbstractAxis::Block),
                 align_content,
                 justify_content,
                 available_grid_space,

--- a/test_fixtures/grid/grid_fr_tracks_min_height_with_padding_border.html
+++ b/test_fixtures/grid/grid_fr_tracks_min_height_with_padding_border.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; border-style: solid; border-width: 5px 10px 15px 20px; padding: 17px 13px 7px 3px; min-height: 100px; grid-template-rows: 1fr;">
+  <div></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_fr_tracks_min_width_with_padding_border.html
+++ b/test_fixtures/grid/grid_fr_tracks_min_width_with_padding_border.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; border-style: solid; border-width: 5px 10px 15px 20px; padding: 17px 13px 7px 3px; min-width: 200px; grid-template-columns: 1fr;">
+  <div></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_min_height_with_padding_border.html
+++ b/test_fixtures/grid/grid_min_height_with_padding_border.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; border-style: solid; border-width: 5px 10px 15px 20px; padding: 17px 13px 7px 3px; min-height: 100px;">
+  <div></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_min_height_with_padding_border_box_sizing.html
+++ b/test_fixtures/grid/grid_min_height_with_padding_border_box_sizing.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; border-style: solid; border-width: 5px 10px 15px 20px; padding: 17px 13px 7px 3px; min-height: 100px; box-sizing: border-box;">
+  <div></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_min_width_with_padding_border.html
+++ b/test_fixtures/grid/grid_min_width_with_padding_border.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; border-style: solid; border-width: 5px 10px 15px 20px; padding: 17px 13px 7px 3px; min-width: 200px;">
+  <div></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_min_width_with_padding_border_box_sizing.html
+++ b/test_fixtures/grid/grid_min_width_with_padding_border_box_sizing.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; border-style: solid; border-width: 5px 10px 15px 20px; padding: 17px 13px 7px 3px; min-width: 200px; box-sizing: border-box;">
+  <div></div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/grid/grid_fr_tracks_min_height_with_padding_border__border_box_ltr.xml
+++ b/tests/xml/grid/grid_fr_tracks_min_height_with_padding_border__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_fr_tracks_min_height_with_padding_border__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" min-height="100px" padding-top="17px" padding-left="3px" padding-bottom="7px" padding-right="13px" border-top="5px" border-left="20px" border-bottom="15px" border-right="10px" grid-template-rows="1fr">
+      <div direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="46" height="100">
+      <node x="23" y="22" width="0" height="56"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_tracks_min_height_with_padding_border__border_box_rtl.xml
+++ b/tests/xml/grid/grid_fr_tracks_min_height_with_padding_border__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_fr_tracks_min_height_with_padding_border__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" min-height="100px" padding-top="17px" padding-left="3px" padding-bottom="7px" padding-right="13px" border-top="5px" border-left="20px" border-bottom="15px" border-right="10px" grid-template-rows="1fr">
+      <div direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="46" height="100">
+      <node x="23" y="22" width="0" height="56"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_tracks_min_height_with_padding_border__content_box_ltr.xml
+++ b/tests/xml/grid/grid_fr_tracks_min_height_with_padding_border__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_fr_tracks_min_height_with_padding_border__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" min-height="100px" padding-top="17px" padding-left="3px" padding-bottom="7px" padding-right="13px" border-top="5px" border-left="20px" border-bottom="15px" border-right="10px" grid-template-rows="1fr">
+      <div box-sizing="content-box" direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="46" height="144">
+      <node x="23" y="22" width="0" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_tracks_min_height_with_padding_border__content_box_rtl.xml
+++ b/tests/xml/grid/grid_fr_tracks_min_height_with_padding_border__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_fr_tracks_min_height_with_padding_border__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" min-height="100px" padding-top="17px" padding-left="3px" padding-bottom="7px" padding-right="13px" border-top="5px" border-left="20px" border-bottom="15px" border-right="10px" grid-template-rows="1fr">
+      <div box-sizing="content-box" direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="46" height="144">
+      <node x="23" y="22" width="0" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_tracks_min_width_with_padding_border__border_box_ltr.xml
+++ b/tests/xml/grid/grid_fr_tracks_min_width_with_padding_border__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_fr_tracks_min_width_with_padding_border__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" min-width="200px" padding-top="17px" padding-left="3px" padding-bottom="7px" padding-right="13px" border-top="5px" border-left="20px" border-bottom="15px" border-right="10px" grid-template-columns="1fr">
+      <div direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="44">
+      <node x="23" y="22" width="154" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_tracks_min_width_with_padding_border__border_box_rtl.xml
+++ b/tests/xml/grid/grid_fr_tracks_min_width_with_padding_border__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_fr_tracks_min_width_with_padding_border__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" min-width="200px" padding-top="17px" padding-left="3px" padding-bottom="7px" padding-right="13px" border-top="5px" border-left="20px" border-bottom="15px" border-right="10px" grid-template-columns="1fr">
+      <div direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="44">
+      <node x="23" y="22" width="154" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_tracks_min_width_with_padding_border__content_box_ltr.xml
+++ b/tests/xml/grid/grid_fr_tracks_min_width_with_padding_border__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_fr_tracks_min_width_with_padding_border__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" min-width="200px" padding-top="17px" padding-left="3px" padding-bottom="7px" padding-right="13px" border-top="5px" border-left="20px" border-bottom="15px" border-right="10px" grid-template-columns="1fr">
+      <div box-sizing="content-box" direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="246" height="44">
+      <node x="23" y="22" width="200" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_tracks_min_width_with_padding_border__content_box_rtl.xml
+++ b/tests/xml/grid/grid_fr_tracks_min_width_with_padding_border__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_fr_tracks_min_width_with_padding_border__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" min-width="200px" padding-top="17px" padding-left="3px" padding-bottom="7px" padding-right="13px" border-top="5px" border-left="20px" border-bottom="15px" border-right="10px" grid-template-columns="1fr">
+      <div box-sizing="content-box" direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="246" height="44">
+      <node x="23" y="22" width="200" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_min_height_with_padding_border__border_box_ltr.xml
+++ b/tests/xml/grid/grid_min_height_with_padding_border__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_min_height_with_padding_border__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" min-height="100px" padding-top="17px" padding-left="3px" padding-bottom="7px" padding-right="13px" border-top="5px" border-left="20px" border-bottom="15px" border-right="10px">
+      <div direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="46" height="100">
+      <node x="23" y="22" width="0" height="56"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_min_height_with_padding_border__border_box_rtl.xml
+++ b/tests/xml/grid/grid_min_height_with_padding_border__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_min_height_with_padding_border__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" min-height="100px" padding-top="17px" padding-left="3px" padding-bottom="7px" padding-right="13px" border-top="5px" border-left="20px" border-bottom="15px" border-right="10px">
+      <div direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="46" height="100">
+      <node x="23" y="22" width="0" height="56"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_min_height_with_padding_border__content_box_ltr.xml
+++ b/tests/xml/grid/grid_min_height_with_padding_border__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_min_height_with_padding_border__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" min-height="100px" padding-top="17px" padding-left="3px" padding-bottom="7px" padding-right="13px" border-top="5px" border-left="20px" border-bottom="15px" border-right="10px">
+      <div box-sizing="content-box" direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="46" height="144">
+      <node x="23" y="22" width="0" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_min_height_with_padding_border__content_box_rtl.xml
+++ b/tests/xml/grid/grid_min_height_with_padding_border__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_min_height_with_padding_border__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" min-height="100px" padding-top="17px" padding-left="3px" padding-bottom="7px" padding-right="13px" border-top="5px" border-left="20px" border-bottom="15px" border-right="10px">
+      <div box-sizing="content-box" direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="46" height="144">
+      <node x="23" y="22" width="0" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_min_height_with_padding_border_box_sizing__border_box_ltr.xml
+++ b/tests/xml/grid/grid_min_height_with_padding_border_box_sizing__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_min_height_with_padding_border_box_sizing__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" min-height="100px" padding-top="17px" padding-left="3px" padding-bottom="7px" padding-right="13px" border-top="5px" border-left="20px" border-bottom="15px" border-right="10px">
+      <div direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="46" height="100">
+      <node x="23" y="22" width="0" height="56"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_min_height_with_padding_border_box_sizing__border_box_rtl.xml
+++ b/tests/xml/grid/grid_min_height_with_padding_border_box_sizing__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_min_height_with_padding_border_box_sizing__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" min-height="100px" padding-top="17px" padding-left="3px" padding-bottom="7px" padding-right="13px" border-top="5px" border-left="20px" border-bottom="15px" border-right="10px">
+      <div direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="46" height="100">
+      <node x="23" y="22" width="0" height="56"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_min_height_with_padding_border_box_sizing__content_box_ltr.xml
+++ b/tests/xml/grid/grid_min_height_with_padding_border_box_sizing__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_min_height_with_padding_border_box_sizing__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" min-height="100px" padding-top="17px" padding-left="3px" padding-bottom="7px" padding-right="13px" border-top="5px" border-left="20px" border-bottom="15px" border-right="10px">
+      <div box-sizing="content-box" direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="46" height="100">
+      <node x="23" y="22" width="0" height="56"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_min_height_with_padding_border_box_sizing__content_box_rtl.xml
+++ b/tests/xml/grid/grid_min_height_with_padding_border_box_sizing__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_min_height_with_padding_border_box_sizing__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" min-height="100px" padding-top="17px" padding-left="3px" padding-bottom="7px" padding-right="13px" border-top="5px" border-left="20px" border-bottom="15px" border-right="10px">
+      <div box-sizing="content-box" direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="46" height="100">
+      <node x="23" y="22" width="0" height="56"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_min_width_with_padding_border__border_box_ltr.xml
+++ b/tests/xml/grid/grid_min_width_with_padding_border__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_min_width_with_padding_border__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" min-width="200px" padding-top="17px" padding-left="3px" padding-bottom="7px" padding-right="13px" border-top="5px" border-left="20px" border-bottom="15px" border-right="10px">
+      <div direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="44">
+      <node x="23" y="22" width="154" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_min_width_with_padding_border__border_box_rtl.xml
+++ b/tests/xml/grid/grid_min_width_with_padding_border__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_min_width_with_padding_border__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" min-width="200px" padding-top="17px" padding-left="3px" padding-bottom="7px" padding-right="13px" border-top="5px" border-left="20px" border-bottom="15px" border-right="10px">
+      <div direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="44">
+      <node x="23" y="22" width="154" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_min_width_with_padding_border__content_box_ltr.xml
+++ b/tests/xml/grid/grid_min_width_with_padding_border__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_min_width_with_padding_border__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" min-width="200px" padding-top="17px" padding-left="3px" padding-bottom="7px" padding-right="13px" border-top="5px" border-left="20px" border-bottom="15px" border-right="10px">
+      <div box-sizing="content-box" direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="246" height="44">
+      <node x="23" y="22" width="200" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_min_width_with_padding_border__content_box_rtl.xml
+++ b/tests/xml/grid/grid_min_width_with_padding_border__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_min_width_with_padding_border__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" min-width="200px" padding-top="17px" padding-left="3px" padding-bottom="7px" padding-right="13px" border-top="5px" border-left="20px" border-bottom="15px" border-right="10px">
+      <div box-sizing="content-box" direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="246" height="44">
+      <node x="23" y="22" width="200" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_min_width_with_padding_border_box_sizing__border_box_ltr.xml
+++ b/tests/xml/grid/grid_min_width_with_padding_border_box_sizing__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_min_width_with_padding_border_box_sizing__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" min-width="200px" padding-top="17px" padding-left="3px" padding-bottom="7px" padding-right="13px" border-top="5px" border-left="20px" border-bottom="15px" border-right="10px">
+      <div direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="44">
+      <node x="23" y="22" width="154" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_min_width_with_padding_border_box_sizing__border_box_rtl.xml
+++ b/tests/xml/grid/grid_min_width_with_padding_border_box_sizing__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_min_width_with_padding_border_box_sizing__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" min-width="200px" padding-top="17px" padding-left="3px" padding-bottom="7px" padding-right="13px" border-top="5px" border-left="20px" border-bottom="15px" border-right="10px">
+      <div direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="44">
+      <node x="23" y="22" width="154" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_min_width_with_padding_border_box_sizing__content_box_ltr.xml
+++ b/tests/xml/grid/grid_min_width_with_padding_border_box_sizing__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_min_width_with_padding_border_box_sizing__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" min-width="200px" padding-top="17px" padding-left="3px" padding-bottom="7px" padding-right="13px" border-top="5px" border-left="20px" border-bottom="15px" border-right="10px">
+      <div box-sizing="content-box" direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="44">
+      <node x="23" y="22" width="154" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_min_width_with_padding_border_box_sizing__content_box_rtl.xml
+++ b/tests/xml/grid/grid_min_width_with_padding_border_box_sizing__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_min_width_with_padding_border_box_sizing__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" min-width="200px" padding-top="17px" padding-left="3px" padding-bottom="7px" padding-right="13px" border-top="5px" border-left="20px" border-bottom="15px" border-right="10px">
+      <div box-sizing="content-box" direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="44">
+      <node x="23" y="22" width="154" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -23603,6 +23603,54 @@ mod grid {
 
     #[cfg(feature = "grid")]
     #[test]
+    fn grid_fr_tracks_min_height_with_padding_border__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_fr_tracks_min_height_with_padding_border__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_tracks_min_height_with_padding_border__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_fr_tracks_min_height_with_padding_border__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_tracks_min_height_with_padding_border__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_fr_tracks_min_height_with_padding_border__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_tracks_min_height_with_padding_border__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_fr_tracks_min_height_with_padding_border__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_tracks_min_width_with_padding_border__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_fr_tracks_min_width_with_padding_border__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_tracks_min_width_with_padding_border__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_fr_tracks_min_width_with_padding_border__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_tracks_min_width_with_padding_border__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_fr_tracks_min_width_with_padding_border__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_tracks_min_width_with_padding_border__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_fr_tracks_min_width_with_padding_border__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
     fn grid_gap__border_box_ltr() {
         crate::run_xml_test("grid", "grid_gap__border_box_ltr");
     }
@@ -25135,6 +25183,102 @@ mod grid {
     #[test]
     fn grid_min_content_single_item__content_box_rtl() {
         crate::run_xml_test("grid", "grid_min_content_single_item__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_min_height_with_padding_border__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_min_height_with_padding_border__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_min_height_with_padding_border__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_min_height_with_padding_border__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_min_height_with_padding_border__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_min_height_with_padding_border__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_min_height_with_padding_border__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_min_height_with_padding_border__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_min_height_with_padding_border_box_sizing__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_min_height_with_padding_border_box_sizing__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_min_height_with_padding_border_box_sizing__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_min_height_with_padding_border_box_sizing__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_min_height_with_padding_border_box_sizing__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_min_height_with_padding_border_box_sizing__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_min_height_with_padding_border_box_sizing__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_min_height_with_padding_border_box_sizing__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_min_width_with_padding_border__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_min_width_with_padding_border__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_min_width_with_padding_border__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_min_width_with_padding_border__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_min_width_with_padding_border__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_min_width_with_padding_border__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_min_width_with_padding_border__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_min_width_with_padding_border__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_min_width_with_padding_border_box_sizing__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_min_width_with_padding_border_box_sizing__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_min_width_with_padding_border_box_sizing__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_min_width_with_padding_border_box_sizing__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_min_width_with_padding_border_box_sizing__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_min_width_with_padding_border_box_sizing__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_min_width_with_padding_border_box_sizing__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_min_width_with_padding_border_box_sizing__content_box_rtl");
     }
 
     #[cfg(feature = "grid")]


### PR DESCRIPTION
# Objective

Fix the failing subtests (2, 4, 14, 16) of [WPT grid-box-sizing-001](https://wpt.live/css/css-grid/grid-model/grid-box-sizing-001.html) — the cases where a grid container has padding/border and a `min-height`/`min-width` but no definite size.

The track sizing algorithm operates on the container's content box, but `compute_grid_layout` passed the border-box `min_size`/`max_size` straight into `track_sizing_algorithm`, where they're used in the "stretch auto tracks" and "expand flexible tracks" steps (and as the percentage-basis fallback). Tracks were therefore stretched to the border-box min-size, and the final container size added padding+border on top again — oversizing the container and its tracks by the padding+border amount.

Fix (in `compute_grid_layout`):

```rust
let inner_min_size = min_size.maybe_sub(content_box_inset.sum_axes());
let inner_max_size = max_size.maybe_sub(content_box_inset.sum_axes());
// passed to all four track_sizing_algorithm calls in place of min_size/max_size
```

The border-box `min_size`/`max_size` are still used where border-box sizes are expected (clamping `outer_node_size`, `container_border_box`, and `auto_fit_container_size`).

## Context

Verified against the Blitz WPT runner: `grid-box-sizing-001.html` goes 20/24 → 24/24, and across the full css-grid + css-flexbox suites the only changes vs taffy main are improvements:

- `css/css-grid/grid-model/grid-box-sizing-001.html`: FAIL (20/24) → PASS
- `css/css-grid/alignment/grid-gutters-016.html`: FAIL → PASS
- `css/css-grid/layout-algorithm/flex-sizing-columns-min-max-width-001.html`: 8/12 → 11/12
- `css/css-grid/layout-algorithm/flex-sizing-rows-min-max-height-001.html`: 8/12 → 11/12

Added gentest fixtures covering `min-width`/`min-height` with padding+border for both `box-sizing` values and for auto and `1fr` tracks, and regenerated tests (Chrome agrees with the new behaviour).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/21ba7380559549c89e149f1baaf8f81e
Requested by: @nicoburns