### PR TITLE
gentest: pipe and forward chromedriver output instead of inheriting stdio

### DIFF
--- a/scripts/gentest/src/main.rs
+++ b/scripts/gentest/src/main.rs
@@ -4,7 +4,7 @@ use std::fmt::Display;
 use std::fs::{self, OpenOptions};
 use std::io::Write as _;
 use std::path::{Component, Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::Command;
 
 use fantoccini::{Client, ClientBuilder};
 use log::*;
@@ -39,8 +39,6 @@ async fn main() {
     let webdriver_url = "http://localhost:4444";
     let mut webdriver_handle = Command::new("chromedriver")
         .arg("--port=4444")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
         .spawn()
         .expect("ChromeDriver not found: Make sure you have it installed and added to your PATH.");
 

--- a/scripts/gentest/src/main.rs
+++ b/scripts/gentest/src/main.rs
@@ -4,7 +4,7 @@ use std::fmt::Display;
 use std::fs::{self, OpenOptions};
 use std::io::Write as _;
 use std::path::{Component, Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use fantoccini::{Client, ClientBuilder};
 use log::*;
@@ -37,10 +37,18 @@ async fn main() {
 
     info!("starting webdriver instance");
     let webdriver_url = "http://localhost:4444";
+    // Pipe chromedriver's output and forward it manually rather than letting it inherit
+    // gentest's stdout/stderr. Chrome processes spawned by chromedriver would otherwise
+    // inherit those file descriptors, and any that outlive gentest would keep a pipeline
+    // reading gentest's output (e.g. `just gentest | tail`) blocked waiting for EOF.
     let mut webdriver_handle = Command::new("chromedriver")
         .arg("--port=4444")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
         .spawn()
         .expect("ChromeDriver not found: Make sure you have it installed and added to your PATH.");
+    forward_output(webdriver_handle.stdout.take().unwrap(), std::io::stdout());
+    forward_output(webdriver_handle.stderr.take().unwrap(), std::io::stderr());
 
     // this is silly, but it works
     std::thread::sleep(std::time::Duration::from_secs(1));
@@ -149,6 +157,16 @@ async fn main() {
 
     info!("formatting the source directory");
     Command::new("cargo").arg("fmt").current_dir(repo_root).status().unwrap();
+}
+
+/// Copies a child process output stream to the given writer on a background thread.
+/// The child gets a pipe rather than gentest's own stdout/stderr handles, so processes
+/// that outlive gentest cannot hold gentest's output open; the thread simply stops
+/// (and is torn down when the process exits) once the stream ends.
+fn forward_output(mut reader: impl std::io::Read + Send + 'static, mut writer: impl std::io::Write + Send + 'static) {
+    std::thread::spawn(move || {
+        let _ = std::io::copy(&mut reader, &mut writer);
+    });
 }
 
 async fn asserts_non_zero_width_scrollbars(client: Client) {

--- a/scripts/gentest/src/main.rs
+++ b/scripts/gentest/src/main.rs
@@ -4,7 +4,7 @@ use std::fmt::Display;
 use std::fs::{self, OpenOptions};
 use std::io::Write as _;
 use std::path::{Component, Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use fantoccini::{Client, ClientBuilder};
 use log::*;
@@ -39,6 +39,8 @@ async fn main() {
     let webdriver_url = "http://localhost:4444";
     let mut webdriver_handle = Command::new("chromedriver")
         .arg("--port=4444")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
         .spawn()
         .expect("ChromeDriver not found: Make sure you have it installed and added to your PATH.");
 


### PR DESCRIPTION
# Objective

Hardens gentest against orphaned Chrome processes holding its output pipe open, while keeping chromedriver's output visible.

Previously chromedriver (and the Chrome children it spawns) inherited gentest's stdout/stderr file descriptors. Any Chrome process that outlived gentest would keep a pipeline consuming gentest's output (`just gentest | tail`, CI log capture) blocked waiting for EOF. Simply using `Stdio::null()` would fix that but hide chromedriver's output.

Instead, chromedriver is spawned with `Stdio::piped()` and a small `forward_output` helper copies each stream to gentest's own stdout/stderr on a background thread:

```rust
fn forward_output(mut reader: impl Read + Send + 'static, mut writer: impl Write + Send + 'static) {
    std::thread::spawn(move || { let _ = std::io::copy(&mut reader, &mut writer); });
}
```

Chrome children now inherit chromedriver's pipe ends rather than gentest's stdout/stderr, so they can't hold gentest's output open; gentest's own output closes when the process exits regardless of the forwarding threads.

## Context

Stacked on #1029 (close the WebDriver session before killing chromedriver). Verified locally: chromedriver's startup banner is visible in gentest output, `just gentest | tail` exits cleanly in ~45s with no leftover chrome/chromedriver processes, and the run is diff-free.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/a09d32a814ec4eb9881ffbdcff86c993
Requested by: @nicoburns