### PR TITLE
Add generated test for a new formatting context separating from an adjoining float

### DIFF
--- a/test_fixtures/float/float_new_fc_separates.html
+++ b/test_fixtures/float/float_new_fc_separates.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    A block establishing a new formatting context that does not fit beside a float is
+    pushed below it, and its top margin no longer collapses with preceding margins
+    (so the float, which adjoins the unresolved margin strut, does not move down).
+    Reduced from WPT css/CSS2/floats/new-fc-separates-from-float.html
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; overflow: hidden; width: 200px;">
+  <div style="display: block;">
+    <div style="display: block;">
+      <div style="display: block; float: left; width: 200px; height: 200px;"></div>
+    </div>
+    <div style="display: block; overflow: hidden; margin-top: 200px; width: 200px; height: 1px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/float/float_new_fc_separates__border_box_ltr.xml
+++ b/tests/xml/float/float_new_fc_separates__border_box_ltr.xml
@@ -1,0 +1,23 @@
+<test name="float_new_fc_separates__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" overflow-x="hidden" overflow-y="hidden" scrollbar-width="15" width="200px">
+      <div display="block" direction="ltr">
+        <div display="block" direction="ltr">
+          <div display="block" direction="ltr" float="left" width="200px" height="200px"/>
+        </div>
+        <div display="block" direction="ltr" overflow-x="hidden" overflow-y="hidden" scrollbar-width="15" width="200px" height="1px" margin-top="200px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="201" scroll_width="0" scroll_height="0">
+      <node x="0" y="0" width="200" height="201">
+        <node x="0" y="0" width="200" height="0">
+          <node x="0" y="0" width="200" height="200"/>
+        </node>
+        <node x="0" y="200" width="200" height="1" scroll_width="0" scroll_height="0"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_new_fc_separates__border_box_rtl.xml
+++ b/tests/xml/float/float_new_fc_separates__border_box_rtl.xml
@@ -1,0 +1,23 @@
+<test name="float_new_fc_separates__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" overflow-x="hidden" overflow-y="hidden" scrollbar-width="15" width="200px">
+      <div display="block" direction="rtl">
+        <div display="block" direction="rtl">
+          <div display="block" direction="rtl" float="left" width="200px" height="200px"/>
+        </div>
+        <div display="block" direction="rtl" overflow-x="hidden" overflow-y="hidden" scrollbar-width="15" width="200px" height="1px" margin-top="200px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="201" scroll_width="0" scroll_height="0">
+      <node x="0" y="0" width="200" height="201">
+        <node x="0" y="0" width="200" height="0">
+          <node x="0" y="0" width="200" height="200"/>
+        </node>
+        <node x="0" y="200" width="200" height="1" scroll_width="0" scroll_height="0"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_new_fc_separates__content_box_ltr.xml
+++ b/tests/xml/float/float_new_fc_separates__content_box_ltr.xml
@@ -1,0 +1,23 @@
+<test name="float_new_fc_separates__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" overflow-x="hidden" overflow-y="hidden" scrollbar-width="15" width="200px">
+      <div display="block" box-sizing="content-box" direction="ltr">
+        <div display="block" box-sizing="content-box" direction="ltr">
+          <div display="block" box-sizing="content-box" direction="ltr" float="left" width="200px" height="200px"/>
+        </div>
+        <div display="block" box-sizing="content-box" direction="ltr" overflow-x="hidden" overflow-y="hidden" scrollbar-width="15" width="200px" height="1px" margin-top="200px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="201" scroll_width="0" scroll_height="0">
+      <node x="0" y="0" width="200" height="201">
+        <node x="0" y="0" width="200" height="0">
+          <node x="0" y="0" width="200" height="200"/>
+        </node>
+        <node x="0" y="200" width="200" height="1" scroll_width="0" scroll_height="0"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_new_fc_separates__content_box_rtl.xml
+++ b/tests/xml/float/float_new_fc_separates__content_box_rtl.xml
@@ -1,0 +1,23 @@
+<test name="float_new_fc_separates__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" overflow-x="hidden" overflow-y="hidden" scrollbar-width="15" width="200px">
+      <div display="block" box-sizing="content-box" direction="rtl">
+        <div display="block" box-sizing="content-box" direction="rtl">
+          <div display="block" box-sizing="content-box" direction="rtl" float="left" width="200px" height="200px"/>
+        </div>
+        <div display="block" box-sizing="content-box" direction="rtl" overflow-x="hidden" overflow-y="hidden" scrollbar-width="15" width="200px" height="1px" margin-top="200px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="201" scroll_width="0" scroll_height="0">
+      <node x="0" y="0" width="200" height="201">
+        <node x="0" y="0" width="200" height="0">
+          <node x="0" y="0" width="200" height="200"/>
+        </node>
+        <node x="0" y="200" width="200" height="1" scroll_width="0" scroll_height="0"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -16820,6 +16820,26 @@ mod float {
     }
 
     #[test]
+    fn float_new_fc_separates__border_box_ltr() {
+        crate::run_xml_test("float", "float_new_fc_separates__border_box_ltr");
+    }
+
+    #[test]
+    fn float_new_fc_separates__content_box_ltr() {
+        crate::run_xml_test("float", "float_new_fc_separates__content_box_ltr");
+    }
+
+    #[test]
+    fn float_new_fc_separates__border_box_rtl() {
+        crate::run_xml_test("float", "float_new_fc_separates__border_box_rtl");
+    }
+
+    #[test]
+    fn float_new_fc_separates__content_box_rtl() {
+        crate::run_xml_test("float", "float_new_fc_separates__content_box_rtl");
+    }
+
+    #[test]
     fn float_simple__border_box_ltr() {
         crate::run_xml_test("float", "float_simple__border_box_ltr");
     }


### PR DESCRIPTION
# Objective

Adds a generated regression test `float_new_fc_separates` (HTML fixture in `test_fixtures/float/`, expectations produced from Chrome by gentest; reduced from WPT `css/CSS2/floats/new-fc-separates-from-float.html`): a block establishing a new formatting context that does not fit beside a float is pushed below it, and its top margin does not collapse with preceding margins — so the float (which occurs between collapsing margins) does not move down with the NFC's 200px top margin.

## Context

Originally 7/7 of the series splitting #992, implementing this behavior; the code changes were superseded by #991 (`find_bfc_slot` with segment skipping and `item_pushed_below_float` margin separation), which makes this test pass on `main` on its own. This PR now contains only the test and targets `main` independently (it does not depend on #1046).

Link to Devin session: https://app.devin.ai/sessions/b02d24a17f3a4881b9e794b4b67b6ca3
Requested by: @nicoburns