### PR TITLE
BFC roots avoid floats across their entire height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,11 @@
   })?;
   ```
 
+- Block/float: `FloatContext::find_bfc_slot` and `BlockContext::find_bfc_slot` take an additional `height: Option<f32>` parameter. When provided, the returned slot accounts for the floats beside all segments that a box of that height would span, not just the segment at the box's top edge
+
 ### Fixed
+
+- Block/float: a box that establishes an independent formatting context now avoids floats across its entire height, not just at its top edge. The box is laid out, and if floats lower down intrude on the space it occupies, its position/width are re-resolved using its actual height (up to 4 attempts)
 
 - `TaffyTree::remove` now marks the removed node's former parent as dirty, like `remove_child`, `remove_child_at_index` and `remove_children_range` already did. Previously the parent and its ancestors kept their stale cached layout, so recomputing the layout of an ancestor did not account for the removed node (#998)
 

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -189,6 +189,7 @@ impl BlockContext<'_> {
         direction: Direction,
         clear: Clear,
         after: Option<usize>,
+        height: Option<f32>,
     ) -> BfcSlot {
         let mut slot = self.bfc.float_context.find_bfc_slot(
             min_y + self.y_offset,
@@ -197,6 +198,7 @@ impl BlockContext<'_> {
             direction,
             clear,
             after,
+            height,
         );
         slot.y -= self.y_offset;
         slot.x -= self.insets[0];
@@ -1068,105 +1070,11 @@ fn perform_final_layout_on_in_flow_children(
 
             // Handle non-floated boxes
 
-            let mut y_margin_offset: f32 = 0.0;
+            let mut y_margin_offset: f32;
             #[cfg(feature = "float_layout")]
-            let mut item_avoids_floats = false;
+            let mut item_avoids_floats: bool;
             #[cfg(feature = "float_layout")]
-            let mut item_pushed_below_float = false;
-
-            let (stretch_width, float_avoiding_position, float_avoiding_width) = if item.is_in_same_bfc {
-                let stretch_width = container_inner_width - item_non_auto_x_margin_sum;
-                let position = Point { x: 0.0, y: 0.0 };
-                let width = 0.0;
-
-                (stretch_width, position, width)
-            } else {
-                'block: {
-                    // Set y_margin_offset (different bfc child)
-                    if !is_collapsing_with_first_margin_set || !own_margins_collapse_with_children.start {
-                        y_margin_offset =
-                            active_collapsible_margin_set.collapse_with_margin(item_non_auto_margin.top).resolve();
-                    };
-                    let min_y = committed_y_offset + y_margin_offset;
-
-                    // In addition to the running flag, check the float context directly:
-                    // floats placed by the subtree of a preceding in-flow sibling (in the same
-                    // BFC) are not reflected in the flag
-                    #[cfg(feature = "float_layout")]
-                    if has_active_floats || block_ctx.has_active_floats(min_y) {
-                        let x_margins = [item_non_auto_margin.left, item_non_auto_margin.right];
-                        // An auto width resolves to at least the negation of the margin sum
-                        // (so that the margin box width is non-negative, per CSS2 §10.3.3)
-                        let min_auto_width = -item_non_auto_x_margin_sum;
-
-                        // Find the highest slot (at or below `min_y`) with enough horizontal space
-                        // for the item's border box, which must not overlap any float
-                        let mut slot_segment = None;
-                        let slot = loop {
-                            let slot = block_ctx.find_bfc_slot(min_y, x_margins, direction, item.clear, slot_segment);
-                            let Some(segment_id) = slot.segment_id else { break slot };
-                            let width = item
-                                .size
-                                .width
-                                .unwrap_or(slot.stretch_width.max(min_auto_width))
-                                .maybe_clamp(item.min_size.width, item.max_size.width);
-                            if width <= slot.border_width + 0.001 {
-                                break slot;
-                            }
-                            slot_segment = Some(segment_id);
-                        };
-
-                        // If the item had to move down to avoid floats then it "separates from the
-                        // float": similarly to clearance, its top margin no longer collapses with
-                        // the parent's margins.
-                        if slot.y > min_y {
-                            item_pushed_below_float = true;
-                        }
-
-                        has_active_floats = slot.segment_id.is_some();
-                        item_avoids_floats = true;
-                        let stretch_width = slot.stretch_width.max(min_auto_width);
-                        break 'block (stretch_width, Point { x: slot.x, y: slot.y }, slot.border_width);
-                    }
-
-                    if !has_active_floats {
-                        let stretch_width = container_inner_width - item_non_auto_x_margin_sum;
-                        break 'block (
-                            stretch_width,
-                            Point { x: resolved_content_box_inset.left, y: min_y },
-                            container_inner_width,
-                        );
-                    }
-
-                    unreachable!("One of the above cases will always be hit");
-                }
-            };
-
-            // Tables and replaced elements are not stretch-sized: they resolve their own
-            // size (for replaced elements an auto width resolves to the intrinsic size
-            // <https://www.w3.org/TR/CSS22/visudet.html#block-replaced-width>)
-            let known_dimensions = if item.is_table || item.is_replaced {
-                Size::NONE
-            } else {
-                item.size
-                    .map_width(|width| {
-                        Some(width.unwrap_or(stretch_width).maybe_clamp(item.min_size.width, item.max_size.width))
-                    })
-                    .maybe_clamp(item.min_size, item.max_size)
-            };
-
-            //
-
-            let inputs = LayoutInput {
-                run_mode,
-                sizing_mode: SizingMode::InherentSize,
-                axis: RequestedAxis::Both,
-                known_dimensions,
-                known_dimensions_are_definite: Size { width: true, height: true },
-                parent_size,
-                available_space: available_space.map_width(|_| AvailableSpace::Definite(stretch_width)),
-                vertical_margins_are_collapsible: if item.is_in_same_bfc { Line::TRUE } else { Line::FALSE },
-            };
+            let mut item_pushed_below_float: bool;
 
             #[cfg(feature = "float_layout")]
             let clear_threshold = block_ctx.cleared_threshold(item.clear);
@@ -1175,35 +1083,167 @@ fn perform_final_layout_on_in_flow_children(
             #[cfg(not(feature = "float_layout"))]
             let clear_pos = f32::NEG_INFINITY;
 
-            let item_layout = if item.is_in_same_bfc {
-                // Replaced elements may not have a known width (they are sized by their
-                // measure function rather than stretch-sized)
-                let width = known_dimensions.width.unwrap_or(stretch_width);
+            // A box that establishes an independent formatting context must not overlap floats
+            // across its entire height, but its height is only known after it has been laid out.
+            // So the slot it is laid out into is found using the height from the previous layout
+            // attempt (initially none), retrying while the slot changes given the actual height.
+            #[cfg(feature = "float_layout")]
+            let mut item_height_hint: Option<f32> = None;
+            #[cfg(feature = "float_layout")]
+            let mut remaining_attempts: u8 = 4;
 
-                // TODO: account for auto margins
-                let inset_left = item_non_auto_margin.left + content_box_inset.left;
-                let inset_right = container_outer_width - width - inset_left;
-                let insets = [inset_left, inset_right];
-
-                // Compute child layout
-                let mut child_block_ctx =
-                    block_ctx.sub_context((y_offset_for_absolute + item_non_auto_margin.top).max(clear_pos), insets);
-                let output = tree.compute_block_child_layout(item.node_id, inputs, Some(&mut child_block_ctx));
-
-                // Extract float contribution from child block context
+            let (stretch_width, float_avoiding_position, float_avoiding_width, item_layout) = loop {
                 #[cfg(feature = "float_layout")]
                 {
-                    let child_contribution = child_block_ctx.floated_content_height_contribution();
-                    let child_top_adjoining_floats = child_block_ctx.top_adjoining_floats();
-                    block_ctx.add_child_floated_content_height_contribution(y_offset_for_absolute + child_contribution);
-                    // Floats placed while the position of the child's top margin strut was unresolved
-                    // also adjoin this block's current strut
-                    block_ctx.merge_adjoining_floats(child_top_adjoining_floats);
+                    item_avoids_floats = false;
+                    item_pushed_below_float = false;
+                }
+                y_margin_offset = 0.0;
+
+                let (stretch_width, float_avoiding_position, float_avoiding_width) = if item.is_in_same_bfc {
+                    let stretch_width = container_inner_width - item_non_auto_x_margin_sum;
+                    let position = Point { x: 0.0, y: 0.0 };
+                    let width = 0.0;
+
+                    (stretch_width, position, width)
+                } else {
+                    'block: {
+                        // Set y_margin_offset (different bfc child)
+                        if !is_collapsing_with_first_margin_set || !own_margins_collapse_with_children.start {
+                            y_margin_offset =
+                                active_collapsible_margin_set.collapse_with_margin(item_non_auto_margin.top).resolve();
+                        };
+                        let min_y = committed_y_offset + y_margin_offset;
+
+                        // In addition to the running flag, check the float context directly:
+                        // floats placed by the subtree of a preceding in-flow sibling (in the same
+                        // BFC) are not reflected in the flag
+                        #[cfg(feature = "float_layout")]
+                        if has_active_floats || block_ctx.has_active_floats(min_y) {
+                            let x_margins = [item_non_auto_margin.left, item_non_auto_margin.right];
+                            // An auto width resolves to at least the negation of the margin sum
+                            // (so that the margin box width is non-negative, per CSS2 §10.3.3)
+                            let min_auto_width = -item_non_auto_x_margin_sum;
+
+                            // Find the highest slot (at or below `min_y`) with enough horizontal space
+                            // for the item's border box, which must not overlap any float
+                            let mut slot_segment = None;
+                            let slot = loop {
+                                let slot = block_ctx.find_bfc_slot(
+                                    min_y,
+                                    x_margins,
+                                    direction,
+                                    item.clear,
+                                    slot_segment,
+                                    item_height_hint,
+                                );
+                                let Some(segment_id) = slot.segment_id else { break slot };
+                                let width = item
+                                    .size
+                                    .width
+                                    .unwrap_or(slot.stretch_width.max(min_auto_width))
+                                    .maybe_clamp(item.min_size.width, item.max_size.width);
+                                if width <= slot.border_width + 0.001 {
+                                    break slot;
+                                }
+                                slot_segment = Some(segment_id);
+                            };
+
+                            // If the item had to move down to avoid floats then it "separates from the
+                            // float": similarly to clearance, its top margin no longer collapses with
+                            // the parent's margins.
+                            if slot.y > min_y {
+                                item_pushed_below_float = true;
+                            }
+
+                            has_active_floats = slot.segment_id.is_some();
+                            item_avoids_floats = true;
+                            let stretch_width = slot.stretch_width.max(min_auto_width);
+                            break 'block (stretch_width, Point { x: slot.x, y: slot.y }, slot.border_width);
+                        }
+
+                        if !has_active_floats {
+                            let stretch_width = container_inner_width - item_non_auto_x_margin_sum;
+                            break 'block (
+                                stretch_width,
+                                Point { x: resolved_content_box_inset.left, y: min_y },
+                                container_inner_width,
+                            );
+                        }
+
+                        unreachable!("One of the above cases will always be hit");
+                    }
+                };
+
+                // Tables and replaced elements are not stretch-sized: they resolve their own
+                // size (for replaced elements an auto width resolves to the intrinsic size
+                // <https://www.w3.org/TR/CSS22/visudet.html#block-replaced-width>)
+                let known_dimensions = if item.is_table || item.is_replaced {
+                    Size::NONE
+                } else {
+                    item.size
+                        .map_width(|width| {
+                            Some(width.unwrap_or(stretch_width).maybe_clamp(item.min_size.width, item.max_size.width))
+                        })
+                        .maybe_clamp(item.min_size, item.max_size)
+                };
+
+                //
+
+                let inputs = LayoutInput {
+                    run_mode,
+                    sizing_mode: SizingMode::InherentSize,
+                    axis: RequestedAxis::Both,
+                    known_dimensions,
+                    known_dimensions_are_definite: Size { width: true, height: true },
+                    parent_size,
+                    available_space: available_space.map_width(|_| AvailableSpace::Definite(stretch_width)),
+                    vertical_margins_are_collapsible: if item.is_in_same_bfc { Line::TRUE } else { Line::FALSE },
+                };
+
+                let item_layout = if item.is_in_same_bfc {
+                    // Replaced elements may not have a known width (they are sized by their
+                    // measure function rather than stretch-sized)
+                    let width = known_dimensions.width.unwrap_or(stretch_width);
+
+                    // TODO: account for auto margins
+                    let inset_left = item_non_auto_margin.left + content_box_inset.left;
+                    let inset_right = container_outer_width - width - inset_left;
+                    let insets = [inset_left, inset_right];
+
+                    // Compute child layout
+                    let mut child_block_ctx = block_ctx
+                        .sub_context((y_offset_for_absolute + item_non_auto_margin.top).max(clear_pos), insets);
+                    let output = tree.compute_block_child_layout(item.node_id, inputs, Some(&mut child_block_ctx));
+
+                    // Extract float contribution from child block context
+                    #[cfg(feature = "float_layout")]
+                    {
+                        let child_contribution = child_block_ctx.floated_content_height_contribution();
+                        let child_top_adjoining_floats = child_block_ctx.top_adjoining_floats();
+                        block_ctx
+                            .add_child_floated_content_height_contribution(y_offset_for_absolute + child_contribution);
+                        // Floats placed while the position of the child's top margin strut was unresolved
+                        // also adjoin this block's current strut
+                        block_ctx.merge_adjoining_floats(child_top_adjoining_floats);
+                    }
+
+                    output
+                } else {
+                    tree.compute_child_layout(item.node_id, inputs)
+                };
+
+                // If the item avoids floats and is taller than the segment it was placed in, then
+                // floats lower down may reduce the space available to it: retry with its actual
+                // height unless doing so does not change the slot
+                #[cfg(feature = "float_layout")]
+                if item_avoids_floats && remaining_attempts > 1 && item_height_hint != Some(item_layout.size.height) {
+                    item_height_hint = Some(item_layout.size.height);
+                    remaining_attempts -= 1;
+                    continue;
                 }
 
-                output
-            } else {
-                tree.compute_child_layout(item.node_id, inputs)
+                break (stretch_width, float_avoiding_position, float_avoiding_width, item_layout);
             };
             let final_size = item_layout.size;
 

--- a/src/compute/float.rs
+++ b/src/compute/float.rs
@@ -657,6 +657,11 @@ impl FloatContext {
     ///     negative margin lets the border box extend outside the containing block.
     ///
     /// When there are no floats beside the box, its (possibly negative) margins apply as usual.
+    ///
+    /// If `height` is provided, the insets of all segments that a box of that height starting
+    /// at the slot's y position would span are taken into account (the box must not overlap
+    /// floats across its entire height, not just at its top edge).
+    #[allow(clippy::too_many_arguments)]
     pub fn find_bfc_slot(
         &self,
         min_y: f32,
@@ -665,6 +670,7 @@ impl FloatContext {
         direction: Direction,
         clear: Clear,
         after: Option<usize>,
+        height: Option<f32>,
     ) -> BfcSlot {
         let margin_insets = [containing_block_insets[0] + margins[0], containing_block_insets[1] + margins[1]];
         let no_float_width = self.available_width - margin_insets[0] - margin_insets[1];
@@ -700,25 +706,41 @@ impl FloatContext {
                     Direction::Rtl => 1,
                 };
                 let trail = 1 - lead;
-                let has_lead_float = segment.has_float[lead];
-                let has_trail_float = segment.has_float[trail];
+                let slot_y = segment.y.start.max(min_y);
+
+                // Union the insets of all segments the box would span (only counting sides
+                // that a float actually occupies)
+                let mut seg_insets = [0.0f32; 2];
+                let mut seg_has_float = [false; 2];
+                let spanned_end_y = slot_y + height.unwrap_or(0.0);
+                for seg in &self.segments[start_idx..] {
+                    for side in 0..2 {
+                        if seg.has_float[side] {
+                            seg_insets[side] = seg_insets[side].max(seg.insets[side]);
+                            seg_has_float[side] = true;
+                        }
+                    }
+                    if seg.y.end >= spanned_end_y {
+                        break;
+                    }
+                }
+
+                let has_lead_float = seg_has_float[lead];
+                let has_trail_float = seg_has_float[trail];
                 let mut fit_insets = [0.0; 2];
                 let mut stretch_insets = [0.0; 2];
                 fit_insets[lead] =
-                    if has_lead_float { segment.insets[lead].max(margin_insets[lead]) } else { margin_insets[lead] };
+                    if has_lead_float { seg_insets[lead].max(margin_insets[lead]) } else { margin_insets[lead] };
                 stretch_insets[lead] = fit_insets[lead];
                 fit_insets[trail] = if has_trail_float {
-                    segment.insets[trail].max(containing_block_insets[trail])
+                    seg_insets[trail].max(containing_block_insets[trail])
                 } else {
                     // A positive trailing margin may overflow the containing block edge (it does
                     // not affect fit), but a negative one widens the space for the border box
                     margin_insets[trail].min(containing_block_insets[trail])
                 };
-                stretch_insets[trail] = if has_trail_float {
-                    segment.insets[trail].max(margin_insets[trail])
-                } else {
-                    margin_insets[trail]
-                };
+                stretch_insets[trail] =
+                    if has_trail_float { seg_insets[trail].max(margin_insets[trail]) } else { margin_insets[trail] };
                 BfcSlot {
                     segment_id: Some(start_idx),
                     x: fit_insets[0],

--- a/test_fixtures/float/float_bfc_avoids_floats_across_entire_height.html
+++ b/test_fixtures/float/float_bfc_avoids_floats_across_entire_height.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    An auto-width BFC root must not overlap floats across its entire height, not just at
+    its top edge: its width accounts for a float that only intrudes lower down.
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 125px;">
+  <div style="float: left; width: 20px; height: 50px;"></div>
+  <div style="float: right; clear: left; width: 25px; height: 50px;"></div>
+  <div style="display: block; overflow: hidden; height: 100px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/float/float_zero_width_blocks_bfc_negative_margin.html
+++ b/test_fixtures/float/float_zero_width_blocks_bfc_negative_margin.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    A zero-width float still acts as an obstacle: a BFC root with a negative leading margin
+    may not be placed to the outside of its edge.
+    Reduced from WPT css/CSS2/floats/zero-width-floats-positioning.tentative.html
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 125px;">
+  <div style="float: left; width: 0px; height: 50px;"></div>
+  <div style="float: right; clear: left; width: 25px; height: 50px;"></div>
+  <div style="display: block; overflow: hidden; margin-left: -50px; height: 100px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/float/float_bfc_avoids_floats_across_entire_height__border_box_ltr.xml
+++ b/tests/xml/float/float_bfc_avoids_floats_across_entire_height__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="float_bfc_avoids_floats_across_entire_height__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="125px">
+      <div direction="ltr" float="left" width="20px" height="50px"/>
+      <div direction="ltr" float="right" clear="left" width="25px" height="50px"/>
+      <div display="block" direction="ltr" overflow-x="hidden" overflow-y="hidden" scrollbar-width="15" height="100px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="125" height="100">
+      <node x="0" y="0" width="20" height="50"/>
+      <node x="100" y="50" width="25" height="50"/>
+      <node x="20" y="0" width="80" height="100" scroll_width="0" scroll_height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_bfc_avoids_floats_across_entire_height__border_box_rtl.xml
+++ b/tests/xml/float/float_bfc_avoids_floats_across_entire_height__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="float_bfc_avoids_floats_across_entire_height__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="125px">
+      <div direction="rtl" float="left" width="20px" height="50px"/>
+      <div direction="rtl" float="right" clear="left" width="25px" height="50px"/>
+      <div display="block" direction="rtl" overflow-x="hidden" overflow-y="hidden" scrollbar-width="15" height="100px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="125" height="100">
+      <node x="0" y="0" width="20" height="50"/>
+      <node x="100" y="50" width="25" height="50"/>
+      <node x="20" y="0" width="80" height="100" scroll_width="0" scroll_height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_bfc_avoids_floats_across_entire_height__content_box_ltr.xml
+++ b/tests/xml/float/float_bfc_avoids_floats_across_entire_height__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="float_bfc_avoids_floats_across_entire_height__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="125px">
+      <div box-sizing="content-box" direction="ltr" float="left" width="20px" height="50px"/>
+      <div box-sizing="content-box" direction="ltr" float="right" clear="left" width="25px" height="50px"/>
+      <div display="block" box-sizing="content-box" direction="ltr" overflow-x="hidden" overflow-y="hidden" scrollbar-width="15" height="100px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="125" height="100">
+      <node x="0" y="0" width="20" height="50"/>
+      <node x="100" y="50" width="25" height="50"/>
+      <node x="20" y="0" width="80" height="100" scroll_width="0" scroll_height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_bfc_avoids_floats_across_entire_height__content_box_rtl.xml
+++ b/tests/xml/float/float_bfc_avoids_floats_across_entire_height__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="float_bfc_avoids_floats_across_entire_height__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="125px">
+      <div box-sizing="content-box" direction="rtl" float="left" width="20px" height="50px"/>
+      <div box-sizing="content-box" direction="rtl" float="right" clear="left" width="25px" height="50px"/>
+      <div display="block" box-sizing="content-box" direction="rtl" overflow-x="hidden" overflow-y="hidden" scrollbar-width="15" height="100px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="125" height="100">
+      <node x="0" y="0" width="20" height="50"/>
+      <node x="100" y="50" width="25" height="50"/>
+      <node x="20" y="0" width="80" height="100" scroll_width="0" scroll_height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_zero_width_blocks_bfc_negative_margin__border_box_ltr.xml
+++ b/tests/xml/float/float_zero_width_blocks_bfc_negative_margin__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="float_zero_width_blocks_bfc_negative_margin__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="125px">
+      <div direction="ltr" float="left" width="0px" height="50px"/>
+      <div direction="ltr" float="right" clear="left" width="25px" height="50px"/>
+      <div display="block" direction="ltr" overflow-x="hidden" overflow-y="hidden" scrollbar-width="15" height="100px" margin-left="-50px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="125" height="100">
+      <node x="0" y="0" width="0" height="50"/>
+      <node x="100" y="50" width="25" height="50"/>
+      <node x="0" y="0" width="100" height="100" scroll_width="0" scroll_height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_zero_width_blocks_bfc_negative_margin__border_box_rtl.xml
+++ b/tests/xml/float/float_zero_width_blocks_bfc_negative_margin__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="float_zero_width_blocks_bfc_negative_margin__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="125px">
+      <div direction="rtl" float="left" width="0px" height="50px"/>
+      <div direction="rtl" float="right" clear="left" width="25px" height="50px"/>
+      <div display="block" direction="rtl" overflow-x="hidden" overflow-y="hidden" scrollbar-width="15" height="100px" margin-left="-50px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="125" height="100">
+      <node x="0" y="0" width="0" height="50"/>
+      <node x="100" y="50" width="25" height="50"/>
+      <node x="0" y="0" width="100" height="100" scroll_width="0" scroll_height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_zero_width_blocks_bfc_negative_margin__content_box_ltr.xml
+++ b/tests/xml/float/float_zero_width_blocks_bfc_negative_margin__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="float_zero_width_blocks_bfc_negative_margin__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="125px">
+      <div box-sizing="content-box" direction="ltr" float="left" width="0px" height="50px"/>
+      <div box-sizing="content-box" direction="ltr" float="right" clear="left" width="25px" height="50px"/>
+      <div display="block" box-sizing="content-box" direction="ltr" overflow-x="hidden" overflow-y="hidden" scrollbar-width="15" height="100px" margin-left="-50px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="125" height="100">
+      <node x="0" y="0" width="0" height="50"/>
+      <node x="100" y="50" width="25" height="50"/>
+      <node x="0" y="0" width="100" height="100" scroll_width="0" scroll_height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_zero_width_blocks_bfc_negative_margin__content_box_rtl.xml
+++ b/tests/xml/float/float_zero_width_blocks_bfc_negative_margin__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="float_zero_width_blocks_bfc_negative_margin__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="125px">
+      <div box-sizing="content-box" direction="rtl" float="left" width="0px" height="50px"/>
+      <div box-sizing="content-box" direction="rtl" float="right" clear="left" width="25px" height="50px"/>
+      <div display="block" box-sizing="content-box" direction="rtl" overflow-x="hidden" overflow-y="hidden" scrollbar-width="15" height="100px" margin-left="-50px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="125" height="100">
+      <node x="0" y="0" width="0" height="50"/>
+      <node x="100" y="50" width="25" height="50"/>
+      <node x="0" y="0" width="100" height="100" scroll_width="0" scroll_height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -17384,6 +17384,26 @@ mod float {
     }
 
     #[test]
+    fn float_bfc_avoids_floats_across_entire_height__border_box_ltr() {
+        crate::run_xml_test("float", "float_bfc_avoids_floats_across_entire_height__border_box_ltr");
+    }
+
+    #[test]
+    fn float_bfc_avoids_floats_across_entire_height__content_box_ltr() {
+        crate::run_xml_test("float", "float_bfc_avoids_floats_across_entire_height__content_box_ltr");
+    }
+
+    #[test]
+    fn float_bfc_avoids_floats_across_entire_height__border_box_rtl() {
+        crate::run_xml_test("float", "float_bfc_avoids_floats_across_entire_height__border_box_rtl");
+    }
+
+    #[test]
+    fn float_bfc_avoids_floats_across_entire_height__content_box_rtl() {
+        crate::run_xml_test("float", "float_bfc_avoids_floats_across_entire_height__content_box_rtl");
+    }
+
+    #[test]
     fn float_bfc_large_negative_margin_moves_below_float__border_box_ltr() {
         crate::run_xml_test("float", "float_bfc_large_negative_margin_moves_below_float__border_box_ltr");
     }
@@ -17741,6 +17761,26 @@ mod float {
     #[test]
     fn float_simple__content_box_rtl() {
         crate::run_xml_test("float", "float_simple__content_box_rtl");
+    }
+
+    #[test]
+    fn float_zero_width_blocks_bfc_negative_margin__border_box_ltr() {
+        crate::run_xml_test("float", "float_zero_width_blocks_bfc_negative_margin__border_box_ltr");
+    }
+
+    #[test]
+    fn float_zero_width_blocks_bfc_negative_margin__content_box_ltr() {
+        crate::run_xml_test("float", "float_zero_width_blocks_bfc_negative_margin__content_box_ltr");
+    }
+
+    #[test]
+    fn float_zero_width_blocks_bfc_negative_margin__border_box_rtl() {
+        crate::run_xml_test("float", "float_zero_width_blocks_bfc_negative_margin__border_box_rtl");
+    }
+
+    #[test]
+    fn float_zero_width_blocks_bfc_negative_margin__content_box_rtl() {
+        crate::run_xml_test("float", "float_zero_width_blocks_bfc_negative_margin__content_box_rtl");
     }
 }
 


### PR DESCRIPTION
# Objective

A box that establishes an independent formatting context (BFC root) only avoided floats at its top edge: `find_bfc_slot` considered only the segment containing the box's top, so floats lower down could overlap the box.

`find_bfc_slot` gains a `height: Option<f32>` parameter that unions the (float-occupied) insets of all segments a box of that height would span. Since the height is only known after layout, `perform_final_layout_on_in_flow_children` now lays the item out in a loop, feeding the resulting height back as a hint until it stabilises (capped at 4 attempts; the repeated `compute_child_layout` call hits the layout cache when inputs are unchanged).

## Context

Rebased onto latest main (post-0.13.0, including #1056/#1061/#1062/#1064/#1065, `display: flow-root` #997, `known_dimensions_are_definite` #1003 and the `compute_layout_with_measure` refactor #1091). Originally last in the stack #1061 (merged) → #1062 (merged) → this; now a standalone PR against main.

WPT `css/CSS2/floats` + `css/CSS2/floats-clear` via blitz main (WPT @ `a95401e4e0`):

- base (taffy main @ `d4a2b3bf`): **227 PASS / 110 FAIL / 0 CRASH** (337 run)
- this branch: **235 PASS / 102 FAIL / 0 CRASH** — no test regresses. Newly passing: `floats-wrap-top-below-bfc-001l/001r/002l/002r/003l/003r.xht`, `floats-bfc-003.html`, and `zero-width-floats-positioning.tentative.html` (regressed on main by #1056; needs both #1062 and this PR)

Regression tests: gentest fixtures `float_bfc_avoids_floats_across_entire_height` and `float_zero_width_blocks_bfc_negative_margin` (the latter needs both #1062 and this PR, so it lives here). `cargo test` (5597 generated + unit tests), `cargo fmt` and `cargo clippy --workspace` are clean.

## Feedback wanted

The relayout loop in `perform_final_layout_on_in_flow_children` is the trickiest part: whether the "retry with measured height" approach (vs e.g. a FloatFitter-style search) and the 4-attempt cap are acceptable.

Link to Devin session: https://app.devin.ai/sessions/270b3ff69263411fa628f56810dbe2dd
Requested by: @nicoburns