### PR TITLE
Grid: only distribute beyond limits to tracks with a max-content max sizing function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Grid: when distributing a spanning item's max-content contribution to its spanned tracks' base sizes "beyond limits", tracks are now eligible only if their *max* track sizing function is `max-content` (or `fit-content()`), per [CSS Grid §12.5.1](https://www.w3.org/TR/css-grid-1/#extra-space). Previously tracks whose *min* track sizing function was `max-content` were also eligible, so a track such as `minmax(max-content, 20px)` could grow beyond its fixed `20px` limit, stealing space from `max-content` tracks ([WPT: grid-content-sized-columns-resolution](https://wpt.live/css/css-grid/parsing/grid-content-sized-columns-resolution.html))
+
 - Grid: an explicitly specified preferred or minimum size is no longer clamped by the spanned tracks' fixed max track sizing functions when computing an item's minimum contribution. That clamp only applies to the content-based (automatic) minimum size, per [CSS Grid §6.6](https://www.w3.org/TR/css-grid-1/#min-size-auto). Fixes e.g. an item with `min-width: 12px` in a `minmax(auto, 10px)` track sizing the track to `12px` rather than `10px`
 
 - Grid: when distributing a spanning item's intrinsic size contribution to its spanned tracks, space distributed "beyond limits" now ignores the tracks' growth limits (still capping growth at any `fit-content()` argument), per [CSS Grid §12.5.1](https://www.w3.org/TR/css-grid-1/#extra-space). Previously the growth limits were still enforced, so tracks such as `minmax(min-content, 10px)` could not expand beyond `10px` to accommodate an item's contribution

--- a/src/compute/grid/track_sizing.rs
+++ b/src/compute/grid/track_sizing.rs
@@ -1050,10 +1050,8 @@ fn distribute_item_space_to_base_size(
                     (|track: &GridTrack| track.max_track_sizing_function.is_intrinsic()) as fn(&GridTrack) -> bool
                 }
                 IntrinsicContributionType::Maximum => {
-                    (|track: &GridTrack| {
-                        track.min_track_sizing_function.is_max_content()
-                            || track.max_track_sizing_function.is_max_or_fit_content()
-                    }) as fn(&GridTrack) -> bool
+                    (|track: &GridTrack| track.max_track_sizing_function.is_max_or_fit_content())
+                        as fn(&GridTrack) -> bool
                 }
             };
 

--- a/test_fixtures/grid/grid_content_sized_columns_max_content_and_max_content_fixed_and_max_content.html
+++ b/test_fixtures/grid/grid_content_sized_columns_max_content_and_max_content_fixed_and_max_content.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 300px; grid-template-columns: max-content minmax(max-content, 20px) max-content;">
+  <div style="grid-row: 1; grid-column: 1;">X&#8203;X&#8203;X&#8203;X&#8203;X</div>
+  <div style="grid-row: 1; grid-column: 3;">X&#8203;X&#8203;X</div>
+  <div style="grid-row: 1; grid-column: 1 / -1;">XX&#8203;XX&#8203;XX&#8203;XX&#8203;XX&#8203;XX&#8203;XX</div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/grid/grid_content_sized_columns_max_content_and_max_content_fixed_and_max_content__border_box_ltr.xml
+++ b/tests/xml/grid/grid_content_sized_columns_max_content_and_max_content_fixed_and_max_content__border_box_ltr.xml
@@ -1,0 +1,23 @@
+<test name="grid_content_sized_columns_max_content_and_max_content_fixed_and_max_content__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="300px" grid-template-columns="max-content minmax(max-content,20px) max-content">
+      <text direction="ltr" grid-row-start="1" grid-column-start="1">
+        X​X​X​X​X
+      </text>
+      <text direction="ltr" grid-row-start="1" grid-column-start="3">
+        X​X​X
+      </text>
+      <text direction="ltr" grid-row-start="1" grid-column-start="1" grid-column-end="-1">
+        XX​XX​XX​XX​XX​XX​XX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="10">
+      <node x="0" y="0" width="70" height="10"/>
+      <node x="90" y="0" width="50" height="10"/>
+      <node x="0" y="0" width="140" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_content_sized_columns_max_content_and_max_content_fixed_and_max_content__border_box_rtl.xml
+++ b/tests/xml/grid/grid_content_sized_columns_max_content_and_max_content_fixed_and_max_content__border_box_rtl.xml
@@ -1,0 +1,23 @@
+<test name="grid_content_sized_columns_max_content_and_max_content_fixed_and_max_content__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="300px" grid-template-columns="max-content minmax(max-content,20px) max-content">
+      <text direction="rtl" grid-row-start="1" grid-column-start="1">
+        X​X​X​X​X
+      </text>
+      <text direction="rtl" grid-row-start="1" grid-column-start="3">
+        X​X​X
+      </text>
+      <text direction="rtl" grid-row-start="1" grid-column-start="1" grid-column-end="-1">
+        XX​XX​XX​XX​XX​XX​XX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="10">
+      <node x="230" y="0" width="70" height="10"/>
+      <node x="160" y="0" width="50" height="10"/>
+      <node x="160" y="0" width="140" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_content_sized_columns_max_content_and_max_content_fixed_and_max_content__content_box_ltr.xml
+++ b/tests/xml/grid/grid_content_sized_columns_max_content_and_max_content_fixed_and_max_content__content_box_ltr.xml
@@ -1,0 +1,23 @@
+<test name="grid_content_sized_columns_max_content_and_max_content_fixed_and_max_content__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="300px" grid-template-columns="max-content minmax(max-content,20px) max-content">
+      <text box-sizing="content-box" direction="ltr" grid-row-start="1" grid-column-start="1">
+        X​X​X​X​X
+      </text>
+      <text box-sizing="content-box" direction="ltr" grid-row-start="1" grid-column-start="3">
+        X​X​X
+      </text>
+      <text box-sizing="content-box" direction="ltr" grid-row-start="1" grid-column-start="1" grid-column-end="-1">
+        XX​XX​XX​XX​XX​XX​XX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="10">
+      <node x="0" y="0" width="70" height="10"/>
+      <node x="90" y="0" width="50" height="10"/>
+      <node x="0" y="0" width="140" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_content_sized_columns_max_content_and_max_content_fixed_and_max_content__content_box_rtl.xml
+++ b/tests/xml/grid/grid_content_sized_columns_max_content_and_max_content_fixed_and_max_content__content_box_rtl.xml
@@ -1,0 +1,23 @@
+<test name="grid_content_sized_columns_max_content_and_max_content_fixed_and_max_content__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="300px" grid-template-columns="max-content minmax(max-content,20px) max-content">
+      <text box-sizing="content-box" direction="rtl" grid-row-start="1" grid-column-start="1">
+        X​X​X​X​X
+      </text>
+      <text box-sizing="content-box" direction="rtl" grid-row-start="1" grid-column-start="3">
+        X​X​X
+      </text>
+      <text box-sizing="content-box" direction="rtl" grid-row-start="1" grid-column-start="1" grid-column-end="-1">
+        XX​XX​XX​XX​XX​XX​XX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="10">
+      <node x="230" y="0" width="70" height="10"/>
+      <node x="160" y="0" width="50" height="10"/>
+      <node x="160" y="0" width="140" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -18915,6 +18915,42 @@ mod grid {
 
     #[cfg(feature = "grid")]
     #[test]
+    fn grid_content_sized_columns_max_content_and_max_content_fixed_and_max_content__border_box_ltr() {
+        crate::run_xml_test(
+            "grid",
+            "grid_content_sized_columns_max_content_and_max_content_fixed_and_max_content__border_box_ltr",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_content_sized_columns_max_content_and_max_content_fixed_and_max_content__content_box_ltr() {
+        crate::run_xml_test(
+            "grid",
+            "grid_content_sized_columns_max_content_and_max_content_fixed_and_max_content__content_box_ltr",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_content_sized_columns_max_content_and_max_content_fixed_and_max_content__border_box_rtl() {
+        crate::run_xml_test(
+            "grid",
+            "grid_content_sized_columns_max_content_and_max_content_fixed_and_max_content__border_box_rtl",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_content_sized_columns_max_content_and_max_content_fixed_and_max_content__content_box_rtl() {
+        crate::run_xml_test(
+            "grid",
+            "grid_content_sized_columns_max_content_and_max_content_fixed_and_max_content__content_box_rtl",
+        );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
     fn grid_definite_size_auto_tracks_asymmetric_max_content__border_box_ltr() {
         crate::run_xml_test("grid", "grid_definite_size_auto_tracks_asymmetric_max_content__border_box_ltr");
     }


### PR DESCRIPTION
# Objective

Fix a track sizing regression introduced in #1022 that was caught by the Servo Taffy-main upgrade WPT run ([`css/css-grid/parsing/grid-content-sized-columns-resolution.html`](https://wpt.live/css/css-grid/parsing/grid-content-sized-columns-resolution.html), subtest `gridMaxContentAndMaxContentFixedAndMaxContent`).

For `grid-template-columns: max-content minmax(max-content, 20px) max-content` with a spanning item, the expected column sizes are `70px 20px 50px`, but Taffy `main` produced `63.33px 33.33px 43.33px` — the `minmax(max-content, 20px)` track grew past its fixed `20px` limit.

## Context

When distributing a spanning item's max-content contribution to base sizes "beyond limits" ([CSS Grid §12.5.1](https://www.w3.org/TR/css-grid-1/#extra-space)), eligibility is:

> when accommodating max-content contributions: any affected track that happens to also have a max-content max track sizing function; if there are no such tracks, then all affected tracks.

Taffy's filter additionally accepted tracks whose *min* track sizing function is max-content:

```rust
IntrinsicContributionType::Maximum => {
-   track.min_track_sizing_function.is_max_content()
-       || track.max_track_sizing_function.is_max_or_fit_content()
+   track.max_track_sizing_function.is_max_or_fit_content()
}
```

The extra `min` clause dates back to the original grid implementation (#205), but it was harmless before #1022 because the beyond-limits distribution still (incorrectly) enforced growth limits. Once #1022 correctly made beyond-limits distribution ignore growth limits, the over-broad filter allowed tracks with a max-content *min* but a fixed *max* (e.g. `minmax(max-content, 20px)`) to grow past their limit, stealing space from the genuinely eligible `max-content` tracks.

Bisected with a standalone repro: `v0.12.1` → correct, first bad commit `1a2d05ab` (#1022). The bug only manifests when the axis available space is not max-content (e.g. a definite grid width), which is why Taffy's existing tests (mostly max-content sized fixtures) didn't catch it.

Added a gentest fixture ported from the failing WPT subtest (definite 300px grid width); it fails without the fix and passes with it.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/4da04f758ad8431d809c1af2ccbdea05
Requested by: @nicoburns