### PR TITLE
Zero-width float edges in BFC slots; float state snapshot/restore

### DIFF
--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -58,6 +58,21 @@ impl BlockFormattingContext {
     }
 }
 
+/// A snapshot of the float placement state of a `BlockContext`, allowing float
+/// placements from a discarded speculative layout attempt to be undone.
+#[cfg(feature = "float_layout")]
+#[derive(Debug, Clone)]
+pub struct FloatStateSnapshot {
+    /// The state of the `FloatContext` at the time of the snapshot
+    float_context: FloatContext,
+    /// The value of `BlockContext::adjoining_floats` at the time of the snapshot
+    adjoining_floats: [bool; 2],
+    /// The value of `BlockContext::top_adjoining_floats` at the time of the snapshot
+    top_adjoining_floats: Option<[bool; 2]>,
+    /// The value of `BlockContext::float_content_contribution` at the time of the snapshot
+    float_content_contribution: f32,
+}
+
 /// Context for each individual Block within a Block Formatting Context
 ///
 /// Contains a mutable reference to the BlockFormattingContext + block-specific data
@@ -169,6 +184,27 @@ impl BlockContext<'_> {
         self.float_content_contribution = self.float_content_contribution.max(pos.y + floated_box.height);
 
         pos
+    }
+
+    /// Capture the current float placement state so that it can later be restored
+    /// with [`Self::restore_float_state`]. This allows callers performing speculative
+    /// layout (e.g. inline layout that may need to re-run line breaking) to undo
+    /// float placements made during a discarded layout attempt.
+    pub fn snapshot_float_state(&self) -> FloatStateSnapshot {
+        FloatStateSnapshot {
+            float_context: self.bfc.float_context.clone(),
+            adjoining_floats: self.adjoining_floats,
+            top_adjoining_floats: self.top_adjoining_floats,
+            float_content_contribution: self.float_content_contribution,
+        }
+    }
+
+    /// Restore float placement state previously captured with [`Self::snapshot_float_state`]
+    pub fn restore_float_state(&mut self, snapshot: &FloatStateSnapshot) {
+        self.bfc.float_context = snapshot.float_context.clone();
+        self.adjoining_floats = snapshot.adjoining_floats;
+        self.top_adjoining_floats = snapshot.top_adjoining_floats;
+        self.float_content_contribution = snapshot.float_content_contribution;
     }
 
     /// Search a space suitable for laying out non-floated content into

--- a/src/compute/float.rs
+++ b/src/compute/float.rs
@@ -96,6 +96,10 @@ struct Segment {
     /// The insets of a segment created for a float are seeded with the float's containing
     /// block insets on both sides, so a non-zero inset alone does not imply a float.
     has_float: [bool; 2],
+    /// Whether a zero-width float's edge lies at the left (slot 0) / right (slot 1) inset.
+    /// Such an edge does not constrain the width of adjacent boxes, but it does act as an
+    /// obstacle that a float-avoiding box may not be moved past by a negative margin.
+    zero_width_edge: [bool; 2],
 }
 
 impl Segment {
@@ -281,8 +285,12 @@ impl FloatContext {
     /// vertical start and end at exact segment boundaries
     fn subdivide_segment(&mut self, idx: usize, divide_at_y: f32) {
         let old_segment = &mut self.segments[idx];
-        let new_segment =
-            Segment { insets: old_segment.insets, has_float: old_segment.has_float, y: divide_at_y..old_segment.y.end };
+        let new_segment = Segment {
+            insets: old_segment.insets,
+            has_float: old_segment.has_float,
+            zero_width_edge: old_segment.zero_width_edge,
+            y: divide_at_y..old_segment.y.end,
+        };
         if !old_segment.y.contains(&divide_at_y) || old_segment.y.start == divide_at_y {
             debug_log!("old_segment", dbg:&mut *old_segment);
             debug_log!("divide_at_y", dbg:divide_at_y);
@@ -474,7 +482,12 @@ impl FloatContext {
         if start.is_none() {
             let last_y_end = self.segments.last().map(|seg| seg.y.end).unwrap_or(0.0);
             if start_y > last_y_end {
-                self.segments.push(Segment { y: last_y_end..start_y, insets: [0.0, 0.0], has_float: [false; 2] });
+                self.segments.push(Segment {
+                    y: last_y_end..start_y,
+                    insets: [0.0, 0.0],
+                    has_float: [false; 2],
+                    zero_width_edge: [false; 2],
+                });
             }
 
             let start_y = last_y_end.max(start_y);
@@ -482,8 +495,15 @@ impl FloatContext {
             let mut insets = containing_block_insets;
             insets[slot] += floated_box.width;
             let mut has_float = [false; 2];
-            has_float[slot] = true;
-            self.segments.push(Segment { y: start_y..(start_y + floated_box.height), insets, has_float });
+            has_float[slot] = floated_box.width > 0.0;
+            let mut zero_width_edge = [false; 2];
+            zero_width_edge[slot] = floated_box.width == 0.0;
+            self.segments.push(Segment {
+                y: start_y..(start_y + floated_box.height),
+                insets,
+                has_float,
+                zero_width_edge,
+            });
 
             // Update last_placed_float
             let start_idx = self.segments.len() - 1;
@@ -516,7 +536,12 @@ impl FloatContext {
             None => {
                 let last_y_end = self.segments.last().map(|seg| seg.y.end).unwrap_or(0.0);
                 if min_y > last_y_end {
-                    self.segments.push(Segment { y: last_y_end..min_y, insets: [0.0, 0.0], has_float: [false; 2] });
+                    self.segments.push(Segment {
+                        y: last_y_end..min_y,
+                        insets: [0.0, 0.0],
+                        has_float: [false; 2],
+                        zero_width_edge: [false; 2],
+                    });
                 }
                 self.segments.len() - 1
             }
@@ -547,7 +572,8 @@ impl FloatContext {
         let placed_inset_plus_width = placed_inset + floated_box.width;
         for segment in &mut self.segments[start_idx..=end_idx] {
             segment.insets[slot] = placed_inset_plus_width;
-            segment.has_float[slot] = true;
+            segment.has_float[slot] |= floated_box.width > 0.0;
+            segment.zero_width_edge[slot] |= floated_box.width == 0.0;
         }
 
         // Update last_placed_float
@@ -692,7 +718,34 @@ impl FloatContext {
             .segments
             .get(hwm..)
             .and_then(|segments| segments.iter().position(|segment| segment.y.end > min_y).map(|idx| idx + hwm));
-        let start_idx = start_idx.unwrap_or(self.segments.len());
+        let Some(first_idx) = start_idx else {
+            // Below all floats
+            return BfcSlot {
+                y: self.segments.last().map(|segment| segment.y.end).unwrap_or(min_y).max(min_y),
+                ..no_float_slot
+            };
+        };
+        // Segments without an actual float edge on either side (e.g. created by zero-width
+        // floats) don't constrain boxes horizontally: look below them for the constraining
+        // segment, but position the box at the original (unconstrained) y position. Any
+        // zero-width float edges passed over on the way act as obstacles that the box may
+        // not be moved past by a negative margin.
+        let slot_y = self.segments[first_idx].y.start.max(min_y);
+        let mut zero_width_edge = [false; 2];
+        let start_idx = self
+            .segments
+            .get(first_idx..)
+            .and_then(|segments| {
+                segments
+                    .iter()
+                    .position(|segment| {
+                        zero_width_edge[0] |= segment.zero_width_edge[0];
+                        zero_width_edge[1] |= segment.zero_width_edge[1];
+                        segment.has_float != [false, false]
+                    })
+                    .map(|idx| idx + first_idx)
+            })
+            .unwrap_or(self.segments.len());
         match self.segments.get(start_idx) {
             Some(segment) => {
                 let lead = match direction {
@@ -704,11 +757,23 @@ impl FloatContext {
                 let has_trail_float = segment.has_float[trail];
                 let mut fit_insets = [0.0; 2];
                 let mut stretch_insets = [0.0; 2];
-                fit_insets[lead] =
-                    if has_lead_float { segment.insets[lead].max(margin_insets[lead]) } else { margin_insets[lead] };
+                fit_insets[lead] = if has_lead_float {
+                    segment.insets[lead].max(margin_insets[lead])
+                } else if zero_width_edge[lead] {
+                    // No box-constraining float on the leading side, but a zero-width float's
+                    // edge lies at the containing block's content edge: a negative leading
+                    // margin does not move the border edge past that obstacle.
+                    margin_insets[lead].max(containing_block_insets[lead])
+                } else {
+                    margin_insets[lead]
+                };
                 stretch_insets[lead] = fit_insets[lead];
                 fit_insets[trail] = if has_trail_float {
                     segment.insets[trail].max(containing_block_insets[trail])
+                } else if zero_width_edge[trail] {
+                    // A zero-width float's edge on the trailing side stops a negative trailing
+                    // margin from widening the space for the border box
+                    containing_block_insets[trail]
                 } else {
                     // A positive trailing margin may overflow the containing block edge (it does
                     // not affect fit), but a negative one widens the space for the border box
@@ -716,22 +781,21 @@ impl FloatContext {
                 };
                 stretch_insets[trail] = if has_trail_float {
                     segment.insets[trail].max(margin_insets[trail])
+                } else if zero_width_edge[trail] {
+                    margin_insets[trail].max(containing_block_insets[trail])
                 } else {
                     margin_insets[trail]
                 };
                 BfcSlot {
                     segment_id: Some(start_idx),
                     x: fit_insets[0],
-                    y: segment.y.start.max(min_y),
+                    y: slot_y,
                     border_width: self.available_width - fit_insets[0] - fit_insets[1],
                     stretch_width: self.available_width - stretch_insets[0] - stretch_insets[1],
                 }
             }
-            // Below all floats
-            None => BfcSlot {
-                y: self.segments.last().map(|segment| segment.y.end).unwrap_or(min_y).max(min_y),
-                ..no_float_slot
-            },
+            // Only unconstrained segments at or below the box's position
+            None => BfcSlot { segment_id: Some(first_idx), y: slot_y, ..no_float_slot },
         }
     }
 }

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -38,6 +38,8 @@ pub(crate) mod grid;
 
 pub use leaf::compute_leaf_layout;
 
+#[cfg(feature = "float_layout")]
+pub use self::block::FloatStateSnapshot;
 #[cfg(feature = "block_layout")]
 pub use self::block::{compute_block_layout, BlockContext, BlockFormattingContext};
 

--- a/tests/hand_written/floats.rs
+++ b/tests/hand_written/floats.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "float_layout")]
 use taffy::geometry::Point;
 use taffy::prelude::*;
-use taffy::style::{Clear, Float};
+use taffy::style::{Clear, Float, Overflow};
 use taffy_test_helpers::new_test_tree;
 
 /// Regression test for <https://wpt.live/css/CSS2/floats-clear/floats-146.xht>
@@ -148,4 +148,96 @@ fn float_beside_existing_float_moves_down_instead_of_overflowing() {
     assert_eq!(taffy.layout(left).unwrap().location, Point { x: 0.0, y: 0.0 });
     assert_eq!(taffy.layout(right).unwrap().location, Point { x: 40.0, y: 50.0 });
     assert_eq!(taffy.layout(left2).unwrap().location, Point { x: 0.0, y: 100.0 });
+}
+
+/// Regression test for <https://wpt.live/css/CSS2/floats/zero-width-floats.html>
+///
+/// A BFC root with negative horizontal margins placed beside only zero-width floats
+/// must not have those margins clamped: zero-width floats don't constrain the width
+/// of adjacent boxes, so the box behaves as if no float were present.
+#[test]
+fn bfc_negative_margins_not_clamped_by_zero_width_floats() {
+    let mut taffy = new_test_tree();
+
+    let zero_width_left = taffy.new_leaf(float_block(0.0, 50.0, Float::Left)).unwrap();
+    let zero_width_right =
+        taffy.new_leaf(Style { clear: Clear::Left, ..float_block(0.0, 150.0, Float::Right) }).unwrap();
+    let bfc = taffy
+        .new_leaf(Style {
+            display: Display::Block,
+            overflow: Point { x: Overflow::Hidden, y: Overflow::Hidden },
+            margin: Rect { left: length(-50.0), right: length(-50.0), top: zero(), bottom: zero() },
+            size: Size { width: auto(), height: length(100.0) },
+            ..Default::default()
+        })
+        .unwrap();
+
+    let root = taffy.new_with_children(root_style(100.0), &[zero_width_left, zero_width_right, bfc]).unwrap();
+
+    taffy.compute_layout(root, Size::MAX_CONTENT).unwrap();
+
+    let layout = taffy.layout(bfc).unwrap();
+    // Negative margins expand the BFC past the containing block on both sides
+    assert_eq!(layout.location, Point { x: -50.0, y: 0.0 });
+    assert_eq!(layout.size, Size { width: 200.0, height: 100.0 });
+}
+
+/// Regression test for <https://wpt.live/css/CSS2/floats/zero-width-floats-positioning.tentative.html>
+///
+/// When a BFC root is narrowed to fit beside a real (positive-width) float, a zero-width
+/// float's edge acts as an obstacle: a negative margin may not move the border edge past it.
+#[test]
+fn zero_width_float_edge_blocks_negative_margin_beside_real_float() {
+    let mut taffy = new_test_tree();
+
+    let zero_width_left = taffy.new_leaf(float_block(0.0, 50.0, Float::Left)).unwrap();
+    let real_right = taffy.new_leaf(Style { clear: Clear::Left, ..float_block(25.0, 50.0, Float::Right) }).unwrap();
+    let bfc = taffy
+        .new_leaf(Style {
+            display: Display::Block,
+            overflow: Point { x: Overflow::Hidden, y: Overflow::Hidden },
+            margin: Rect { left: length(-50.0), right: zero(), top: zero(), bottom: zero() },
+            size: Size { width: auto(), height: length(100.0) },
+            ..Default::default()
+        })
+        .unwrap();
+
+    let root = taffy.new_with_children(root_style(125.0), &[zero_width_left, real_right, bfc]).unwrap();
+
+    taffy.compute_layout(root, Size::MAX_CONTENT).unwrap();
+
+    let layout = taffy.layout(bfc).unwrap();
+    // The zero-width left float's edge stops the negative left margin; the real right
+    // float (below the zero-width float due to clear: left) narrows the box.
+    assert_eq!(layout.location, Point { x: 0.0, y: 0.0 });
+    assert_eq!(layout.size, Size { width: 100.0, height: 100.0 });
+}
+
+/// Regression test for <https://wpt.live/css/CSS2/floats/floats-wrap-bfc-with-margin-006.tentative.html>
+///
+/// A negative leading margin on a BFC root beside a real float on the trailing side only
+/// is applied as usual (there is no float edge on the leading side to act as an obstacle).
+#[test]
+fn bfc_negative_leading_margin_beside_trailing_float() {
+    let mut taffy = new_test_tree();
+
+    let real_right = taffy.new_leaf(float_block(25.0, 50.0, Float::Right)).unwrap();
+    let bfc = taffy
+        .new_leaf(Style {
+            display: Display::Block,
+            overflow: Point { x: Overflow::Hidden, y: Overflow::Hidden },
+            margin: Rect { left: length(-50.0), right: zero(), top: zero(), bottom: zero() },
+            size: Size { width: auto(), height: length(50.0) },
+            ..Default::default()
+        })
+        .unwrap();
+
+    let root = taffy.new_with_children(root_style(50.0), &[real_right, bfc]).unwrap();
+
+    taffy.compute_layout(root, Size::MAX_CONTENT).unwrap();
+
+    let layout = taffy.layout(bfc).unwrap();
+    // width = 50 (container) + 50 (negative margin) - 25 (float) = 75
+    assert_eq!(layout.location, Point { x: -50.0, y: 0.0 });
+    assert_eq!(layout.size, Size { width: 75.0, height: 50.0 });
 }


### PR DESCRIPTION
# Objective

Fix remaining Blitz WPT failures in the "floats × inline content / line boxes" group involving zero-width floats and BFC roots with negative margins, and add an API needed by Blitz's inline layout (see DioxusLabs/blitz#630).

This PR has been rebuilt on top of latest `main` (which already landed overlapping fixes in #1055, #1056, #1061, #1062, #1064, #1065), so it is now much smaller than its original form.

## Changes

### 1. `find_bfc_slot`: zero-width float edges vs. real float edges

`Segment` now tracks `zero_width_edge: [bool; 2]` alongside `has_float` (which is now only set for positive-width floats). When searching for the slot for a float-avoiding box (BFC root):

- Segments with no real float edge on either side (e.g. created only by zero-width floats) don't constrain the box's width: the search continues below them to find the constraining segment, while keeping the box's original (unconstrained) `y` position.
- Zero-width float edges passed over on the way act as obstacles: a negative margin may not move the box's border edge past them (matching Chromium's behavior per WPT `zero-width-floats-positioning.tentative.html`).
- When no real float edge exists at all, margins (including negative margins) apply as usual (WPT `zero-width-floats.html`).

This distinguishes three previously-conflated cases which WPT expects to behave differently:

| scenario | expected behavior |
|---|---|
| only zero-width floats beside box | negative margins fully applied (no clamping) |
| real float on trailing side only | negative leading margin fully applied (#1061 behavior preserved, `floats-wrap-bfc-with-margin-006`) |
| real float on trailing side + zero-width float edge on leading side | leading negative margin clamped at the zero-width edge; box narrowed by the real float |

### 2. `BlockContext::snapshot_float_state` / `restore_float_state`

New public API (exporting a new opaque `FloatStateSnapshot` type) allowing callers performing speculative layout — such as inline layout that may need to re-run line breaking — to roll back float placements made during a discarded layout attempt. Used by Blitz's inline layout in DioxusLabs/blitz#630 to fix floats-in-inline placement when Parley rewinds content.

## Context

Diagnosed from Blitz WPT failures on DioxusLabs/blitz#625; the Blitz-side changes are in DioxusLabs/blitz#630 (which pins taffy to this branch for CI; it should be re-pinned to `main` once this merges).

Newly passing WPT tests attributable to the taffy changes in this PR (measured with blitz#630, `css/CSS2/floats css/CSS2/floats-clear` suites):
- `css/CSS2/floats/zero-width-floats.html`
- `css/CSS2/floats/zero-width-floats-positioning.tentative.html` (kept passing; regressed by upstream main alone)

Overall suite result with blitz#630 (retargeted to blitz `main`, which now includes #625) + this branch: **231 PASS / 106 FAIL / 0 CRASH of 337** vs a blitz-`main` baseline of 227 PASS / 110 FAIL. No previously-passing test regresses.

## Testing

- `cargo test` (all pass, including 3 new hand-written regression tests covering the three scenarios above)
- `cargo fmt` and `cargo clippy --workspace` clean


Link to Devin session: https://app.devin.ai/sessions/ca393611e919410aaa93e816fdf90a54
Requested by: @nicoburns