### PR TITLE
Float placement: allow floats to overflow their containing block per CSS2 §9.5.1 rules 3 & 7

### DIFF
--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -959,7 +959,9 @@ fn perform_final_layout_on_in_flow_children(
                     parent_size,
                     Size { width: AvailableSpace::Definite(available_width), height: AvailableSpace::MaxContent },
                     SizingMode::InherentSize,
-                    Line::TRUE,
+                    // A float establishes a new block formatting context: its margins do not
+                    // collapse with the margins of its children
+                    Line::FALSE,
                 );
                 let margin_box = item_layout.size + item_non_auto_margin.sum_axes();
 

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -959,9 +959,7 @@ fn perform_final_layout_on_in_flow_children(
                     parent_size,
                     Size { width: AvailableSpace::Definite(available_width), height: AvailableSpace::MaxContent },
                     SizingMode::InherentSize,
-                    // A float establishes a new block formatting context: its margins do not
-                    // collapse with the margins of its children
-                    Line::FALSE,
+                    Line::TRUE,
                 );
                 let margin_box = item_layout.size + item_non_auto_margin.sum_axes();
 

--- a/src/compute/float.rs
+++ b/src/compute/float.rs
@@ -100,16 +100,45 @@ struct Segment {
 
 impl Segment {
     /// Whether the segment can fit the passed floated box (in the horizontal axis)
-    fn fits_float_width(&self, floated_box: Size<f32>, direction: FloatDirection, bfc_width: f32) -> bool {
-        let slot = direction as usize;
-        self.insets[slot] == 0.0 || (bfc_width - floated_box.width - self.inset_sum()) >= 0.0
+    ///
+    /// See [`float_fits_horizontally`] for the details of the fit rules.
+    fn fits_float_width(
+        &self,
+        floated_box: Size<f32>,
+        direction: FloatDirection,
+        bfc_width: f32,
+        cb_insets: [f32; 2],
+    ) -> bool {
+        float_fits_horizontally(floated_box.width, direction, bfc_width, self.insets, cb_insets)
     }
+}
 
-    /// The total space taken up by both insets
-    #[inline(always)]
-    fn inset_sum(&self) -> f32 {
-        self.insets[0] + self.insets[1]
-    }
+/// Whether a floated box of the given width fits horizontally given the float insets
+/// (`float_insets`) and containing block insets (`cb_insets`) that apply to it.
+///
+/// A float is normally placed at the further-in of the float edge and the containing block
+/// edge on the side it is floated towards (its "lead" side). From that position it must:
+///
+///   - not overlap any float on the opposite ("trail") side (CSS2 §9.5.1 rule 3), and
+///   - not extend past the containing block's trail edge if there is a float on its lead
+///     side (CSS2 §9.5.1 rule 7: a float may only stick out of its containing block if it
+///     is already as far towards its float direction as possible).
+///
+/// Note that a float which is not constrained by other floats *may* overflow its
+/// containing block's trail edge (rules 1 and 7).
+fn float_fits_horizontally(
+    width: f32,
+    direction: FloatDirection,
+    bfc_width: f32,
+    float_insets: [f32; 2],
+    cb_insets: [f32; 2],
+) -> bool {
+    let lead = direction as usize;
+    let trail = 1 - lead;
+    let x_inset = float_insets[lead].max(cb_insets[lead]);
+    let fits_opposite_floats = float_insets[trail] == 0.0 || x_inset + width <= bfc_width - float_insets[trail];
+    let fits_containing_block = float_insets[lead] == 0.0 || x_inset + width <= bfc_width - cb_insets[trail];
+    fits_opposite_floats && fits_containing_block
 }
 
 /// Helper type for placing a single floated box
@@ -122,28 +151,39 @@ struct FloatFitter {
     bfc_width: f32,
     /// The total height of the set of segments currently being considered
     slot_height: f64,
-    /// The union of the insets of the set of segments currently being considered
-    insets: [f32; 2],
+    /// The union of the float insets of the set of segments currently being considered
+    float_insets: [f32; 2],
+    /// The insets of the box's containing block from the edges of the Block Formatting Context
+    cb_insets: [f32; 2],
 }
 
 impl FloatFitter {
     /// Create a new `FloatFitter`
-    fn new(bfc_width: f32, slot_height: f32, insets: [f32; 2]) -> Self {
-        Self { bfc_width, slot_height: slot_height as f64, insets }
+    fn new(bfc_width: f32, slot_height: f32, cb_insets: [f32; 2]) -> Self {
+        Self { bfc_width, slot_height: slot_height as f64, float_insets: [0.0, 0.0], cb_insets }
     }
 
     // Horizontal fitting
 
     /// Union the insets of another segment. This is a "max" of the insets on each side.
     fn union_insets(&mut self, insets: [f32; 2]) {
-        self.insets[0] = self.insets[0].max(insets[0]);
-        self.insets[1] = self.insets[1].max(insets[1]);
+        self.float_insets[0] = self.float_insets[0].max(insets[0]);
+        self.float_insets[1] = self.float_insets[1].max(insets[1]);
+    }
+
+    /// The inset from the edge of the BFC (on the side the box is floated towards) that the
+    /// box would be placed at given the currently accounted for insets
+    fn placed_inset(&self, direction: FloatDirection) -> f32 {
+        let lead = direction as usize;
+        self.float_insets[lead].max(self.cb_insets[lead])
     }
 
     /// Given the currently accounted for insets, check whether there is an x position
-    /// such that the box fits horizontally
-    fn fits_horiontally(&self, width: f32) -> bool {
-        self.insets == [0.0, 0.0] || self.bfc_width - self.insets[0] - self.insets[1] - width >= 0.0
+    /// such that the box fits horizontally.
+    ///
+    /// See [`float_fits_horizontally`] for the details of the fit rules.
+    fn fits_horiontally(&self, width: f32, direction: FloatDirection) -> bool {
+        float_fits_horizontally(width, direction, self.bfc_width, self.float_insets, self.cb_insets)
     }
 
     // Vertical fitting
@@ -362,7 +402,7 @@ impl FloatContext {
 
             // Candidate start segment doesn't have (horizontal) space for the float:
             // => retry with the next segment
-            if !start_segment.fits_float_width(floated_box, direction, self.available_width) {
+            if !start_segment.fits_float_width(floated_box, direction, self.available_width, containing_block_insets) {
                 start_idx += 1;
                 end_idx = end_idx.max(start_idx);
                 continue;
@@ -384,7 +424,7 @@ impl FloatContext {
                 // This means no existing segment can accomodate the float so we must create a new
                 // segment below all existing segments
                 let Some(end_segment) = self.segments.get(end_idx) else {
-                    let inset = fitter.insets[slot];
+                    let inset = fitter.placed_inset(direction);
                     break 'outer (Some(start_idx), None, inset);
                 };
 
@@ -393,7 +433,7 @@ impl FloatContext {
                 // If it does not fit horizontally then it will never fit in this position, so
                 // continue the outer loop to find and check a new position
                 fitter.union_insets(end_segment.insets);
-                if !fitter.fits_horiontally(floated_box.width) {
+                if !fitter.fits_horiontally(floated_box.width, direction) {
                     start_idx += 1;
                     end_idx = end_idx.max(start_idx);
                     continue 'outer;
@@ -411,7 +451,7 @@ impl FloatContext {
                     continue;
                 }
 
-                let inset = fitter.insets[slot];
+                let inset = fitter.placed_inset(direction);
                 break 'outer (Some(start_idx), Some(end_idx), inset);
             }
         };

--- a/tests/hand_written/floats.rs
+++ b/tests/hand_written/floats.rs
@@ -98,3 +98,54 @@ fn clear_past_zero_width_float() {
     // container's height is 1 + 99 = 100.
     assert_eq!(taffy.layout(container).unwrap().size.height, 100.0);
 }
+
+fn float_block(width: f32, height: f32, float: Float) -> Style {
+    Style {
+        display: Display::Block,
+        float,
+        size: Size { width: length(width), height: length(height) },
+        ..Default::default()
+    }
+}
+
+fn root_style(width: f32) -> Style {
+    Style { display: Display::Block, size: Size { width: length(width), height: auto() }, ..Default::default() }
+}
+
+/// Regression test for <https://wpt.live/css/CSS2/floats/floats-rule3-outside-left-001.xht>
+///
+/// CSS2 float rule 7: a float that is wider than its containing block and has no other
+/// float beside it may overflow the containing block's edge rather than being pushed down.
+#[test]
+fn oversized_float_overflows_containing_block() {
+    let mut taffy = new_test_tree();
+
+    let float_a = taffy.new_leaf(float_block(150.0, 50.0, Float::Left)).unwrap();
+    let root = taffy.new_with_children(root_style(100.0), &[float_a]).unwrap();
+
+    taffy.compute_layout(root, Size::MAX_CONTENT).unwrap();
+
+    assert_eq!(taffy.layout(float_a).unwrap().location, Point { x: 0.0, y: 0.0 });
+}
+
+/// CSS2 float rules 3 & 7: a float with another float beside it must not overlap that float
+/// (rule 3) nor extend past the containing block's opposite edge (rule 7) - it must move down.
+#[test]
+fn float_beside_existing_float_moves_down_instead_of_overflowing() {
+    let mut taffy = new_test_tree();
+
+    // Rule 3: an opposite-direction float that doesn't fit must move down, not overlap
+    let left = taffy.new_leaf(float_block(60.0, 50.0, Float::Left)).unwrap();
+    let right = taffy.new_leaf(float_block(60.0, 50.0, Float::Right)).unwrap();
+    // Rule 7: a same-direction float that doesn't fit must move down, not overflow the
+    // containing block's trailing edge
+    let left2 = taffy.new_leaf(float_block(60.0, 50.0, Float::Left)).unwrap();
+
+    let root = taffy.new_with_children(root_style(100.0), &[left, right, left2]).unwrap();
+
+    taffy.compute_layout(root, Size::MAX_CONTENT).unwrap();
+
+    assert_eq!(taffy.layout(left).unwrap().location, Point { x: 0.0, y: 0.0 });
+    assert_eq!(taffy.layout(right).unwrap().location, Point { x: 40.0, y: 50.0 });
+    assert_eq!(taffy.layout(left2).unwrap().location, Point { x: 0.0, y: 100.0 });
+}


### PR DESCRIPTION
# Objective

Part 1/5 of the float placement fixes split out from #1063 (verified together against Blitz PR DioxusLabs/blitz#625; see #1063 for full WPT numbers: 195→226 PASS, 0 regressions across the stack).

A float that is wider than its containing block was unconditionally pushed down looking for space that never exists. Per CSS2 §9.5.1, an oversized float may overflow the containing block's trailing edge (rules 1/7) — it only has to move down when another float prohibits the position:

- rule 3: it must not overlap a float on the opposite side, and
- rule 7: it must not extend past the containing block's trailing edge when there is a float on its lead side.

Horizontal fitting is centralized in a new `float_fits_horizontally(width, direction, bfc_width, float_insets, cb_insets)` used by both `Segment::fits_float_width` and `FloatFitter`:

```rust
fits_opposite_floats  = float_insets[trail] == 0 || x_inset + width <= bfc_width - float_insets[trail];
fits_containing_block = float_insets[lead]  == 0 || x_inset + width <= bfc_width - cb_insets[trail];
```

`FloatFitter` now tracks float insets separately from containing-block insets (`placed_inset()` gives the final lead-side inset).

Fixes WPT `css/CSS2/floats/floats-rule3-outside-{left,right}-00{1,2}.xht` and `floats-rule7-outside-{left,right}-001.xht`. Regression tests added in `tests/hand_written/floats.rs`.

## Context

Stack (bottom-up): this PR → margin-collapse fix → height-aware slot search → zero-height floats → float snapshot API. Together they supersede #1063.

Link to Devin session: https://app.devin.ai/sessions/2aa49a15ca484966b5b71922bfd2bb58
Requested by: @nicoburns