### PR TITLE
Include container's own padding in block/grid content_size (scrollable overflow)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### Fixed
 
+- Block/Grid: `Layout::content_size` now measures the scrollable overflow region from the container's padding-box origin (mirrored for RTL) and includes the container's own end-side padding, matching the existing Flexbox behaviour and browser `scrollWidth`/`scrollHeight` semantics. Previously Block and Grid measured relative to the content box and excluded the container's padding entirely, so `Layout::scroll_width()`/`scroll_height()` were too small by the padding sum (#1050)
+
+- Grid: items in tracks that overflow the container now contribute their position within the container to `Layout::content_size`, not just their own size. Previously each item's contribution was measured relative to its own grid area, so e.g. two stacked 500px-tall rows overflowing a 200px-tall scroll container produced a `content_size.height` of 500 rather than 1000
+
 - Grid: when the auto-placement search collides with an occupied area, the search cursor now jumps past the entire colliding occupied interval rather than just the part of it within the queried area. Previously a small item searching a grid occupied by large items advanced one track at a time, scanning up to 10000x10000 candidate positions
 
 - Block/float: a box that establishes an independent formatting context now avoids floats placed by the subtree of a preceding in-flow sibling, not just floats among its direct siblings. Previously the presence of active floats was only tracked for direct float children, so such a box could overlap a float placed by a nested descendant of an earlier sibling

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -509,6 +509,7 @@ fn compute_inner(
         container_percentage_resolution_height,
         content_box_inset,
         resolved_content_box_inset,
+        resolved_border,
         text_align,
         direction,
         own_margins_collapse_with_children,
@@ -555,9 +556,21 @@ fn compute_inner(
                 inflow_content_size = Size::ZERO;
                 for item in items.iter() {
                     if let Some(layout) = item.final_layout.as_ref() {
+                        let contribution_location = if direction.is_rtl() {
+                            Point {
+                                x: container_outer_width
+                                    - (layout.location.x + layout.size.width)
+                                    - resolved_border.right,
+                                y: layout.location.y - resolved_border.top,
+                            }
+                        } else {
+                            Point {
+                                x: layout.location.x - resolved_border.left,
+                                y: layout.location.y - resolved_border.top,
+                            }
+                        };
                         inflow_content_size = inflow_content_size.f32_max(compute_content_size_contribution(
-                            layout.location
-                                + Point { x: -resolved_content_box_inset.left, y: -resolved_content_box_inset.top },
+                            contribution_location,
                             layout.size,
                             layout.content_size,
                             item.overflow,
@@ -629,6 +642,10 @@ fn compute_inner(
 
     #[cfg(feature = "content_size")]
     {
+        // The container's own padding at the end of the content is part of its scrollable
+        // overflow region, so it is included in the in-flow content size.
+        inflow_content_size.width += if direction.is_rtl() { resolved_padding.left } else { resolved_padding.right };
+        inflow_content_size.height += resolved_padding.bottom;
         output.content_size = inflow_content_size.f32_max(absolute_content_size);
     }
 
@@ -797,6 +814,7 @@ fn perform_final_layout_on_in_flow_children(
     container_percentage_resolution_height: Option<f32>,
     content_box_inset: Rect<f32>,
     resolved_content_box_inset: Rect<f32>,
+    resolved_border: Rect<f32>,
     text_align: TextAlign,
     direction: Direction,
     own_margins_collapse_with_children: Line<bool>,
@@ -915,8 +933,16 @@ fn perform_final_layout_on_in_flow_children(
                 {
                     // TODO: Should content size of floated boxes count as "inflow_content_size"
                     // or should it be counted separately?
+                    let contribution_location = if direction.is_rtl() {
+                        Point {
+                            x: container_outer_width - (location.x + item_layout.size.width) - resolved_border.right,
+                            y: location.y - resolved_border.top,
+                        }
+                    } else {
+                        Point { x: location.x - resolved_border.left, y: location.y - resolved_border.top }
+                    };
                     inflow_content_size = inflow_content_size.f32_max(compute_content_size_contribution(
-                        location,
+                        contribution_location,
                         item_layout.size,
                         item_layout.content_size,
                         item.overflow,
@@ -1245,8 +1271,16 @@ fn perform_final_layout_on_in_flow_children(
 
             #[cfg(feature = "content_size")]
             {
+                let contribution_location = if direction.is_rtl() {
+                    Point {
+                        x: container_outer_width - (location.x + final_size.width) - resolved_border.right,
+                        y: location.y - resolved_border.top,
+                    }
+                } else {
+                    Point { x: location.x - resolved_border.left, y: location.y - resolved_border.top }
+                };
                 inflow_content_size = inflow_content_size.f32_max(compute_content_size_contribution(
-                    location + Point { x: -resolved_content_box_inset.left, y: -resolved_content_box_inset.top },
+                    contribution_location,
                     final_size,
                     item_layout.content_size,
                     item.overflow,

--- a/src/compute/grid/alignment.rs
+++ b/src/compute/grid/alignment.rs
@@ -67,6 +67,7 @@ pub(super) fn align_tracks(
 }
 
 /// Align and size a grid item into it's final position
+#[allow(clippy::too_many_arguments)]
 pub(super) fn align_and_position_item(
     tree: &mut impl LayoutGridContainer,
     node: NodeId,
@@ -75,6 +76,8 @@ pub(super) fn align_and_position_item(
     container_alignment_styles: InBothAbsAxis<Option<AlignItems>>,
     baseline_shim: f32,
     direction: Direction,
+    container_border_box_width: f32,
+    container_border: Rect<f32>,
 ) -> (Size<f32>, f32, f32) {
     let grid_area_size = Size { width: grid_area.right - grid_area.left, height: grid_area.bottom - grid_area.top };
 
@@ -282,12 +285,21 @@ pub(super) fn align_and_position_item(
     );
 
     #[cfg(feature = "content_size")]
-    let contribution = compute_content_size_contribution(
-        Point { x: x - grid_area.left, y: y - grid_area.top },
-        Size { width, height },
-        layout_output.content_size,
-        overflow,
-    );
+    let contribution = {
+        // Contributions to the container's content size are measured from the container's
+        // padding-box origin (mirrored for RTL), matching the scrollable overflow region.
+        let contribution_location = if direction.is_rtl() {
+            Point { x: container_border_box_width - (x + width) - container_border.right, y: y - container_border.top }
+        } else {
+            Point { x: x - container_border.left, y: y - container_border.top }
+        };
+        compute_content_size_contribution(
+            contribution_location,
+            Size { width, height },
+            layout_output.content_size,
+            overflow,
+        )
+    };
     #[cfg(not(feature = "content_size"))]
     let contribution = Size::ZERO;
 

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -587,6 +587,8 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
 
     #[cfg_attr(not(feature = "content_size"), allow(unused_mut))]
     let mut item_content_size_contribution = Size::ZERO;
+    #[cfg_attr(not(feature = "content_size"), allow(unused_mut, unused))]
+    let mut absolute_content_size = Size::ZERO;
 
     // Sort items back into original order to allow them to be matched up with styles
     items.sort_by_key(|item| item.source_order);
@@ -610,6 +612,8 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
             container_alignment_styles,
             item.baseline_shim,
             direction,
+            container_border_box.width,
+            border,
         );
         item.y_position = y_position;
         item.height = height;
@@ -701,11 +705,20 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
 
             // TODO: Baseline alignment support for absolutely positioned items (should check if is actually specified)
             #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
-            let (content_size_contribution, _, _) =
-                align_and_position_item(tree, child, order, grid_area, container_alignment_styles, 0.0, direction);
+            let (content_size_contribution, _, _) = align_and_position_item(
+                tree,
+                child,
+                order,
+                grid_area,
+                container_alignment_styles,
+                0.0,
+                direction,
+                container_border_box.width,
+                border,
+            );
             #[cfg(feature = "content_size")]
             {
-                item_content_size_contribution = item_content_size_contribution.f32_max(content_size_contribution);
+                absolute_content_size = absolute_content_size.f32_max(content_size_contribution);
             }
 
             order += 1;
@@ -751,9 +764,21 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
         item.y_position + item.baseline.unwrap_or(item.height)
     };
 
+    // The container's own padding at the end of the content is part of its scrollable
+    // overflow region, so it is included in the in-flow content size.
+    #[cfg(feature = "content_size")]
+    let content_size = {
+        let mut content_size = item_content_size_contribution;
+        content_size.width += if direction.is_rtl() { padding.left } else { padding.right };
+        content_size.height += padding.bottom;
+        content_size.f32_max(absolute_content_size)
+    };
+    #[cfg(not(feature = "content_size"))]
+    let content_size = item_content_size_contribution;
+
     LayoutOutput::from_sizes_and_baselines(
         container_border_box,
-        item_content_size_contribution,
+        content_size,
         Point { x: None, y: Some(grid_container_baseline) },
     )
 }

--- a/test_fixtures/block/block_overflow_scroll_container_padding.html
+++ b/test_fixtures/block/block_overflow_scroll_container_padding.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 300px; height: 200px; padding: 20px 10px; overflow: scroll;">
+  <div style="width: 100px; height: 1000px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/flex_overflow_scroll_container_padding.html
+++ b/test_fixtures/flex/flex_overflow_scroll_container_padding.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; width: 300px; height: 200px; padding: 20px 10px; overflow: scroll;">
+  <div style="width: 100px; height: 1000px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_overflow_scroll_container_padding.html
+++ b/test_fixtures/grid/grid_overflow_scroll_container_padding.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 300px; height: 200px; padding: 20px 10px; overflow: scroll;">
+  <div style="width: 100px; height: 1000px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/hand_written/scroll_size.rs
+++ b/tests/hand_written/scroll_size.rs
@@ -10,8 +10,9 @@ use taffy_test_helpers::new_test_tree;
 const CONTENT: f32 = 1000.0;
 const CONTAINER: f32 = 200.0;
 const BORDER: f32 = 20.0;
+const PADDING: f32 = 20.0;
 
-fn scroller(display: Display, border: Rect<LengthPercentage>) -> Layout {
+fn scroller_with_padding(display: Display, border: Rect<LengthPercentage>, padding: Rect<LengthPercentage>) -> Layout {
     let mut tree = new_test_tree();
     let child = tree
         .new_leaf(Style { size: Size { width: length(100.0), height: length(CONTENT) }, ..Default::default() })
@@ -23,6 +24,7 @@ fn scroller(display: Display, border: Rect<LengthPercentage>) -> Layout {
                 box_sizing: BoxSizing::BorderBox,
                 size: Size { width: length(300.0), height: length(CONTAINER) },
                 border,
+                padding,
                 overflow: Point { x: Overflow::Scroll, y: Overflow::Scroll },
                 ..Default::default()
             },
@@ -32,6 +34,10 @@ fn scroller(display: Display, border: Rect<LengthPercentage>) -> Layout {
 
     tree.compute_layout(node, Size::MAX_CONTENT).unwrap();
     *tree.layout(node).unwrap()
+}
+
+fn scroller(display: Display, border: Rect<LengthPercentage>) -> Layout {
+    scroller_with_padding(display, border, edge(0.0, 0.0))
 }
 
 fn edge(top: f32, bottom: f32) -> Rect<LengthPercentage> {
@@ -79,5 +85,68 @@ fn content_size_excludes_the_containers_own_border() {
 
             assert_eq!(layout.content_size.height, CONTENT, "{display:?} with border {top}/{bottom}");
         }
+    }
+}
+
+#[test]
+fn content_size_includes_the_containers_own_padding() {
+    for display in [Display::Block, Display::Flex, Display::Grid] {
+        for (top, bottom) in [(PADDING, 0.0), (0.0, PADDING), (PADDING, PADDING), (0.0, 0.0)] {
+            let layout = scroller_with_padding(display, edge(0.0, 0.0), edge(top, bottom));
+
+            assert_eq!(layout.content_size.height, CONTENT + top + bottom, "{display:?} with padding {top}/{bottom}");
+        }
+    }
+}
+
+#[test]
+fn scroll_height_accounts_for_the_containers_own_padding() {
+    for display in [Display::Block, Display::Flex, Display::Grid] {
+        for (top, bottom) in [(PADDING, 0.0), (0.0, PADDING), (PADDING, PADDING), (0.0, 0.0)] {
+            let layout = scroller_with_padding(display, edge(0.0, 0.0), edge(top, bottom));
+
+            // The scrollable overflow region runs from the padding-box origin to the end of
+            // the content plus the container's end-side padding.
+            let expected = (top + CONTENT + bottom) - CONTAINER;
+            assert_eq!(layout.scroll_height(), expected, "{display:?} with padding {top}/{bottom}");
+        }
+    }
+}
+
+/// Items in overflowing rows must contribute their position within the container (not just
+/// their size) to the container's content size.
+#[test]
+fn grid_content_size_includes_item_positions_in_overflowing_tracks() {
+    let mut tree = new_test_tree();
+    let child = || Style { size: Size { width: length(100.0), height: length(500.0) }, ..Default::default() };
+    let c1 = tree.new_leaf(child()).unwrap();
+    let c2 = tree.new_leaf(child()).unwrap();
+    let node = tree
+        .new_with_children(
+            Style {
+                display: Display::Grid,
+                size: Size { width: length(300.0), height: length(CONTAINER) },
+                overflow: Point { x: Overflow::Scroll, y: Overflow::Scroll },
+                ..Default::default()
+            },
+            &[c1, c2],
+        )
+        .unwrap();
+
+    tree.compute_layout(node, Size::MAX_CONTENT).unwrap();
+    let layout = tree.layout(node).unwrap();
+
+    assert_eq!(layout.content_size.height, 1000.0);
+    assert_eq!(layout.scroll_height(), 1000.0 - CONTAINER);
+}
+
+#[test]
+fn scroll_height_agrees_with_borders_and_padding_combined() {
+    for display in [Display::Block, Display::Flex, Display::Grid] {
+        let layout = scroller_with_padding(display, edge(BORDER, BORDER), edge(PADDING, PADDING));
+
+        let padding_box = CONTAINER - BORDER - BORDER;
+        let expected = (PADDING + CONTENT + PADDING) - padding_box;
+        assert_eq!(layout.scroll_height(), expected, "{display:?}");
     }
 }

--- a/tests/xml/block/block_overflow_scroll_container_padding__border_box_ltr.xml
+++ b/tests/xml/block/block_overflow_scroll_container_padding__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="block_overflow_scroll_container_padding__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" overflow-x="scroll" overflow-y="scroll" scrollbar-width="15" width="300px" height="200px" padding-top="20px" padding-left="10px" padding-bottom="20px" padding-right="10px">
+      <div direction="ltr" width="100px" height="1000px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="200" scroll_width="0" scroll_height="855">
+      <node x="10" y="20" width="100" height="1000"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_overflow_scroll_container_padding__border_box_rtl.xml
+++ b/tests/xml/block/block_overflow_scroll_container_padding__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="block_overflow_scroll_container_padding__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" overflow-x="scroll" overflow-y="scroll" scrollbar-width="15" width="300px" height="200px" padding-top="20px" padding-left="10px" padding-bottom="20px" padding-right="10px">
+      <div direction="rtl" width="100px" height="1000px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="200" scroll_width="0" scroll_height="855">
+      <node x="190" y="20" width="100" height="1000"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_overflow_scroll_container_padding__content_box_ltr.xml
+++ b/tests/xml/block/block_overflow_scroll_container_padding__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="block_overflow_scroll_container_padding__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" overflow-x="scroll" overflow-y="scroll" scrollbar-width="15" width="300px" height="200px" padding-top="20px" padding-left="10px" padding-bottom="20px" padding-right="10px">
+      <div box-sizing="content-box" direction="ltr" width="100px" height="1000px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="320" height="240" scroll_width="0" scroll_height="815">
+      <node x="10" y="20" width="100" height="1000"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_overflow_scroll_container_padding__content_box_rtl.xml
+++ b/tests/xml/block/block_overflow_scroll_container_padding__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="block_overflow_scroll_container_padding__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" overflow-x="scroll" overflow-y="scroll" scrollbar-width="15" width="300px" height="200px" padding-top="20px" padding-left="10px" padding-bottom="20px" padding-right="10px">
+      <div box-sizing="content-box" direction="rtl" width="100px" height="1000px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="320" height="240" scroll_width="0" scroll_height="815">
+      <node x="210" y="20" width="100" height="1000"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_overflow_scroll_container_padding__border_box_ltr.xml
+++ b/tests/xml/flex/flex_overflow_scroll_container_padding__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="flex_overflow_scroll_container_padding__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" overflow-x="scroll" overflow-y="scroll" scrollbar-width="15" width="300px" height="200px" padding-top="20px" padding-left="10px" padding-bottom="20px" padding-right="10px">
+      <div direction="ltr" width="100px" height="1000px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="200" scroll_width="0" scroll_height="855">
+      <node x="10" y="20" width="100" height="1000"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_overflow_scroll_container_padding__border_box_rtl.xml
+++ b/tests/xml/flex/flex_overflow_scroll_container_padding__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="flex_overflow_scroll_container_padding__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" overflow-x="scroll" overflow-y="scroll" scrollbar-width="15" width="300px" height="200px" padding-top="20px" padding-left="10px" padding-bottom="20px" padding-right="10px">
+      <div direction="rtl" width="100px" height="1000px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="200" scroll_width="0" scroll_height="855">
+      <node x="190" y="20" width="100" height="1000"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_overflow_scroll_container_padding__content_box_ltr.xml
+++ b/tests/xml/flex/flex_overflow_scroll_container_padding__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="flex_overflow_scroll_container_padding__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" overflow-x="scroll" overflow-y="scroll" scrollbar-width="15" width="300px" height="200px" padding-top="20px" padding-left="10px" padding-bottom="20px" padding-right="10px">
+      <div box-sizing="content-box" direction="ltr" width="100px" height="1000px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="320" height="240" scroll_width="0" scroll_height="815">
+      <node x="10" y="20" width="100" height="1000"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_overflow_scroll_container_padding__content_box_rtl.xml
+++ b/tests/xml/flex/flex_overflow_scroll_container_padding__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="flex_overflow_scroll_container_padding__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" overflow-x="scroll" overflow-y="scroll" scrollbar-width="15" width="300px" height="200px" padding-top="20px" padding-left="10px" padding-bottom="20px" padding-right="10px">
+      <div box-sizing="content-box" direction="rtl" width="100px" height="1000px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="320" height="240" scroll_width="0" scroll_height="815">
+      <node x="210" y="20" width="100" height="1000"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overflow_scroll_container_padding__border_box_ltr.xml
+++ b/tests/xml/grid/grid_overflow_scroll_container_padding__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_overflow_scroll_container_padding__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" overflow-x="scroll" overflow-y="scroll" scrollbar-width="15" width="300px" height="200px" padding-top="20px" padding-left="10px" padding-bottom="20px" padding-right="10px">
+      <div direction="ltr" width="100px" height="1000px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="200" scroll_width="0" scroll_height="855">
+      <node x="10" y="20" width="100" height="1000"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overflow_scroll_container_padding__border_box_rtl.xml
+++ b/tests/xml/grid/grid_overflow_scroll_container_padding__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_overflow_scroll_container_padding__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" overflow-x="scroll" overflow-y="scroll" scrollbar-width="15" width="300px" height="200px" padding-top="20px" padding-left="10px" padding-bottom="20px" padding-right="10px">
+      <div direction="rtl" width="100px" height="1000px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="200" scroll_width="0" scroll_height="855">
+      <node x="190" y="20" width="100" height="1000"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overflow_scroll_container_padding__content_box_ltr.xml
+++ b/tests/xml/grid/grid_overflow_scroll_container_padding__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_overflow_scroll_container_padding__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" overflow-x="scroll" overflow-y="scroll" scrollbar-width="15" width="300px" height="200px" padding-top="20px" padding-left="10px" padding-bottom="20px" padding-right="10px">
+      <div box-sizing="content-box" direction="ltr" width="100px" height="1000px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="320" height="240" scroll_width="0" scroll_height="815">
+      <node x="10" y="20" width="100" height="1000"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_overflow_scroll_container_padding__content_box_rtl.xml
+++ b/tests/xml/grid/grid_overflow_scroll_container_padding__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_overflow_scroll_container_padding__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" overflow-x="scroll" overflow-y="scroll" scrollbar-width="15" width="300px" height="200px" padding-top="20px" padding-left="10px" padding-bottom="20px" padding-right="10px">
+      <div box-sizing="content-box" direction="rtl" width="100px" height="1000px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="320" height="240" scroll_width="0" scroll_height="815">
+      <node x="210" y="20" width="100" height="1000"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -4138,6 +4138,26 @@ mod block {
     }
 
     #[test]
+    fn block_overflow_scroll_container_padding__border_box_ltr() {
+        crate::run_xml_test("block", "block_overflow_scroll_container_padding__border_box_ltr");
+    }
+
+    #[test]
+    fn block_overflow_scroll_container_padding__content_box_ltr() {
+        crate::run_xml_test("block", "block_overflow_scroll_container_padding__content_box_ltr");
+    }
+
+    #[test]
+    fn block_overflow_scroll_container_padding__border_box_rtl() {
+        crate::run_xml_test("block", "block_overflow_scroll_container_padding__border_box_rtl");
+    }
+
+    #[test]
+    fn block_overflow_scroll_container_padding__content_box_rtl() {
+        crate::run_xml_test("block", "block_overflow_scroll_container_padding__content_box_rtl");
+    }
+
+    #[test]
     fn block_overflow_scroll_direction_rtl__border_box_ltr() {
         crate::run_xml_test("block", "block_overflow_scroll_direction_rtl__border_box_ltr");
     }
@@ -10639,6 +10659,26 @@ mod flex {
     #[test]
     fn flex_nested_direction_rtl__content_box_rtl() {
         crate::run_xml_test("flex", "flex_nested_direction_rtl__content_box_rtl");
+    }
+
+    #[test]
+    fn flex_overflow_scroll_container_padding__border_box_ltr() {
+        crate::run_xml_test("flex", "flex_overflow_scroll_container_padding__border_box_ltr");
+    }
+
+    #[test]
+    fn flex_overflow_scroll_container_padding__content_box_ltr() {
+        crate::run_xml_test("flex", "flex_overflow_scroll_container_padding__content_box_ltr");
+    }
+
+    #[test]
+    fn flex_overflow_scroll_container_padding__border_box_rtl() {
+        crate::run_xml_test("flex", "flex_overflow_scroll_container_padding__border_box_rtl");
+    }
+
+    #[test]
+    fn flex_overflow_scroll_container_padding__content_box_rtl() {
+        crate::run_xml_test("flex", "flex_overflow_scroll_container_padding__content_box_rtl");
     }
 
     #[test]
@@ -27125,6 +27165,30 @@ mod grid {
     #[test]
     fn grid_overflow_rows__content_box_rtl() {
         crate::run_xml_test("grid", "grid_overflow_rows__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overflow_scroll_container_padding__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_overflow_scroll_container_padding__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overflow_scroll_container_padding__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_overflow_scroll_container_padding__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overflow_scroll_container_padding__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_overflow_scroll_container_padding__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_overflow_scroll_container_padding__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_overflow_scroll_container_padding__content_box_rtl");
     }
 
     #[cfg(feature = "grid")]


### PR DESCRIPTION
# Objective

Fixes #1050

`Layout::scroll_width()`/`scroll_height()` were too small by the container's padding sum for Block and Grid containers, because those algorithms measured `content_size` relative to the *content box* and excluded the container's own padding from the scrollable overflow region. Flexbox already measured from the padding-box origin and included the end-side padding — matching browser `scrollWidth`/`scrollHeight` semantics. Block and Grid now do the same.

New uniform meaning of `Layout::content_size` (previously Flexbox-only): the size of the scrollable overflow region measured from the padding-box origin (mirrored for RTL) — start-side padding offsets the children, end-side padding is included after them.

Pseudo-diff of the contribution location (per in-flow child, LTR):

```diff
- location - content_box_inset.{left,top}   // content-box relative (block)
- location - grid_area.{left,top}           // item's own grid area (grid!)
+ location - border.{left,top}              // padding-box relative, like flexbox
```

plus `content_size += padding.{right,bottom}` (`.left` for RTL) after the in-flow union, before maxing with absolutely-positioned children's contributions (same order as Flexbox).

This also fixes a second, more severe Grid bug found along the way: each grid item's contribution was measured relative to *its own grid area*, so items in overflowing tracks contributed only their size, not their position — e.g. two stacked 500px rows overflowing a 200px scroll container produced `content_size.height = 500` instead of 1000.

## Context

- Verified against Chrome (headless, same setup): `scrollHeight` includes both start and end padding for block, flex, and grid; the padded-scroller fixture in this PR records `scroll_height="855"` = (20+1000+20) − (200−15 scrollbar) from real Chrome.
- Note the issue's expected value (820) is slightly wrong — it omits the end-side padding; the browser-correct value is 840 (855 with a 15px scrollbar).
- #871 / #1007 fixed the border asymmetry in the same formula but did not address padding.
- New generated test fixtures (`*_overflow_scroll_container_padding`) record the browser scroll sizes; the follow-up PR re-enables `scroll_width`/`scroll_height` assertions in the XML test runner so these are actually checked.
- Hand-written tests in `tests/hand_written/scroll_size.rs` cover the padding cases and the grid overflowing-tracks case directly against `content_size`/`scroll_height()`.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/d723d44c40e7415397afd7599ba5fc1e
Requested by: @nicoburns