### PR TITLE
Record zero-width floats in float context segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Fixed
 
+- Block/float: zero-width floats are now recorded in the float context, so their edge acts as an obstacle that a box establishing an independent formatting context cannot be placed to the outside of (e.g. via a negative margin) ([WPT: zero-width-floats-positioning](https://wpt.live/css/CSS2/floats/zero-width-floats-positioning.tentative.html))
+
 - Block/float: a negative margin on a BFC root's float-free side now applies as usual (moving the border edge outside the containing block and widening an auto width) instead of being clamped to the containing block edge. Previously the containing block insets were treated as float insets on both sides, so e.g. a box with `margin-left: -50px` beside a right float could not extend past its containing block's left edge ([WPT: floats-wrap-bfc-with-margin-006/007](https://wpt.live/css/CSS2/floats/floats-wrap-bfc-with-margin-006.tentative.html))
 
 - Block/Grid: `Layout::content_size` now measures the scrollable overflow region from the container's padding-box origin (mirrored for RTL) and includes the container's own end-side padding, matching the existing Flexbox behaviour and browser `scrollWidth`/`scrollHeight` semantics. Previously Block and Grid measured relative to the content box and excluded the container's padding entirely, so `Layout::scroll_width()`/`scroll_height()` were too small by the padding sum (#1050)

--- a/src/compute/float.rs
+++ b/src/compute/float.rs
@@ -416,8 +416,10 @@ impl FloatContext {
             }
         };
 
-        // Short-circuit for zero-sized boxes
-        if floated_box.width == 0.0 || floated_box.height == 0.0 {
+        // Short-circuit for zero-height boxes. Zero-width boxes are still recorded in segments:
+        // their edge acts as an obstacle that boxes establishing an independent formatting
+        // context may not be placed to the outside of (e.g. via a negative margin).
+        if floated_box.height == 0.0 {
             // TODO: need to update last_placed_float?
 
             return PlacedFloatedBox {


### PR DESCRIPTION
# Objective

Zero-width floats were invisible to segment-based placement: `place_floated_box_inner` short-circuited for any zero-sized box, so a zero-width (nonzero-height) float created no segment and its edge did not constrain boxes establishing an independent formatting context. The short-circuit now only applies to zero-*height* boxes: a zero-width float creates a segment (`has_float` set, inset unchanged) whose edge is an obstacle that e.g. a BFC root's negative margin cannot cross.

Complements #1056, which made `clear` and float rule 5 account for zero-sized floats (which this change preserves for the zero-height case).

## Context

Split out of #1057. Second in the stack: #1061 (merged) → this → #1057 (BFC roots avoid floats across their entire height, rebased on this branch).

Fixes half of WPT `css/CSS2/floats/zero-width-floats-positioning.tentative.html`, which regressed on main with #1056 (its previous pass was incidental: the zero-width float was ignored for `clear`). The test only passes once #1057's full-height float avoidance also lands, so the gentest fixture covering this behavior (`float_zero_width_blocks_bfc_negative_margin`) lives in #1057; suite counts are unchanged by this PR alone (201 PASS / 124 FAIL, no regressions, WPT @ `a95401e4e0` via blitz).

`cargo test`, `cargo fmt`, `cargo clippy --workspace` clean.


Link to Devin session: https://app.devin.ai/sessions/270b3ff69263411fa628f56810dbe2dd
Requested by: @nicoburns