### PR TITLE
Block: allow elements containing only floated children to be collapsed through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Grid: when the auto-placement search collides with an occupied area, the search cursor now jumps past the entire colliding occupied interval rather than just the part of it within the queried area. Previously a small item searching a grid occupied by large items advanced one track at a time, scanning up to 10000x10000 candidate positions
 
+- Block: an element containing only floated children can now be collapsed through (its own margins collapse with each other), per [CSS2.2 §8.3.1](https://www.w3.org/TR/CSS22/box.html#collapsing-margins) — floated children are out-of-flow and do not prevent collapse-through
+
 - Grid: when distributing a spanning item's max-content contribution to its spanned tracks' base sizes "beyond limits", tracks are now eligible only if their *max* track sizing function is `max-content` (or `fit-content()`), per [CSS Grid §12.5.1](https://www.w3.org/TR/css-grid-1/#extra-space). Previously tracks whose *min* track sizing function was `max-content` were also eligible, so a track such as `minmax(max-content, 20px)` could grow beyond its fixed `20px` limit, stealing space from `max-content` tracks ([WPT: grid-content-sized-columns-resolution](https://wpt.live/css/css-grid/parsing/grid-content-sized-columns-resolution.html))
 
 - Grid: an explicitly specified preferred or minimum size is no longer clamped by the spanned tracks' fixed max track sizing functions when computing an item's minimum contribution. That clamp only applies to the content-based (automatic) minimum size, per [CSS Grid §6.6](https://www.w3.org/TR/css-grid-1/#min-size-auto). Fixes e.g. an item with `min-width: 12px` in a `minmax(auto, 10px)` track sizing the track to `12px` rather than `10px`

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -546,8 +546,13 @@ fn compute_inner(
     }
 
     // Determine whether this node can be collapsed through
-    let all_in_flow_children_can_be_collapsed_through =
-        items.iter().all(|item| item.position == Position::Absolute || item.can_be_collapsed_through);
+    let all_in_flow_children_can_be_collapsed_through = items.iter().all(|item| {
+        #[cfg(feature = "float_layout")]
+        if item.float.is_floated() {
+            return true;
+        }
+        item.position == Position::Absolute || item.can_be_collapsed_through
+    });
     let can_be_collapsed_through =
         !has_styles_preventing_being_collapsed_through && all_in_flow_children_can_be_collapsed_through;
 


### PR DESCRIPTION
# Objective

Split out of #992 (1/7). Per [CSS2.2 §8.3.1](https://www.w3.org/TR/CSS22/box.html#collapsing-margins), a block's margins can collapse through it if it has no in-flow content. Floated children are out-of-flow, so a block containing only floats should still be collapsed through. Previously any child (including floats and absolutes under `float_layout`) prevented collapse-through.

## Context

One-line change to the `all_in_flow_children_can_be_collapsed_through` predicate in `src/compute/block.rs`: floated items are now skipped, matching the existing treatment of `position: absolute` items.

Part of a stacked series splitting #992 into per-fix PRs; this one is independent and based on `main`. Verified with `cargo test` / `fmt` / `clippy`. The full stack reproduces #992's WPT results (css/CSS2/floats-clear 106 → 125 PASS, css/CSS2/floats 45 → 52 PASS, 0 crashes, no regressions vs current-main baseline).

Link to Devin session: https://app.devin.ai/sessions/b02d24a17f3a4881b9e794b4b67b6ca3
Requested by: @nicoburns