### PR TITLE
BFC boxes avoid floats over their entire height

### DIFF
--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -1159,6 +1159,7 @@ fn perform_final_layout_on_in_flow_children(
                                         sizing_mode: SizingMode::InherentSize,
                                         axis: RequestedAxis::Both,
                                         known_dimensions,
+                                        known_dimensions_are_definite: Size { width: true, height: true },
                                         parent_size,
                                         available_space: available_space
                                             .map_width(|_| AvailableSpace::Definite(stretch_width)),

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -208,6 +208,20 @@ impl BlockContext<'_> {
         self.bfc.float_context.cleared_threshold(clear).map(|threshold| threshold - self.y_offset)
     }
 
+    /// Compute a `BfcSlot` whose insets are the union of the insets of all segments
+    /// intersecting the given y range (in this block's coordinates)
+    pub fn find_bfc_slot_spanning(&self, y_start: f32, y_end: f32, margins: [f32; 2], direction: Direction) -> BfcSlot {
+        let mut slot = self.bfc.float_context.find_bfc_slot_spanning(
+            (y_start + self.y_offset)..(y_end + self.y_offset),
+            self.content_box_insets,
+            margins,
+            direction,
+        );
+        slot.y -= self.y_offset;
+        slot.x -= self.insets[0];
+        slot
+    }
+
     /// Whether a float that is adjoining the current margin-collapse strut has been placed
     /// on the side(s) relevant to the passed clear property
     pub fn has_adjoining_float(&self, clear: Clear) -> bool {
@@ -1073,6 +1087,7 @@ fn perform_final_layout_on_in_flow_children(
             let mut item_avoids_floats = false;
             #[cfg(feature = "float_layout")]
             let mut item_pushed_below_float = false;
+            let mut precomputed_layout: Option<LayoutOutput> = None;
 
             let (stretch_width, float_avoiding_position, float_avoiding_width) = if item.is_in_same_bfc {
                 let stretch_width = container_inner_width - item_non_auto_x_margin_sum;
@@ -1100,7 +1115,8 @@ fn perform_final_layout_on_in_flow_children(
                         let min_auto_width = -item_non_auto_x_margin_sum;
 
                         // Find the highest slot (at or below `min_y`) with enough horizontal space
-                        // for the item's border box, which must not overlap any float
+                        // for the item's border box, which must not overlap any float over its
+                        // entire height (not just at its top)
                         let mut slot_segment = None;
                         let slot = loop {
                             let slot = block_ctx.find_bfc_slot(min_y, x_margins, direction, item.clear, slot_segment);
@@ -1110,8 +1126,67 @@ fn perform_final_layout_on_in_flow_children(
                                 .width
                                 .unwrap_or(slot.stretch_width.max(min_auto_width))
                                 .maybe_clamp(item.min_size.width, item.max_size.width);
-                            if width <= slot.border_width + 0.001 {
-                                break slot;
+                            if width > slot.border_width + 0.001 {
+                                slot_segment = Some(segment_id);
+                                continue;
+                            }
+
+                            // The slot has horizontal space for the item's width at its top, but
+                            // the item may extend down beside lower (wider) floats. Iteratively
+                            // lay the item out at this position, narrowing it to the widest space
+                            // available over its entire height, and retry from the next segment
+                            // if its width does not fit that space.
+                            let mut stretch_width = slot.stretch_width.max(min_auto_width);
+                            let mut fitted = None;
+                            for _ in 0..5 {
+                                let known_dimensions = if item.is_table || item.is_replaced {
+                                    Size::NONE
+                                } else {
+                                    item.size
+                                        .map_width(|width| {
+                                            Some(
+                                                width
+                                                    .unwrap_or(stretch_width)
+                                                    .maybe_clamp(item.min_size.width, item.max_size.width),
+                                            )
+                                        })
+                                        .maybe_clamp(item.min_size, item.max_size)
+                                };
+                                let layout = tree.compute_child_layout(
+                                    item.node_id,
+                                    LayoutInput {
+                                        run_mode,
+                                        sizing_mode: SizingMode::InherentSize,
+                                        axis: RequestedAxis::Both,
+                                        known_dimensions,
+                                        parent_size,
+                                        available_space: available_space
+                                            .map_width(|_| AvailableSpace::Definite(stretch_width)),
+                                        vertical_margins_are_collapsible: Line::FALSE,
+                                    },
+                                );
+                                let spanning = block_ctx.find_bfc_slot_spanning(
+                                    slot.y,
+                                    slot.y + layout.size.height,
+                                    x_margins,
+                                    direction,
+                                );
+                                if layout.size.width > spanning.border_width + 0.001 {
+                                    // A fixed width can never fit at this position; an auto width
+                                    // may fit after re-resolving against the narrower space
+                                    let narrower_stretch = spanning.stretch_width.max(min_auto_width);
+                                    if item.size.width.is_some() || narrower_stretch >= stretch_width {
+                                        break;
+                                    }
+                                    stretch_width = narrower_stretch;
+                                    continue;
+                                }
+                                fitted = Some((spanning, layout));
+                                break;
+                            }
+                            if let Some((spanning, layout)) = fitted {
+                                precomputed_layout = Some(layout);
+                                break BfcSlot { segment_id: slot.segment_id, y: slot.y, ..spanning };
                             }
                             slot_segment = Some(segment_id);
                         };
@@ -1203,7 +1278,10 @@ fn perform_final_layout_on_in_flow_children(
 
                 output
             } else {
-                tree.compute_child_layout(item.node_id, inputs)
+                match precomputed_layout.take() {
+                    Some(layout) => layout,
+                    None => tree.compute_child_layout(item.node_id, inputs),
+                }
             };
             let final_size = item_layout.size;
 

--- a/src/compute/float.rs
+++ b/src/compute/float.rs
@@ -637,6 +637,45 @@ impl FloatContext {
         }
     }
 
+    /// Compute a [`BfcSlot`] whose insets are the union of the insets of all segments
+    /// intersecting the given y range: the widest box placed at `y.start` that avoids all
+    /// floats down to `y.end`
+    pub fn find_bfc_slot_spanning(
+        &self,
+        y: Range<f32>,
+        containing_block_insets: [f32; 2],
+        margins: [f32; 2],
+        direction: Direction,
+    ) -> BfcSlot {
+        let mut seg_insets = [f32::NEG_INFINITY; 2];
+        for segment in &self.segments {
+            if segment.y.start < y.end - 0.001 && segment.y.end > y.start + 0.001 {
+                seg_insets[0] = seg_insets[0].max(segment.insets[0]);
+                seg_insets[1] = seg_insets[1].max(segment.insets[1]);
+            }
+        }
+
+        let margin_insets = [containing_block_insets[0] + margins[0], containing_block_insets[1] + margins[1]];
+        let lead = match direction {
+            Direction::Ltr => 0,
+            Direction::Rtl => 1,
+        };
+        let trail = 1 - lead;
+        let mut fit_insets = [0.0; 2];
+        let mut stretch_insets = [0.0; 2];
+        fit_insets[lead] = seg_insets[lead].max(containing_block_insets[lead]).max(margin_insets[lead]);
+        stretch_insets[lead] = fit_insets[lead];
+        fit_insets[trail] = seg_insets[trail].max(containing_block_insets[trail]);
+        stretch_insets[trail] = fit_insets[trail].max(containing_block_insets[trail] + margins[trail].max(0.0));
+        BfcSlot {
+            segment_id: None,
+            x: fit_insets[0],
+            y: y.start,
+            border_width: self.available_width - fit_insets[0] - fit_insets[1],
+            stretch_width: self.available_width - stretch_insets[0] - stretch_insets[1],
+        }
+    }
+
     /// Search for a space suitable for laying out a box that establishes an independent
     /// formatting context (whose border box must not overlap floats).
     ///

--- a/src/compute/float.rs
+++ b/src/compute/float.rs
@@ -648,13 +648,20 @@ impl FloatContext {
         direction: Direction,
     ) -> BfcSlot {
         let mut seg_insets = [f32::NEG_INFINITY; 2];
+        let mut has_float = [false, false];
         for segment in &self.segments {
             if segment.y.start < y.end - 0.001 && segment.y.end > y.start + 0.001 {
-                seg_insets[0] = seg_insets[0].max(segment.insets[0]);
-                seg_insets[1] = seg_insets[1].max(segment.insets[1]);
+                for side in 0..2 {
+                    if segment.has_float[side] {
+                        has_float[side] = true;
+                        seg_insets[side] = seg_insets[side].max(segment.insets[side]);
+                    }
+                }
             }
         }
 
+        // Margins are applied with the same semantics as in `find_bfc_slot`, based on
+        // whether a float intrudes on the relevant side anywhere within the y range
         let margin_insets = [containing_block_insets[0] + margins[0], containing_block_insets[1] + margins[1]];
         let lead = match direction {
             Direction::Ltr => 0,
@@ -663,10 +670,16 @@ impl FloatContext {
         let trail = 1 - lead;
         let mut fit_insets = [0.0; 2];
         let mut stretch_insets = [0.0; 2];
-        fit_insets[lead] = seg_insets[lead].max(containing_block_insets[lead]).max(margin_insets[lead]);
+        fit_insets[lead] =
+            if has_float[lead] { seg_insets[lead].max(margin_insets[lead]) } else { margin_insets[lead] };
         stretch_insets[lead] = fit_insets[lead];
-        fit_insets[trail] = seg_insets[trail].max(containing_block_insets[trail]);
-        stretch_insets[trail] = fit_insets[trail].max(containing_block_insets[trail] + margins[trail].max(0.0));
+        fit_insets[trail] = if has_float[trail] {
+            seg_insets[trail].max(containing_block_insets[trail])
+        } else {
+            margin_insets[trail].min(containing_block_insets[trail])
+        };
+        stretch_insets[trail] =
+            if has_float[trail] { seg_insets[trail].max(margin_insets[trail]) } else { margin_insets[trail] };
         BfcSlot {
             segment_id: None,
             x: fit_insets[0],

--- a/tests/hand_written/floats.rs
+++ b/tests/hand_written/floats.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "float_layout")]
 use taffy::geometry::Point;
 use taffy::prelude::*;
-use taffy::style::{Clear, Float};
+use taffy::style::{Clear, Float, Overflow};
 use taffy_test_helpers::new_test_tree;
 
 /// Regression test for <https://wpt.live/css/CSS2/floats-clear/floats-146.xht>
@@ -148,4 +148,134 @@ fn float_beside_existing_float_moves_down_instead_of_overflowing() {
     assert_eq!(taffy.layout(left).unwrap().location, Point { x: 0.0, y: 0.0 });
     assert_eq!(taffy.layout(right).unwrap().location, Point { x: 40.0, y: 50.0 });
     assert_eq!(taffy.layout(left2).unwrap().location, Point { x: 0.0, y: 100.0 });
+}
+
+/// Regression test for <https://wpt.live/css/CSS2/floats/new-fc-relayout.html>
+///
+/// A box that establishes a new formatting context must not overlap floats over its
+/// *entire* height, not just at its top: if it extends down beside lower (wider)
+/// floats, an auto width re-resolves against the narrower available space.
+#[test]
+fn new_fc_narrows_beside_lower_floats() {
+    let mut taffy = new_test_tree();
+
+    let float_a = taffy
+        .new_leaf(Style {
+            display: Display::Block,
+            float: Float::Right,
+            size: Size { width: length(50.0), height: length(50.0) },
+            ..Default::default()
+        })
+        .unwrap();
+    let float_b = taffy
+        .new_leaf(Style {
+            display: Display::Block,
+            float: Float::Right,
+            size: Size { width: length(75.0), height: length(50.0) },
+            ..Default::default()
+        })
+        .unwrap();
+    // Content whose height grows as the available width narrows: two 25px-wide blocks
+    // that fit side-by-side at width 50 but stack at width 25
+    let content_a = taffy
+        .new_leaf(Style {
+            display: Display::Block,
+            float: Float::Left,
+            size: Size { width: length(25.0), height: length(75.0) },
+            ..Default::default()
+        })
+        .unwrap();
+    let bfc_box = taffy
+        .new_with_children(
+            Style {
+                display: Display::Block,
+                overflow: taffy::geometry::Point { x: Overflow::Hidden, y: Overflow::Hidden },
+                size: Size { width: auto(), height: auto() },
+                ..Default::default()
+            },
+            &[content_a],
+        )
+        .unwrap();
+
+    let root = taffy
+        .new_with_children(
+            Style {
+                display: Display::Block,
+                size: Size { width: length(100.0), height: auto() },
+                ..Default::default()
+            },
+            &[float_a, float_b, bfc_box],
+        )
+        .unwrap();
+
+    taffy.compute_layout(root, Size::MAX_CONTENT).unwrap();
+
+    // float_a occupies (50..100, 0..50); float_b does not fit beside it: (25..100, 50..100)
+    assert_eq!(taffy.layout(float_a).unwrap().location, Point { x: 50.0, y: 0.0 });
+    assert_eq!(taffy.layout(float_b).unwrap().location, Point { x: 25.0, y: 50.0 });
+    // The BFC box is 75 tall, so it extends down beside float_b and its auto width
+    // resolves to 25 (not the 50 available at its top)
+    let bfc_layout = taffy.layout(bfc_box).unwrap();
+    assert_eq!(bfc_layout.location, Point { x: 0.0, y: 0.0 });
+    assert_eq!(bfc_layout.size, Size { width: 25.0, height: 75.0 });
+}
+
+/// Regression test for <https://wpt.live/css/CSS2/floats/new-fc-beside-adjoining-float.html>
+///
+/// A new formatting context that fits beside an adjoining float stays beside it (its
+/// margin remains adjoining and pulls the float down with it).
+#[test]
+fn new_fc_beside_adjoining_float() {
+    let mut taffy = new_test_tree();
+
+    let float = taffy
+        .new_leaf(Style {
+            display: Display::Block,
+            float: Float::Left,
+            size: Size { width: length(200.0), height: length(10.0) },
+            ..Default::default()
+        })
+        .unwrap();
+    let float_wrapper =
+        taffy.new_with_children(Style { display: Display::Block, ..Default::default() }, &[float]).unwrap();
+    let bfc_box = taffy
+        .new_leaf(Style {
+            display: Display::Block,
+            overflow: taffy::geometry::Point { x: Overflow::Hidden, y: Overflow::Hidden },
+            size: Size { width: length(100.0), height: length(10.0) },
+            margin: Rect { top: length(190.0), ..Rect::zero() },
+            ..Default::default()
+        })
+        .unwrap();
+    // A 300px-wide block inside a 200px-wide BFC root: the 100px-wide BFC box fits
+    // beside the 200px-wide float
+    let inner = taffy
+        .new_with_children(
+            Style {
+                display: Display::Block,
+                size: Size { width: length(300.0), height: auto() },
+                margin: Rect { top: length(50.0), ..Rect::zero() },
+                ..Default::default()
+            },
+            &[float_wrapper, bfc_box],
+        )
+        .unwrap();
+    let root = taffy
+        .new_with_children(
+            Style {
+                display: Display::Block,
+                overflow: taffy::geometry::Point { x: Overflow::Hidden, y: Overflow::Hidden },
+                size: Size { width: length(200.0), height: auto() },
+                ..Default::default()
+            },
+            &[inner],
+        )
+        .unwrap();
+
+    taffy.compute_layout(root, Size::MAX_CONTENT).unwrap();
+
+    // The BFC box's 190px top margin adjoins the float and pulls it down; the box is
+    // placed beside the float rather than being pushed below it
+    assert_eq!(taffy.layout(bfc_box).unwrap().location, Point { x: 200.0, y: 0.0 });
+    assert_eq!(taffy.layout(root).unwrap().size.height, 200.0);
 }


### PR DESCRIPTION
# Objective

Fix Blitz WPT failures where a box establishing a new formatting context could overlap floats below its top edge.

BFC-box placement checked float insets only at the segment containing the box's top, so the box could overlap wider floats lower down. Per CSS2 §9.5 (and the csswg-drafts#2452 resolution), its border box must not overlap any float over its entire height, and an auto width re-resolves against the narrower available space.

## Context

Originally the second PR of a stack on #1056 (now merged); rebased onto latest main (post #1061/#1062/#1064/#1065/#1003).

New `FloatContext::find_bfc_slot_spanning(y_range, ...)` in `src/compute/float.rs`: the union of float insets over a y range, i.e. the widest slot at `y_range.start` that avoids all floats down to `y_range.end`. Margins are applied with the same semantics as `find_bfc_slot` (per-side, based on whether a float intrudes on that side anywhere in the range).

BFC-box placement in `src/compute/block.rs` now verifies the fit over the box's full height, pseudocode:

```
loop over candidate slots:
    if item width doesn't fit slot at its top: next segment
    layout item at slot's stretch width
    spanning = find_bfc_slot_spanning(slot.y .. slot.y + height)
    if item width fits spanning:  place at spanning slot (may be narrower/inset further)
    else if width is auto and spanning stretch is narrower:  re-layout at narrower width (bounded retries)
    else: next segment
```

Regression tests added in `tests/hand_written/floats.rs` reproducing `new-fc-relayout.html` and `new-fc-beside-adjoining-float.html`.

### WPT results (blitz main + taffy path override, `css/CSS2/floats css/CSS2/floats-clear`, 337 run)

- Before (taffy main @ d31313f8): 227 PASS / 110 FAIL / 0 CRASH
- After: **240 PASS / 97 FAIL / 0 CRASH** — 13 newly passing, no per-test regressions

Newly passing:
- css/CSS2/floats-clear/floats-bfc-003.html
- css/CSS2/floats/floats-wrap-bfc-003-left-table.xht
- css/CSS2/floats/floats-wrap-bfc-003-right-table.xht
- css/CSS2/floats/floats-wrap-bfc-004.xht
- css/CSS2/floats/floats-wrap-bfc-with-margin-004.html / -005.html
- css/CSS2/floats/floats-wrap-top-below-bfc-001l.xht / -001r.xht
- css/CSS2/floats/floats-wrap-top-below-bfc-002l.xht / -002r.xht
- css/CSS2/floats/floats-wrap-top-below-bfc-003l.xht / -003r.xht
- css/CSS2/floats/zero-width-floats-positioning.tentative.html

Note: blitz doesn't currently compile against taffy main (the new `LayoutInput::known_dimensions_are_definite` field from #1003 and `Display::FlowRoot`); WPT was run on blitz main with a small local shim adding the missing field.

## Feedback wanted

The placement retry is bounded at 5 layout iterations per candidate slot; content whose height/width relationship oscillates settles on the last computed layout.


Link to Devin session: https://app.devin.ai/sessions/21f083bacc8f44a2ab371090f63e9c93
Requested by: @nicoburns