### PR TITLE
Float: treat clear with no relevant floats as a no-op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Grid: when the auto-placement search collides with an occupied area, the search cursor now jumps past the entire colliding occupied interval rather than just the part of it within the queried area. Previously a small item searching a grid occupied by large items advanced one track at a time, scanning up to 10000x10000 candidate positions
 
+- Block/float: `clear` on an element no longer has any effect when no float has been placed on the relevant side(s). Previously `FloatContext::cleared_threshold` treated an empty float context as a float ending at `y=0`, which could spuriously clamp the position of cleared elements
+
 - Block: an element containing only floated children can now be collapsed through (its own margins collapse with each other), per [CSS2.2 §8.3.1](https://www.w3.org/TR/CSS22/box.html#collapsing-margins) — floated children are out-of-flow and do not prevent collapse-through
 
 - Grid: when distributing a spanning item's max-content contribution to its spanned tracks' base sizes "beyond limits", tracks are now eligible only if their *max* track sizing function is `max-content` (or `fit-content()`), per [CSS Grid §12.5.1](https://www.w3.org/TR/css-grid-1/#extra-space). Previously tracks whose *min* track sizing function was `max-content` were also eligible, so a track such as `minmax(max-content, 20px)` could grow beyond its fixed `20px` limit, stealing space from `max-content` tracks ([WPT: grid-content-sized-columns-resolution](https://wpt.live/css/css-grid/parsing/grid-content-sized-columns-resolution.html))

--- a/src/compute/float.rs
+++ b/src/compute/float.rs
@@ -462,22 +462,22 @@ impl FloatContext {
     }
 
     /// Get the end segment of the last float on side(s) specified by the clear parameter (if any)
+    ///
+    /// Returns `None` if no float has been placed on the relevant side(s)
     fn cleared_segment(&self, clear: Clear) -> Option<usize> {
+        let left_end = self.last_placed_floats[0].end;
+        let right_end = self.last_placed_floats[1].end;
         match clear {
-            Clear::Left => Some(self.last_placed_floats[0].end),
-            Clear::Right => Some(self.last_placed_floats[1].end),
-            Clear::Both => {
-                let left_end = self.last_placed_floats[0].end;
-                let right_end = self.last_placed_floats[1].end;
-                Some(left_end.max(right_end))
-            }
-            Clear::None => None,
+            Clear::Left if left_end > 0 => Some(left_end),
+            Clear::Right if right_end > 0 => Some(right_end),
+            Clear::Both if left_end > 0 || right_end > 0 => Some(left_end.max(right_end)),
+            _ => None,
         }
     }
 
     /// Get the bottom of lowest relevant float for the specific clear property
     pub fn cleared_threshold(&self, clear: Clear) -> Option<f32> {
-        self.cleared_segment(clear).and_then(|idx| self.segments.get(idx.max(1) - 1)).map(|seg| seg.y.end)
+        self.cleared_segment(clear).and_then(|idx| self.segments.get(idx - 1)).map(|seg| seg.y.end)
     }
 
     /// Search for a space suitable for laying out non-floated content into

--- a/tests/hand_written.rs
+++ b/tests/hand_written.rs
@@ -3,6 +3,8 @@ mod hand_written {
     mod block_replaced;
     mod border_and_padding;
     mod caching;
+    #[cfg(feature = "float_layout")]
+    mod float_clearance;
     mod floats;
     mod measure;
     mod min_max_overrides;

--- a/tests/hand_written/float_clearance.rs
+++ b/tests/hand_written/float_clearance.rs
@@ -1,0 +1,47 @@
+//! Regression tests for clearance calculation and its interaction with margin collapsing.
+//!
+//! Scenarios are reduced from WPT tests in css/CSS2/floats-clear and css/CSS2/floats.
+use taffy::prelude::*;
+use taffy::{Clear, Float};
+
+fn block(tree: &mut TaffyTree<()>, style: Style, children: &[NodeId]) -> NodeId {
+    tree.new_with_children(Style { display: Display::Block, ..style }, children).unwrap()
+}
+
+fn assert_layout(tree: &TaffyTree<()>, node: NodeId, x: f32, y: f32, width: f32, height: f32) {
+    let layout = tree.layout(node).unwrap();
+    assert_eq!(layout.location.x, x, "x of {node:?}");
+    assert_eq!(layout.location.y, y, "y of {node:?}");
+    assert_eq!(layout.size.width, width, "width of {node:?}");
+    assert_eq!(layout.size.height, height, "height of {node:?}");
+}
+
+/// Reduced from WPT css/CSS2/floats-clear/clear-002.xht
+///
+/// A cleared float should clear past prior floats, but `clear` on the first float
+/// (with no prior floats on the relevant side) should not move it down.
+#[test]
+fn clear_on_float_with_and_without_preceding_float() {
+    let t = &mut TaffyTree::new();
+    let f1 = block(
+        t,
+        Style { float: Float::Right, size: Size { width: length(96.0), height: length(96.0) }, ..Default::default() },
+        &[],
+    );
+    let f2 = block(
+        t,
+        Style {
+            float: Float::Right,
+            clear: Clear::Right,
+            size: Size { width: length(96.0), height: length(96.0) },
+            ..Default::default()
+        },
+        &[],
+    );
+    let container =
+        block(t, Style { size: Size { width: length(500.0), height: auto() }, ..Default::default() }, &[f1, f2]);
+    t.compute_layout(container, Size::MAX_CONTENT).unwrap();
+
+    assert_layout(t, f1, 404.0, 0.0, 96.0, 96.0);
+    assert_layout(t, f2, 404.0, 96.0, 96.0, 96.0);
+}


### PR DESCRIPTION
# Objective

Split out of #992 (2/7). `clear` on an element must have no effect when no float exists on the relevant side(s) ([CSS2.2 §9.5.2](https://www.w3.org/TR/CSS22/visuren.html#flow-control)). Previously `FloatContext::cleared_threshold` treated an empty float context as a float ending at `y=0`, so `clear` could spuriously clamp a (potentially negative-positioned) element's position to 0.

## Context

`cleared_segment` now returns `None` when `last_placed_floats[side].end == 0` (no float ever placed on that side), so `cleared_threshold` returns `None` and no clearance logic runs.

Adds a regression test (`clear_on_float_with_and_without_preceding_float`, reduced from WPT `css/CSS2/floats-clear/clear-002.xht`) and introduces the `tests/hand_written/float_clearance.rs` module used by the rest of the stack.

Stacked on #1040; part of the series splitting #992 into per-fix PRs.

Link to Devin session: https://app.devin.ai/sessions/b02d24a17f3a4881b9e794b4b67b6ca3
Requested by: @nicoburns