### PR TITLE
Fix intrinsic width contribution of floats under definite available space

### DIFF
--- a/src/compute/float.rs
+++ b/src/compute/float.rs
@@ -638,27 +638,36 @@ pub struct FloatIntrinsicWidthCalculator {
     available_width: AvailableSpace,
     /// The running total intrinsic width contribution
     contribution: f32,
+    /// The widest single float (the floats' min-content contribution)
+    widest: f32,
 }
 
 impl FloatIntrinsicWidthCalculator {
     /// Create a new `FloatIntrinsicWidthCalculator`
     pub fn new(available_width: AvailableSpace) -> Self {
-        Self { available_width, contribution: 0.0 }
+        Self { available_width, contribution: 0.0, widest: 0.0 }
     }
 
     /// Add a float to the computation
     pub fn add_float(&mut self, width: f32, _direction: FloatDirection, _clear: Clear) {
         match self.available_width {
-            AvailableSpace::Definite(_) => {
-                // We will never hit this code path with definite available space
-            }
+            // Definite available width means the container is being fit-content sized
+            // (e.g. it is itself a float being shrink-to-fit sized). The floats' max-content
+            // contribution (widths summed) is clamped by the available width in `result`.
+            AvailableSpace::Definite(_) | AvailableSpace::MaxContent => self.contribution += width,
             AvailableSpace::MinContent => self.contribution = self.contribution.max(width),
-            AvailableSpace::MaxContent => self.contribution += width,
         };
+        self.widest = self.widest.max(width);
     }
 
     /// Get the computed float contribution to intrinsic width
     pub fn result(&self) -> f32 {
-        self.contribution
+        match self.available_width {
+            // Fit-content sizing: clamp the max-content contribution between the available
+            // width and the min-content contribution (floats narrow by wrapping onto new
+            // bands, but never below the widest single float).
+            AvailableSpace::Definite(available_width) => self.contribution.min(available_width).max(self.widest),
+            _ => self.contribution,
+        }
     }
 }

--- a/test_fixtures/float/float_shrink_to_fit_contains_floats.html
+++ b/test_fixtures/float/float_shrink_to_fit_contains_floats.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 400px; height: 200px;">
+  <div style="display: block; float: left;">
+    <div style="display: block; float: left; width: 15px; height: 10px; border: 1px solid red;"></div>
+    <div style="display: block; float: left; width: 15px; height: 10px; border: 1px solid red;"></div>
+    <div style="display: block; float: left; width: 15px; height: 10px; border: 1px solid red;"></div>
+  </div>
+  <div style="display: block; clear: both;"></div>
+  <div style="display: block; float: left;">
+    <div style="display: block; float: left; width: 120px; height: 10px; border: 1px solid red;"></div>
+    <div style="display: block; float: left; width: 120px; height: 10px; border: 1px solid red;"></div>
+    <div style="display: block; float: left; width: 120px; height: 10px; border: 1px solid red;"></div>
+    <div style="display: block; float: left; width: 120px; height: 10px; border: 1px solid red;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/float/float_shrink_to_fit_contains_floats__border_box_ltr.xml
+++ b/tests/xml/float/float_shrink_to_fit_contains_floats__border_box_ltr.xml
@@ -1,0 +1,35 @@
+<test name="float_shrink_to_fit_contains_floats__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="400px" height="200px">
+      <div display="block" direction="ltr" float="left">
+        <div display="block" direction="ltr" float="left" width="15px" height="10px" border-top="1px" border-left="1px" border-bottom="1px" border-right="1px"/>
+        <div display="block" direction="ltr" float="left" width="15px" height="10px" border-top="1px" border-left="1px" border-bottom="1px" border-right="1px"/>
+        <div display="block" direction="ltr" float="left" width="15px" height="10px" border-top="1px" border-left="1px" border-bottom="1px" border-right="1px"/>
+      </div>
+      <div display="block" direction="ltr" clear="both"/>
+      <div display="block" direction="ltr" float="left">
+        <div display="block" direction="ltr" float="left" width="120px" height="10px" border-top="1px" border-left="1px" border-bottom="1px" border-right="1px"/>
+        <div display="block" direction="ltr" float="left" width="120px" height="10px" border-top="1px" border-left="1px" border-bottom="1px" border-right="1px"/>
+        <div display="block" direction="ltr" float="left" width="120px" height="10px" border-top="1px" border-left="1px" border-bottom="1px" border-right="1px"/>
+        <div display="block" direction="ltr" float="left" width="120px" height="10px" border-top="1px" border-left="1px" border-bottom="1px" border-right="1px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="200">
+      <node x="0" y="0" width="45" height="10">
+        <node x="0" y="0" width="15" height="10"/>
+        <node x="15" y="0" width="15" height="10"/>
+        <node x="30" y="0" width="15" height="10"/>
+      </node>
+      <node x="0" y="10" width="400" height="0"/>
+      <node x="0" y="10" width="400" height="20">
+        <node x="0" y="0" width="120" height="10"/>
+        <node x="120" y="0" width="120" height="10"/>
+        <node x="240" y="0" width="120" height="10"/>
+        <node x="0" y="10" width="120" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_shrink_to_fit_contains_floats__border_box_rtl.xml
+++ b/tests/xml/float/float_shrink_to_fit_contains_floats__border_box_rtl.xml
@@ -1,0 +1,35 @@
+<test name="float_shrink_to_fit_contains_floats__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="400px" height="200px">
+      <div display="block" direction="rtl" float="left">
+        <div display="block" direction="rtl" float="left" width="15px" height="10px" border-top="1px" border-left="1px" border-bottom="1px" border-right="1px"/>
+        <div display="block" direction="rtl" float="left" width="15px" height="10px" border-top="1px" border-left="1px" border-bottom="1px" border-right="1px"/>
+        <div display="block" direction="rtl" float="left" width="15px" height="10px" border-top="1px" border-left="1px" border-bottom="1px" border-right="1px"/>
+      </div>
+      <div display="block" direction="rtl" clear="both"/>
+      <div display="block" direction="rtl" float="left">
+        <div display="block" direction="rtl" float="left" width="120px" height="10px" border-top="1px" border-left="1px" border-bottom="1px" border-right="1px"/>
+        <div display="block" direction="rtl" float="left" width="120px" height="10px" border-top="1px" border-left="1px" border-bottom="1px" border-right="1px"/>
+        <div display="block" direction="rtl" float="left" width="120px" height="10px" border-top="1px" border-left="1px" border-bottom="1px" border-right="1px"/>
+        <div display="block" direction="rtl" float="left" width="120px" height="10px" border-top="1px" border-left="1px" border-bottom="1px" border-right="1px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="200">
+      <node x="0" y="0" width="45" height="10">
+        <node x="0" y="0" width="15" height="10"/>
+        <node x="15" y="0" width="15" height="10"/>
+        <node x="30" y="0" width="15" height="10"/>
+      </node>
+      <node x="0" y="10" width="400" height="0"/>
+      <node x="0" y="10" width="400" height="20">
+        <node x="0" y="0" width="120" height="10"/>
+        <node x="120" y="0" width="120" height="10"/>
+        <node x="240" y="0" width="120" height="10"/>
+        <node x="0" y="10" width="120" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_shrink_to_fit_contains_floats__content_box_ltr.xml
+++ b/tests/xml/float/float_shrink_to_fit_contains_floats__content_box_ltr.xml
@@ -1,0 +1,35 @@
+<test name="float_shrink_to_fit_contains_floats__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="400px" height="200px">
+      <div display="block" box-sizing="content-box" direction="ltr" float="left">
+        <div display="block" box-sizing="content-box" direction="ltr" float="left" width="15px" height="10px" border-top="1px" border-left="1px" border-bottom="1px" border-right="1px"/>
+        <div display="block" box-sizing="content-box" direction="ltr" float="left" width="15px" height="10px" border-top="1px" border-left="1px" border-bottom="1px" border-right="1px"/>
+        <div display="block" box-sizing="content-box" direction="ltr" float="left" width="15px" height="10px" border-top="1px" border-left="1px" border-bottom="1px" border-right="1px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="ltr" clear="both"/>
+      <div display="block" box-sizing="content-box" direction="ltr" float="left">
+        <div display="block" box-sizing="content-box" direction="ltr" float="left" width="120px" height="10px" border-top="1px" border-left="1px" border-bottom="1px" border-right="1px"/>
+        <div display="block" box-sizing="content-box" direction="ltr" float="left" width="120px" height="10px" border-top="1px" border-left="1px" border-bottom="1px" border-right="1px"/>
+        <div display="block" box-sizing="content-box" direction="ltr" float="left" width="120px" height="10px" border-top="1px" border-left="1px" border-bottom="1px" border-right="1px"/>
+        <div display="block" box-sizing="content-box" direction="ltr" float="left" width="120px" height="10px" border-top="1px" border-left="1px" border-bottom="1px" border-right="1px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="200">
+      <node x="0" y="0" width="51" height="12">
+        <node x="0" y="0" width="17" height="12"/>
+        <node x="17" y="0" width="17" height="12"/>
+        <node x="34" y="0" width="17" height="12"/>
+      </node>
+      <node x="0" y="12" width="400" height="0"/>
+      <node x="0" y="12" width="400" height="24">
+        <node x="0" y="0" width="122" height="12"/>
+        <node x="122" y="0" width="122" height="12"/>
+        <node x="244" y="0" width="122" height="12"/>
+        <node x="0" y="12" width="122" height="12"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_shrink_to_fit_contains_floats__content_box_rtl.xml
+++ b/tests/xml/float/float_shrink_to_fit_contains_floats__content_box_rtl.xml
@@ -1,0 +1,35 @@
+<test name="float_shrink_to_fit_contains_floats__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="400px" height="200px">
+      <div display="block" box-sizing="content-box" direction="rtl" float="left">
+        <div display="block" box-sizing="content-box" direction="rtl" float="left" width="15px" height="10px" border-top="1px" border-left="1px" border-bottom="1px" border-right="1px"/>
+        <div display="block" box-sizing="content-box" direction="rtl" float="left" width="15px" height="10px" border-top="1px" border-left="1px" border-bottom="1px" border-right="1px"/>
+        <div display="block" box-sizing="content-box" direction="rtl" float="left" width="15px" height="10px" border-top="1px" border-left="1px" border-bottom="1px" border-right="1px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="rtl" clear="both"/>
+      <div display="block" box-sizing="content-box" direction="rtl" float="left">
+        <div display="block" box-sizing="content-box" direction="rtl" float="left" width="120px" height="10px" border-top="1px" border-left="1px" border-bottom="1px" border-right="1px"/>
+        <div display="block" box-sizing="content-box" direction="rtl" float="left" width="120px" height="10px" border-top="1px" border-left="1px" border-bottom="1px" border-right="1px"/>
+        <div display="block" box-sizing="content-box" direction="rtl" float="left" width="120px" height="10px" border-top="1px" border-left="1px" border-bottom="1px" border-right="1px"/>
+        <div display="block" box-sizing="content-box" direction="rtl" float="left" width="120px" height="10px" border-top="1px" border-left="1px" border-bottom="1px" border-right="1px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="200">
+      <node x="0" y="0" width="51" height="12">
+        <node x="0" y="0" width="17" height="12"/>
+        <node x="17" y="0" width="17" height="12"/>
+        <node x="34" y="0" width="17" height="12"/>
+      </node>
+      <node x="0" y="12" width="400" height="0"/>
+      <node x="0" y="12" width="400" height="24">
+        <node x="0" y="0" width="122" height="12"/>
+        <node x="122" y="0" width="122" height="12"/>
+        <node x="244" y="0" width="122" height="12"/>
+        <node x="0" y="12" width="122" height="12"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -16880,6 +16880,26 @@ mod float {
     }
 
     #[test]
+    fn float_shrink_to_fit_contains_floats__border_box_ltr() {
+        crate::run_xml_test("float", "float_shrink_to_fit_contains_floats__border_box_ltr");
+    }
+
+    #[test]
+    fn float_shrink_to_fit_contains_floats__content_box_ltr() {
+        crate::run_xml_test("float", "float_shrink_to_fit_contains_floats__content_box_ltr");
+    }
+
+    #[test]
+    fn float_shrink_to_fit_contains_floats__border_box_rtl() {
+        crate::run_xml_test("float", "float_shrink_to_fit_contains_floats__border_box_rtl");
+    }
+
+    #[test]
+    fn float_shrink_to_fit_contains_floats__content_box_rtl() {
+        crate::run_xml_test("float", "float_shrink_to_fit_contains_floats__content_box_rtl");
+    }
+
+    #[test]
     fn float_simple__border_box_ltr() {
         crate::run_xml_test("float", "float_simple__border_box_ltr");
     }


### PR DESCRIPTION
# Objective

Fix a regression (found via Blitz WPT tests `css/css-flexbox/flexbox-flex-basis-content-003a/b.html`, which regressed in DioxusLabs/blitz#625) where a shrink-to-fit (fit-content) sized block whose children are floats resolved to zero content width, collapsing to just its padding/border.

## Context

Since #994, floats are laid out with a *definite* available width (shrink-to-fit sizing):

```rust
// block.rs: perform_final_layout_on_in_flow_children
Size { width: AvailableSpace::Definite(available_width), height: AvailableSpace::MaxContent }
```

When such a float has `width: auto` and itself contains floats, `determine_content_based_container_width` is now invoked with `AvailableSpace::Definite(..)`, and `FloatIntrinsicWidthCalculator::add_float` dropped all float contributions in that case:

```rust
AvailableSpace::Definite(_) => {
    // We will never hit this code path with definite available space
}
```

That assumption was true before #994 (floats used to be laid out with `Size::MAX_CONTENT`) but no longer holds, so the container's width collapsed to 0 + padding/border.

This PR implements fit-content semantics for the definite case:

```rust
// add_float
Definite(_) | MaxContent => contribution += width,
MinContent => contribution = contribution.max(width),

// result
Definite(available) => contribution.min(available).max(widest_single_float),
```

i.e. the floats' max-content contribution (widths summed), clamped between the available width and the widest single float (floats can narrow by wrapping onto new bands, but never below the widest float).

Verified against Chrome via a new generated test (`test_fixtures/float/float_shrink_to_fit_contains_floats.html`, checked expectations match Chrome's layout), and against Blitz's WPT runner with this taffy patched in: both regressed `flexbox-flex-basis-content-003a/b` tests pass again, and `css/css-flexbox` + `css/CSS2/floats{,-clear}` show net improvements (+2 and +3 tests respectively) with no regressions relative to taffy `main` (9abaf40e).


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/7a0e4686a5ef441aa99d94ea528d68d5
Requested by: @nicoburns