### PR TITLE
gentest: ensure document is fully loaded before measuring fixtures

### DIFF
--- a/scripts/gentest/src/main.rs
+++ b/scripts/gentest/src/main.rs
@@ -515,7 +515,19 @@ async fn test_root_element(
         .map_err(|_| format!("timed out loading the test fixture {name} ({})", fixture_path.display()))?
         .map_err(|err| format!("could not load the test fixture {name}: {err}"))?;
 
-    // Navigation can occasionally return before the document is fully loaded, so retry a few times
+    // Navigation can occasionally return before the document is fully loaded, in which case the
+    // test helper script and stylesheet may not have been applied yet. Wait for the load event
+    // (after which stylesheets are guaranteed to be applied) before reading anything back.
+    const AWAIT_LOAD: &str = "
+        const done = arguments[arguments.length - 1];
+        if (document.readyState === 'complete') { done(); } else { addEventListener('load', done); }
+    ";
+    timeout(TIMEOUT, client.execute_async(AWAIT_LOAD, vec![]))
+        .await
+        .map_err(|_| format!("timed out waiting for the test fixture {name} to finish loading"))?
+        .map_err(|err| format!("could not wait for the test fixture {name} to finish loading: {err}"))?;
+
+    // Retry a few times as a backstop in case anything is still not ready
     let mut attempts = 0;
     let description = loop {
         let result = timeout(TIMEOUT, client.execute("return getTestData()", vec![]))

--- a/scripts/gentest/test_helper.js
+++ b/scripts/gentest/test_helper.js
@@ -334,7 +334,26 @@ function describeElement(e) {
   };
 }
 
+// Check that the test base stylesheet has loaded and is applied. This can be false when the
+// document is not fully loaded yet, in which case the styles that implement the body classes
+// set below would be missing and every variant would be measured as border-box/ltr.
+function assertStylesheetApplied() {
+  const previousClassName = document.body.className;
+  document.body.className = "content-box rtl";
+  const probe = document.createElement("div");
+  document.body.appendChild(probe);
+  const style = getComputedStyle(probe);
+  const applied = style.direction === "rtl" && style.boxSizing === "content-box";
+  probe.remove();
+  document.body.className = previousClassName;
+  if (!applied) {
+    throw new Error(`the test base stylesheet is not applied (document readyState: ${document.readyState})`);
+  }
+}
+
 function getTestData() {
+  assertStylesheetApplied();
+
   document.body.className = "border-box ltr";
   const borderBoxLtrData = describeElement(document.getElementById('test-root'));
   document.body.className = "content-box ltr";


### PR DESCRIPTION
# Objective

Fix the intermittent "Generated Test Freshness" CI flake where a fixture's variants are occasionally regenerated with the wrong direction/box-sizing (e.g. run 31195628006 job 92923011154 on #991, where `align_self_flex_end_override_flex_start__*_rtl` was regenerated with `direction="ltr"` and the content-box variants lost their `box-sizing` attributes).

## Context

Root cause: the ltr/rtl and border-box/content-box variants are produced by `getTestData()` setting classes on `<body>` (`.rtl *`, `.content-box *`, etc.) whose rules live in the external `test_base_style.css`. Navigation can return before the document has fully loaded, and the existing retry in `test_root_element` only retries when `getTestData()` *errors* — i.e. when `test_helper.js` hasn't loaded yet. If the script has loaded but the stylesheet hasn't been applied yet, `getTestData()` succeeds and silently measures every variant as border-box/ltr, exactly matching the observed bad diffs.

Fix, in two layers:

1. After navigating to a fixture, gentest now explicitly waits for the window `load` event (after which stylesheets are guaranteed to be applied) via `execute_async`, bounded by the existing script timeout:

```rust
const AWAIT_LOAD: &str = "
    const done = arguments[arguments.length - 1];
    if (document.readyState === 'complete') { done(); } else { addEventListener('load', done); }
";
timeout(TIMEOUT, client.execute_async(AWAIT_LOAD, vec![])).await??;
```

2. As a backstop, `getTestData()` verifies that the variant classes actually take effect (a probe element under `body.content-box.rtl` must compute `direction: rtl` and `box-sizing: content-box`) and throws otherwise — covering the case where a stylesheet fails to load rather than loads slowly — which the existing retry loop handles, and which fails the run loudly instead of silently writing wrong expectations.

The probe uses a fresh child of `<body>` rather than `#test-root` because fixtures may set `direction`/`box-sizing` inline on the test root, which would defeat the class-based check (an earlier version of the check that inspected `#test-root` false-positived on `grid_min_height_with_padding_border_box_sizing`, whose fixture forces `box-sizing` inline).

Verified locally: 6 consecutive full gentest runs across both commits produce zero diffs against the committed `tests/xml`.

Link to Devin session: https://app.devin.ai/sessions/6761102d6b234b70bd2f87c249d4baa8
Requested by: @nicoburns