### PR TITLE
Jump auto-placement search past entire colliding occupied intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Grid: when the auto-placement search collides with an occupied area, the search cursor now jumps past the entire colliding occupied interval rather than just the part of it within the queried area. Previously a small item searching a grid occupied by large items advanced one track at a time, scanning up to 10000x10000 candidate positions
+
 - Grid: when distributing a spanning item's max-content contribution to its spanned tracks' base sizes "beyond limits", tracks are now eligible only if their *max* track sizing function is `max-content` (or `fit-content()`), per [CSS Grid §12.5.1](https://www.w3.org/TR/css-grid-1/#extra-space). Previously tracks whose *min* track sizing function was `max-content` were also eligible, so a track such as `minmax(max-content, 20px)` could grow beyond its fixed `20px` limit, stealing space from `max-content` tracks ([WPT: grid-content-sized-columns-resolution](https://wpt.live/css/css-grid/parsing/grid-content-sized-columns-resolution.html))
 
 - Grid: an explicitly specified preferred or minimum size is no longer clamped by the spanned tracks' fixed max track sizing functions when computing an item's minimum contribution. That clamp only applies to the content-based (automatic) minimum size, per [CSS Grid §6.6](https://www.w3.org/TR/css-grid-1/#min-size-auto). Fixes e.g. an item with `min-width: 12px` in a `minmax(auto, 10px)` track sizing the track to `12px` rather than `10px`

--- a/src/compute/grid/types/cell_occupancy.rs
+++ b/src/compute/grid/types/cell_occupancy.rs
@@ -124,17 +124,19 @@ impl TrackIntervals {
         self.intervals = result;
     }
 
-    /// Find the cell within `range` which an auto-placement search along the track would collide
-    /// with last: the maximum occupied cell in the range when searching forwards, or the minimum
-    /// when searching backwards (`reversed == true`). Returns the cell's start line, or `None` if
-    /// the range is entirely unoccupied.
+    /// Find the extent of the occupied interval which an auto-placement search along the track
+    /// would collide with last: the end of the last overlapping interval when searching forwards,
+    /// or the start of the first overlapping interval when searching backwards (`reversed ==
+    /// true`). Returns the extremal occupied cell of that interval (which may lie outside
+    /// `range`: every search position before the returned extent also collides with the
+    /// interval), or `None` if the range is entirely unoccupied.
     fn collision_extent(&self, range: &Range<i16>, reversed: bool) -> Option<i16> {
         if reversed {
             let interval = self.intervals.iter().find(|interval| interval.overlaps(range))?;
-            Some(max(interval.range.start, range.start))
+            Some(interval.range.start)
         } else {
             let interval = self.intervals.iter().rev().find(|interval| interval.overlaps(range))?;
-            Some(min(interval.range.end, range.end) - 1)
+            Some(interval.range.end - 1)
         }
     }
 
@@ -485,14 +487,14 @@ mod tests {
             let mut track = TrackIntervals::default();
             track.paint(2..4, AutoPlaced);
             track.paint(6..8, DefinitelyPlaced);
-            // Forward search: the maximum occupied cell within the range
+            // Forward search: the last cell of the last overlapping interval
             assert_eq!(track.collision_extent(&(0..10), false), Some(7));
-            assert_eq!(track.collision_extent(&(0..7), false), Some(6));
+            assert_eq!(track.collision_extent(&(0..7), false), Some(7));
             assert_eq!(track.collision_extent(&(0..6), false), Some(3));
             assert_eq!(track.collision_extent(&(4..6), false), None);
-            // Reverse search: the minimum occupied cell within the range
+            // Reverse search: the first cell of the first overlapping interval
             assert_eq!(track.collision_extent(&(0..10), true), Some(2));
-            assert_eq!(track.collision_extent(&(3..10), true), Some(3));
+            assert_eq!(track.collision_extent(&(3..10), true), Some(2));
             assert_eq!(track.collision_extent(&(4..10), true), Some(6));
         }
 
@@ -558,19 +560,19 @@ mod tests {
                 CellOccupancyMatrix::with_track_counts(TrackCounts::from_raw(0, 4, 0), TrackCounts::from_raw(0, 4, 0));
             matrix.mark_area_as(Horizontal, line(1, 3), line(0, 1), AutoPlaced);
 
-            // Forwards: jump past the last occupied cell within the queried area
+            // Forwards: jump past the end of the last colliding interval
             assert_eq!(
                 matrix.line_area_collision_jump(Horizontal, line(0, 2), line(0, 1), false),
-                Some(OriginZeroLine(2))
+                Some(OriginZeroLine(3))
             );
             assert_eq!(
                 matrix.line_area_collision_jump(Horizontal, line(0, 4), line(0, 1), false),
                 Some(OriginZeroLine(3))
             );
-            // Backwards: jump past the first occupied cell within the queried area
+            // Backwards: jump past the start of the first colliding interval
             assert_eq!(
                 matrix.line_area_collision_jump(Horizontal, line(2, 4), line(0, 1), true),
-                Some(OriginZeroLine(1))
+                Some(OriginZeroLine(0))
             );
             assert_eq!(
                 matrix.line_area_collision_jump(Horizontal, line(0, 4), line(0, 1), true),

--- a/tests/hand_written.rs
+++ b/tests/hand_written.rs
@@ -1,4 +1,5 @@
 mod hand_written {
+    mod adversarial_styles;
     mod block_replaced;
     mod border_and_padding;
     mod caching;

--- a/tests/hand_written/adversarial_styles.rs
+++ b/tests/hand_written/adversarial_styles.rs
@@ -1,0 +1,76 @@
+//! Tests for style inputs which are valid to construct, but which are degenerate or hostile
+//! (non-finite numbers, extreme values, or internally inconsistent grid templates).
+//!
+//! These tests are primarily about layout *terminating* without panicking.
+#[cfg(test)]
+mod adversarial_styles {
+    use taffy::prelude::*;
+    use taffy_test_helpers::new_test_tree;
+
+    fn definite(size: f32) -> Size<AvailableSpace> {
+        Size { width: AvailableSpace::Definite(size), height: AvailableSpace::Definite(size) }
+    }
+
+    /// When auto-placement collides with an occupied area, the search cursor must jump past the
+    /// whole occupied interval. Jumping only within the queried area used to make the search
+    /// advance one track at a time through large occupied areas, so a small item searching a grid
+    /// occupied by a maximum-size item scanned (10000 tracks)^2 candidate positions.
+    #[test]
+    fn small_item_in_max_size_occupied_grid_terminates() {
+        let mut tree = new_test_tree();
+        let big = tree
+            .new_leaf(Style {
+                grid_row: Line { start: GridPlacement::from_span(10000), end: GridPlacement::Auto },
+                grid_column: Line { start: GridPlacement::from_span(10000), end: GridPlacement::Auto },
+                ..Default::default()
+            })
+            .unwrap();
+        let small = tree
+            .new_leaf(Style {
+                grid_row: Line { start: GridPlacement::from_span(10000), end: GridPlacement::Auto },
+                grid_column: Line { start: GridPlacement::from_span(1), end: GridPlacement::Auto },
+                ..Default::default()
+            })
+            .unwrap();
+        let root = tree
+            .new_with_children(
+                Style {
+                    display: Display::Grid,
+                    size: Size { width: Dimension::from_length(100.0), height: Dimension::from_length(100.0) },
+                    ..Default::default()
+                },
+                &[big, small],
+            )
+            .unwrap();
+
+        tree.compute_layout(root, definite(100.0)).unwrap();
+    }
+
+    /// Items may span thousands of tracks and be placed thousands of tracks outside of the explicit
+    /// grid. Auto-placing such items must not take an excessive amount of time.
+    #[test]
+    fn extreme_placements_and_spans_terminate() {
+        let mut tree = new_test_tree();
+        let children: Vec<_> = [
+            Line { start: GridPlacement::Auto, end: GridPlacement::from_span(2000) },
+            Line { start: GridPlacement::from_line_index(-2000), end: GridPlacement::from_line_index(2000) },
+        ]
+        .into_iter()
+        .map(|placement| {
+            tree.new_leaf(Style { grid_row: placement.clone(), grid_column: placement, ..Default::default() }).unwrap()
+        })
+        .collect();
+        let root = tree
+            .new_with_children(
+                Style {
+                    display: Display::Grid,
+                    size: Size { width: Dimension::from_length(100.0), height: Dimension::from_length(100.0) },
+                    ..Default::default()
+                },
+                &children,
+            )
+            .unwrap();
+
+        tree.compute_layout(root, definite(100.0)).unwrap();
+    }
+}


### PR DESCRIPTION
# Objective

Fix a quadratic auto-placement blow-up in the sparse occupancy code from #1015 (split out of #1032; now an independent PR targeting `main` so it can merge on its own).

`TrackIntervals::collision_extent` clipped the collision extent to the queried range, so `line_area_collision_jump` only jumped past the part of the colliding interval *within the queried area*. For a span-1 item every jump degenerated to advancing one track, so a small item searching a grid occupied by a maximum-size item scanned ~10000×10000 candidate positions, each scanning up to 10000 spanned tracks (minutes of CPU per item; a handful of items is effectively a hang).

`collision_extent` now returns the un-clipped extent of the colliding interval:

```rust
// forwards: every start position before the last colliding interval's end still collides
Some(interval.range.end - 1)   // was: Some(min(interval.range.end, range.end) - 1)
// backwards: every position at or after the first colliding interval's start still collides
Some(interval.range.start)     // was: Some(max(interval.range.start, range.start))
```

so the search jumps past the entire colliding interval in one step. No valid candidate positions are skipped: any start position before the returned extent still overlaps the same interval.

## Context

Found while fuzzing `compute_layout` with adversarial style values: several fuzz cases that previously appeared as hangs (>2 minutes) complete in well under a second with this change. An earlier revision of #1032 fixed the equivalent problem in the old dense `CellOccupancyMatrix` via an occupied-cell bounding box; that was superseded by #1015's sparse rework, whose collision-jump search turned out to have the same quadratic behaviour. Regression tests (`small_item_in_max_size_occupied_grid_terminates`, `extreme_placements_and_spans_terminate`) added in `tests/hand_written/adversarial_styles.rs`.

Related (independent) PRs from the same audit: #1035, #1036, #1037. The `CHANGELOG.md` and `tests/hand_written/adversarial_styles.rs` additions will trivially conflict with those when merging — the entries/tests are simply appended in both.

**Residual (not fixed here)**: track *sizing* with several items spanning ~10000 intrinsically-sized tracks is CPU-heavy but bounded (`resolve_intrinsic_track_sizes` distributes per-item space across all spanned tracks; one fuzz case takes ~45s). This is inherent O(items × tracks²)-ish work rather than a termination bug — flagging in case you want a follow-up issue.

## Feedback wanted

The `collision_extent`/`collision_jump` unit tests were updated to encode the new un-clipped jump semantics — worth double-checking you agree no valid candidate positions can be skipped.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/5aa5330a2de7473299560d75fc7dcc0f
Requested by: @nicoburns