### PR TITLE
Block: empty boxes with clearance still collapse their margins internally and with following nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 - Block: clearance prevents the cleared element's top margin from collapsing with preceding margins and with the parent's top margin, per [CSS2.2 §8.3.1](https://www.w3.org/TR/CSS22/box.html#collapsing-margins)
 
+- Block: the top and bottom margins of a self-collapsing element with clearance collapse with each other (and with the margins of following siblings) and are applied inside the parent, extending its content height; they no longer collapse with the bottom margin of the parent block, per [CSS2.2 §8.3.1](https://www.w3.org/TR/CSS22/box.html#collapsing-margins)
+
 - Block/float: `clear` on an element no longer has any effect when no float has been placed on the relevant side(s). Previously `FloatContext::cleared_threshold` treated an empty float context as a float ending at `y=0`, which could spuriously clamp the position of cleared elements
 
 - Block: an element containing only floated children can now be collapsed through (its own margins collapse with each other), per [CSS2.2 §8.3.1](https://www.w3.org/TR/CSS22/box.html#collapsing-margins) — floated children are out-of-flow and do not prevent collapse-through

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -850,6 +850,10 @@ fn perform_final_layout_on_in_flow_children(
     let mut active_collapsible_margin_set = CollapsibleMarginSet::ZERO;
     let mut is_collapsing_with_first_margin_set = true;
     let mut first_baseline: Option<f32> = None;
+    // Whether the active margin set contains the margins of a self-collapsing element with
+    // clearance. Such margins collapse with the margins of following siblings but the resulting
+    // margin does not collapse with the bottom margin of the parent block.
+    let mut active_margin_set_has_clearance = false;
 
     #[cfg(feature = "float_layout")]
     let mut has_active_floats = block_ctx.has_active_floats(committed_y_offset);
@@ -1322,7 +1326,20 @@ fn perform_final_layout_on_in_flow_children(
                 }
             } else {
                 committed_y_offset = location.y - inset_offset.y + item_layout.size.height;
-                active_collapsible_margin_set = bottom_margin_set;
+                // A self-collapsing item with clearance is not collapsed through (its margins do not collapse
+                // with margins of preceding siblings), but its top and bottom margins still collapse with each
+                // other and with the margins of following siblings.
+                if has_clearance && item_layout.margins_can_collapse_through {
+                    // The element's border edge stays at the cleared position, but its collapsed margin
+                    // extends below it: the border edge sits `top margin` inside the collapsed margin, so
+                    // following content is offset by `collapsed margin - top margin` from the border edge.
+                    committed_y_offset -= top_margin_set.resolve();
+                    active_collapsible_margin_set = top_margin_set.collapse_with_set(bottom_margin_set);
+                    active_margin_set_has_clearance = true;
+                } else {
+                    active_collapsible_margin_set = bottom_margin_set;
+                    active_margin_set_has_clearance = false;
+                }
                 y_offset_for_absolute = committed_y_offset + active_collapsible_margin_set.resolve();
                 #[cfg(feature = "float_layout")]
                 {
@@ -1332,9 +1349,17 @@ fn perform_final_layout_on_in_flow_children(
         }
     }
 
-    let last_child_bottom_margin_set = active_collapsible_margin_set;
-    let bottom_y_margin_offset =
-        if own_margins_collapse_with_children.end { 0.0 } else { last_child_bottom_margin_set.resolve() };
+    // The margins of a self-collapsing element with clearance do not collapse with the bottom
+    // margin of the parent block: they extend the parent's content height instead of escaping it
+    let last_child_bottom_margin_set =
+        if active_margin_set_has_clearance { CollapsibleMarginSet::ZERO } else { active_collapsible_margin_set };
+    let bottom_y_margin_offset = if active_margin_set_has_clearance {
+        active_collapsible_margin_set.resolve()
+    } else if own_margins_collapse_with_children.end {
+        0.0
+    } else {
+        last_child_bottom_margin_set.resolve()
+    };
 
     committed_y_offset += resolved_content_box_inset.bottom + bottom_y_margin_offset;
     let content_height = f32_max(0.0, committed_y_offset);

--- a/test_fixtures/float/float_clear_empty_block_then_margin.html
+++ b/test_fixtures/float/float_clear_empty_block_then_margin.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Clearance on a self-collapsing block suppresses margin collapsing with following
+    siblings, and a following cleared sibling with a large top margin gets no clearance.
+    Reduced from WPT css/CSS2/floats-clear/clear-with-top-margin-after-cleared-empty-block.html
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px; border-top: 1px solid;">
+  <div style="display: block; float: left; width: 100px; height: 20px;"></div>
+  <div style="display: block; clear: both;"></div>
+  <div style="display: block; clear: both; margin-top: 100px; height: 20px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/float/float_clear_self_collapsing_margins.html
+++ b/test_fixtures/float/float_clear_self_collapsing_margins.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    The top and bottom margins of a self-collapsing block with clearance collapse with
+    each other and are applied inside the parent (they do not collapse with the parent's
+    bottom margin). Reduced from WPT css/CSS2/floats-clear/margin-collapse-clear-013.xht
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 300px;">
+  <div style="display: block;">
+    <div style="display: block; float: left; width: 100px; height: 100px;"></div>
+    <div style="display: block; clear: left; margin-top: 40px; margin-bottom: 140px;"></div>
+  </div>
+  <div style="display: block; height: 100px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/float/float_clear_empty_block_then_margin__border_box_ltr.xml
+++ b/tests/xml/float/float_clear_empty_block_then_margin__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="float_clear_empty_block_then_margin__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px" border-top="1px">
+      <div display="block" direction="ltr" float="left" width="100px" height="20px"/>
+      <div display="block" direction="ltr" clear="both"/>
+      <div display="block" direction="ltr" clear="both" height="20px" margin-top="100px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="141">
+      <node x="0" y="1" width="100" height="20"/>
+      <node x="0" y="21" width="100" height="0"/>
+      <node x="0" y="121" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_clear_empty_block_then_margin__border_box_rtl.xml
+++ b/tests/xml/float/float_clear_empty_block_then_margin__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="float_clear_empty_block_then_margin__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px" border-top="1px">
+      <div display="block" direction="rtl" float="left" width="100px" height="20px"/>
+      <div display="block" direction="rtl" clear="both"/>
+      <div display="block" direction="rtl" clear="both" height="20px" margin-top="100px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="141">
+      <node x="0" y="1" width="100" height="20"/>
+      <node x="0" y="21" width="100" height="0"/>
+      <node x="0" y="121" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_clear_empty_block_then_margin__content_box_ltr.xml
+++ b/tests/xml/float/float_clear_empty_block_then_margin__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="float_clear_empty_block_then_margin__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px" border-top="1px">
+      <div display="block" box-sizing="content-box" direction="ltr" float="left" width="100px" height="20px"/>
+      <div display="block" box-sizing="content-box" direction="ltr" clear="both"/>
+      <div display="block" box-sizing="content-box" direction="ltr" clear="both" height="20px" margin-top="100px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="141">
+      <node x="0" y="1" width="100" height="20"/>
+      <node x="0" y="21" width="100" height="0"/>
+      <node x="0" y="121" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_clear_empty_block_then_margin__content_box_rtl.xml
+++ b/tests/xml/float/float_clear_empty_block_then_margin__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="float_clear_empty_block_then_margin__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px" border-top="1px">
+      <div display="block" box-sizing="content-box" direction="rtl" float="left" width="100px" height="20px"/>
+      <div display="block" box-sizing="content-box" direction="rtl" clear="both"/>
+      <div display="block" box-sizing="content-box" direction="rtl" clear="both" height="20px" margin-top="100px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="141">
+      <node x="0" y="1" width="100" height="20"/>
+      <node x="0" y="21" width="100" height="0"/>
+      <node x="0" y="121" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_clear_self_collapsing_margins__border_box_ltr.xml
+++ b/tests/xml/float/float_clear_self_collapsing_margins__border_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="float_clear_self_collapsing_margins__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="300px">
+      <div display="block" direction="ltr">
+        <div display="block" direction="ltr" float="left" width="100px" height="100px"/>
+        <div display="block" direction="ltr" clear="left" margin-top="40px" margin-bottom="140px"/>
+      </div>
+      <div display="block" direction="ltr" height="100px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="300">
+      <node x="0" y="0" width="300" height="200">
+        <node x="0" y="0" width="100" height="100"/>
+        <node x="0" y="100" width="300" height="0"/>
+      </node>
+      <node x="0" y="200" width="300" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_clear_self_collapsing_margins__border_box_rtl.xml
+++ b/tests/xml/float/float_clear_self_collapsing_margins__border_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="float_clear_self_collapsing_margins__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="300px">
+      <div display="block" direction="rtl">
+        <div display="block" direction="rtl" float="left" width="100px" height="100px"/>
+        <div display="block" direction="rtl" clear="left" margin-top="40px" margin-bottom="140px"/>
+      </div>
+      <div display="block" direction="rtl" height="100px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="300">
+      <node x="0" y="0" width="300" height="200">
+        <node x="0" y="0" width="100" height="100"/>
+        <node x="0" y="100" width="300" height="0"/>
+      </node>
+      <node x="0" y="200" width="300" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_clear_self_collapsing_margins__content_box_ltr.xml
+++ b/tests/xml/float/float_clear_self_collapsing_margins__content_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="float_clear_self_collapsing_margins__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="300px">
+      <div display="block" box-sizing="content-box" direction="ltr">
+        <div display="block" box-sizing="content-box" direction="ltr" float="left" width="100px" height="100px"/>
+        <div display="block" box-sizing="content-box" direction="ltr" clear="left" margin-top="40px" margin-bottom="140px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="ltr" height="100px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="300">
+      <node x="0" y="0" width="300" height="200">
+        <node x="0" y="0" width="100" height="100"/>
+        <node x="0" y="100" width="300" height="0"/>
+      </node>
+      <node x="0" y="200" width="300" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_clear_self_collapsing_margins__content_box_rtl.xml
+++ b/tests/xml/float/float_clear_self_collapsing_margins__content_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="float_clear_self_collapsing_margins__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="300px">
+      <div display="block" box-sizing="content-box" direction="rtl">
+        <div display="block" box-sizing="content-box" direction="rtl" float="left" width="100px" height="100px"/>
+        <div display="block" box-sizing="content-box" direction="rtl" clear="left" margin-top="40px" margin-bottom="140px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="rtl" height="100px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="300">
+      <node x="0" y="0" width="300" height="200">
+        <node x="0" y="0" width="100" height="100"/>
+        <node x="0" y="100" width="300" height="0"/>
+      </node>
+      <node x="0" y="200" width="300" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -16740,6 +16740,26 @@ mod float {
     }
 
     #[test]
+    fn float_clear_empty_block_then_margin__border_box_ltr() {
+        crate::run_xml_test("float", "float_clear_empty_block_then_margin__border_box_ltr");
+    }
+
+    #[test]
+    fn float_clear_empty_block_then_margin__content_box_ltr() {
+        crate::run_xml_test("float", "float_clear_empty_block_then_margin__content_box_ltr");
+    }
+
+    #[test]
+    fn float_clear_empty_block_then_margin__border_box_rtl() {
+        crate::run_xml_test("float", "float_clear_empty_block_then_margin__border_box_rtl");
+    }
+
+    #[test]
+    fn float_clear_empty_block_then_margin__content_box_rtl() {
+        crate::run_xml_test("float", "float_clear_empty_block_then_margin__content_box_rtl");
+    }
+
+    #[test]
     fn float_clear_negative_clearance__border_box_ltr() {
         crate::run_xml_test("float", "float_clear_negative_clearance__border_box_ltr");
     }
@@ -16777,6 +16797,26 @@ mod float {
     #[test]
     fn float_clear_no_preceding_float__content_box_rtl() {
         crate::run_xml_test("float", "float_clear_no_preceding_float__content_box_rtl");
+    }
+
+    #[test]
+    fn float_clear_self_collapsing_margins__border_box_ltr() {
+        crate::run_xml_test("float", "float_clear_self_collapsing_margins__border_box_ltr");
+    }
+
+    #[test]
+    fn float_clear_self_collapsing_margins__content_box_ltr() {
+        crate::run_xml_test("float", "float_clear_self_collapsing_margins__content_box_ltr");
+    }
+
+    #[test]
+    fn float_clear_self_collapsing_margins__border_box_rtl() {
+        crate::run_xml_test("float", "float_clear_self_collapsing_margins__border_box_rtl");
+    }
+
+    #[test]
+    fn float_clear_self_collapsing_margins__content_box_rtl() {
+        crate::run_xml_test("float", "float_clear_self_collapsing_margins__content_box_rtl");
     }
 
     #[test]


### PR DESCRIPTION
# Objective

Split out of #992 (5/7). Per [CSS2.2 §8.3.1](https://www.w3.org/TR/CSS22/box.html#collapsing-margins), a self-collapsing (empty) block with clearance:

- still collapses its own top and bottom margins with each other and with the margins of *following* siblings (but not preceding ones — clearance separates those);
- its resulting collapsed margin is applied *inside* the parent (extending the parent's content height) and does **not** collapse with the parent's bottom margin.

Previously the element's top margin was dropped and its bottom margin escaped through the parent like any other trailing margin.

## Context

Tracked via a new `active_margin_set_has_clearance` flag:

```rust
if has_clearance && item_layout.margins_can_collapse_through {
    // border edge sits `top margin` inside the collapsed margin
    committed_y_offset -= top_margin_set.resolve();
    active_collapsible_margin_set = top_margin_set.collapse_with_set(bottom_margin_set);
    active_margin_set_has_clearance = true;
}
```

and at the end of layout, if the flag is still set, the trailing margin is resolved into the parent's content height instead of being returned as `last_child_bottom_margin_set`.

Adds *generated tests* (HTML fixtures in `test_fixtures/float/`, expectations produced from Chrome by gentest): `float_clear_empty_block_then_margin` (reduced from WPT `clear-with-top-margin-after-cleared-empty-block.html`) and `float_clear_self_collapsing_margins` (reduced from WPT `margin-collapse-clear-013.xht`).

Stacked on #1043; part of the series splitting #992 into per-fix PRs.

Link to Devin session: https://app.devin.ai/sessions/b02d24a17f3a4881b9e794b4b67b6ca3
Requested by: @nicoburns