### PR TITLE
Gentest: support `grid-template-areas` and named grid placements

### DIFF
--- a/scripts/gentest/src/main.rs
+++ b/scripts/gentest/src/main.rs
@@ -701,6 +701,7 @@ fn generate_node(w: &mut XmlWriter, node: &Value) {
     );
     maybe_write(w, "grid-auto-rows", serialize_array(&style["gridAutoRows"], ' ', serialize_track_definition));
     maybe_write(w, "grid-auto-columns", serialize_array(&style["gridAutoColumns"], ' ', serialize_track_definition));
+    maybe_write(w, "grid-template-areas", get_str_attr(&style["gridTemplateAreas"], None));
 
     maybe_write(w, "grid-row-start", serialize_grid_position(&style["gridRowStart"]));
     maybe_write(w, "grid-row-end", serialize_grid_position(&style["gridRowEnd"]));
@@ -803,6 +804,7 @@ fn serialize_grid_position(grid_position: &serde_json::Value) -> Option<Cow<'sta
                 "auto" => None, //Some(Cow::from("auto")),
                 "span" => Some(Cow::from(format!("span {}", value()))),
                 "line" => Some(Cow::from((value() as i32).to_string())),
+                "named" => Some(Cow::from(grid_position.get("value").unwrap().as_str().unwrap().to_string())),
                 _ => unreachable!(),
             },
             _ => unreachable!(),

--- a/scripts/gentest/test_helper.js
+++ b/scripts/gentest/test_helper.js
@@ -191,7 +191,15 @@ function parseGridPosition(input) {
   if (input === 'auto') return { kind: 'auto' };
   if (/^span +\d+$/.test(input)) return { kind: 'span', value: parseInt(input.replace(/[^\d]/g, ''), 10) };
   if (/^-?\d+$/.test(input)) return { kind: 'line', value: parseInt(input, 10) };
+  // Named line/area placements (e.g. "a", "a 2", "span a", "span a 2") are passed through
+  // verbatim and parsed on the Rust side
+  if (/^(span +)?(-?\d+ +)?[a-zA-Z_][a-zA-Z0-9_-]*( +-?\d+)?$/.test(input)) return { kind: 'named', value: input };
   return undefined;
+}
+
+function parseGridTemplateAreas(input) {
+  if (input === '' || input === 'none') return undefined;
+  return input;
 }
 
 function describeElement(e) {
@@ -240,6 +248,7 @@ function describeElement(e) {
       gridAutoRows: parseGridTrackDefinitions(e.style.gridAutoRows),
       gridAutoColumns: parseGridTrackDefinitions(e.style.gridAutoColumns),
       gridAutoFlow: parseGridAutoFlow(e.style.gridAutoFlow),
+      gridTemplateAreas: parseGridTemplateAreas(e.style.gridTemplateAreas),
 
       gridRowStart: parseGridPosition(e.style.gridRowStart),
       gridRowEnd: parseGridPosition(e.style.gridRowEnd),

--- a/test_fixtures/grid/grid_dense_auto_placement_two_explicit_rows.html
+++ b/test_fixtures/grid/grid_dense_auto_placement_two_explicit_rows.html
@@ -9,8 +9,8 @@
 </head>
 <body>
 
-<!-- 3rd case of the WPT test css/css-grid/placement/grid-container-change-grid-tracks-recompute-child-positions-001.html -->
-<div id="test-root" style="display: grid; grid-auto-flow: row dense; grid-template-rows: 10px; grid-template-columns: 10px; grid-template-areas: 'a .'; grid-auto-rows: 5px; grid-auto-columns: 5px;">
+<!-- 1st case of the WPT test css/css-grid/placement/grid-container-change-grid-tracks-recompute-child-positions-001.html -->
+<div id="test-root" style="display: grid; grid-auto-flow: row dense; grid-template-rows: 10px 10px; grid-template-columns: 10px; grid-auto-rows: 5px; grid-auto-columns: 5px;">
   <div style="grid-column-start: 1;"></div>
   <div style="grid-row-start: 1;"></div>
   <div></div>

--- a/test_fixtures/grid/grid_template_areas_named_placement.html
+++ b/test_fixtures/grid/grid_template_areas_named_placement.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-rows: 20px 40px 30px; grid-template-columns: 50px 70px; grid-template-areas: 'header header' 'nav main' 'footer .';">
+  <div style="grid-row-start: header-start; grid-row-end: header-end; grid-column-start: header-start; grid-column-end: header-end;"></div>
+  <div style="grid-row-start: nav; grid-column-start: nav;"></div>
+  <div style="grid-row-start: main; grid-column-start: main;"></div>
+  <div style="grid-row-start: footer; grid-column-start: footer;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_template_areas_single_named_cell.html
+++ b/test_fixtures/grid/grid_template_areas_single_named_cell.html
@@ -9,8 +9,8 @@
 </head>
 <body>
 
-<!-- 3rd case of the WPT test css/css-grid/placement/grid-container-change-grid-tracks-recompute-child-positions-001.html -->
-<div id="test-root" style="display: grid; grid-auto-flow: row dense; grid-template-rows: 10px; grid-template-columns: 10px; grid-template-areas: 'a .'; grid-auto-rows: 5px; grid-auto-columns: 5px;">
+<!-- 2nd case of the WPT test css/css-grid/placement/grid-container-change-grid-tracks-recompute-child-positions-001.html -->
+<div id="test-root" style="display: grid; grid-auto-flow: row dense; grid-template-rows: 10px; grid-template-columns: 10px; grid-template-areas: 'a'; grid-auto-rows: 5px; grid-auto-columns: 5px;">
   <div style="grid-column-start: 1;"></div>
   <div style="grid-row-start: 1;"></div>
   <div></div>

--- a/test_fixtures/grid/grid_template_areas_unnamed_cells.html
+++ b/test_fixtures/grid/grid_template_areas_unnamed_cells.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-auto-flow: row dense; grid-template-rows: 10px; grid-template-columns: 10px; grid-template-areas: 'a .'; grid-auto-rows: 5px; grid-auto-columns: 5px;">
+  <div></div>
+  <div></div>
+  <div></div>
+</div>
+
+</body>
+</html>

--- a/tests/xml.rs
+++ b/tests/xml.rs
@@ -301,10 +301,9 @@ fn build_style<S: CheapCloneStr>(xnode: roxmltree::Node) -> taffy::Style<S> {
         grid_template_columns: grid_template_columns.tracks,
         grid_template_column_names: grid_template_columns.line_names,
 
-        // TODO
         grid_auto_rows: parse_or_default::<GridAutoTracks>(xnode.attribute("grid-auto-rows")).0,
         grid_auto_columns: parse_or_default::<GridAutoTracks>(xnode.attribute("grid-auto-columns")).0,
-        grid_template_areas: Default::default(),
+        grid_template_areas: xnode.attribute("grid-template-areas").map(|input| input.parse().unwrap()),
 
         grid_row: Line {
             start: parse_or_default(xnode.attribute("grid-row-start")),

--- a/tests/xml/grid/grid_dense_auto_placement_two_explicit_rows__border_box_ltr.xml
+++ b/tests/xml/grid/grid_dense_auto_placement_two_explicit_rows__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_dense_auto_placement_two_explicit_rows__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" grid-auto-flow="row dense" grid-template-rows="10px 10px" grid-template-columns="10px" grid-auto-rows="5px" grid-auto-columns="5px">
+      <div direction="ltr" grid-column-start="1"/>
+      <div direction="ltr" grid-row-start="1"/>
+      <div direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="10" height="25">
+      <node x="0" y="10" width="10" height="10"/>
+      <node x="0" y="0" width="10" height="10"/>
+      <node x="0" y="20" width="10" height="5"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_dense_auto_placement_two_explicit_rows__border_box_rtl.xml
+++ b/tests/xml/grid/grid_dense_auto_placement_two_explicit_rows__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_dense_auto_placement_two_explicit_rows__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" grid-auto-flow="row dense" grid-template-rows="10px 10px" grid-template-columns="10px" grid-auto-rows="5px" grid-auto-columns="5px">
+      <div direction="rtl" grid-column-start="1"/>
+      <div direction="rtl" grid-row-start="1"/>
+      <div direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="10" height="25">
+      <node x="0" y="10" width="10" height="10"/>
+      <node x="0" y="0" width="10" height="10"/>
+      <node x="0" y="20" width="10" height="5"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_dense_auto_placement_two_explicit_rows__content_box_ltr.xml
+++ b/tests/xml/grid/grid_dense_auto_placement_two_explicit_rows__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_dense_auto_placement_two_explicit_rows__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" grid-auto-flow="row dense" grid-template-rows="10px 10px" grid-template-columns="10px" grid-auto-rows="5px" grid-auto-columns="5px">
+      <div box-sizing="content-box" direction="ltr" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="1"/>
+      <div box-sizing="content-box" direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="10" height="25">
+      <node x="0" y="10" width="10" height="10"/>
+      <node x="0" y="0" width="10" height="10"/>
+      <node x="0" y="20" width="10" height="5"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_dense_auto_placement_two_explicit_rows__content_box_rtl.xml
+++ b/tests/xml/grid/grid_dense_auto_placement_two_explicit_rows__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_dense_auto_placement_two_explicit_rows__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" grid-auto-flow="row dense" grid-template-rows="10px 10px" grid-template-columns="10px" grid-auto-rows="5px" grid-auto-columns="5px">
+      <div box-sizing="content-box" direction="rtl" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="1"/>
+      <div box-sizing="content-box" direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="10" height="25">
+      <node x="0" y="10" width="10" height="10"/>
+      <node x="0" y="0" width="10" height="10"/>
+      <node x="0" y="20" width="10" height="5"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_template_areas_named_placement__border_box_ltr.xml
+++ b/tests/xml/grid/grid_template_areas_named_placement__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_template_areas_named_placement__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" grid-template-rows="20px 40px 30px" grid-template-columns="50px 70px" grid-template-areas="&quot;header header&quot; &quot;nav main&quot; &quot;footer .&quot;">
+      <div direction="ltr" grid-row-start="header-start" grid-row-end="header-end" grid-column-start="header-start" grid-column-end="header-end"/>
+      <div direction="ltr" grid-row-start="nav" grid-column-start="nav"/>
+      <div direction="ltr" grid-row-start="main" grid-column-start="main"/>
+      <div direction="ltr" grid-row-start="footer" grid-column-start="footer"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="90">
+      <node x="0" y="0" width="120" height="20"/>
+      <node x="0" y="20" width="50" height="40"/>
+      <node x="50" y="20" width="70" height="40"/>
+      <node x="0" y="60" width="50" height="30"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_template_areas_named_placement__border_box_rtl.xml
+++ b/tests/xml/grid/grid_template_areas_named_placement__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_template_areas_named_placement__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" grid-template-rows="20px 40px 30px" grid-template-columns="50px 70px" grid-template-areas="&quot;header header&quot; &quot;nav main&quot; &quot;footer .&quot;">
+      <div direction="rtl" grid-row-start="header-start" grid-row-end="header-end" grid-column-start="header-start" grid-column-end="header-end"/>
+      <div direction="rtl" grid-row-start="nav" grid-column-start="nav"/>
+      <div direction="rtl" grid-row-start="main" grid-column-start="main"/>
+      <div direction="rtl" grid-row-start="footer" grid-column-start="footer"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="90">
+      <node x="0" y="0" width="120" height="20"/>
+      <node x="70" y="20" width="50" height="40"/>
+      <node x="0" y="20" width="70" height="40"/>
+      <node x="70" y="60" width="50" height="30"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_template_areas_named_placement__content_box_ltr.xml
+++ b/tests/xml/grid/grid_template_areas_named_placement__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_template_areas_named_placement__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" grid-template-rows="20px 40px 30px" grid-template-columns="50px 70px" grid-template-areas="&quot;header header&quot; &quot;nav main&quot; &quot;footer .&quot;">
+      <div box-sizing="content-box" direction="ltr" grid-row-start="header-start" grid-row-end="header-end" grid-column-start="header-start" grid-column-end="header-end"/>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="nav" grid-column-start="nav"/>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="main" grid-column-start="main"/>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="footer" grid-column-start="footer"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="90">
+      <node x="0" y="0" width="120" height="20"/>
+      <node x="0" y="20" width="50" height="40"/>
+      <node x="50" y="20" width="70" height="40"/>
+      <node x="0" y="60" width="50" height="30"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_template_areas_named_placement__content_box_rtl.xml
+++ b/tests/xml/grid/grid_template_areas_named_placement__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_template_areas_named_placement__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" grid-template-rows="20px 40px 30px" grid-template-columns="50px 70px" grid-template-areas="&quot;header header&quot; &quot;nav main&quot; &quot;footer .&quot;">
+      <div box-sizing="content-box" direction="rtl" grid-row-start="header-start" grid-row-end="header-end" grid-column-start="header-start" grid-column-end="header-end"/>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="nav" grid-column-start="nav"/>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="main" grid-column-start="main"/>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="footer" grid-column-start="footer"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="90">
+      <node x="0" y="0" width="120" height="20"/>
+      <node x="70" y="20" width="50" height="40"/>
+      <node x="0" y="20" width="70" height="40"/>
+      <node x="70" y="60" width="50" height="30"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_template_areas_single_named_cell__border_box_ltr.xml
+++ b/tests/xml/grid/grid_template_areas_single_named_cell__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_template_areas_single_named_cell__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" grid-auto-flow="row dense" grid-template-rows="10px" grid-template-columns="10px" grid-auto-rows="5px" grid-auto-columns="5px" grid-template-areas="&quot;a&quot;">
+      <div direction="ltr" grid-column-start="1"/>
+      <div direction="ltr" grid-row-start="1"/>
+      <div direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="10" height="20">
+      <node x="0" y="10" width="10" height="5"/>
+      <node x="0" y="0" width="10" height="10"/>
+      <node x="0" y="15" width="10" height="5"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_template_areas_single_named_cell__border_box_rtl.xml
+++ b/tests/xml/grid/grid_template_areas_single_named_cell__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_template_areas_single_named_cell__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" grid-auto-flow="row dense" grid-template-rows="10px" grid-template-columns="10px" grid-auto-rows="5px" grid-auto-columns="5px" grid-template-areas="&quot;a&quot;">
+      <div direction="rtl" grid-column-start="1"/>
+      <div direction="rtl" grid-row-start="1"/>
+      <div direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="10" height="20">
+      <node x="0" y="10" width="10" height="5"/>
+      <node x="0" y="0" width="10" height="10"/>
+      <node x="0" y="15" width="10" height="5"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_template_areas_single_named_cell__content_box_ltr.xml
+++ b/tests/xml/grid/grid_template_areas_single_named_cell__content_box_ltr.xml
@@ -1,17 +1,17 @@
-<test name="grid_template_areas_unnamed_cells__content_box_ltr" use-rounding="true">
+<test name="grid_template_areas_single_named_cell__content_box_ltr" use-rounding="true">
   <viewport width="max-content" height="max-content"/>
   <input>
-    <div display="grid" box-sizing="content-box" direction="ltr" grid-auto-flow="row dense" grid-template-rows="10px" grid-template-columns="10px" grid-auto-rows="5px" grid-auto-columns="5px" grid-template-areas="&quot;a .&quot;">
+    <div display="grid" box-sizing="content-box" direction="ltr" grid-auto-flow="row dense" grid-template-rows="10px" grid-template-columns="10px" grid-auto-rows="5px" grid-auto-columns="5px" grid-template-areas="&quot;a&quot;">
       <div box-sizing="content-box" direction="ltr" grid-column-start="1"/>
       <div box-sizing="content-box" direction="ltr" grid-row-start="1"/>
       <div box-sizing="content-box" direction="ltr"/>
     </div>
   </input>
   <expectations>
-    <node x="0" y="0" width="15" height="15">
+    <node x="0" y="0" width="10" height="20">
       <node x="0" y="10" width="10" height="5"/>
       <node x="0" y="0" width="10" height="10"/>
-      <node x="10" y="0" width="5" height="10"/>
+      <node x="0" y="15" width="10" height="5"/>
     </node>
   </expectations>
 </test>

--- a/tests/xml/grid/grid_template_areas_single_named_cell__content_box_rtl.xml
+++ b/tests/xml/grid/grid_template_areas_single_named_cell__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_template_areas_single_named_cell__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" grid-auto-flow="row dense" grid-template-rows="10px" grid-template-columns="10px" grid-auto-rows="5px" grid-auto-columns="5px" grid-template-areas="&quot;a&quot;">
+      <div box-sizing="content-box" direction="rtl" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="1"/>
+      <div box-sizing="content-box" direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="10" height="20">
+      <node x="0" y="10" width="10" height="5"/>
+      <node x="0" y="0" width="10" height="10"/>
+      <node x="0" y="15" width="10" height="5"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_template_areas_unnamed_cells__border_box_ltr.xml
+++ b/tests/xml/grid/grid_template_areas_unnamed_cells__border_box_ltr.xml
@@ -2,16 +2,16 @@
   <viewport width="max-content" height="max-content"/>
   <input>
     <div display="grid" direction="ltr" grid-auto-flow="row dense" grid-template-rows="10px" grid-template-columns="10px" grid-auto-rows="5px" grid-auto-columns="5px" grid-template-areas="&quot;a .&quot;">
-      <div direction="ltr"/>
-      <div direction="ltr"/>
+      <div direction="ltr" grid-column-start="1"/>
+      <div direction="ltr" grid-row-start="1"/>
       <div direction="ltr"/>
     </div>
   </input>
   <expectations>
     <node x="0" y="0" width="15" height="15">
+      <node x="0" y="10" width="10" height="5"/>
       <node x="0" y="0" width="10" height="10"/>
       <node x="10" y="0" width="5" height="10"/>
-      <node x="0" y="10" width="10" height="5"/>
     </node>
   </expectations>
 </test>

--- a/tests/xml/grid/grid_template_areas_unnamed_cells__border_box_ltr.xml
+++ b/tests/xml/grid/grid_template_areas_unnamed_cells__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_template_areas_unnamed_cells__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" grid-auto-flow="row dense" grid-template-rows="10px" grid-template-columns="10px" grid-auto-rows="5px" grid-auto-columns="5px" grid-template-areas="&quot;a .&quot;">
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="15" height="15">
+      <node x="0" y="0" width="10" height="10"/>
+      <node x="10" y="0" width="5" height="10"/>
+      <node x="0" y="10" width="10" height="5"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_template_areas_unnamed_cells__border_box_rtl.xml
+++ b/tests/xml/grid/grid_template_areas_unnamed_cells__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_template_areas_unnamed_cells__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" grid-auto-flow="row dense" grid-template-rows="10px" grid-template-columns="10px" grid-auto-rows="5px" grid-auto-columns="5px" grid-template-areas="&quot;a .&quot;">
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="15" height="15">
+      <node x="5" y="0" width="10" height="10"/>
+      <node x="0" y="0" width="5" height="10"/>
+      <node x="5" y="10" width="10" height="5"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_template_areas_unnamed_cells__border_box_rtl.xml
+++ b/tests/xml/grid/grid_template_areas_unnamed_cells__border_box_rtl.xml
@@ -2,16 +2,16 @@
   <viewport width="max-content" height="max-content"/>
   <input>
     <div display="grid" direction="rtl" grid-auto-flow="row dense" grid-template-rows="10px" grid-template-columns="10px" grid-auto-rows="5px" grid-auto-columns="5px" grid-template-areas="&quot;a .&quot;">
-      <div direction="rtl"/>
-      <div direction="rtl"/>
+      <div direction="rtl" grid-column-start="1"/>
+      <div direction="rtl" grid-row-start="1"/>
       <div direction="rtl"/>
     </div>
   </input>
   <expectations>
     <node x="0" y="0" width="15" height="15">
+      <node x="5" y="10" width="10" height="5"/>
       <node x="5" y="0" width="10" height="10"/>
       <node x="0" y="0" width="5" height="10"/>
-      <node x="5" y="10" width="10" height="5"/>
     </node>
   </expectations>
 </test>

--- a/tests/xml/grid/grid_template_areas_unnamed_cells__content_box_ltr.xml
+++ b/tests/xml/grid/grid_template_areas_unnamed_cells__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_template_areas_unnamed_cells__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" grid-auto-flow="row dense" grid-template-rows="10px" grid-template-columns="10px" grid-auto-rows="5px" grid-auto-columns="5px" grid-template-areas="&quot;a .&quot;">
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="15" height="15">
+      <node x="0" y="0" width="10" height="10"/>
+      <node x="10" y="0" width="5" height="10"/>
+      <node x="0" y="10" width="10" height="5"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_template_areas_unnamed_cells__content_box_rtl.xml
+++ b/tests/xml/grid/grid_template_areas_unnamed_cells__content_box_rtl.xml
@@ -2,16 +2,16 @@
   <viewport width="max-content" height="max-content"/>
   <input>
     <div display="grid" box-sizing="content-box" direction="rtl" grid-auto-flow="row dense" grid-template-rows="10px" grid-template-columns="10px" grid-auto-rows="5px" grid-auto-columns="5px" grid-template-areas="&quot;a .&quot;">
-      <div box-sizing="content-box" direction="rtl"/>
-      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="1"/>
       <div box-sizing="content-box" direction="rtl"/>
     </div>
   </input>
   <expectations>
     <node x="0" y="0" width="15" height="15">
+      <node x="5" y="10" width="10" height="5"/>
       <node x="5" y="0" width="10" height="10"/>
       <node x="0" y="0" width="5" height="10"/>
-      <node x="5" y="10" width="10" height="5"/>
     </node>
   </expectations>
 </test>

--- a/tests/xml/grid/grid_template_areas_unnamed_cells__content_box_rtl.xml
+++ b/tests/xml/grid/grid_template_areas_unnamed_cells__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_template_areas_unnamed_cells__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" grid-auto-flow="row dense" grid-template-rows="10px" grid-template-columns="10px" grid-auto-rows="5px" grid-auto-columns="5px" grid-template-areas="&quot;a .&quot;">
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="15" height="15">
+      <node x="5" y="0" width="10" height="10"/>
+      <node x="0" y="0" width="5" height="10"/>
+      <node x="5" y="10" width="10" height="5"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -29211,6 +29211,54 @@ mod grid {
 
     #[cfg(feature = "grid")]
     #[test]
+    fn grid_template_areas_named_placement__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_template_areas_named_placement__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_template_areas_named_placement__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_template_areas_named_placement__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_template_areas_named_placement__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_template_areas_named_placement__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_template_areas_named_placement__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_template_areas_named_placement__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_template_areas_unnamed_cells__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_template_areas_unnamed_cells__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_template_areas_unnamed_cells__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_template_areas_unnamed_cells__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_template_areas_unnamed_cells__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_template_areas_unnamed_cells__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_template_areas_unnamed_cells__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_template_areas_unnamed_cells__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
     fn grid_unsafe_align_self_end_overflow__border_box_ltr() {
         crate::run_xml_test("grid", "grid_unsafe_align_self_end_overflow__border_box_ltr");
     }

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -18969,6 +18969,30 @@ mod grid {
 
     #[cfg(feature = "grid")]
     #[test]
+    fn grid_dense_auto_placement_two_explicit_rows__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_dense_auto_placement_two_explicit_rows__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_dense_auto_placement_two_explicit_rows__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_dense_auto_placement_two_explicit_rows__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_dense_auto_placement_two_explicit_rows__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_dense_auto_placement_two_explicit_rows__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_dense_auto_placement_two_explicit_rows__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_dense_auto_placement_two_explicit_rows__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
     fn grid_display_none_fixed_size__border_box_ltr() {
         crate::run_xml_test("grid", "grid_display_none_fixed_size__border_box_ltr");
     }
@@ -29231,6 +29255,30 @@ mod grid {
     #[test]
     fn grid_template_areas_named_placement__content_box_rtl() {
         crate::run_xml_test("grid", "grid_template_areas_named_placement__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_template_areas_single_named_cell__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_template_areas_single_named_cell__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_template_areas_single_named_cell__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_template_areas_single_named_cell__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_template_areas_single_named_cell__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_template_areas_single_named_cell__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_template_areas_single_named_cell__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_template_areas_single_named_cell__content_box_rtl");
     }
 
     #[cfg(feature = "grid")]


### PR DESCRIPTION
# Objective

Enable the test generator to express `grid-template-areas` (and named-line/area placements), giving `NamedLineResolver` its first generated-test coverage. Stacked on #1026 (CSS parsing for `GridTemplateAreas`), which this uses on the Rust side.

Touchpoints:
- `scripts/gentest/test_helper.js`: capture `e.style.gridTemplateAreas` verbatim (skipping `''`/`none`), and extend `parseGridPosition` to pass named placements (`a`, `a 2`, `span a`, `header-start`, ...) through as `{ kind: 'named', value }`
- `scripts/gentest/src/main.rs`: write these out as the `grid-template-areas` XML attribute and verbatim named `grid-*-start/end` attributes
- `tests/xml.rs`: `grid_template_areas: xnode.attribute("grid-template-areas").map(|input| input.parse().unwrap())` (replacing the `Default::default()` TODO)

New fixtures + generated tests (16 total, all passing):
- The three static cases of the WPT test `css/css-grid/placement/grid-container-change-grid-tracks-recompute-child-positions-001.html` (from #1021/#1024), with faithful item placements (`grid-column: 1` / `grid-row: 1` / auto): `grid_dense_auto_placement_two_explicit_rows` (case 1, no areas), `grid_template_areas_single_named_cell` (case 2, `"a"`), and `grid_template_areas_unnamed_cells` (case 3, `"a ."` — `.` cells widening the explicit grid). The hand-written port of this test in `tests/hand_written/relayout.rs` is removed in favour of these gentests (the dynamic aspect was deemed unimportant)
- `grid_template_areas_named_placement`: classic header/nav/main/footer template with items placed via named lines/areas

## Context

Named placements were previously dropped by the generator (`parseGridPosition` returned `undefined` → auto), so fixtures placing items by area name silently degraded to auto-placement; they are now round-tripped verbatim and parsed by Taffy's existing `GridPlacement` parser.

Regenerating also produced changed expectations for the 4 `absolute_safe_align_self_end_overflow` flex tests (current headless Chrome 133 reports `y="-100"` instead of `y="0"`); those were reverted here to keep this PR scoped — happy to follow up separately if the new expectations are actually correct.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/b593446a7dfd44f8a4c2d72c494bf1e7
Requested by: @nicoburns