### PR TITLE
Fix float placement per CSS2 §9.5.1 rules 3–9 (overflow, height-aware slots, zero-height floats)

### DIFF
--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -959,7 +959,9 @@ fn perform_final_layout_on_in_flow_children(
                     parent_size,
                     Size { width: AvailableSpace::Definite(available_width), height: AvailableSpace::MaxContent },
                     SizingMode::InherentSize,
-                    Line::TRUE,
+                    // A float establishes a new block formatting context: its margins do not
+                    // collapse with the margins of its children
+                    Line::FALSE,
                 );
                 let margin_box = item_layout.size + item_non_auto_margin.sum_axes();
 

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -186,6 +186,7 @@ impl BlockContext<'_> {
         &self,
         min_y: f32,
         margins: [f32; 2],
+        height: f32,
         direction: Direction,
         clear: Clear,
         after: Option<usize>,
@@ -194,6 +195,7 @@ impl BlockContext<'_> {
             min_y + self.y_offset,
             self.content_box_insets,
             margins,
+            height,
             direction,
             clear,
             after,
@@ -1050,7 +1052,8 @@ fn perform_final_layout_on_in_flow_children(
             #[cfg(feature = "float_layout")]
             let mut item_pushed_below_float = false;
 
-            let (stretch_width, float_avoiding_position, float_avoiding_width) = if item.is_in_same_bfc {
+            #[cfg_attr(not(feature = "float_layout"), allow(unused_mut))]
+            let (mut stretch_width, mut float_avoiding_position, mut float_avoiding_width) = if item.is_in_same_bfc {
                 let stretch_width = container_inner_width - item_non_auto_x_margin_sum;
                 let position = Point { x: 0.0, y: 0.0 };
                 let width = 0.0;
@@ -1075,11 +1078,18 @@ fn perform_final_layout_on_in_flow_children(
                         // (so that the margin box width is non-negative, per CSS2 §10.3.3)
                         let min_auto_width = -item_non_auto_x_margin_sum;
 
+                        // If the item's height is known up-front then it can be accounted for in
+                        // the slot search (the item's border box must not overlap floats over its
+                        // entire height). Otherwise the slot is re-checked after layout below.
+                        let known_height =
+                            item.size.height.maybe_clamp(item.min_size.height, item.max_size.height).unwrap_or(0.0);
+
                         // Find the highest slot (at or below `min_y`) with enough horizontal space
                         // for the item's border box, which must not overlap any float
                         let mut slot_segment = None;
                         let slot = loop {
-                            let slot = block_ctx.find_bfc_slot(min_y, x_margins, direction, item.clear, slot_segment);
+                            let slot = block_ctx
+                                .find_bfc_slot(min_y, x_margins, known_height, direction, item.clear, slot_segment);
                             let Some(segment_id) = slot.segment_id else { break slot };
                             let width = item
                                 .size
@@ -1150,7 +1160,8 @@ fn perform_final_layout_on_in_flow_children(
             #[cfg(not(feature = "float_layout"))]
             let clear_pos = f32::NEG_INFINITY;
 
-            let item_layout = if item.is_in_same_bfc {
+            #[cfg_attr(not(feature = "float_layout"), allow(unused_mut))]
+            let mut item_layout = if item.is_in_same_bfc {
                 // Replaced elements may not have a known width (they are sized by their
                 // measure function rather than stretch-sized)
                 let width = known_dimensions.width.unwrap_or(stretch_width);
@@ -1180,6 +1191,76 @@ fn perform_final_layout_on_in_flow_children(
             } else {
                 tree.compute_child_layout(item.node_id, inputs)
             };
+
+            // The initial slot search only accounts for the item's height if it is known up-front.
+            // Now that the item has been laid out its height is known: re-run the slot search with
+            // the actual height (the item's border box must not overlap floats over its entire
+            // height), re-laying the item out if this changes the slot.
+            #[cfg(feature = "float_layout")]
+            if item_avoids_floats {
+                let min_y = committed_y_offset + y_margin_offset;
+                let x_margins = [item_non_auto_margin.left, item_non_auto_margin.right];
+                let min_auto_width = -item_non_auto_x_margin_sum;
+
+                for _ in 0..4 {
+                    let height = item_layout.size.height;
+                    let mut slot_segment = None;
+                    let slot = loop {
+                        let slot =
+                            block_ctx.find_bfc_slot(min_y, x_margins, height, direction, item.clear, slot_segment);
+                        let Some(segment_id) = slot.segment_id else { break slot };
+                        let width = item
+                            .size
+                            .width
+                            .unwrap_or(slot.stretch_width.max(min_auto_width))
+                            .maybe_clamp(item.min_size.width, item.max_size.width);
+                        if width <= slot.border_width + 0.001 {
+                            break slot;
+                        }
+                        slot_segment = Some(segment_id);
+                    };
+
+                    let slot_unchanged = (slot.y - float_avoiding_position.y).abs() <= 0.001
+                        && (slot.x - float_avoiding_position.x).abs() <= 0.001
+                        && (slot.border_width - float_avoiding_width).abs() <= 0.001;
+                    if slot_unchanged {
+                        break;
+                    }
+
+                    if slot.y > min_y {
+                        item_pushed_below_float = true;
+                    }
+                    has_active_floats = slot.segment_id.is_some();
+                    stretch_width = slot.stretch_width.max(min_auto_width);
+                    float_avoiding_position = Point { x: slot.x, y: slot.y };
+                    float_avoiding_width = slot.border_width;
+
+                    let known_dimensions = if item.is_table || item.is_replaced {
+                        Size::NONE
+                    } else {
+                        item.size
+                            .map_width(|width| {
+                                Some(
+                                    width
+                                        .unwrap_or(stretch_width)
+                                        .maybe_clamp(item.min_size.width, item.max_size.width),
+                                )
+                            })
+                            .maybe_clamp(item.min_size, item.max_size)
+                    };
+                    let inputs = LayoutInput {
+                        run_mode,
+                        sizing_mode: SizingMode::InherentSize,
+                        axis: RequestedAxis::Both,
+                        known_dimensions,
+                        parent_size,
+                        available_space: available_space.map_width(|_| AvailableSpace::Definite(stretch_width)),
+                        vertical_margins_are_collapsible: Line::FALSE,
+                    };
+                    item_layout = tree.compute_child_layout(item.node_id, inputs);
+                }
+            }
+
             let final_size = item_layout.size;
 
             let top_margin_set = item_layout.top_margin.collapse_with_margin(item_margin.top.unwrap_or(0.0));

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -171,10 +171,28 @@ impl BlockContext<'_> {
         pos
     }
 
+    /// Snapshot the current float placement state. The snapshot can be passed to
+    /// [`restore_float_snapshot`](Self::restore_float_snapshot) to undo the placement of any
+    /// floats placed after the snapshot was taken (e.g. to speculatively place floats).
+    pub fn float_snapshot(&self) -> FloatContext {
+        self.bfc.float_context.clone()
+    }
+
+    /// Restore a float placement state snapshot taken with
+    /// [`float_snapshot`](Self::float_snapshot)
+    pub fn restore_float_snapshot(&mut self, snapshot: FloatContext) {
+        self.bfc.float_context = snapshot;
+    }
+
     /// Search a space suitable for laying out non-floated content into
-    pub fn find_content_slot(&self, min_y: f32, clear: Clear, after: Option<usize>) -> ContentSlot {
-        let mut slot =
-            self.bfc.float_context.find_content_slot(min_y + self.y_offset, self.content_box_insets, clear, after);
+    pub fn find_content_slot(&self, min_y: f32, height: f32, clear: Clear, after: Option<usize>) -> ContentSlot {
+        let mut slot = self.bfc.float_context.find_content_slot(
+            min_y + self.y_offset,
+            self.content_box_insets,
+            height,
+            clear,
+            after,
+        );
         slot.y -= self.y_offset;
         slot.x -= self.insets[0];
         slot
@@ -1088,8 +1106,14 @@ fn perform_final_layout_on_in_flow_children(
                         // for the item's border box, which must not overlap any float
                         let mut slot_segment = None;
                         let slot = loop {
-                            let slot = block_ctx
-                                .find_bfc_slot(min_y, x_margins, known_height, direction, item.clear, slot_segment);
+                            let slot = block_ctx.find_bfc_slot(
+                                min_y,
+                                x_margins,
+                                known_height,
+                                direction,
+                                item.clear,
+                                slot_segment,
+                            );
                             let Some(segment_id) = slot.segment_id else { break slot };
                             let width = item
                                 .size

--- a/src/compute/float.rs
+++ b/src/compute/float.rs
@@ -96,16 +96,45 @@ struct Segment {
 
 impl Segment {
     /// Whether the segment can fit the passed floated box (in the horizontal axis)
-    fn fits_float_width(&self, floated_box: Size<f32>, direction: FloatDirection, bfc_width: f32) -> bool {
-        let slot = direction as usize;
-        self.insets[slot] == 0.0 || (bfc_width - floated_box.width - self.inset_sum()) >= 0.0
+    ///
+    /// See [`float_fits_horizontally`] for the details of the fit rules.
+    fn fits_float_width(
+        &self,
+        floated_box: Size<f32>,
+        direction: FloatDirection,
+        bfc_width: f32,
+        cb_insets: [f32; 2],
+    ) -> bool {
+        float_fits_horizontally(floated_box.width, direction, bfc_width, self.insets, cb_insets)
     }
+}
 
-    /// The total space taken up by both insets
-    #[inline(always)]
-    fn inset_sum(&self) -> f32 {
-        self.insets[0] + self.insets[1]
-    }
+/// Whether a floated box of the given width fits horizontally given the float insets
+/// (`float_insets`) and containing block insets (`cb_insets`) that apply to it.
+///
+/// A float is normally placed at the further-in of the float edge and the containing block
+/// edge on the side it is floated towards (its "lead" side). From that position it must:
+///
+///   - not overlap any float on the opposite ("trail") side (CSS2 §9.5.1 rule 3), and
+///   - not extend past the containing block's trail edge if there is a float on its lead
+///     side (CSS2 §9.5.1 rule 7: a float may only stick out of its containing block if it
+///     is already as far towards its float direction as possible).
+///
+/// Note that a float which is not constrained by other floats *may* overflow its
+/// containing block's trail edge (rules 1 and 7).
+fn float_fits_horizontally(
+    width: f32,
+    direction: FloatDirection,
+    bfc_width: f32,
+    float_insets: [f32; 2],
+    cb_insets: [f32; 2],
+) -> bool {
+    let lead = direction as usize;
+    let trail = 1 - lead;
+    let x_inset = float_insets[lead].max(cb_insets[lead]);
+    let fits_opposite_floats = float_insets[trail] == 0.0 || x_inset + width <= bfc_width - float_insets[trail];
+    let fits_containing_block = float_insets[lead] == 0.0 || x_inset + width <= bfc_width - cb_insets[trail];
+    fits_opposite_floats && fits_containing_block
 }
 
 /// Helper type for placing a single floated box
@@ -118,28 +147,39 @@ struct FloatFitter {
     bfc_width: f32,
     /// The total height of the set of segments currently being considered
     slot_height: f64,
-    /// The union of the insets of the set of segments currently being considered
-    insets: [f32; 2],
+    /// The union of the float insets of the set of segments currently being considered
+    float_insets: [f32; 2],
+    /// The insets of the box's containing block from the edges of the Block Formatting Context
+    cb_insets: [f32; 2],
 }
 
 impl FloatFitter {
     /// Create a new `FloatFitter`
-    fn new(bfc_width: f32, slot_height: f32, insets: [f32; 2]) -> Self {
-        Self { bfc_width, slot_height: slot_height as f64, insets }
+    fn new(bfc_width: f32, slot_height: f32, cb_insets: [f32; 2]) -> Self {
+        Self { bfc_width, slot_height: slot_height as f64, float_insets: [0.0, 0.0], cb_insets }
     }
 
     // Horizontal fitting
 
     /// Union the insets of another segment. This is a "max" of the insets on each side.
     fn union_insets(&mut self, insets: [f32; 2]) {
-        self.insets[0] = self.insets[0].max(insets[0]);
-        self.insets[1] = self.insets[1].max(insets[1]);
+        self.float_insets[0] = self.float_insets[0].max(insets[0]);
+        self.float_insets[1] = self.float_insets[1].max(insets[1]);
+    }
+
+    /// The inset from the edge of the BFC (on the side the box is floated towards) that the
+    /// box would be placed at given the currently accounted for insets
+    fn placed_inset(&self, direction: FloatDirection) -> f32 {
+        let lead = direction as usize;
+        self.float_insets[lead].max(self.cb_insets[lead])
     }
 
     /// Given the currently accounted for insets, check whether there is an x position
-    /// such that the box fits horizontally
-    fn fits_horiontally(&self, width: f32) -> bool {
-        self.insets == [0.0, 0.0] || self.bfc_width - self.insets[0] - self.insets[1] - width >= 0.0
+    /// such that the box fits horizontally.
+    ///
+    /// See [`float_fits_horizontally`] for the details of the fit rules.
+    fn fits_horiontally(&self, width: f32, direction: FloatDirection) -> bool {
+        float_fits_horizontally(width, direction, self.bfc_width, self.float_insets, self.cb_insets)
     }
 
     // Vertical fitting
@@ -335,7 +375,7 @@ impl FloatContext {
 
             // Candidate start segment doesn't have (horizontal) space for the float:
             // => retry with the next segment
-            if !start_segment.fits_float_width(floated_box, direction, self.available_width) {
+            if !start_segment.fits_float_width(floated_box, direction, self.available_width, containing_block_insets) {
                 start_idx += 1;
                 end_idx = end_idx.max(start_idx);
                 continue;
@@ -357,7 +397,7 @@ impl FloatContext {
                 // This means no existing segment can accomodate the float so we must create a new
                 // segment below all existing segments
                 let Some(end_segment) = self.segments.get(end_idx) else {
-                    let inset = fitter.insets[slot];
+                    let inset = fitter.placed_inset(direction);
                     break 'outer (Some(start_idx), None, inset);
                 };
 
@@ -366,7 +406,7 @@ impl FloatContext {
                 // If it does not fit horizontally then it will never fit in this position, so
                 // continue the outer loop to find and check a new position
                 fitter.union_insets(end_segment.insets);
-                if !fitter.fits_horiontally(floated_box.width) {
+                if !fitter.fits_horiontally(floated_box.width, direction) {
                     start_idx += 1;
                     end_idx = end_idx.max(start_idx);
                     continue 'outer;
@@ -384,7 +424,7 @@ impl FloatContext {
                     continue;
                 }
 
-                let inset = fitter.insets[slot];
+                let inset = fitter.placed_inset(direction);
                 break 'outer (Some(start_idx), Some(end_idx), inset);
             }
         };

--- a/src/compute/float.rs
+++ b/src/compute/float.rs
@@ -429,8 +429,8 @@ impl FloatContext {
             }
         };
 
-        // Short-circuit for zero-sized boxes
-        if floated_box.width == 0.0 || floated_box.height == 0.0 {
+        // Short-circuit for zero-width boxes
+        if floated_box.width == 0.0 {
             // TODO: need to update last_placed_float?
 
             return PlacedFloatedBox {
@@ -439,6 +439,38 @@ impl FloatContext {
                 y: start_y,
                 x_inset: placed_inset,
             };
+        }
+
+        // A zero-height float takes up no space, but it still affects the placement of content
+        // and floats whose vertical extent crosses its position, so record it as a zero-height
+        // segment.
+        if floated_box.height == 0.0 {
+            let insert_idx = match start {
+                Some(mut idx) => {
+                    if start_y != self.segments[idx].y.start {
+                        self.subdivide_segment(idx, start_y);
+                        idx += 1;
+                    }
+                    idx
+                }
+                None => {
+                    let last_y_end = self.segments.last().map(|seg| seg.y.end).unwrap_or(0.0);
+                    if start_y > last_y_end {
+                        self.segments.push(Segment { y: last_y_end..start_y, insets: [0.0, 0.0] });
+                    }
+                    start_y = start_y.max(last_y_end);
+                    self.segments.len()
+                }
+            };
+
+            let mut insets =
+                self.segments.get(insert_idx).map(|segment| segment.insets).unwrap_or(containing_block_insets);
+            insets[slot] = insets[slot].max(placed_inset + floated_box.width);
+            self.segments.splice(insert_idx..insert_idx, core::iter::once(Segment { y: start_y..start_y, insets }));
+
+            self.update_last_placed_float(direction, insert_idx..(insert_idx + 1));
+
+            return PlacedFloatedBox { width: floated_box.width, height: 0.0, y: start_y, x_inset: placed_inset };
         }
 
         // Handle case where floated box is placed after all existing segments
@@ -544,10 +576,18 @@ impl FloatContext {
     }
 
     /// Search for a space suitable for laying out non-floated content into
+    ///
+    /// If `height` is non-zero then the returned slot accounts for all floats that a box of that
+    /// height starting at the slot's y position would be adjacent to (a line box is shortened by
+    /// any float that its vertical extent intersects). The returned slot's `height` is the
+    /// vertical extent (from the slot's y position) over which the slot's width is valid: content
+    /// taller than this may be adjacent to further floats and should be re-placed with its actual
+    /// height.
     pub fn find_content_slot(
         &self,
         min_y: f32,
         containing_block_insets: [f32; 2],
+        height: f32,
         clear: Clear,
         after: Option<usize>,
     ) -> ContentSlot {
@@ -573,20 +613,39 @@ impl FloatContext {
         let segment = self.segments.get(start_idx);
         match segment {
             Some(segment) => {
-                let inset_left = segment.insets[0].max(containing_block_insets[0]);
-                let inset_right = segment.insets[1].max(containing_block_insets[1]);
+                let y = segment.y.start.max(min_y);
+                let end_y = y + height;
+
+                // Union the float insets of all segments that the box's vertical extent
+                // intersects, then extend the slot's height over any further segments whose
+                // insets do not exceed that union (the slot's width remains valid there).
+                let mut float_insets = segment.insets;
+                let mut slot_height = f32::INFINITY;
+                for seg in &self.segments[(start_idx + 1)..] {
+                    if seg.y.start < end_y {
+                        float_insets[0] = float_insets[0].max(seg.insets[0]);
+                        float_insets[1] = float_insets[1].max(seg.insets[1]);
+                    } else if seg.insets[0] > float_insets[0] || seg.insets[1] > float_insets[1] {
+                        slot_height = seg.y.start - y;
+                        break;
+                    }
+                }
+
+                let inset_left = float_insets[0].max(containing_block_insets[0]);
+                let inset_right = float_insets[1].max(containing_block_insets[1]);
                 ContentSlot {
                     segment_id: Some(start_idx),
                     x: inset_left,
-                    y: segment.y.start.max(min_y),
+                    y,
                     width: self.available_width - inset_left - inset_right,
-                    height: f32::INFINITY,
+                    height: slot_height,
                 }
             }
+            // Below all floats
             None => ContentSlot {
                 segment_id: None,
                 x: containing_block_insets[0],
-                y: min_y,
+                y: self.segments.last().map(|segment| segment.y.end).unwrap_or(min_y).max(min_y),
                 width: self.available_width - containing_block_insets[0] - containing_block_insets[1],
                 height: f32::INFINITY,
             },
@@ -610,6 +669,7 @@ impl FloatContext {
     ///     the containing block edge.
     ///
     /// When there are no floats beside the box, its (possibly negative) margins apply as usual.
+    #[allow(clippy::too_many_arguments)]
     pub fn find_bfc_slot(
         &self,
         min_y: f32,

--- a/src/compute/float.rs
+++ b/src/compute/float.rs
@@ -615,6 +615,7 @@ impl FloatContext {
         min_y: f32,
         containing_block_insets: [f32; 2],
         margins: [f32; 2],
+        height: f32,
         direction: Direction,
         clear: Clear,
         after: Option<usize>,
@@ -644,6 +645,22 @@ impl FloatContext {
         let start_idx = start_idx.unwrap_or(self.segments.len());
         match self.segments.get(start_idx) {
             Some(segment) => {
+                let y = segment.y.start.max(min_y);
+
+                // The box's border box must not overlap floats over its entire height, so union
+                // the float insets of all segments that the box's vertical extent intersects
+                let mut float_insets = segment.insets;
+                if height > 0.0 {
+                    let end_y = y + height;
+                    for seg in &self.segments[(start_idx + 1)..] {
+                        if seg.y.start >= end_y {
+                            break;
+                        }
+                        float_insets[0] = float_insets[0].max(seg.insets[0]);
+                        float_insets[1] = float_insets[1].max(seg.insets[1]);
+                    }
+                }
+
                 let lead = match direction {
                     Direction::Ltr => 0,
                     Direction::Rtl => 1,
@@ -651,14 +668,14 @@ impl FloatContext {
                 let trail = 1 - lead;
                 let mut fit_insets = [0.0; 2];
                 let mut stretch_insets = [0.0; 2];
-                fit_insets[lead] = segment.insets[lead].max(containing_block_insets[lead]).max(margin_insets[lead]);
+                fit_insets[lead] = float_insets[lead].max(containing_block_insets[lead]).max(margin_insets[lead]);
                 stretch_insets[lead] = fit_insets[lead];
-                fit_insets[trail] = segment.insets[trail].max(containing_block_insets[trail]);
+                fit_insets[trail] = float_insets[trail].max(containing_block_insets[trail]);
                 stretch_insets[trail] = fit_insets[trail].max(containing_block_insets[trail] + margins[trail].max(0.0));
                 BfcSlot {
                     segment_id: Some(start_idx),
                     x: fit_insets[0],
-                    y: segment.y.start.max(min_y),
+                    y,
                     border_width: self.available_width - fit_insets[0] - fit_insets[1],
                     stretch_width: self.available_width - stretch_insets[0] - stretch_insets[1],
                 }

--- a/tests/hand_written/floats.rs
+++ b/tests/hand_written/floats.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "float_layout")]
 use taffy::geometry::Point;
 use taffy::prelude::*;
-use taffy::style::Float;
+use taffy::style::{Float, Overflow};
 use taffy_test_helpers::new_test_tree;
 
 /// Regression test for <https://wpt.live/css/CSS2/floats-clear/floats-146.xht>
@@ -50,4 +50,127 @@ fn float_no_higher_than_earlier_floats() {
     assert_eq!(layout_b.location, Point { x: 0.0, y: 85.0 });
     // C must not be placed higher than B (it fits next to B on the right)
     assert_eq!(layout_c.location, Point { x: 302.0, y: 85.0 });
+}
+
+fn float_block(width: f32, height: f32, float: Float) -> Style {
+    Style {
+        display: Display::Block,
+        float,
+        size: Size { width: length(width), height: length(height) },
+        ..Default::default()
+    }
+}
+
+fn root_style(width: f32) -> Style {
+    Style { display: Display::Block, size: Size { width: length(width), height: auto() }, ..Default::default() }
+}
+
+/// Regression test for <https://wpt.live/css/CSS2/floats/floats-rule3-outside-left-001.xht>
+///
+/// CSS2 float rule 7: a float that is wider than its containing block and has no other
+/// float beside it may overflow the containing block's edge rather than being pushed down.
+#[test]
+fn oversized_float_overflows_containing_block() {
+    let mut taffy = new_test_tree();
+
+    let float_a = taffy.new_leaf(float_block(150.0, 50.0, Float::Left)).unwrap();
+    let root = taffy.new_with_children(root_style(100.0), &[float_a]).unwrap();
+
+    taffy.compute_layout(root, Size::MAX_CONTENT).unwrap();
+
+    assert_eq!(taffy.layout(float_a).unwrap().location, Point { x: 0.0, y: 0.0 });
+}
+
+/// CSS2 float rules 3 & 7: a float with another float beside it must not overlap that float
+/// (rule 3) nor extend past the containing block's opposite edge (rule 7) - it must move down.
+#[test]
+fn float_beside_existing_float_moves_down_instead_of_overflowing() {
+    let mut taffy = new_test_tree();
+
+    // Rule 3: an opposite-direction float that doesn't fit must move down, not overlap
+    let left = taffy.new_leaf(float_block(60.0, 50.0, Float::Left)).unwrap();
+    let right = taffy.new_leaf(float_block(60.0, 50.0, Float::Right)).unwrap();
+    // Rule 7: a same-direction float that doesn't fit must move down, not overflow the
+    // containing block's trailing edge
+    let left2 = taffy.new_leaf(float_block(60.0, 50.0, Float::Left)).unwrap();
+
+    let root = taffy.new_with_children(root_style(100.0), &[left, right, left2]).unwrap();
+
+    taffy.compute_layout(root, Size::MAX_CONTENT).unwrap();
+
+    assert_eq!(taffy.layout(left).unwrap().location, Point { x: 0.0, y: 0.0 });
+    assert_eq!(taffy.layout(right).unwrap().location, Point { x: 40.0, y: 50.0 });
+    assert_eq!(taffy.layout(left2).unwrap().location, Point { x: 0.0, y: 100.0 });
+}
+
+/// Regression test for <https://wpt.live/css/CSS2/floats/floats-zero-height-wrap-002.xht>
+///
+/// A zero-height float takes up no space, but still affects the placement of content
+/// whose vertical extent crosses its position.
+#[test]
+fn zero_height_float_affects_crossing_content() {
+    let mut taffy = new_test_tree();
+
+    let f1 = taffy.new_leaf(float_block(10.0, 30.0, Float::Left)).unwrap();
+    let zero =
+        taffy.new_leaf(Style { clear: taffy::style::Clear::Left, ..float_block(100.0, 0.0, Float::Left) }).unwrap();
+    // A BFC box whose vertical extent would cross the zero-height float: it doesn't fit
+    // beside the float's 100px inset, so it must be placed below it
+    let bfc = taffy
+        .new_leaf(Style {
+            display: Display::Block,
+            overflow: Point { x: Overflow::Hidden, y: Overflow::Hidden },
+            size: Size { width: length(450.0), height: length(40.0) },
+            ..Default::default()
+        })
+        .unwrap();
+
+    let root = taffy.new_with_children(root_style(500.0), &[f1, zero, bfc]).unwrap();
+
+    taffy.compute_layout(root, Size::MAX_CONTENT).unwrap();
+
+    assert_eq!(taffy.layout(f1).unwrap().location, Point { x: 0.0, y: 0.0 });
+    assert_eq!(taffy.layout(zero).unwrap().location, Point { x: 0.0, y: 30.0 });
+    assert_eq!(taffy.layout(bfc).unwrap().location, Point { x: 0.0, y: 30.0 });
+}
+
+/// Regression test for <https://wpt.live/css/CSS2/floats/floats-wrap-top-below-bfc-001l.xht>
+///
+/// A box establishing a new block formatting context must not overlap floats over its full
+/// vertical extent: if it would intersect a float lower down, it moves below that float.
+#[test]
+fn bfc_avoids_floats_over_full_height() {
+    let mut taffy = new_test_tree();
+
+    let spacer = taffy.new_leaf(float_block(100.0, 30.0, Float::None)).unwrap();
+    // A float placed below the spacer
+    let float_a = taffy.new_leaf(float_block(80.0, 30.0, Float::Left)).unwrap();
+    // A BFC box: too wide to fit beside the float, so it must be placed below it even though
+    // there is float-free space beside the spacer above the float
+    let bfc = taffy
+        .new_leaf(Style {
+            display: Display::Block,
+            overflow: Point { x: Overflow::Hidden, y: Overflow::Hidden },
+            size: Size { width: length(40.0), height: length(60.0) },
+            ..Default::default()
+        })
+        .unwrap();
+
+    let inner = taffy
+        .new_with_children(
+            Style {
+                display: Display::Block,
+                size: Size { width: length(100.0), height: auto() },
+                ..Default::default()
+            },
+            &[float_a],
+        )
+        .unwrap();
+    let root = taffy.new_with_children(root_style(100.0), &[spacer, inner, bfc]).unwrap();
+
+    taffy.compute_layout(root, Size::MAX_CONTENT).unwrap();
+
+    assert_eq!(taffy.layout(float_a).unwrap().location, Point { x: 0.0, y: 0.0 });
+    // The BFC box starts below the float (y = 30 + 30 = 60), not beside the spacer
+    assert_eq!(taffy.layout(bfc).unwrap().location, Point { x: 0.0, y: 60.0 });
 }


### PR DESCRIPTION
# Objective

Fix float placement per CSS2 §9.5.1 rules 3–9 to address a cluster of Blitz WPT failures ("float placement rules" group, measured on DioxusLabs/blitz#625).

Changes:

- **Rules 3 & 7 (horizontal overflow)**: a float that is too wide may overflow its containing block, but must not overlap a float on the opposite side, and (rule 7) must not extend past the trailing content edge when there is a float on its lead side. `FloatContext::place_floated_box` previously shifted such floats down; horizontal fit is now computed as:
  ```rust
  fits_opposite_floats = trail_inset == 0 || x + width <= bfc_width - trail_inset
  fits_containing_block = lead_float_inset == 0 || x + width <= bfc_width - cb_trail_inset
  ```
  so oversized floats stay at the top and overflow when no other float prohibits it.
- **Height-aware slot search**: `find_content_slot` and `find_bfc_slot` now take the candidate box's `height` and union float insets across *all* segments the box's vertical extent crosses (a box that establishes an independent FC must avoid floats over its full height; line boxes are shortened by floats whose top is below the line top). `compute_block_layout` re-runs the slot search after child layout if the actual height differs from the estimate. This fixes the `floats-wrap-top-below-*` family.
- **Zero-height floats**: `place_floated_box` now inserts a zero-height segment (and updates last-placed-float state) so zero-height floats still affect the placement of later floats and cleared content (`floats-zero-height-wrap-*`).
- **Content slot below all floats**: the fall-through slot now starts at the last segment's end rather than `min_y`, so inline content cannot be placed higher than existing floats.
- **Float margins don't collapse**: floats establish BFCs, so their child layout is now invoked with `Line::FALSE` margin collapsing.
- **New `BlockContext::float_snapshot` / `restore_float_snapshot` API**: clones/restores the `FloatContext`, letting callers (Blitz inline layout) speculatively place floats mid-line and undo them if the line's content is later rewound or cannot fit beside them (needed for `white-space: nowrap` and unbreakable content).

Regression tests added in `tests/hand_written/floats.rs` for rule-3/7 overflow, moving down instead of overflowing, zero-height floats affecting crossing content, and BFC boxes avoiding floats over their full height.

## Context

Verified against Blitz PR [#625](https://github.com/DioxusLabs/blitz/pull/625) plus companion Blitz PR (inline float integration) on the `css/CSS2/floats` + `css/CSS2/floats-clear` WPT subsuites (`WPT_DIR=... cargo run --release --package wpt css/CSS2/floats css/CSS2/floats-clear`):

- Baseline: **195 PASS / 130 FAIL / 0 CRASH** of 325 run
- With this PR + companion Blitz PR: **226 PASS / 99 FAIL / 0 CRASH** — **31 newly passing, 0 regressions**

Newly passing tests:

```
css/CSS2/floats-clear/clear-float-002.xht
css/CSS2/floats-clear/clear-float-003.xht
css/CSS2/floats-clear/floats-132.xht
css/CSS2/floats-clear/floats-149.xht
css/CSS2/floats-clear/floats-bfc-003.html
css/CSS2/floats/float-in-inline-001.html
css/CSS2/floats/float-in-inline-002.html
css/CSS2/floats/float-nowrap-hyphen-rewind-1.html
css/CSS2/floats/floats-placement-004.html
css/CSS2/floats/floats-placement-vertical-001b.xht
css/CSS2/floats/floats-placement-vertical-001c.xht
css/CSS2/floats/floats-rule3-outside-{left,right}-00{1,2}.xht   (4 tests)
css/CSS2/floats/floats-rule7-outside-{left,right}-001.xht       (2 tests)
css/CSS2/floats/floats-wrap-top-below-bfc-00{1,2,3}{l,r}.xht    (6 tests)
css/CSS2/floats/floats-wrap-top-below-inline-00{1,2,3}{l,r}.xht (6 tests)
css/CSS2/floats/floats-zero-height-wrap-00{1,2}.xht             (2 tests)
```

Still failing in this group (not addressed): `floats-placement-005.html`, `floats-placement-vertical-003/004.xht`, and `floats-clear/floats-007/039/040/101/141/143.xht` (these need further work, e.g. inline-block baseline interactions in their references).

`cargo fmt`, `cargo clippy --workspace`, and `cargo test --features float_layout` (5349 tests) all pass.

## Feedback wanted

The `float_snapshot`/`restore_float_snapshot` API is a pragmatic way to let the inline layout speculatively place floats; happy to reshape it (e.g. a transactional guard) if preferred.


Link to Devin session: https://app.devin.ai/sessions/2aa49a15ca484966b5b71922bfd2bb58
Requested by: @nicoburns