### PR TITLE
Grid: resolve abspos grid lines to adjacent track edges under content alignment

### DIFF
--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -680,20 +680,38 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
                     maybe_grid_line.and_then(|line: OriginZeroLine| line.try_into_track_vec_index(final_row_counts))
                 });
 
+            // Content alignment (align-content/justify-content) may distribute free space before, between,
+            // or after tracks. Grid lines used by absolutely positioned items resolve to the edges of the
+            // tracks adjacent to the line rather than to the raw gutter offset:
+            //   - As a start edge, a line resolves to the start of the track that follows it
+            //   - As an end edge, a line resolves to the end of the track that precedes it
+            /// Resolve a grid line (by track vector index) used as a start edge to a position
+            fn line_as_start_edge(tracks: &[GridTrack], index: usize) -> f32 {
+                tracks.get(index + 1).unwrap_or(&tracks[index]).offset
+            }
+            /// Resolve a grid line (by track vector index) used as an end edge to a position
+            fn line_as_end_edge(tracks: &[GridTrack], index: usize) -> f32 {
+                if index == 0 {
+                    tracks.get(1).unwrap_or(&tracks[0]).offset
+                } else {
+                    tracks[index].offset
+                }
+            }
+
             let grid_area = Rect {
-                top: maybe_row_indexes.start.map(|index| rows[index].offset).unwrap_or(border.top),
+                top: maybe_row_indexes.start.map(|index| line_as_start_edge(&rows, index)).unwrap_or(border.top),
                 bottom: maybe_row_indexes
                     .end
-                    .map(|index| rows[index].offset)
+                    .map(|index| line_as_end_edge(&rows, index))
                     .unwrap_or(container_border_box.height - border.bottom - scrollbar_gutter.y),
-                left: maybe_col_indexes.start.map(|index| columns[index].offset).unwrap_or_else(|| {
+                left: maybe_col_indexes.start.map(|index| line_as_start_edge(&columns, index)).unwrap_or_else(|| {
                     if direction.is_rtl() {
                         border.left + scrollbar_gutter.x
                     } else {
                         border.left
                     }
                 }),
-                right: maybe_col_indexes.end.map(|index| columns[index].offset).unwrap_or_else(|| {
+                right: maybe_col_indexes.end.map(|index| line_as_end_edge(&columns, index)).unwrap_or_else(|| {
                     if direction.is_rtl() {
                         container_border_box.width - border.right
                     } else {

--- a/test_fixtures/grid/grid_absolute_content_alignment_center.html
+++ b/test_fixtures/grid/grid_absolute_content_alignment_center.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-columns: 100px 50px; grid-template-rows: 70px 30px; width: 400px; height: 200px; justify-content: center; align-content: center; position: relative;">
+  <div style="background-color: red; position: absolute; grid-column: 1 / 2; grid-row: 1 / 2; width: 100%; height: 100%;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_absolute_content_alignment_end_rtl.html
+++ b/test_fixtures/grid/grid_absolute_content_alignment_end_rtl.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; direction: rtl; grid-template-columns: 100px 50px; grid-template-rows: 70px 30px; width: 400px; height: 200px; justify-content: end; align-content: end; position: relative;">
+  <div style="background-color: red; position: absolute; grid-column: 1 / 2; grid-row: 1 / 2; width: 100%; height: 100%;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_absolute_content_alignment_space_between.html
+++ b/test_fixtures/grid/grid_absolute_content_alignment_space_between.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-columns: 100px 50px; grid-template-rows: 70px 30px; width: 400px; height: 200px; justify-content: space-between; align-content: space-between; position: relative;">
+  <div style="background-color: red; position: absolute; grid-column: 2 / 3; grid-row: 2 / 3; width: 100%; height: 100%;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/grid/grid_absolute_content_alignment_center__border_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_content_alignment_center__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_content_alignment_center__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" align-content="center" justify-content="center" width="400px" height="200px" grid-template-rows="70px 30px" grid-template-columns="100px 50px">
+      <div direction="ltr" position="absolute" width="100%" height="100%" grid-row-start="1" grid-row-end="2" grid-column-start="1" grid-column-end="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="200">
+      <node x="125" y="50" width="100" height="70"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_content_alignment_center__border_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_content_alignment_center__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_content_alignment_center__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" align-content="center" justify-content="center" width="400px" height="200px" grid-template-rows="70px 30px" grid-template-columns="100px 50px">
+      <div direction="rtl" position="absolute" width="100%" height="100%" grid-row-start="1" grid-row-end="2" grid-column-start="1" grid-column-end="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="200">
+      <node x="175" y="50" width="100" height="70"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_content_alignment_center__content_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_content_alignment_center__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_content_alignment_center__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" align-content="center" justify-content="center" width="400px" height="200px" grid-template-rows="70px 30px" grid-template-columns="100px 50px">
+      <div box-sizing="content-box" direction="ltr" position="absolute" width="100%" height="100%" grid-row-start="1" grid-row-end="2" grid-column-start="1" grid-column-end="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="200">
+      <node x="125" y="50" width="100" height="70"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_content_alignment_center__content_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_content_alignment_center__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_content_alignment_center__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" align-content="center" justify-content="center" width="400px" height="200px" grid-template-rows="70px 30px" grid-template-columns="100px 50px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" width="100%" height="100%" grid-row-start="1" grid-row-end="2" grid-column-start="1" grid-column-end="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="200">
+      <node x="175" y="50" width="100" height="70"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_content_alignment_end_rtl__border_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_content_alignment_end_rtl__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_content_alignment_end_rtl__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" align-content="end" justify-content="end" width="400px" height="200px" grid-template-rows="70px 30px" grid-template-columns="100px 50px">
+      <div direction="ltr" position="absolute" width="100%" height="100%" grid-row-start="1" grid-row-end="2" grid-column-start="1" grid-column-end="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="200">
+      <node x="50" y="100" width="100" height="70"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_content_alignment_end_rtl__border_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_content_alignment_end_rtl__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_content_alignment_end_rtl__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" align-content="end" justify-content="end" width="400px" height="200px" grid-template-rows="70px 30px" grid-template-columns="100px 50px">
+      <div direction="rtl" position="absolute" width="100%" height="100%" grid-row-start="1" grid-row-end="2" grid-column-start="1" grid-column-end="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="200">
+      <node x="50" y="100" width="100" height="70"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_content_alignment_end_rtl__content_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_content_alignment_end_rtl__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_content_alignment_end_rtl__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" align-content="end" justify-content="end" width="400px" height="200px" grid-template-rows="70px 30px" grid-template-columns="100px 50px">
+      <div box-sizing="content-box" direction="ltr" position="absolute" width="100%" height="100%" grid-row-start="1" grid-row-end="2" grid-column-start="1" grid-column-end="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="200">
+      <node x="50" y="100" width="100" height="70"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_content_alignment_end_rtl__content_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_content_alignment_end_rtl__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_content_alignment_end_rtl__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" align-content="end" justify-content="end" width="400px" height="200px" grid-template-rows="70px 30px" grid-template-columns="100px 50px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" width="100%" height="100%" grid-row-start="1" grid-row-end="2" grid-column-start="1" grid-column-end="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="200">
+      <node x="50" y="100" width="100" height="70"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_content_alignment_space_between__border_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_content_alignment_space_between__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_content_alignment_space_between__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" align-content="space-between" justify-content="space-between" width="400px" height="200px" grid-template-rows="70px 30px" grid-template-columns="100px 50px">
+      <div direction="ltr" position="absolute" width="100%" height="100%" grid-row-start="2" grid-row-end="3" grid-column-start="2" grid-column-end="3"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="200">
+      <node x="350" y="170" width="50" height="30"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_content_alignment_space_between__border_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_content_alignment_space_between__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_content_alignment_space_between__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" align-content="space-between" justify-content="space-between" width="400px" height="200px" grid-template-rows="70px 30px" grid-template-columns="100px 50px">
+      <div direction="rtl" position="absolute" width="100%" height="100%" grid-row-start="2" grid-row-end="3" grid-column-start="2" grid-column-end="3"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="200">
+      <node x="0" y="170" width="50" height="30"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_content_alignment_space_between__content_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_content_alignment_space_between__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_content_alignment_space_between__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" align-content="space-between" justify-content="space-between" width="400px" height="200px" grid-template-rows="70px 30px" grid-template-columns="100px 50px">
+      <div box-sizing="content-box" direction="ltr" position="absolute" width="100%" height="100%" grid-row-start="2" grid-row-end="3" grid-column-start="2" grid-column-end="3"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="200">
+      <node x="350" y="170" width="50" height="30"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_content_alignment_space_between__content_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_content_alignment_space_between__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_content_alignment_space_between__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" align-content="space-between" justify-content="space-between" width="400px" height="200px" grid-template-rows="70px 30px" grid-template-columns="100px 50px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" width="100%" height="100%" grid-row-start="2" grid-row-end="3" grid-column-start="2" grid-column-end="3"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="200">
+      <node x="0" y="170" width="50" height="30"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -17359,6 +17359,78 @@ mod grid {
 
     #[cfg(feature = "grid")]
     #[test]
+    fn grid_absolute_content_alignment_center__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_content_alignment_center__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_content_alignment_center__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_content_alignment_center__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_content_alignment_center__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_content_alignment_center__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_content_alignment_center__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_content_alignment_center__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_content_alignment_end_rtl__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_content_alignment_end_rtl__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_content_alignment_end_rtl__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_content_alignment_end_rtl__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_content_alignment_end_rtl__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_content_alignment_end_rtl__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_content_alignment_end_rtl__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_content_alignment_end_rtl__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_content_alignment_space_between__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_content_alignment_space_between__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_content_alignment_space_between__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_content_alignment_space_between__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_content_alignment_space_between__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_content_alignment_space_between__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_content_alignment_space_between__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_content_alignment_space_between__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
     fn grid_absolute_direction_rtl__border_box_ltr() {
         crate::run_xml_test("grid", "grid_absolute_direction_rtl__border_box_ltr");
     }


### PR DESCRIPTION
# Objective

Fix the failing WPT tests `css/css-grid/abspos/grid-positioned-items-content-alignment-001.html` and `grid-positioned-items-content-alignment-rtl-001.html`.

When `align-content`/`justify-content` distributes free space (center, end, space-between/around/evenly), absolutely positioned grid items attached to grid lines were positioned using the raw gutter-track offset, which does not include the alignment offset applied to the following track. This made their grid area erroneously span the distributed free space, e.g. for `justify-content: center` an item on column lines 1/2 got `x=0, width=225` instead of `x=125, width=100`.

Fix: resolve a grid line used by an abspos item to the edges of its adjacent tracks:

```
start edge of grid area => offset of the track *following* the line
end edge of grid area   => end of the track *preceding* the line (the gutter offset),
                           falling back to the following track's start at line 0
```

With this, both content-alignment tests pass fully (60/60 subtests each) in the Blitz WPT runner, and the `grid-positioned-items-gaps-001`/`-rtl-001`/`-002` tests also improve (gaps-002 tests now fully pass); no other `css-grid/abspos` test regressed. `cargo test --workspace` passes.

## Context

Generated tests added via gentest fixtures: `grid_absolute_content_alignment_center`, `grid_absolute_content_alignment_space_between`, `grid_absolute_content_alignment_end_rtl`. No public API change, so no RELEASES.md entry.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/66f228c7e94242d6a8e704aa8953ae20
Requested by: @nicoburns