### PR TITLE
Record zero-height floats as zero-height segments so they affect later placement

### DIFF
--- a/src/compute/float.rs
+++ b/src/compute/float.rs
@@ -456,18 +456,43 @@ impl FloatContext {
             }
         };
 
-        // Short-circuit for zero-height boxes. Zero-width boxes are still recorded in segments:
-        // their edge acts as an obstacle that boxes establishing an independent formatting
-        // context may not be placed to the outside of (e.g. via a negative margin).
+        // A zero-height float takes up no space, but it still affects the placement of content
+        // and floats whose vertical extent crosses its position, so record it as a zero-height
+        // segment.
         if floated_box.height == 0.0 {
-            // TODO: need to update last_placed_float?
-
-            return PlacedFloatedBox {
-                width: floated_box.width,
-                height: floated_box.height,
-                y: start_y,
-                x_inset: placed_inset,
+            let insert_idx = match start {
+                Some(mut idx) => {
+                    if start_y != self.segments[idx].y.start {
+                        self.subdivide_segment(idx, start_y);
+                        idx += 1;
+                    }
+                    idx
+                }
+                None => {
+                    let last_y_end = self.segments.last().map(|seg| seg.y.end).unwrap_or(0.0);
+                    if start_y > last_y_end {
+                        self.segments.push(Segment {
+                            y: last_y_end..start_y,
+                            insets: [0.0, 0.0],
+                            has_float: [false; 2],
+                        });
+                    }
+                    start_y = start_y.max(last_y_end);
+                    self.segments.len()
+                }
             };
+
+            let mut insets =
+                self.segments.get(insert_idx).map(|segment| segment.insets).unwrap_or(containing_block_insets);
+            let mut has_float = self.segments.get(insert_idx).map(|segment| segment.has_float).unwrap_or([false; 2]);
+            insets[slot] = insets[slot].max(placed_inset + floated_box.width);
+            has_float[slot] = true;
+            self.segments
+                .splice(insert_idx..insert_idx, core::iter::once(Segment { y: start_y..start_y, insets, has_float }));
+
+            self.update_last_placed_float(direction, insert_idx..(insert_idx + 1));
+
+            return PlacedFloatedBox { width: floated_box.width, height: 0.0, y: start_y, x_inset: placed_inset };
         }
 
         // Handle case where floated box is placed after all existing segments

--- a/tests/hand_written/floats.rs
+++ b/tests/hand_written/floats.rs
@@ -190,3 +190,34 @@ fn bfc_avoids_floats_over_full_height() {
     // The BFC box starts below the float (y = 30 + 30 = 60), not beside the spacer
     assert_eq!(taffy.layout(bfc).unwrap().location, Point { x: 0.0, y: 60.0 });
 }
+
+/// Regression test for <https://wpt.live/css/CSS2/floats/floats-zero-height-wrap-002.xht>
+///
+/// A zero-height float takes up no space, but still affects the placement of content
+/// whose vertical extent crosses its position.
+#[test]
+fn zero_height_float_affects_crossing_content() {
+    let mut taffy = new_test_tree();
+
+    let f1 = taffy.new_leaf(float_block(10.0, 30.0, Float::Left)).unwrap();
+    let zero =
+        taffy.new_leaf(Style { clear: taffy::style::Clear::Left, ..float_block(100.0, 0.0, Float::Left) }).unwrap();
+    // A BFC box whose vertical extent would cross the zero-height float: it doesn't fit
+    // beside the float's 100px inset, so it must be placed below it
+    let bfc = taffy
+        .new_leaf(Style {
+            display: Display::Block,
+            overflow: Point { x: Overflow::Hidden, y: Overflow::Hidden },
+            size: Size { width: length(450.0), height: length(40.0) },
+            ..Default::default()
+        })
+        .unwrap();
+
+    let root = taffy.new_with_children(root_style(500.0), &[f1, zero, bfc]).unwrap();
+
+    taffy.compute_layout(root, Size::MAX_CONTENT).unwrap();
+
+    assert_eq!(taffy.layout(f1).unwrap().location, Point { x: 0.0, y: 0.0 });
+    assert_eq!(taffy.layout(zero).unwrap().location, Point { x: 0.0, y: 30.0 });
+    assert_eq!(taffy.layout(bfc).unwrap().location, Point { x: 0.0, y: 30.0 });
+}


### PR DESCRIPTION
# Objective

Part 4/5 of the float placement fixes split from #1063 (stacked on #1066).

Zero-height floats were short-circuited in `place_floated_box` as zero-sized boxes and never recorded, so they had no effect on later floats or content. Per CSS2 they take up no vertical space but still constrain the placement of floats and content whose vertical extent crosses their position.

`place_floated_box` now inserts a zero-height `Segment` (subdividing or extending the segment list as needed), records the float's inset on it, and updates the last-placed-float state; only zero-*width* boxes keep the short-circuit.

Fixes WPT `css/CSS2/floats/floats-zero-height-wrap-00{1,2}.xht`. Regression test added in `tests/hand_written/floats.rs`.

## Context

Stack (bottom-up): rules 3&7 overflow (#1064) → margin collapse (#1065) → height-aware slots (#1066) → this PR → float snapshot API (#1068). Together they supersede #1063 (closed). Latest WPT verification after restacking onto latest main: blitz `css/CSS2/floats`+`floats-clear` = 246 PASS / 91 FAIL / 0 CRASH of 337 with #1066+#1067 + DioxusLabs/blitz#628, vs 227 PASS / 110 FAIL on current blitz main (19 newly passing, 0 regressions).

Link to Devin session: https://app.devin.ai/sessions/2aa49a15ca484966b5b71922bfd2bb58
Requested by: @nicoburns