### PR TITLE
Don't collapse a float's margins with the margins of its children

### DIFF
--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -959,7 +959,9 @@ fn perform_final_layout_on_in_flow_children(
                     parent_size,
                     Size { width: AvailableSpace::Definite(available_width), height: AvailableSpace::MaxContent },
                     SizingMode::InherentSize,
-                    Line::TRUE,
+                    // A float establishes a new block formatting context: its margins do not
+                    // collapse with the margins of its children
+                    Line::FALSE,
                 );
                 let margin_box = item_layout.size + item_non_auto_margin.sum_axes();
 


### PR DESCRIPTION
# Objective

Part 2/5 of the float placement fixes split from #1063 (stacked on #1064).

A float establishes a new block formatting context, so its margins must not collapse with those of its children (CSS2 §8.3.1). Float child layout in `perform_final_layout_on_in_flow_children` now passes `Line::FALSE` instead of `Line::TRUE` for `vertical_margins_are_collapsible`.

## Context

Stack (bottom-up): rules 3&7 overflow (#1064) → this PR → height-aware slot search → zero-height floats → float snapshot API. Together they supersede #1063; WPT verification numbers for the whole stack are in #1063.

Link to Devin session: https://app.devin.ai/sessions/2aa49a15ca484966b5b71922bfd2bb58
Requested by: @nicoburns