### PR TITLE
Grid: represent `grid-template-areas` as `Option<GridTemplateAreas>` with explicit template size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Grid: `Style::grid_template_areas` is now `Option<GridTemplateAreas<S>>`, where the new `GridTemplateAreas` struct bundles the named areas (`areas`) with the overall size of the area template (`row_count`/`column_count`). This allows templates containing unnamed (`.`) cells beyond the extents of the named areas (e.g. `grid-template-areas: "a ."`) to be represented, as such cells still contribute to the size of the explicit grid. `GridContainerStyle` gains `grid_template_area_row_count`/`grid_template_area_column_count` methods (with default implementations that derive the counts from the extents of the named areas), which are now used to determine the size of the explicit grid
+
 ### Fixed
 
 - Grid: an explicitly specified preferred or minimum size is no longer clamped by the spanned tracks' fixed max track sizing functions when computing an item's minimum contribution. That clamp only applies to the content-based (automatic) minimum size, per [CSS Grid §6.6](https://www.w3.org/TR/css-grid-1/#min-size-auto). Fixes e.g. an item with `min-width: 12px` in a `minmax(auto, 10px)` track sizing the track to `12px` rather than `10px`

--- a/src/compute/grid/types/named.rs
+++ b/src/compute/grid/types/named.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     CheapCloneStr, GenericGridTemplateComponent, GenericRepetition as _, GridAreaAxis, GridAreaEnd, GridContainerStyle,
-    GridPlacement, GridTemplateArea, Line, NonNamedGridPlacement, RepetitionCount,
+    GridPlacement, GridTemplateArea, GridTemplateAreas, Line, NonNamedGridPlacement, RepetitionCount,
 };
 use core::{borrow::Borrow, cmp::Ordering, fmt::Debug};
 
@@ -489,13 +489,17 @@ mod tests {
     #[test]
     fn area_lines_saturate_when_converted_to_grid_lines() {
         let style = Style {
-            grid_template_areas: vec![GridTemplateArea {
-                name: DefaultCheapStr::from("area"),
-                row_start: 1,
-                row_end: 2,
-                column_start: u16::MAX,
-                column_end: u16::MAX,
-            }],
+            grid_template_areas: Some(GridTemplateAreas {
+                areas: vec![GridTemplateArea {
+                    name: DefaultCheapStr::from("area"),
+                    row_start: 1,
+                    row_end: 2,
+                    column_start: u16::MAX,
+                    column_end: u16::MAX,
+                }],
+                row_count: 1,
+                column_count: u16::MAX,
+            }),
             ..Style::DEFAULT
         };
         let resolver = NamedLineResolver::new(&style, 0, 0);

--- a/src/compute/grid/types/named.rs
+++ b/src/compute/grid/types/named.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     CheapCloneStr, GenericGridTemplateComponent, GenericRepetition as _, GridAreaAxis, GridAreaEnd, GridContainerStyle,
-    GridPlacement, GridTemplateArea, GridTemplateAreas, Line, NonNamedGridPlacement, RepetitionCount,
+    GridPlacement, GridTemplateArea, Line, NonNamedGridPlacement, RepetitionCount,
 };
 use core::{borrow::Borrow, cmp::Ordering, fmt::Debug};
 
@@ -441,6 +441,7 @@ mod tests {
     use super::*;
     use crate::style::GenericGridPlacement;
     use crate::sys::DefaultCheapStr;
+    use crate::GridTemplateAreas;
     use crate::Style;
 
     fn resolver(explicit_track_count: u16) -> NamedLineResolver<DefaultCheapStr> {

--- a/src/compute/grid/types/named.rs
+++ b/src/compute/grid/types/named.rs
@@ -81,15 +81,15 @@ impl<S: CheapCloneStr> NamedLineResolver<S> {
         let mut column_lines: Map<StrHasher<S>, Vec<u32>> = Map::new();
         let mut row_lines: Map<StrHasher<S>, Vec<u32>> = Map::new();
 
-        let mut area_column_count = 0;
-        let mut area_row_count = 0;
+        // The size of the area template may be larger than the extents of the named areas
+        // due to unnamed (`.`) cells, so it is taken from the style rather than being derived
+        // from the areas themselves.
+        let area_column_count = style.grid_template_area_column_count();
+        let area_row_count = style.grid_template_area_row_count();
         if let Some(area_iter) = style.grid_template_areas() {
             for area in area_iter.into_iter() {
                 // TODO: Investigate eliminating clones
                 areas.insert(StrHasher(area.name.clone()), area.clone());
-
-                area_column_count = area_column_count.max(area.column_end.max(1) - 1);
-                area_row_count = area_row_count.max(area.row_end.max(1) - 1);
 
                 let col_start_name = S::from(format!("{}-start", area.name.as_ref()));
                 upsert_line_name_map(&mut column_lines, col_start_name, area.column_start as u32);

--- a/src/style/grid.rs
+++ b/src/style/grid.rs
@@ -15,6 +15,22 @@ use crate::util::parse::{
     from_str_from_css, parse_css_str_entirely, CssParseResult, FromCss, ParseError, Parser, Token,
 };
 
+/// Defines the value of the `grid-template-areas` property: the named areas plus the overall
+/// size (in tracks) of the area template.
+///
+/// The template may be larger than the extents of the named areas due to unnamed (`.`) cells,
+/// so the size is stored explicitly.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct GridTemplateAreas<CustomIdent: CheapCloneStr> {
+    /// The named grid areas
+    pub areas: crate::util::sys::GridTrackVec<GridTemplateArea<CustomIdent>>,
+    /// The number of rows in the area template
+    pub row_count: u16,
+    /// The number of columns in the area template
+    pub column_count: u16,
+}
+
 /// Defines a grid area
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -176,6 +192,20 @@ pub trait GridContainerStyle: CoreStyle {
 
     /// Named grid areas
     fn grid_template_areas(&self) -> Option<Self::GridTemplateAreas<'_>>;
+    /// The number of rows in the `grid-template-areas` template (0 if there is no template).
+    /// May be greater than the extent of the named areas due to unnamed (`.`) cells.
+    fn grid_template_area_row_count(&self) -> u16 {
+        self.grid_template_areas()
+            .map(|areas| areas.into_iter().map(|area| area.row_end.max(1) - 1).max().unwrap_or(0))
+            .unwrap_or(0)
+    }
+    /// The number of columns in the `grid-template-areas` template (0 if there is no template).
+    /// May be greater than the extent of the named areas due to unnamed (`.`) cells.
+    fn grid_template_area_column_count(&self) -> u16 {
+        self.grid_template_areas()
+            .map(|areas| areas.into_iter().map(|area| area.column_end.max(1) - 1).max().unwrap_or(0))
+            .unwrap_or(0)
+    }
     /// Defines the line names for row lines
     fn grid_template_column_names(&self) -> Option<Self::TemplateLineNames<'_>>;
     /// Defines the size of implicitly created rows

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -37,7 +37,7 @@ pub use self::grid::{
 #[cfg(feature = "grid")]
 pub(crate) use self::grid::{GridAreaAxis, GridAreaEnd};
 #[cfg(feature = "grid")]
-pub use self::grid::{GridTemplateArea, NamedGridLine, TemplateLineNames};
+pub use self::grid::{GridTemplateArea, GridTemplateAreas, NamedGridLine, TemplateLineNames};
 #[cfg(feature = "grid")]
 pub(crate) use self::grid::{NonNamedGridPlacement, OriginZeroGridPlacement};
 
@@ -567,7 +567,7 @@ pub struct Style<S: CheapCloneStr = DefaultCheapStr> {
     // Grid container named properties
     /// Defines the rectangular grid areas
     #[cfg(feature = "grid")]
-    pub grid_template_areas: GridTrackVec<GridTemplateArea<S>>,
+    pub grid_template_areas: Option<GridTemplateAreas<S>>,
     /// The named lines between the columns
     #[cfg(feature = "grid")]
     pub grid_template_column_names: GridTrackVec<GridTrackVec<S>>,
@@ -643,7 +643,7 @@ impl<S: CheapCloneStr> Style<S> {
         #[cfg(feature = "grid")]
         grid_template_columns: GridTrackVec::new(),
         #[cfg(feature = "grid")]
-        grid_template_areas: GridTrackVec::new(),
+        grid_template_areas: None,
         #[cfg(feature = "grid")]
         grid_template_column_names: GridTrackVec::new(),
         #[cfg(feature = "grid")]
@@ -1046,7 +1046,17 @@ impl<S: CheapCloneStr> GridContainerStyle for Style<S> {
     #[inline(always)]
     #[cfg(feature = "grid")]
     fn grid_template_areas(&self) -> Option<Self::GridTemplateAreas<'_>> {
-        Some(self.grid_template_areas.iter().cloned())
+        self.grid_template_areas.as_ref().map(|template| template.areas.iter().cloned())
+    }
+    #[inline(always)]
+    #[cfg(feature = "grid")]
+    fn grid_template_area_row_count(&self) -> u16 {
+        self.grid_template_areas.as_ref().map(|template| template.row_count).unwrap_or(0)
+    }
+    #[inline(always)]
+    #[cfg(feature = "grid")]
+    fn grid_template_area_column_count(&self) -> u16 {
+        self.grid_template_areas.as_ref().map(|template| template.column_count).unwrap_or(0)
     }
 
     #[inline(always)]
@@ -1111,6 +1121,14 @@ impl<T: GridContainerStyle> GridContainerStyle for &'_ T {
     #[inline(always)]
     fn grid_template_areas(&self) -> Option<Self::GridTemplateAreas<'_>> {
         (*self).grid_template_areas()
+    }
+    #[inline(always)]
+    fn grid_template_area_row_count(&self) -> u16 {
+        (*self).grid_template_area_row_count()
+    }
+    #[inline(always)]
+    fn grid_template_area_column_count(&self) -> u16 {
+        (*self).grid_template_area_column_count()
     }
     #[cfg(feature = "grid")]
     #[inline(always)]
@@ -1346,12 +1364,12 @@ mod tests {
         assert_type_size::<GridTemplateComponent<String>>(56);
         assert_type_size::<GridPlacement<String>>(32);
         assert_type_size::<Line<GridPlacement<String>>>(64);
-        assert_type_size::<Style<String>>(544);
+        assert_type_size::<Style<String>>(552);
 
         // String-type dependent (Arc<str>)
         assert_type_size::<GridTemplateComponent<Arc<str>>>(56);
         assert_type_size::<GridPlacement<Arc<str>>>(24);
         assert_type_size::<Line<GridPlacement<Arc<str>>>>(48);
-        assert_type_size::<Style<Arc<str>>>(512);
+        assert_type_size::<Style<Arc<str>>>(520);
     }
 }


### PR DESCRIPTION
# Objective

Allow `grid-template-areas` templates whose size exceeds the extents of their named areas — i.e. templates containing unnamed (`.`) cells such as `"a ."` — to be represented in Taffy, so that Stylo's computed value (which stores the template `width` and row count explicitly) can be converted losslessly.

Follow-up to #1021, which found that the 3rd case of the WPT test `grid-container-change-grid-tracks-recompute-child-positions-001.html` could not be faithfully encoded: with only the named area `a` (1..2 / 1..2), Taffy inferred a 1-column explicit grid and placed the auto-placed item in row 3 instead of column 2.

## Changes

```rust
// New struct (mirrors Stylo's TemplateAreas { areas, strings.len(), width })
pub struct GridTemplateAreas<S: CheapCloneStr> {
    pub areas: GridTrackVec<GridTemplateArea<S>>,
    pub row_count: u16,
    pub column_count: u16,
}

// Breaking change to Style
- pub grid_template_areas: GridTrackVec<GridTemplateArea<S>>,
+ pub grid_template_areas: Option<GridTemplateAreas<S>>,

// GridContainerStyle: new methods, with defaults preserving the old derive-from-extents behavior
fn grid_template_area_row_count(&self) -> u16 { /* max of area.row_end - 1 */ }
fn grid_template_area_column_count(&self) -> u16 { /* max of area.column_end - 1 */ }
```

`NamedLineResolver::new` now takes the area template size from these style methods instead of deriving it from the named areas' extents; the counts feed into `explicit_{col,row}_count` as before.

The WPT-ported test from #1021 is switched to the faithful encoding (area `a` = 1..2/1..2, `column_count: 2`) and passes.

`Style<String>` grows from 544 to 552 bytes (`Vec` field → `Option<{Vec, u16, u16}>`); size assertions updated per the note in `style_sizes`.

## Context

Stylo's computed `grid-template-areas` (`TemplateAreas`) stores `areas: OwnedSlice<NamedArea>`, `strings` (one per row, giving the row count) and `width: u32` (column count), so `.` cells contribute to the template size without appearing in `areas`. A companion Blitz PR updates the `stylo_taffy` conversion to pass `width` / `strings.len()` through.

CHANGELOG.md updated.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/b593446a7dfd44f8a4c2d72c494bf1e7
Requested by: @nicoburns