### PR TITLE
Add BlockContext::float_snapshot/restore_float_snapshot for speculative float placement

### DIFF
--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -172,6 +172,19 @@ impl BlockContext<'_> {
         pos
     }
 
+    /// Snapshot the current float placement state. The snapshot can be passed to
+    /// [`restore_float_snapshot`](Self::restore_float_snapshot) to undo the placement of any
+    /// floats placed after the snapshot was taken (e.g. to speculatively place floats).
+    pub fn float_snapshot(&self) -> FloatContext {
+        self.bfc.float_context.clone()
+    }
+
+    /// Restore a float placement state snapshot taken with
+    /// [`float_snapshot`](Self::float_snapshot)
+    pub fn restore_float_snapshot(&mut self, snapshot: FloatContext) {
+        self.bfc.float_context = snapshot;
+    }
+
     /// Search a space suitable for laying out non-floated content into
     pub fn find_content_slot(&self, min_y: f32, height: f32, clear: Clear, after: Option<usize>) -> ContentSlot {
         let mut slot = self.bfc.float_context.find_content_slot(

--- a/tests/hand_written/floats.rs
+++ b/tests/hand_written/floats.rs
@@ -150,6 +150,37 @@ fn float_beside_existing_float_moves_down_instead_of_overflowing() {
     assert_eq!(taffy.layout(left2).unwrap().location, Point { x: 0.0, y: 100.0 });
 }
 
+/// Regression test for <https://wpt.live/css/CSS2/floats/floats-zero-height-wrap-002.xht>
+///
+/// A zero-height float takes up no space, but still affects the placement of content
+/// whose vertical extent crosses its position.
+#[test]
+fn zero_height_float_affects_crossing_content() {
+    let mut taffy = new_test_tree();
+
+    let f1 = taffy.new_leaf(float_block(10.0, 30.0, Float::Left)).unwrap();
+    let zero =
+        taffy.new_leaf(Style { clear: taffy::style::Clear::Left, ..float_block(100.0, 0.0, Float::Left) }).unwrap();
+    // A BFC box whose vertical extent would cross the zero-height float: it doesn't fit
+    // beside the float's 100px inset, so it must be placed below it
+    let bfc = taffy
+        .new_leaf(Style {
+            display: Display::Block,
+            overflow: Point { x: Overflow::Hidden, y: Overflow::Hidden },
+            size: Size { width: length(450.0), height: length(40.0) },
+            ..Default::default()
+        })
+        .unwrap();
+
+    let root = taffy.new_with_children(root_style(500.0), &[f1, zero, bfc]).unwrap();
+
+    taffy.compute_layout(root, Size::MAX_CONTENT).unwrap();
+
+    assert_eq!(taffy.layout(f1).unwrap().location, Point { x: 0.0, y: 0.0 });
+    assert_eq!(taffy.layout(zero).unwrap().location, Point { x: 0.0, y: 30.0 });
+    assert_eq!(taffy.layout(bfc).unwrap().location, Point { x: 0.0, y: 30.0 });
+}
+
 /// Regression test for <https://wpt.live/css/CSS2/floats/floats-wrap-top-below-bfc-001l.xht>
 ///
 /// A box establishing a new block formatting context must not overlap floats over its full
@@ -189,35 +220,4 @@ fn bfc_avoids_floats_over_full_height() {
     assert_eq!(taffy.layout(float_a).unwrap().location, Point { x: 0.0, y: 0.0 });
     // The BFC box starts below the float (y = 30 + 30 = 60), not beside the spacer
     assert_eq!(taffy.layout(bfc).unwrap().location, Point { x: 0.0, y: 60.0 });
-}
-
-/// Regression test for <https://wpt.live/css/CSS2/floats/floats-zero-height-wrap-002.xht>
-///
-/// A zero-height float takes up no space, but still affects the placement of content
-/// whose vertical extent crosses its position.
-#[test]
-fn zero_height_float_affects_crossing_content() {
-    let mut taffy = new_test_tree();
-
-    let f1 = taffy.new_leaf(float_block(10.0, 30.0, Float::Left)).unwrap();
-    let zero =
-        taffy.new_leaf(Style { clear: taffy::style::Clear::Left, ..float_block(100.0, 0.0, Float::Left) }).unwrap();
-    // A BFC box whose vertical extent would cross the zero-height float: it doesn't fit
-    // beside the float's 100px inset, so it must be placed below it
-    let bfc = taffy
-        .new_leaf(Style {
-            display: Display::Block,
-            overflow: Point { x: Overflow::Hidden, y: Overflow::Hidden },
-            size: Size { width: length(450.0), height: length(40.0) },
-            ..Default::default()
-        })
-        .unwrap();
-
-    let root = taffy.new_with_children(root_style(500.0), &[f1, zero, bfc]).unwrap();
-
-    taffy.compute_layout(root, Size::MAX_CONTENT).unwrap();
-
-    assert_eq!(taffy.layout(f1).unwrap().location, Point { x: 0.0, y: 0.0 });
-    assert_eq!(taffy.layout(zero).unwrap().location, Point { x: 0.0, y: 30.0 });
-    assert_eq!(taffy.layout(bfc).unwrap().location, Point { x: 0.0, y: 30.0 });
 }


### PR DESCRIPTION
# Objective

Part 5/5 of the float placement fixes split from #1063 (stacked on #1067).

Adds a small public API for callers integrating inline layout (e.g. Blitz):

```rust
impl BlockContext<'_> {
    pub fn float_snapshot(&self) -> FloatContext;
    pub fn restore_float_snapshot(&mut self, snapshot: FloatContext);
}
```

An inline layout engine may need to place a float mid-line before knowing whether the line's content fits beside it (e.g. `white-space: nowrap` or unbreakable content discovered later on the line). The snapshot lets it speculatively place floats and roll them back if the line must be re-laid without them. DioxusLabs/blitz#628 currently pins #1067's head (so its revocable-float logic is temporarily removed); re-adding it on top of this API fixes WPT `float-nowrap-3/9.html` there.

## Feedback wanted

This is a pragmatic clone/restore API; happy to reshape it (e.g. a transactional guard type) if preferred.

## Context

Stack (bottom-up): rules 3&7 overflow (#1064) → margin collapse (#1065) → height-aware slots (#1066) → zero-height floats (#1067) → this PR. Together they supersede #1063 (closed). Latest WPT verification: blitz `css/CSS2/floats`+`floats-clear` = 246 PASS / 91 FAIL / 0 CRASH of 337 with #1066+#1067 + DioxusLabs/blitz#628 (19 newly passing vs blitz main's 227/110/0; +2 more — `float-nowrap-3/9` — with this PR's API used).

Link to Devin session: https://app.devin.ai/sessions/2aa49a15ca484966b5b71922bfd2bb58
Requested by: @nicoburns