### PR TITLE
Block: clearance suppresses top-margin collapsing with the parent's top margin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 - Block: clearance is now computed per [CSS2.2 §9.5.2](https://www.w3.org/TR/CSS22/visuren.html#flow-control) from the hypothetical position of the cleared element (including its collapsed top margin), supporting *negative clearance* and suppressing clearance when a large top margin already places the element past the relevant float(s). Previously the cleared element's position was simply clamped to the bottom of the floats, ignoring its top margin
 
+- Block: clearance prevents the cleared element's top margin from collapsing with preceding margins and with the parent's top margin, per [CSS2.2 §8.3.1](https://www.w3.org/TR/CSS22/box.html#collapsing-margins)
+
 - Block/float: `clear` on an element no longer has any effect when no float has been placed on the relevant side(s). Previously `FloatContext::cleared_threshold` treated an empty float context as a float ending at `y=0`, which could spuriously clamp the position of cleared elements
 
 - Block: an element containing only floated children can now be collapsed through (its own margins collapse with each other), per [CSS2.2 §8.3.1](https://www.w3.org/TR/CSS22/box.html#collapsing-margins) — floated children are out-of-flow and do not prevent collapse-through

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -1180,7 +1180,12 @@ fn perform_final_layout_on_in_flow_children(
             }
 
             // Update first_child_top_margin_set
-            if is_collapsing_with_first_margin_set {
+            //
+            // The top margin of an item with clearance does not collapse with the container's top margin,
+            // so clearance terminates collapsing without contributing the item's own margins.
+            if is_collapsing_with_first_margin_set && has_clearance {
+                is_collapsing_with_first_margin_set = false;
+            } else if is_collapsing_with_first_margin_set {
                 if item.can_be_collapsed_through {
                     first_child_top_margin_set = first_child_top_margin_set
                         .collapse_with_set(top_margin_set)


### PR DESCRIPTION
# Objective

Split out of #992 (4/7). Per [CSS2.2 §8.3.1](https://www.w3.org/TR/CSS22/box.html#collapsing-margins), the top margin of an element with clearance does not collapse with the parent block's top margin (clearance is a separator). Previously a cleared element's top margin could still be contributed to `first_child_top_margin_set` and escape through the parent.

## Context

Small change in the `first_child_top_margin_set` update: if the item `has_clearance` (introduced in #1042), collapsing with the first margin set is terminated *without* contributing the item's own margins:

```rust
if is_collapsing_with_first_margin_set && has_clearance {
    is_collapsing_with_first_margin_set = false;
} else if is_collapsing_with_first_margin_set { ... }
```

Stacked on #1042; part of the series splitting #992 into per-fix PRs. Covered by the stack's regression tests (e.g. `clear_with_top_margin_after_cleared_empty_block` in #1043's follow-up) and WPT `css/CSS2/floats-clear` results for the full stack.

Link to Devin session: https://app.devin.ai/sessions/b02d24a17f3a4881b9e794b4b67b6ca3
Requested by: @nicoburns