### PR TITLE
Harden grid layout against degenerate/adversarial style inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 - Grid: the track sizing algorithm no longer loops forever when styles contain non-finite values (e.g. `NaN` flex factors or non-finite lengths). The "find the size of an fr" and "distribute space up to limits" loops are now bounded by the track count
 
+- Grid: when the auto-placement search collides with an occupied area, the search cursor now jumps past the entire colliding occupied interval rather than just the part of it within the queried area. Previously a small item searching a grid occupied by large items advanced one track at a time, scanning up to 10000x10000 candidate positions
+
 - Grid: fixed an infinite loop in auto-placement when an item's placement resolved to a span larger than the implicit grid size estimate (e.g. a zero span — an invalid value which is now normalized to 1 — combined with an unresolvable named span). The auto-placement search now bails out (and clamps the placement into the limited grid) when a span cannot fit even at the start of the grid
 
 - Grid: when distributing a spanning item's max-content contribution to its spanned tracks' base sizes "beyond limits", tracks are now eligible only if their *max* track sizing function is `max-content` (or `fit-content()`), per [CSS Grid §12.5.1](https://www.w3.org/TR/css-grid-1/#extra-space). Previously tracks whose *min* track sizing function was `max-content` were also eligible, so a track such as `minmax(max-content, 20px)` could grow beyond its fixed `20px` limit, stealing space from `max-content` tracks ([WPT: grid-content-sized-columns-resolution](https://wpt.live/css/css-grid/parsing/grid-content-sized-columns-resolution.html))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Fixed
 
+- Grid: fixed a subtract-with-overflow panic (in debug builds) when resolving named lines for a template containing a repetition with fewer line name sets than tracks. Any template combining line names with a repetition created by the `repeat()` style helper (or parsed from CSS such as `[a] repeat(2, 10px) [c] 10px`) could trigger this. In release builds the same bug silently mis-numbered the lines following the repetition
+
+- Grid: the track sizing algorithm no longer loops forever when styles contain non-finite values (e.g. `NaN` flex factors or non-finite lengths). The "find the size of an fr" and "distribute space up to limits" loops are now bounded by the track count
+
+- Grid: auto-placement no longer scans up to the full 10000x10000 cell limit per candidate position when placing items with very large spans. The occupancy matrix now tracks the bounding box of occupied cells and only searches within it
+
 - Grid: an explicitly specified preferred or minimum size is no longer clamped by the spanned tracks' fixed max track sizing functions when computing an item's minimum contribution. That clamp only applies to the content-based (automatic) minimum size, per [CSS Grid §6.6](https://www.w3.org/TR/css-grid-1/#min-size-auto). Fixes e.g. an item with `min-width: 12px` in a `minmax(auto, 10px)` track sizing the track to `12px` rather than `10px`
 
 - Grid: when distributing a spanning item's intrinsic size contribution to its spanned tracks, space distributed "beyond limits" now ignores the tracks' growth limits (still capping growth at any `fit-content()` argument), per [CSS Grid §12.5.1](https://www.w3.org/TR/css-grid-1/#extra-space). Previously the growth limits were still enforced, so tracks such as `minmax(min-content, 10px)` could not expand beyond `10px` to accommodate an item's contribution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 - Grid: auto-placement no longer scans up to the full 10000x10000 cell limit per candidate position when placing items with very large spans. The occupancy matrix now tracks the bounding box of occupied cells and only searches within it
 
+- Grid: fixed an infinite loop in auto-placement when an item's placement resolved to a span larger than the implicit grid size estimate (e.g. a zero span — an invalid value which is now normalized to 1 — combined with an unresolvable named span). The auto-placement search now bails out (and clamps the placement into the limited grid) when a span cannot fit even at the start of the grid
+
 - Grid: when distributing a spanning item's max-content contribution to its spanned tracks' base sizes "beyond limits", tracks are now eligible only if their *max* track sizing function is `max-content` (or `fit-content()`), per [CSS Grid §12.5.1](https://www.w3.org/TR/css-grid-1/#extra-space). Previously tracks whose *min* track sizing function was `max-content` were also eligible, so a track such as `minmax(max-content, 20px)` could grow beyond its fixed `20px` limit, stealing space from `max-content` tracks ([WPT: grid-content-sized-columns-resolution](https://wpt.live/css/css-grid/parsing/grid-content-sized-columns-resolution.html))
 
 - Grid: an explicitly specified preferred or minimum size is no longer clamped by the spanned tracks' fixed max track sizing functions when computing an item's minimum contribution. That clamp only applies to the content-based (automatic) minimum size, per [CSS Grid §6.6](https://www.w3.org/TR/css-grid-1/#min-size-auto). Fixes e.g. an item with `min-width: 12px` in a `minmax(auto, 10px)` track sizing the track to `12px` rather than `10px`

--- a/src/compute/grid/placement.rs
+++ b/src/compute/grid/placement.rs
@@ -448,6 +448,12 @@ fn place_indefinitely_positioned_item(
                 primary_span.end > primary_axis_grid_end_line
             };
             if primary_out_of_bounds {
+                // If the span is out of bounds even at the search start position then it can never fit,
+                // as searching only ever moves the span further away from the start of the grid. Bail out
+                // and let `record_grid_placement` clamp the placement into the limited grid
+                if primary_idx == primary_start_position {
+                    return (primary_span, secondary_span);
+                }
                 secondary_idx = advance_position(secondary_idx, secondary_axis_is_reversed);
                 primary_idx = primary_start_position;
                 continue;

--- a/src/compute/grid/track_sizing.rs
+++ b/src/compute/grid/track_sizing.rs
@@ -1302,7 +1302,12 @@ fn find_size_of_fr(tracks: &[GridTrack], space_to_fill: f32) -> f32 {
     // condition can never be true for the first iteration.
     let mut hypothetical_fr_size = f32::INFINITY;
     let mut previous_iter_hypothetical_fr_size;
-    loop {
+    // Every restart of the algorithm treats at least one more flexible track as inflexible, so a valid
+    // hypothetical fr size is always found within `tracks.len() + 1` iterations. Non-finite values (which
+    // can arise from non-finite style inputs) break that invariant as comparisons against `NaN` are always
+    // false, so we bound the iteration count to guarantee termination.
+    let max_iterations = tracks.len() + 1;
+    for _ in 0..max_iterations {
         // Let leftover space be the space to fill minus the base sizes of the non-flexible grid tracks.
         // Let flex factor sum be the sum of the flex factors of the flexible tracks. If this value is less than 1, set it to 1 instead.
         // We compute both of these in a single loop to avoid iterating over the data twice
@@ -1393,8 +1398,16 @@ fn distribute_space_up_to_limits(
     /// extra space when it gets to exactly zero, we will stop when it falls below this amount
     const THRESHOLD: f32 = 0.01;
 
+    // Each iteration freezes at least one track at its limit, so the loop always completes within
+    // `tracks.len() + 1` iterations. Non-finite values (which can arise from non-finite style inputs) can
+    // prevent any space from being distributed, so we bound the iteration count to guarantee termination.
+    let max_iterations = tracks.len() + 1;
+
     let mut space_to_distribute = space_to_distribute;
-    while space_to_distribute > THRESHOLD {
+    for _ in 0..max_iterations {
+        if space_to_distribute <= THRESHOLD {
+            break;
+        }
         let track_distribution_proportion_sum: f32 = tracks
             .iter()
             .filter(|track| track_affected_property(track) + track.item_incurred_increase < track_limit(track))

--- a/src/compute/grid/types/cell_occupancy.rs
+++ b/src/compute/grid/types/cell_occupancy.rs
@@ -4,7 +4,7 @@ use crate::compute::grid::OriginZeroLine;
 use crate::geometry::AbsoluteAxis;
 use crate::geometry::Line;
 use crate::util::sys::Vec;
-use core::cmp::max;
+use core::cmp::{max, min};
 use core::fmt::Debug;
 use core::ops::Range;
 use grid::Grid;
@@ -30,6 +30,24 @@ pub(crate) struct CellOccupancyMatrix {
     columns: TrackCounts,
     /// The counts of implicit and explicit rows
     rows: TrackCounts,
+    /// The range of rows (as indexes into `inner`) which contain occupied cells
+    occupied_rows: Range<usize>,
+    /// The range of columns (as indexes into `inner`) which contain occupied cells
+    occupied_columns: Range<usize>,
+}
+
+/// Extend a range of track indexes such that it also contains another range
+fn union_range(range: &Range<usize>, other: Range<usize>) -> Range<usize> {
+    if range.is_empty() {
+        return other;
+    }
+    min(range.start, other.start)..max(range.end, other.end)
+}
+
+/// Intersect a range of track indexes with the range of tracks which may contain occupied cells
+fn intersect_occupied(range: Range<i16>, occupied: &Range<usize>) -> Range<i16> {
+    let clamp = |value: usize| value.min(i16::MAX as usize) as i16;
+    max(range.start, clamp(occupied.start))..min(range.end, clamp(occupied.end))
 }
 
 /// Debug impl that represents the matrix in a compact 2d text format
@@ -71,7 +89,7 @@ impl CellOccupancyMatrix {
     /// Create a CellOccupancyMatrix given a set of provisional track counts. The grid can expand as needed to fit more tracks,
     /// the provisional track counts represent a best effort attempt to avoid the extra allocations this requires.
     pub fn with_track_counts(columns: TrackCounts, rows: TrackCounts) -> Self {
-        Self { inner: Grid::new(rows.len(), columns.len()), rows, columns }
+        Self { inner: Grid::new(rows.len(), columns.len()), rows, columns, occupied_rows: 0..0, occupied_columns: 0..0 }
     }
 
     /// Determines whether the specified area fits within the tracks currently represented by the matrix
@@ -138,6 +156,16 @@ impl CellOccupancyMatrix {
         self.rows.positive_implicit += req_positive_rows as u16;
         self.columns.negative_implicit += req_negative_cols as u16;
         self.columns.positive_implicit += req_positive_cols as u16;
+
+        // Existing cells have been shifted by the newly created negative tracks
+        if !self.occupied_rows.is_empty() {
+            let offset = req_negative_rows as usize;
+            self.occupied_rows = (self.occupied_rows.start + offset)..(self.occupied_rows.end + offset);
+        }
+        if !self.occupied_columns.is_empty() {
+            let offset = req_negative_cols as usize;
+            self.occupied_columns = (self.occupied_columns.start + offset)..(self.occupied_columns.end + offset);
+        }
     }
 
     /// Mark an area of the matrix as occupied, expanding the allocated space as necessary to accommodate the passed area.
@@ -163,6 +191,12 @@ impl CellOccupancyMatrix {
             self.expand_to_fit_range(row_range.clone(), col_range.clone());
             col_range = self.columns.oz_line_range_to_track_range(column_span);
             row_range = self.rows.oz_line_range_to_track_range(row_span);
+        }
+
+        if value != CellOccupancyState::Unoccupied && !row_range.is_empty() && !col_range.is_empty() {
+            self.occupied_rows = union_range(&self.occupied_rows, row_range.start as usize..row_range.end as usize);
+            self.occupied_columns =
+                union_range(&self.occupied_columns, col_range.start as usize..col_range.end as usize);
         }
 
         for x in row_range {
@@ -198,7 +232,15 @@ impl CellOccupancyMatrix {
             AbsoluteAxis::Vertical => (primary_range, secondary_range),
         };
 
-        // Search for occupied cells in the specified area. Out of bounds cells are considered unoccupied.
+        // Out of bounds cells are considered unoccupied, and occupied cells only exist within the
+        // bounding box of the areas which have been marked as occupied. So we only need to search the
+        // intersection of the requested area with that bounding box. The requested area may be far larger
+        // than the matrix (items may span up to `MAX_GRID_TRACKS` tracks), so restricting the search is
+        // important to prevent the placement algorithm from doing an excessive amount of work.
+        let row_range = intersect_occupied(row_range, &self.occupied_rows);
+        let col_range = intersect_occupied(col_range, &self.occupied_columns);
+
+        // Search for occupied cells in the specified area.
         for x in row_range {
             for y in col_range.clone() {
                 match self.inner.get(x as usize, y as usize) {

--- a/src/compute/grid/types/cell_occupancy.rs
+++ b/src/compute/grid/types/cell_occupancy.rs
@@ -124,17 +124,19 @@ impl TrackIntervals {
         self.intervals = result;
     }
 
-    /// Find the cell within `range` which an auto-placement search along the track would collide
-    /// with last: the maximum occupied cell in the range when searching forwards, or the minimum
-    /// when searching backwards (`reversed == true`). Returns the cell's start line, or `None` if
-    /// the range is entirely unoccupied.
+    /// Find the extent of the occupied interval which an auto-placement search along the track
+    /// would collide with last: the end of the last overlapping interval when searching forwards,
+    /// or the start of the first overlapping interval when searching backwards (`reversed ==
+    /// true`). Returns the extremal occupied cell of that interval (which may lie outside
+    /// `range`: every search position before the returned extent also collides with the
+    /// interval), or `None` if the range is entirely unoccupied.
     fn collision_extent(&self, range: &Range<i16>, reversed: bool) -> Option<i16> {
         if reversed {
             let interval = self.intervals.iter().find(|interval| interval.overlaps(range))?;
-            Some(max(interval.range.start, range.start))
+            Some(interval.range.start)
         } else {
             let interval = self.intervals.iter().rev().find(|interval| interval.overlaps(range))?;
-            Some(min(interval.range.end, range.end) - 1)
+            Some(interval.range.end - 1)
         }
     }
 
@@ -485,14 +487,14 @@ mod tests {
             let mut track = TrackIntervals::default();
             track.paint(2..4, AutoPlaced);
             track.paint(6..8, DefinitelyPlaced);
-            // Forward search: the maximum occupied cell within the range
+            // Forward search: the last cell of the last overlapping interval
             assert_eq!(track.collision_extent(&(0..10), false), Some(7));
-            assert_eq!(track.collision_extent(&(0..7), false), Some(6));
+            assert_eq!(track.collision_extent(&(0..7), false), Some(7));
             assert_eq!(track.collision_extent(&(0..6), false), Some(3));
             assert_eq!(track.collision_extent(&(4..6), false), None);
-            // Reverse search: the minimum occupied cell within the range
+            // Reverse search: the first cell of the first overlapping interval
             assert_eq!(track.collision_extent(&(0..10), true), Some(2));
-            assert_eq!(track.collision_extent(&(3..10), true), Some(3));
+            assert_eq!(track.collision_extent(&(3..10), true), Some(2));
             assert_eq!(track.collision_extent(&(4..10), true), Some(6));
         }
 
@@ -558,19 +560,19 @@ mod tests {
                 CellOccupancyMatrix::with_track_counts(TrackCounts::from_raw(0, 4, 0), TrackCounts::from_raw(0, 4, 0));
             matrix.mark_area_as(Horizontal, line(1, 3), line(0, 1), AutoPlaced);
 
-            // Forwards: jump past the last occupied cell within the queried area
+            // Forwards: jump past the end of the last colliding interval
             assert_eq!(
                 matrix.line_area_collision_jump(Horizontal, line(0, 2), line(0, 1), false),
-                Some(OriginZeroLine(2))
+                Some(OriginZeroLine(3))
             );
             assert_eq!(
                 matrix.line_area_collision_jump(Horizontal, line(0, 4), line(0, 1), false),
                 Some(OriginZeroLine(3))
             );
-            // Backwards: jump past the first occupied cell within the queried area
+            // Backwards: jump past the start of the first colliding interval
             assert_eq!(
                 matrix.line_area_collision_jump(Horizontal, line(2, 4), line(0, 1), true),
-                Some(OriginZeroLine(1))
+                Some(OriginZeroLine(0))
             );
             assert_eq!(
                 matrix.line_area_collision_jump(Horizontal, line(0, 4), line(0, 1), true),

--- a/src/compute/grid/types/named.rs
+++ b/src/compute/grid/types/named.rs
@@ -129,12 +129,10 @@ impl<S: CheapCloneStr> NamedLineResolver<S> {
                         let lines_per_repetition = max(line_name_set_count, repeat.track_count() as u32 + 1) - 1;
 
                         for _ in 0..repeat_count {
-                            let mut line = current_line;
-                            for line_name_set in repeat.lines_names() {
+                            for (line, line_name_set) in (current_line..).zip(repeat.lines_names()) {
                                 for line_name in line_name_set {
                                     upsert_line_name_map(&mut column_lines, line_name.clone(), line);
                                 }
-                                line += 1;
                             }
                             current_line += lines_per_repetition;
 
@@ -183,12 +181,10 @@ impl<S: CheapCloneStr> NamedLineResolver<S> {
                         let lines_per_repetition = max(line_name_set_count, repeat.track_count() as u32 + 1) - 1;
 
                         for _ in 0..repeat_count {
-                            let mut line = current_line;
-                            for line_name_set in repeat.lines_names() {
+                            for (line, line_name_set) in (current_line..).zip(repeat.lines_names()) {
                                 for line_name in line_name_set {
                                     upsert_line_name_map(&mut row_lines, line_name.clone(), line);
                                 }
-                                line += 1;
                             }
                             current_line += lines_per_repetition;
 

--- a/src/compute/grid/types/named.rs
+++ b/src/compute/grid/types/named.rs
@@ -4,9 +4,9 @@ use crate::{
     CheapCloneStr, GenericGridTemplateComponent, GenericRepetition as _, GridAreaAxis, GridAreaEnd, GridContainerStyle,
     GridPlacement, GridTemplateArea, Line, NonNamedGridPlacement, RepetitionCount,
 };
-use core::{borrow::Borrow, cmp::Ordering, fmt::Debug};
+use core::{borrow::Borrow, cmp::max, cmp::Ordering, fmt::Debug};
 
-use super::GridLine;
+use super::{GridLine, MAX_GRID_TRACKS};
 // use alloc::fmt::format;
 use crate::sys::{format, single_value_vec, Map, Vec};
 
@@ -122,19 +122,31 @@ impl<S: CheapCloneStr> NamedLineResolver<S> {
                             RepetitionCount::AutoFill | RepetitionCount::AutoFit => column_auto_repetitions,
                         };
 
+                        // Each repetition spans at least as many lines as it generates tracks, even when it
+                        // has fewer line name sets than that (the final line name set of each repetition
+                        // collapses with the first line name set of the following one).
+                        let line_name_set_count = repeat.lines_names().len() as u32;
+                        let lines_per_repetition = max(line_name_set_count, repeat.track_count() as u32 + 1) - 1;
+
                         for _ in 0..repeat_count {
+                            let mut line = current_line;
                             for line_name_set in repeat.lines_names() {
                                 for line_name in line_name_set {
-                                    upsert_line_name_map(&mut column_lines, line_name.clone(), current_line);
+                                    upsert_line_name_map(&mut column_lines, line_name.clone(), line);
                                 }
-                                current_line += 1;
+                                line += 1;
                             }
-                            // Last line name set collapses with following line name set
-                            current_line -= 1;
+                            current_line += lines_per_repetition;
+
+                            // Names for lines beyond the maximum track limit are never resolvable:
+                            // stop generating them (the explicit grid is clamped to MAX_GRID_TRACKS)
+                            if current_line > MAX_GRID_TRACKS as u32 {
+                                break;
+                            }
                         }
                         // Last line name set collapses with following line name set
                         if repeat_count > 0 {
-                            current_line -= 1;
+                            current_line = current_line.saturating_sub(1);
                         }
                     }
                 }
@@ -164,19 +176,31 @@ impl<S: CheapCloneStr> NamedLineResolver<S> {
                             RepetitionCount::AutoFill | RepetitionCount::AutoFit => row_auto_repetitions,
                         };
 
+                        // Each repetition spans at least as many lines as it generates tracks, even when it
+                        // has fewer line name sets than that (the final line name set of each repetition
+                        // collapses with the first line name set of the following one).
+                        let line_name_set_count = repeat.lines_names().len() as u32;
+                        let lines_per_repetition = max(line_name_set_count, repeat.track_count() as u32 + 1) - 1;
+
                         for _ in 0..repeat_count {
+                            let mut line = current_line;
                             for line_name_set in repeat.lines_names() {
                                 for line_name in line_name_set {
-                                    upsert_line_name_map(&mut row_lines, line_name.clone(), current_line);
+                                    upsert_line_name_map(&mut row_lines, line_name.clone(), line);
                                 }
-                                current_line += 1;
+                                line += 1;
                             }
-                            // Last line name set collapses with following line name set
-                            current_line -= 1;
+                            current_line += lines_per_repetition;
+
+                            // Names for lines beyond the maximum track limit are never resolvable:
+                            // stop generating them (the explicit grid is clamped to MAX_GRID_TRACKS)
+                            if current_line > MAX_GRID_TRACKS as u32 {
+                                break;
+                            }
                         }
                         // Last line name set collapses with following line name set
                         if repeat_count > 0 {
-                            current_line -= 1;
+                            current_line = current_line.saturating_sub(1);
                         }
                     }
                 }

--- a/src/style/grid.rs
+++ b/src/style/grid.rs
@@ -533,9 +533,9 @@ impl<S: CheapCloneStr> GridPlacement<S> {
     pub fn into_origin_zero_placement_ignoring_named(&self, explicit_track_count: u16) -> OriginZeroGridPlacement {
         match self {
             Self::Auto => OriginZeroGridPlacement::Auto,
-            // Spans are clamped to the maximum track limit
-            // https://www.w3.org/TR/css-grid-1/#overlarge-grids
-            Self::Span(span) => OriginZeroGridPlacement::Span(min(*span, MAX_GRID_TRACKS)),
+            // Spans are clamped between 1 (a zero span is an invalid value which is treated as 1)
+            // and the maximum track limit (https://www.w3.org/TR/css-grid-1/#overlarge-grids)
+            Self::Span(span) => OriginZeroGridPlacement::Span((*span).clamp(1, MAX_GRID_TRACKS)),
             // Grid line zero is an invalid index, so it gets treated as Auto
             // See: https://developer.mozilla.org/en-US/docs/Web/CSS/grid-row-start#values
             Self::Line(line) => match line.as_i16() {
@@ -567,9 +567,9 @@ impl NonNamedGridPlacement {
     ) -> OriginZeroGridPlacement {
         match self {
             Self::Auto => OriginZeroGridPlacement::Auto,
-            // Spans are clamped to the maximum track limit
-            // https://www.w3.org/TR/css-grid-1/#overlarge-grids
-            Self::Span(span) => OriginZeroGridPlacement::Span(min(*span, MAX_GRID_TRACKS)),
+            // Spans are clamped between 1 (a zero span is an invalid value which is treated as 1)
+            // and the maximum track limit (https://www.w3.org/TR/css-grid-1/#overlarge-grids)
+            Self::Span(span) => OriginZeroGridPlacement::Span((*span).clamp(1, MAX_GRID_TRACKS)),
             // Grid line zero is an invalid index, so it gets treated as Auto
             // See: https://developer.mozilla.org/en-US/docs/Web/CSS/grid-row-start#values
             Self::Line(line) => match line.as_i16() {

--- a/tests/hand_written.rs
+++ b/tests/hand_written.rs
@@ -1,4 +1,5 @@
 mod hand_written {
+    mod adversarial_styles;
     mod block_replaced;
     mod border_and_padding;
     mod caching;

--- a/tests/hand_written/adversarial_styles.rs
+++ b/tests/hand_written/adversarial_styles.rs
@@ -1,0 +1,127 @@
+//! Tests for style inputs which are valid to construct, but which are degenerate or hostile
+//! (non-finite numbers, extreme values, or internally inconsistent grid templates).
+//!
+//! These tests are primarily about layout *terminating* without panicking.
+#[cfg(test)]
+mod adversarial_styles {
+    use taffy::prelude::*;
+    use taffy::style::{GridTemplateComponent, MaxTrackSizingFunction, MinTrackSizingFunction, TrackSizingFunction};
+    use taffy_test_helpers::new_test_tree;
+
+    fn definite(size: f32) -> Size<AvailableSpace> {
+        Size { width: AvailableSpace::Definite(size), height: AvailableSpace::Definite(size) }
+    }
+
+    /// A `NaN` flex factor makes every comparison in the "find the size of an fr" algorithm false,
+    /// which used to prevent that algorithm from ever finding a valid hypothetical fr size.
+    #[test]
+    fn non_finite_flex_factor_terminates() {
+        for flex_factor in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let mut tree = new_test_tree();
+            let child = tree
+                .new_leaf(Style {
+                    size: Size { width: Dimension::from_length(10.0), height: Dimension::from_length(10.0) },
+                    ..Default::default()
+                })
+                .unwrap();
+            let root = tree
+                .new_with_children(
+                    Style {
+                        display: Display::Grid,
+                        grid_template_columns: vec![GridTemplateComponent::Single(TrackSizingFunction {
+                            min: MinTrackSizingFunction::AUTO,
+                            max: MaxTrackSizingFunction::from_fr(flex_factor),
+                        })],
+                        ..Default::default()
+                    },
+                    &[child],
+                )
+                .unwrap();
+
+            tree.compute_layout(root, definite(100.0)).unwrap();
+        }
+    }
+
+    /// A non-finite size on a grid container makes the space to fill non-finite, which used to
+    /// prevent the "find the size of an fr" algorithm from terminating.
+    #[test]
+    fn non_finite_grid_container_size_terminates() {
+        for width in [f32::NAN, f32::INFINITY] {
+            let mut tree = new_test_tree();
+            let child = tree.new_leaf(Style::default()).unwrap();
+            let root = tree
+                .new_with_children(
+                    Style {
+                        display: Display::Grid,
+                        size: Size { width: Dimension::from_length(width), height: Dimension::from_length(100.0) },
+                        grid_template_columns: vec![repeat(2, vec![fr(1.0)])],
+                        ..Default::default()
+                    },
+                    &[child],
+                )
+                .unwrap();
+
+            tree.compute_layout(root, definite(100.0)).unwrap();
+        }
+    }
+
+    /// `repeat()` definitions are allowed to contain fewer line name sets than they have tracks
+    /// (the `repeat` style helper creates repetitions with no line names at all). Line numbering
+    /// must still account for the tracks that each repetition generates.
+    #[test]
+    fn repetition_without_line_names_resolves_lines() {
+        let mut tree = new_test_tree();
+        let child = tree
+            .new_leaf(Style {
+                size: Size { width: Dimension::from_length(5.0), height: Dimension::from_length(5.0) },
+                grid_column: Line { start: GridPlacement::NamedLine("c".into(), 1), end: GridPlacement::Auto },
+                ..Default::default()
+            })
+            .unwrap();
+        let root = tree
+            .new_with_children(
+                Style {
+                    display: Display::Grid,
+                    size: Size { width: Dimension::from_length(100.0), height: Dimension::from_length(100.0) },
+                    grid_template_columns: vec![repeat(2, vec![length(10.0)]), length(10.0)],
+                    grid_template_column_names: vec![vec![], vec![], vec!["c".into()]],
+                    ..Default::default()
+                },
+                &[child],
+            )
+            .unwrap();
+
+        tree.compute_layout(root, definite(100.0)).unwrap();
+
+        // "c" is the 4th line of the grid: the line after the three 10px columns
+        assert_eq!(tree.layout(child).unwrap().location.x, 30.0);
+    }
+
+    /// Items may span thousands of tracks and be placed thousands of tracks outside of the explicit
+    /// grid. Auto-placing such items must not take an excessive amount of time.
+    #[test]
+    fn extreme_placements_and_spans_terminate() {
+        let mut tree = new_test_tree();
+        let children: Vec<_> = [
+            Line { start: GridPlacement::Auto, end: GridPlacement::from_span(2000) },
+            Line { start: GridPlacement::from_line_index(-2000), end: GridPlacement::from_line_index(2000) },
+        ]
+        .into_iter()
+        .map(|placement| {
+            tree.new_leaf(Style { grid_row: placement.clone(), grid_column: placement, ..Default::default() }).unwrap()
+        })
+        .collect();
+        let root = tree
+            .new_with_children(
+                Style {
+                    display: Display::Grid,
+                    size: Size { width: Dimension::from_length(100.0), height: Dimension::from_length(100.0) },
+                    ..Default::default()
+                },
+                &children,
+            )
+            .unwrap();
+
+        tree.compute_layout(root, definite(100.0)).unwrap();
+    }
+}

--- a/tests/hand_written/adversarial_styles.rs
+++ b/tests/hand_written/adversarial_styles.rs
@@ -5,7 +5,9 @@
 #[cfg(test)]
 mod adversarial_styles {
     use taffy::prelude::*;
-    use taffy::style::{GridTemplateComponent, MaxTrackSizingFunction, MinTrackSizingFunction, TrackSizingFunction};
+    use taffy::style::{
+        Direction, GridTemplateComponent, MaxTrackSizingFunction, MinTrackSizingFunction, TrackSizingFunction,
+    };
     use taffy_test_helpers::new_test_tree;
 
     fn definite(size: f32) -> Size<AvailableSpace> {
@@ -95,6 +97,31 @@ mod adversarial_styles {
 
         // "c" is the 4th line of the grid: the line after the three 10px columns
         assert_eq!(tree.layout(child).unwrap().location.x, 30.0);
+    }
+
+    /// A zero span (an invalid value which gets normalized to 1) combined with an unresolvable
+    /// named span used to size the implicit grid estimate to zero tracks, while auto-placement
+    /// resolved the same placement to a span of 1. The auto-placement search then looped forever
+    /// looking for a position that could never fit.
+    #[test]
+    fn zero_span_and_named_span_terminates() {
+        for direction in [Direction::Ltr, Direction::Rtl] {
+            let mut tree = new_test_tree();
+            let child = tree
+                .new_leaf(Style {
+                    grid_column: Line {
+                        start: GridPlacement::NamedSpan("does-not-exist".into(), 1),
+                        end: GridPlacement::from_span(0),
+                    },
+                    ..Default::default()
+                })
+                .unwrap();
+            let root = tree
+                .new_with_children(Style { display: Display::Grid, direction, ..Default::default() }, &[child])
+                .unwrap();
+
+            tree.compute_layout(root, definite(100.0)).unwrap();
+        }
     }
 
     /// Items may span thousands of tracks and be placed thousands of tracks outside of the explicit

--- a/tests/hand_written/adversarial_styles.rs
+++ b/tests/hand_written/adversarial_styles.rs
@@ -124,6 +124,41 @@ mod adversarial_styles {
         }
     }
 
+    /// When auto-placement collides with an occupied area, the search cursor must jump past the
+    /// whole occupied interval. Jumping only within the queried area used to make the search
+    /// advance one track at a time through large occupied areas, so a small item searching a grid
+    /// occupied by a maximum-size item scanned (10000 tracks)^2 candidate positions.
+    #[test]
+    fn small_item_in_max_size_occupied_grid_terminates() {
+        let mut tree = new_test_tree();
+        let big = tree
+            .new_leaf(Style {
+                grid_row: Line { start: GridPlacement::from_span(10000), end: GridPlacement::Auto },
+                grid_column: Line { start: GridPlacement::from_span(10000), end: GridPlacement::Auto },
+                ..Default::default()
+            })
+            .unwrap();
+        let small = tree
+            .new_leaf(Style {
+                grid_row: Line { start: GridPlacement::from_span(10000), end: GridPlacement::Auto },
+                grid_column: Line { start: GridPlacement::from_span(1), end: GridPlacement::Auto },
+                ..Default::default()
+            })
+            .unwrap();
+        let root = tree
+            .new_with_children(
+                Style {
+                    display: Display::Grid,
+                    size: Size { width: Dimension::from_length(100.0), height: Dimension::from_length(100.0) },
+                    ..Default::default()
+                },
+                &[big, small],
+            )
+            .unwrap();
+
+        tree.compute_layout(root, definite(100.0)).unwrap();
+    }
+
     /// Items may span thousands of tracks and be placed thousands of tracks outside of the explicit
     /// grid. Auto-placing such items must not take an excessive amount of time.
     #[test]


### PR DESCRIPTION
# Objective

Fixes four issues found while auditing Taffy for crashes/panics/hangs reachable from untrusted or adversarial style inputs (via a randomized style fuzzer exercising the public `Style` API):

1. **Panic from ordinary CSS**: `NamedLineResolver` assumed every repetition carries `track_count + 1` line name sets and unconditionally ran `current_line -= 1` per repetition. A repetition with fewer line name sets than tracks — which is what both the `repeat()` style helper and the CSS parser produce for e.g. `[a] repeat(2, 10px) [c] 10px` — underflowed `u32` (panic in debug builds, silently mis-numbered all subsequent lines in release builds). Line numbering now advances by `max(line_name_set_count, track_count + 1) - 1` per repetition:

   ```rust
   let lines_per_repetition = max(line_name_set_count, repeat.track_count() as u32 + 1) - 1;
   ```

   and stops generating names past `MAX_GRID_TRACKS` (those lines are clamped away anyway, and this also prevents `u32` overflow with `repeat(65535, ...)` counts).

2. **Infinite loop from non-finite styles**: `find_size_of_fr`'s termination argument (each restart treats ≥1 more flexible track as inflexible) breaks when `NaN` reaches the comparisons — e.g. a `NaN` fr flex factor, or a `NaN`/`±inf` container size making `space_to_fill` non-finite — so `compute_layout` never returned. Same for the `while space_to_distribute > THRESHOLD` loop in `distribute_space_up_to_limits` when no space can be distributed. Both loops are now bounded at `tracks.len() + 1` iterations, which is the maximum needed for finite inputs.

3. **Infinite loop in auto-placement from a zero span**: the implicit grid size estimate and the actual placement can disagree about an item's span. `Line { start: NamedSpan("nope", 1), end: Span(0) }` is estimated as `(Auto, Span(0))` → span 0 (so the grid gets zero columns), but placement resolves the unresolvable named span to `Span(1)` → span 1. `place_indefinitely_positioned_item`'s search then never finds a fitting position and never terminates (the secondary axis cursor saturates at `i16::MAX` and stops advancing). Two fixes:
   - Zero spans (invalid values per the CSS spec) are now normalized to 1 in `into_origin_zero_placement{,_ignoring_named}`, eliminating the estimate/placement disagreement.
   - Defense in depth: the placement search now bails out when the span is out of bounds even at the search start position (it can never fit anywhere in that case; searching only ever moves the span further from the start of the grid), letting `record_grid_placement` clamp the placement into the limited grid:

   ```rust
   if primary_out_of_bounds {
       if primary_idx == primary_start_position {
           return (primary_span, secondary_span); // can never fit: bail out and clamp
       }
       secondary_idx = advance_position(secondary_idx, secondary_axis_is_reversed);
       primary_idx = primary_start_position;
       continue;
   }
   ```

4. **Quadratic auto-placement DoS (in the new sparse occupancy code from #1015)**: `TrackIntervals::collision_extent` clipped the collision extent to the queried range, so `line_area_collision_jump` only jumped past the part of the colliding interval *within the queried area*. For a span-1 item every jump degenerated to advancing one track, so a small item searching a grid occupied by a maximum-size item scanned ~10000×10000 candidate positions, each scanning up to 10000 spanned tracks (minutes of CPU per item; ~10 items ⇒ effectively a hang). `collision_extent` now returns the un-clipped extent of the colliding interval:

   ```rust
   // forwards: every start position before the last colliding interval's end still collides
   Some(interval.range.end - 1)   // was: Some(min(interval.range.end, range.end) - 1)
   // backwards: every position at or after the first colliding interval's start still collides
   Some(interval.range.start)     // was: Some(max(interval.range.start, range.start))
   ```

   so the search jumps past the entire colliding interval in one step (no valid candidate positions are skipped: any start before the returned extent still overlaps the same interval).

   (An earlier revision of this PR fixed the equivalent problem in the old dense `CellOccupancyMatrix` via an occupied-cell bounding box; that fix was superseded by #1015's sparse rework when merging `main`, and the sparse collision-jump search turned out to have the same quadratic blow-up.)

## Context

Follow-up to #986 (clamping grids at 10,000 tracks), found by fuzzing `compute_layout` with hostile style values: non-finite floats (`NaN`/`±inf`/`f32::MAX`), extreme line numbers/spans/repeat counts, empty repetitions, named lines/areas, RTL, and nested trees.

Repro for (1) without the parser:

```rust
style.grid_template_columns = vec![repeat(2, vec![length(10.0)]), length(10.0)];
style.grid_template_column_names = vec![vec![], vec![], vec!["c".into()]];
// -> subtract-with-overflow in NamedLineResolver::new (debug builds)
```

Repro for (3):

```rust
child_style.grid_column = Line {
    start: GridPlacement::NamedSpan("does-not-exist".into(), 1),
    end: GridPlacement::from_span(0),
};
// -> compute_layout never returns
```

Repro for (4): one auto-placed item spanning 10000×10000, then one spanning 1×10000.

Hand-written regression tests added in `tests/hand_written/adversarial_styles.rs` (these are termination/panic regressions and named-line placements, which the gentest pipeline can't express — `parseGridPosition` in `test_helper.js` doesn't support named lines). `cargo test --workspace` (all gentests + unit tests) passes; the named-line renumbering was additionally sanity-checked against Chrome's line numbering for `[a] repeat(2, 10px) [c] 10px`.

**Residual (not fixed here)**: track *sizing* with several items spanning ~10000 intrinsically-sized tracks is CPU-heavy but bounded (`resolve_intrinsic_track_sizes` distributes per-item space across all spanned tracks; one fuzz case takes ~45s). This is inherent O(items × tracks²)-ish work rather than a termination bug — flagging in case you want a follow-up issue.

## Feedback wanted

- The `current_line > MAX_GRID_TRACKS` cutoff in `NamedLineResolver` stops recording line names once numbering passes the track limit. Lines at exactly `MAX_GRID_TRACKS + 1` (the final line of a fully clamped grid) may lose names in pathological templates — happy to adjust the boundary if you'd prefer.
- In `distribute_space_up_to_limits` the iteration bound relies on each finite-input iteration freezing at least one track at its limit (or distributing all remaining space); all existing tests pass, but extra scrutiny of that invariant would be welcome.
- For (3), normalizing `Span(0)` → `Span(1)` matches the CSS spec (span integers must be positive), but if you'd rather reject zero spans elsewhere (e.g. in the style setters) the placement bail-out alone is also sufficient to guarantee termination.
- For (4), I updated the `collision_extent`/`collision_jump` unit tests to encode the new un-clipped jump semantics — worth double-checking you agree no valid candidate positions can be skipped.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/5aa5330a2de7473299560d75fc7dcc0f
Requested by: @nicoburns