### PR TITLE
Block: force clearance for floats adjoining an unresolved margin-collapse strut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Grid: `Style::grid_template_areas` is now `Option<GridTemplateAreas<S>>`, where the new `GridTemplateAreas` struct bundles the named areas (`areas`) with the overall size of the area template (`row_count`/`column_count`). This allows templates containing unnamed (`.`) cells beyond the extents of the named areas (e.g. `grid-template-areas: "a ."`) to be represented, as such cells still contribute to the size of the explicit grid. `GridContainerStyle` gains `grid_template_area_row_count`/`grid_template_area_column_count` methods (with default implementations that derive the counts from the extents of the named areas), which are now used to determine the size of the explicit grid
 
+- Block/float: `BlockContext::place_floated_box` takes an additional `adjoins_unresolved_strut: bool` parameter indicating whether the float is being placed while the position of the current margin-collapse strut is still unresolved
+
 ### Fixed
 
 - Block/Grid: `Layout::content_size` now measures the scrollable overflow region from the container's padding-box origin (mirrored for RTL) and includes the container's own end-side padding, matching the existing Flexbox behaviour and browser `scrollWidth`/`scrollHeight` semantics. Previously Block and Grid measured relative to the content box and excluded the container's padding entirely, so `Layout::scroll_width()`/`scroll_height()` were too small by the padding sum (#1050)
@@ -15,6 +17,8 @@
 - Grid: when the auto-placement search collides with an occupied area, the search cursor now jumps past the entire colliding occupied interval rather than just the part of it within the queried area. Previously a small item searching a grid occupied by large items advanced one track at a time, scanning up to 10000x10000 candidate positions
 
 - Block/float: a box that establishes an independent formatting context now avoids floats placed by the subtree of a preceding in-flow sibling, not just floats among its direct siblings. Previously the presence of active floats was only tracked for direct float children, so such a box could overlap a float placed by a nested descendant of an earlier sibling
+
+- Block: floats placed while the position of the enclosing margin-collapse strut is unresolved now force clearance on subsequent cleared elements whose margins adjoin the same strut (matching browser behaviour): letting the margins collapse would move the float together with the cleared element. Floats occurring between collapsing margins are also now positioned including the pending collapsible margins, per [CSS2.2 §9.5](https://www.w3.org/TR/CSS22/visuren.html#floats)
 
 - Block: clearance is now computed per [CSS2.2 §9.5.2](https://www.w3.org/TR/CSS22/visuren.html#flow-control) from the hypothetical position of the cleared element (including its collapsed top margin), supporting *negative clearance* and suppressing clearance when a large top margin already places the element past the relevant float(s). Previously the cleared element's position was simply clamped to the bottom of the floats, ignoring its top margin
 

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -50,6 +50,10 @@ impl BlockFormattingContext {
             content_box_insets: [0.0, 0.0],
             float_content_contribution: 0.0,
             is_root: true,
+            #[cfg(feature = "float_layout")]
+            adjoining_floats: [false, false],
+            #[cfg(feature = "float_layout")]
+            top_adjoining_floats: None,
         }
     }
 }
@@ -71,6 +75,17 @@ pub struct BlockContext<'bfc> {
     float_content_contribution: f32,
     /// Whether the node is the root of the Block Formatting Context is belongs to.
     is_root: bool,
+    /// Whether a float has been placed (on each side) whose position adjoins the current
+    /// margin-collapse strut of this block (i.e. whose final position can still be moved by
+    /// margins that collapse into that strut). Such floats force clearance on cleared elements
+    /// whose margins adjoin the same strut.
+    #[cfg(feature = "float_layout")]
+    adjoining_floats: [bool; 2],
+    /// The value of `adjoining_floats` frozen at the first point at which in-flow content was
+    /// committed within this block (resolving the position of the block's top margin strut).
+    /// `None` if no in-flow content has been committed yet.
+    #[cfg(feature = "float_layout")]
+    top_adjoining_floats: Option<[bool; 2]>,
 }
 
 impl BlockContext<'_> {
@@ -84,6 +99,12 @@ impl BlockContext<'_> {
             content_box_insets: insets,
             float_content_contribution: 0.0,
             is_root: false,
+            // Floats adjoining the parent's current strut also adjoin this block's top strut
+            // (if this block's top margin collapses with its first child's, which is checked separately)
+            #[cfg(feature = "float_layout")]
+            adjoining_floats: self.adjoining_floats,
+            #[cfg(feature = "float_layout")]
+            top_adjoining_floats: None,
         }
     }
 
@@ -130,7 +151,11 @@ impl BlockContext<'_> {
         min_y: f32,
         direction: FloatDirection,
         clear: Clear,
+        adjoins_unresolved_strut: bool,
     ) -> Point<f32> {
+        if adjoins_unresolved_strut {
+            self.adjoining_floats[direction as usize] = true;
+        }
         let mut pos = self.bfc.float_context.place_floated_box(
             floated_box,
             min_y + self.y_offset,
@@ -181,6 +206,39 @@ impl BlockContext<'_> {
     /// Get the bottom of lowest relevant float for the specific clear property
     pub fn cleared_threshold(&self, clear: Clear) -> Option<f32> {
         self.bfc.float_context.cleared_threshold(clear).map(|threshold| threshold - self.y_offset)
+    }
+
+    /// Whether a float that is adjoining the current margin-collapse strut has been placed
+    /// on the side(s) relevant to the passed clear property
+    pub fn has_adjoining_float(&self, clear: Clear) -> bool {
+        match clear {
+            Clear::Left => self.adjoining_floats[0],
+            Clear::Right => self.adjoining_floats[1],
+            Clear::Both => self.adjoining_floats[0] || self.adjoining_floats[1],
+            Clear::None => false,
+        }
+    }
+
+    /// Merge adjoining float flags propagated from a child block into this block's flags
+    fn merge_adjoining_floats(&mut self, flags: [bool; 2]) {
+        self.adjoining_floats[0] |= flags[0];
+        self.adjoining_floats[1] |= flags[1];
+    }
+
+    /// Record that in-flow content has been committed within this block, resolving the position of
+    /// the current margin-collapse strut. Floats placed before this point no longer adjoin the
+    /// current strut. The flags for the block's top strut are frozen at the first commit.
+    fn commit_strut(&mut self) {
+        if self.top_adjoining_floats.is_none() {
+            self.top_adjoining_floats = Some(self.adjoining_floats);
+        }
+        self.adjoining_floats = [false, false];
+    }
+
+    /// The adjoining float flags for this block's top margin strut: floats placed while the
+    /// position of the block's top strut was still unresolved
+    fn top_adjoining_floats(&self) -> [bool; 2] {
+        self.top_adjoining_floats.unwrap_or(self.adjoining_floats)
     }
 
     /// Update the height that descendent floats with the height that floats consume
@@ -842,6 +900,14 @@ fn perform_final_layout_on_in_flow_children(
         block_ctx.apply_content_box_inset([resolved_content_box_inset.left, resolved_content_box_inset.right]);
     }
 
+    // If this block's top margin does not collapse with its children's then the position of its
+    // top margin strut is resolved relative to it, and floats adjoining ancestor struts do not
+    // adjoin this block's strut.
+    #[cfg(feature = "float_layout")]
+    if !own_margins_collapse_with_children.start {
+        block_ctx.commit_strut();
+    }
+
     #[cfg_attr(not(feature = "content_size"), allow(unused_mut))]
     let mut inflow_content_size = Size::ZERO;
     let mut committed_y_offset = resolved_content_box_inset.top;
@@ -859,8 +925,6 @@ fn perform_final_layout_on_in_flow_children(
     let mut has_active_floats = block_ctx.has_active_floats(committed_y_offset);
     #[cfg(not(feature = "float_layout"))]
     let has_active_floats = false;
-    #[cfg(feature = "float_layout")]
-    let mut y_offset_for_float = resolved_content_box_inset.top;
 
     for item in items.iter_mut() {
         if item.position == Position::Absolute {
@@ -899,8 +963,29 @@ fn perform_final_layout_on_in_flow_children(
                 );
                 let margin_box = item_layout.size + item_non_auto_margin.sum_axes();
 
-                let mut location =
-                    block_ctx.place_floated_box(margin_box, y_offset_for_float, float_direction, item.clear);
+                // Floats that occur between collapsing margins are positioned as if they had an otherwise
+                // empty anonymous block parent taking part in the flow, so the pending collapsible margins
+                // contribute to the float's minimum y position (unless those margins collapse with the
+                // container's own top margin, in which case they are applied outside the container).
+                //
+                // In the latter case the position of the float is not fully resolved: margins contributed
+                // by later siblings can still collapse into the strut and move the container (and float).
+                // Such floats force clearance on cleared elements whose margins adjoin the same strut.
+                let adjoins_unresolved_strut =
+                    is_collapsing_with_first_margin_set && own_margins_collapse_with_children.start;
+                let y_offset_for_float = if adjoins_unresolved_strut {
+                    committed_y_offset
+                } else {
+                    committed_y_offset + active_collapsible_margin_set.resolve()
+                };
+
+                let mut location = block_ctx.place_floated_box(
+                    margin_box,
+                    y_offset_for_float,
+                    float_direction,
+                    item.clear,
+                    adjoins_unresolved_strut,
+                );
 
                 // Ensure that content that appears after a float does not get positioned before/above the float
                 //
@@ -908,7 +993,6 @@ fn perform_final_layout_on_in_flow_children(
                 // shouldn't cause content to push down to it's level
                 // committed_y_offset = committed_y_offset.max(location.y);
                 // y_offset_for_absolute = y_offset_for_absolute.max(location.y);
-                // y_offset_for_float = y_offset_for_float.max(location.y);
 
                 // Convert the margin-box location returned by float placement into a border-box location
                 // for the output Layout
@@ -1083,7 +1167,11 @@ fn perform_final_layout_on_in_flow_children(
                 #[cfg(feature = "float_layout")]
                 {
                     let child_contribution = child_block_ctx.floated_content_height_contribution();
+                    let child_top_adjoining_floats = child_block_ctx.top_adjoining_floats();
                     block_ctx.add_child_floated_content_height_contribution(y_offset_for_absolute + child_contribution);
+                    // Floats placed while the position of the child's top margin strut was unresolved
+                    // also adjoin this block's current strut
+                    block_ctx.merge_adjoining_floats(child_top_adjoining_floats);
                 }
 
                 output
@@ -1151,7 +1239,12 @@ fn perform_final_layout_on_in_flow_children(
                     // relative to the floats.
                     let hypothetical_y =
                         committed_y_offset + active_collapsible_margin_set.collapse_with_set(top_margin_set).resolve();
-                    if hypothetical_y < threshold {
+                    // Clearance is forced (regardless of the hypothetical position) if a relevant float is
+                    // adjoining the margin-collapse strut that the item's top margin would collapse into:
+                    // if the margins were allowed to collapse they would pull the float down with the item,
+                    // so clearance is inserted to separate the two, placing the item just below the float.
+                    let forced_clearance = block_ctx.has_adjoining_float(item.clear);
+                    if forced_clearance || hypothetical_y < threshold {
                         has_clearance = true;
                         // Clearance stops the item's top margin collapsing with preceding margins. If those
                         // preceding margins collapse with the container's own top margin they are applied
@@ -1320,10 +1413,6 @@ fn perform_final_layout_on_in_flow_children(
                     .collapse_with_set(top_margin_set)
                     .collapse_with_set(bottom_margin_set);
                 y_offset_for_absolute = committed_y_offset + item_layout.size.height + y_margin_offset;
-                #[cfg(feature = "float_layout")]
-                {
-                    y_offset_for_float = committed_y_offset + item_layout.size.height + y_margin_offset;
-                }
             } else {
                 committed_y_offset = location.y - inset_offset.y + item_layout.size.height;
                 // A self-collapsing item with clearance is not collapsed through (its margins do not collapse
@@ -1341,10 +1430,10 @@ fn perform_final_layout_on_in_flow_children(
                     active_margin_set_has_clearance = false;
                 }
                 y_offset_for_absolute = committed_y_offset + active_collapsible_margin_set.resolve();
+                // Committing in-flow content resolves the position of the current margin-collapse strut,
+                // so floats placed before this point no longer force clearance
                 #[cfg(feature = "float_layout")]
-                {
-                    y_offset_for_float = committed_y_offset + active_collapsible_margin_set.resolve();
-                }
+                block_ctx.commit_strut();
             }
         }
     }

--- a/test_fixtures/float/float_forced_clearance_adjoining_float.html
+++ b/test_fixtures/float/float_forced_clearance_adjoining_float.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    A float placed while the enclosing margin-collapse strut is unresolved forces
+    clearance on a later cleared sibling whose top margin adjoins the same strut:
+    no matter how large the margin is, the cleared element sits just below the float.
+    Reduced from WPT css/CSS2/floats-clear/adjoining-float-before-clearance.html
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px;">
+  <div style="display: block;">
+    <div style="display: block;">
+      <div style="display: block; float: left; width: 100px; height: 50px;"></div>
+    </div>
+    <div style="display: block; clear: left; margin-top: 400px; height: 50px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/float/float_negative_clearance_adjoining_float.html
+++ b/test_fixtures/float/float_negative_clearance_adjoining_float.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    An adjoining float followed by a self-collapsing cleared child with a large top
+    margin: forced (negative) clearance separates the margin from the strut, so the
+    container's height ends at the float bottom and the margin does not move the float.
+    Reduced from WPT css/CSS2/floats-clear/negative-clearance-after-adjoining-float.html
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px;">
+  <div style="display: block;">
+    <div style="display: block;">
+      <div style="display: block; float: left; width: 100px; height: 50px;"></div>
+      <div style="display: block; clear: left; margin-top: 200px;"></div>
+    </div>
+    <div style="display: block; height: 50px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/float/float_forced_clearance_adjoining_float__border_box_ltr.xml
+++ b/tests/xml/float/float_forced_clearance_adjoining_float__border_box_ltr.xml
@@ -1,0 +1,23 @@
+<test name="float_forced_clearance_adjoining_float__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px">
+      <div display="block" direction="ltr">
+        <div display="block" direction="ltr">
+          <div display="block" direction="ltr" float="left" width="100px" height="50px"/>
+        </div>
+        <div display="block" direction="ltr" clear="left" height="50px" margin-top="400px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="100" height="100">
+        <node x="0" y="0" width="100" height="0">
+          <node x="0" y="0" width="100" height="50"/>
+        </node>
+        <node x="0" y="50" width="100" height="50"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_forced_clearance_adjoining_float__border_box_rtl.xml
+++ b/tests/xml/float/float_forced_clearance_adjoining_float__border_box_rtl.xml
@@ -1,0 +1,23 @@
+<test name="float_forced_clearance_adjoining_float__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px">
+      <div display="block" direction="rtl">
+        <div display="block" direction="rtl">
+          <div display="block" direction="rtl" float="left" width="100px" height="50px"/>
+        </div>
+        <div display="block" direction="rtl" clear="left" height="50px" margin-top="400px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="100" height="100">
+        <node x="0" y="0" width="100" height="0">
+          <node x="0" y="0" width="100" height="50"/>
+        </node>
+        <node x="0" y="50" width="100" height="50"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_forced_clearance_adjoining_float__content_box_ltr.xml
+++ b/tests/xml/float/float_forced_clearance_adjoining_float__content_box_ltr.xml
@@ -1,0 +1,23 @@
+<test name="float_forced_clearance_adjoining_float__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px">
+      <div display="block" box-sizing="content-box" direction="ltr">
+        <div display="block" box-sizing="content-box" direction="ltr">
+          <div display="block" box-sizing="content-box" direction="ltr" float="left" width="100px" height="50px"/>
+        </div>
+        <div display="block" box-sizing="content-box" direction="ltr" clear="left" height="50px" margin-top="400px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="100" height="100">
+        <node x="0" y="0" width="100" height="0">
+          <node x="0" y="0" width="100" height="50"/>
+        </node>
+        <node x="0" y="50" width="100" height="50"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_forced_clearance_adjoining_float__content_box_rtl.xml
+++ b/tests/xml/float/float_forced_clearance_adjoining_float__content_box_rtl.xml
@@ -1,0 +1,23 @@
+<test name="float_forced_clearance_adjoining_float__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px">
+      <div display="block" box-sizing="content-box" direction="rtl">
+        <div display="block" box-sizing="content-box" direction="rtl">
+          <div display="block" box-sizing="content-box" direction="rtl" float="left" width="100px" height="50px"/>
+        </div>
+        <div display="block" box-sizing="content-box" direction="rtl" clear="left" height="50px" margin-top="400px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="100" height="100">
+        <node x="0" y="0" width="100" height="0">
+          <node x="0" y="0" width="100" height="50"/>
+        </node>
+        <node x="0" y="50" width="100" height="50"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_negative_clearance_adjoining_float__border_box_ltr.xml
+++ b/tests/xml/float/float_negative_clearance_adjoining_float__border_box_ltr.xml
@@ -1,0 +1,25 @@
+<test name="float_negative_clearance_adjoining_float__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px">
+      <div display="block" direction="ltr">
+        <div display="block" direction="ltr">
+          <div display="block" direction="ltr" float="left" width="100px" height="50px"/>
+          <div display="block" direction="ltr" clear="left" margin-top="200px"/>
+        </div>
+        <div display="block" direction="ltr" height="50px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="100" height="100">
+        <node x="0" y="0" width="100" height="50">
+          <node x="0" y="0" width="100" height="50"/>
+          <node x="0" y="50" width="100" height="0"/>
+        </node>
+        <node x="0" y="50" width="100" height="50"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_negative_clearance_adjoining_float__border_box_rtl.xml
+++ b/tests/xml/float/float_negative_clearance_adjoining_float__border_box_rtl.xml
@@ -1,0 +1,25 @@
+<test name="float_negative_clearance_adjoining_float__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px">
+      <div display="block" direction="rtl">
+        <div display="block" direction="rtl">
+          <div display="block" direction="rtl" float="left" width="100px" height="50px"/>
+          <div display="block" direction="rtl" clear="left" margin-top="200px"/>
+        </div>
+        <div display="block" direction="rtl" height="50px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="100" height="100">
+        <node x="0" y="0" width="100" height="50">
+          <node x="0" y="0" width="100" height="50"/>
+          <node x="0" y="50" width="100" height="0"/>
+        </node>
+        <node x="0" y="50" width="100" height="50"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_negative_clearance_adjoining_float__content_box_ltr.xml
+++ b/tests/xml/float/float_negative_clearance_adjoining_float__content_box_ltr.xml
@@ -1,0 +1,25 @@
+<test name="float_negative_clearance_adjoining_float__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px">
+      <div display="block" box-sizing="content-box" direction="ltr">
+        <div display="block" box-sizing="content-box" direction="ltr">
+          <div display="block" box-sizing="content-box" direction="ltr" float="left" width="100px" height="50px"/>
+          <div display="block" box-sizing="content-box" direction="ltr" clear="left" margin-top="200px"/>
+        </div>
+        <div display="block" box-sizing="content-box" direction="ltr" height="50px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="100" height="100">
+        <node x="0" y="0" width="100" height="50">
+          <node x="0" y="0" width="100" height="50"/>
+          <node x="0" y="50" width="100" height="0"/>
+        </node>
+        <node x="0" y="50" width="100" height="50"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_negative_clearance_adjoining_float__content_box_rtl.xml
+++ b/tests/xml/float/float_negative_clearance_adjoining_float__content_box_rtl.xml
@@ -1,0 +1,25 @@
+<test name="float_negative_clearance_adjoining_float__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px">
+      <div display="block" box-sizing="content-box" direction="rtl">
+        <div display="block" box-sizing="content-box" direction="rtl">
+          <div display="block" box-sizing="content-box" direction="rtl" float="left" width="100px" height="50px"/>
+          <div display="block" box-sizing="content-box" direction="rtl" clear="left" margin-top="200px"/>
+        </div>
+        <div display="block" box-sizing="content-box" direction="rtl" height="50px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="100" height="100">
+        <node x="0" y="0" width="100" height="50">
+          <node x="0" y="0" width="100" height="50"/>
+          <node x="0" y="50" width="100" height="0"/>
+        </node>
+        <node x="0" y="50" width="100" height="50"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -16820,6 +16820,46 @@ mod float {
     }
 
     #[test]
+    fn float_forced_clearance_adjoining_float__border_box_ltr() {
+        crate::run_xml_test("float", "float_forced_clearance_adjoining_float__border_box_ltr");
+    }
+
+    #[test]
+    fn float_forced_clearance_adjoining_float__content_box_ltr() {
+        crate::run_xml_test("float", "float_forced_clearance_adjoining_float__content_box_ltr");
+    }
+
+    #[test]
+    fn float_forced_clearance_adjoining_float__border_box_rtl() {
+        crate::run_xml_test("float", "float_forced_clearance_adjoining_float__border_box_rtl");
+    }
+
+    #[test]
+    fn float_forced_clearance_adjoining_float__content_box_rtl() {
+        crate::run_xml_test("float", "float_forced_clearance_adjoining_float__content_box_rtl");
+    }
+
+    #[test]
+    fn float_negative_clearance_adjoining_float__border_box_ltr() {
+        crate::run_xml_test("float", "float_negative_clearance_adjoining_float__border_box_ltr");
+    }
+
+    #[test]
+    fn float_negative_clearance_adjoining_float__content_box_ltr() {
+        crate::run_xml_test("float", "float_negative_clearance_adjoining_float__content_box_ltr");
+    }
+
+    #[test]
+    fn float_negative_clearance_adjoining_float__border_box_rtl() {
+        crate::run_xml_test("float", "float_negative_clearance_adjoining_float__border_box_rtl");
+    }
+
+    #[test]
+    fn float_negative_clearance_adjoining_float__content_box_rtl() {
+        crate::run_xml_test("float", "float_negative_clearance_adjoining_float__content_box_rtl");
+    }
+
+    #[test]
     fn float_new_fc_separates__border_box_ltr() {
         crate::run_xml_test("float", "float_new_fc_separates__border_box_ltr");
     }


### PR DESCRIPTION
# Objective

Split out of #992 (6/7). Per [CSS2.2 §9.5](https://www.w3.org/TR/CSS22/visuren.html#floats) rule 4, a float occurring between collapsing margins is positioned as if it had an otherwise-empty anonymous block parent in normal flow — so pending collapsible margins contribute to its position. When those margins collapse with the container's own top margin the float's position is *unresolved*: later margins collapsing into the same strut would move the float. If a later cleared sibling's top margin adjoins that strut, letting the margins collapse would move the float down together with the cleared element (a circular dependency). Browsers resolve this by *forcing clearance*, separating the cleared element's margin from the strut and leaving the float in place.

## Context

- Floats are now placed at `committed_y_offset + active_collapsible_margin_set.resolve()` when the pending margins do not escape the container (previously the pending margins were ignored entirely).
- `BlockContext` gains per-side `adjoining_floats: [bool; 2]` flags, set when a float is placed while `adjoins_unresolved_strut`, propagated into sub-contexts and merged back from children (`merge_adjoining_floats`/`top_adjoining_floats`), and cleared once in-flow content resolves the strut (`commit_strut`).
- The clearance check (from #1042) becomes `if forced_clearance || hypothetical_y < threshold` where `forced_clearance = block_ctx.has_adjoining_float(item.clear)`.
- **API change** (noted in CHANGELOG): `BlockContext::place_floated_box` takes an additional `adjoins_unresolved_strut: bool` parameter (external callers laying out inline content with floats, e.g. Blitz, need a one-line update).

Adds *generated tests* (HTML fixtures in `test_fixtures/float/`, expectations produced from Chrome by gentest), both failing on `main` and passing with this PR:

- `float_forced_clearance_adjoining_float` (reduced from WPT `css/CSS2/floats-clear/adjoining-float-before-clearance.html`): a 400px top margin on the cleared sibling must not move the adjoining float — forced clearance puts the element just below the float.
- `float_negative_clearance_adjoining_float` (reduced from WPT `negative-clearance-after-adjoining-float.html`): forced (negative) clearance on a self-collapsing cleared child, so the container's height ends at the float bottom.

Final code PR of the series splitting #992 into per-fix PRs; targets `main` directly.

Link to Devin session: https://app.devin.ai/sessions/b02d24a17f3a4881b9e794b4b67b6ca3
Requested by: @nicoburns