### PR TITLE
gentest: close WebDriver session before killing chromedriver so the generator exits cleanly

### DIFF
--- a/scripts/gentest/src/main.rs
+++ b/scripts/gentest/src/main.rs
@@ -4,7 +4,7 @@ use std::fmt::Display;
 use std::fs::{self, OpenOptions};
 use std::io::Write as _;
 use std::path::{Component, Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use fantoccini::{Client, ClientBuilder};
 use log::*;
@@ -39,6 +39,8 @@ async fn main() {
     let webdriver_url = "http://localhost:4444";
     let mut webdriver_handle = Command::new("chromedriver")
         .arg("--port=4444")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
         .spawn()
         .expect("ChromeDriver not found: Make sure you have it installed and added to your PATH.");
 
@@ -58,6 +60,9 @@ async fn main() {
     for (name, fixture_path) in fixtures.iter() {
         test_descs.push(test_root_element(client.clone(), name.clone(), fixture_path).await);
     }
+
+    info!("closing webdriver session...");
+    client.close().await.unwrap();
 
     info!("killing webdriver instance...");
     webdriver_handle.kill().unwrap();

--- a/scripts/gentest/src/main.rs
+++ b/scripts/gentest/src/main.rs
@@ -4,7 +4,7 @@ use std::fmt::Display;
 use std::fs::{self, OpenOptions};
 use std::io::Write as _;
 use std::path::{Component, Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::Command;
 
 use fantoccini::{Client, ClientBuilder};
 use log::*;
@@ -39,8 +39,6 @@ async fn main() {
     let webdriver_url = "http://localhost:4444";
     let mut webdriver_handle = Command::new("chromedriver")
         .arg("--port=4444")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
         .spawn()
         .expect("ChromeDriver not found: Make sure you have it installed and added to your PATH.");
 


### PR DESCRIPTION
# Objective

`just gentest` appeared to hang after generation completed: chromedriver was killed without the WebDriver session being closed first, leaving orphaned headless Chrome children. Those orphans inherit gentest's stdout/stderr, so any pipeline consuming its output (`just gentest | tail`, CI log capture) never sees EOF and blocks forever.

Fix: call `client.close().await` (quits the WebDriver session, letting chromedriver terminate its Chrome children) before killing the chromedriver process.

## Context

Verified locally: 5 consecutive `just gentest | tail` runs each completed in ~30s with no leftover `chrome`/`chromedriver` processes and a diff-free working tree. A complementary chromedriver stdio hardening change is split out into a separate PR. No changes to generated output or the public library API, so no RELEASES.md entry.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/a09d32a814ec4eb9881ffbdcff86c993
Requested by: @nicoburns