### PR TITLE
Fix static position of absolutely positioned flex children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@
 
 ### Fixed
 
+- Flexbox: the static position of absolutely positioned children now resolves `justify-content: start`/`end` and `align-self: start`/`end`/`self-start`/`self-end` as writing-mode relative (flipping for RTL but not for `*-reverse` flex directions or `wrap-reverse`), whereas previously they were treated as flex-relative ([WPT: flex-abspos-staticpos-*](https://wpt.live/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-002.html))
+
+- Flexbox: the static position of absolutely positioned children with `justify-content: space-between` (and the default `normal`) now follows the flex-relative start (matching `flex-start`), so it resolves to the correct edge in `row-reverse`/`column-reverse` containers
+
+- Flexbox: `align-self: baseline` on absolutely positioned children now uses its static-position fallback of `start` instead of `flex-start`
+
+- Flexbox: `auto` margins on absolutely positioned children now only absorb free space when the box is inset-constrained in that axis (both insets set); otherwise they resolve to zero per CSS2 §10.3.7/§10.6.4 ([WPT: flex-abspos-staticpos-margin-001](https://wpt.live/css/css-flexbox/abspos/flex-abspos-staticpos-margin-001.html))
+
 - Block/float: zero-width floats are now recorded in the float context, so their edge acts as an obstacle that a box establishing an independent formatting context cannot be placed to the outside of (e.g. via a negative margin) ([WPT: zero-width-floats-positioning](https://wpt.live/css/CSS2/floats/zero-width-floats-positioning.tentative.html))
 
 - Block/float: a negative margin on a BFC root's float-free side now applies as usual (moving the border edge outside the containing block and widening an auto width) instead of being clamped to the containing block edge. Previously the containing block insets were treated as float insets on both sides, so e.g. a box with `margin-left: -50px` beside a right float could not extend past its containing block's left edge ([WPT: floats-wrap-bfc-with-margin-006/007](https://wpt.live/css/CSS2/floats/floats-wrap-bfc-with-margin-006.tentative.html))

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -2342,12 +2342,14 @@ fn perform_absolute_layout_on_absolute_children(
         }
         .f32_max(Size::ZERO);
 
-        // Expand auto margins to fill available space
+        // Expand auto margins to fill available space. Auto margins only absorb free space
+        // when the box is inset-constrained in that axis (both insets set); otherwise they
+        // resolve to zero and the box is statically positioned (CSS2 §10.3.7 / §10.6.4).
         let resolved_margin = {
             let auto_margin_size = Size {
                 width: {
                     let auto_margin_count = margin.left.is_none() as u8 + margin.right.is_none() as u8;
-                    if auto_margin_count > 0 {
+                    if auto_margin_count > 0 && left.is_some() && right.is_some() {
                         free_space.width / auto_margin_count as f32
                     } else {
                         0.0
@@ -2355,7 +2357,7 @@ fn perform_absolute_layout_on_absolute_children(
                 },
                 height: {
                     let auto_margin_count = margin.top.is_none() as u8 + margin.bottom.is_none() as u8;
-                    if auto_margin_count > 0 {
+                    if auto_margin_count > 0 && top.is_some() && bottom.is_some() {
                         free_space.height / auto_margin_count as f32
                     } else {
                         0.0
@@ -2420,35 +2422,39 @@ fn perform_absolute_layout_on_absolute_children(
             // fallback to `justify-content` on absolutely-positioned flex items (only the
             // cross-axis `align-self` does so). Matching the layout authority over a strict
             // spec read keeps gentest fixtures green; reconsider if Chromium changes behavior.
-            match (constants.justify_content.unwrap_or(JustifyContent::START).keyword(), main_axis_flex_start_reversed)
-            {
-                (AlignContentKeyword::SpaceBetween, _)
+            // `start`/`end` are writing-mode relative (they flip for RTL but not for
+            // reversed flex-directions), whereas `flex-start`/`flex-end` and the
+            // distributed keywords' fallbacks are flex-relative.
+            let start_position = match constants.justify_content.unwrap_or(JustifyContent::FLEX_START).keyword() {
+                AlignContentKeyword::Start => !main_is_rtl,
+                AlignContentKeyword::End => main_is_rtl,
+                _ => true,
+            };
+            match (
+                constants.justify_content.unwrap_or(JustifyContent::FLEX_START).keyword(),
+                main_axis_flex_start_reversed,
+            ) {
+                (AlignContentKeyword::SpaceBetween, false)
                 | (AlignContentKeyword::Stretch, false)
                 | (AlignContentKeyword::FlexStart, false)
                 | (AlignContentKeyword::FlexEnd, true) => {
                     constants.content_box_inset.main_start(constants.dir) + resolved_margin.main_start(constants.dir)
                 }
-                (AlignContentKeyword::Start, false) => {
-                    constants.content_box_inset.main_start(constants.dir) + resolved_margin.main_start(constants.dir)
-                }
-                (AlignContentKeyword::Start, true) => {
-                    constants.container_size.main(constants.dir)
-                        - constants.content_box_inset.main_end(constants.dir)
-                        - final_size.main(constants.dir)
-                        - resolved_margin.main_end(constants.dir)
-                }
-                (AlignContentKeyword::End, false) => {
-                    constants.container_size.main(constants.dir)
-                        - constants.content_box_inset.main_end(constants.dir)
-                        - final_size.main(constants.dir)
-                        - resolved_margin.main_end(constants.dir)
-                }
-                (AlignContentKeyword::End, true) => {
-                    constants.content_box_inset.main_start(constants.dir) + resolved_margin.main_start(constants.dir)
+                (AlignContentKeyword::Start | AlignContentKeyword::End, _) => {
+                    if start_position {
+                        constants.content_box_inset.main_start(constants.dir)
+                            + resolved_margin.main_start(constants.dir)
+                    } else {
+                        constants.container_size.main(constants.dir)
+                            - constants.content_box_inset.main_end(constants.dir)
+                            - final_size.main(constants.dir)
+                            - resolved_margin.main_end(constants.dir)
+                    }
                 }
                 (AlignContentKeyword::FlexEnd, false)
                 | (AlignContentKeyword::FlexStart, true)
-                | (AlignContentKeyword::Stretch, true) => {
+                | (AlignContentKeyword::Stretch, true)
+                | (AlignContentKeyword::SpaceBetween, true) => {
                     constants.container_size.main(constants.dir)
                         - constants.content_box_inset.main_end(constants.dir)
                         - final_size.main(constants.dir)
@@ -2496,33 +2502,34 @@ fn perform_absolute_layout_on_absolute_children(
                 > constants.container_size.cross(constants.dir)
                     - constants.content_box_inset.cross_axis_sum(constants.dir);
             let cross_keyword = resolve_self_alignment_safety(align_self, cross_overflows);
+            // `start`/`end` (and `baseline`, whose static-position fallback is `start`) are
+            // writing-mode relative: they flip for RTL but not for `wrap-reverse`.
+            // `flex-start`/`flex-end` and the `stretch` fallback are flex-relative.
+            let start_position = match cross_keyword {
+                AlignItemsKeyword::Start | AlignItemsKeyword::Baseline => !cross_is_rtl,
+                AlignItemsKeyword::End => cross_is_rtl,
+                _ => true,
+            };
             match (cross_keyword, cross_axis_flex_start_reversed) {
                 // Stretch alignment does not apply to absolutely positioned items
                 // See "Example 3" at https://www.w3.org/TR/css-flexbox-1/#abspos-items
                 // Note: Stretch should be FlexStart not Start when we support both
-                (AlignItemsKeyword::Start, false) => {
-                    constants.content_box_inset.cross_start(constants.dir) + resolved_margin.cross_start(constants.dir)
+                (AlignItemsKeyword::Start | AlignItemsKeyword::End | AlignItemsKeyword::Baseline, _) => {
+                    if start_position {
+                        constants.content_box_inset.cross_start(constants.dir)
+                            + resolved_margin.cross_start(constants.dir)
+                    } else {
+                        constants.container_size.cross(constants.dir)
+                            - constants.content_box_inset.cross_end(constants.dir)
+                            - final_size.cross(constants.dir)
+                            - resolved_margin.cross_end(constants.dir)
+                    }
                 }
-                (AlignItemsKeyword::Start, true) => {
-                    constants.container_size.cross(constants.dir)
-                        - constants.content_box_inset.cross_end(constants.dir)
-                        - final_size.cross(constants.dir)
-                        - resolved_margin.cross_end(constants.dir)
-                }
-                (AlignItemsKeyword::End, false) => {
-                    constants.container_size.cross(constants.dir)
-                        - constants.content_box_inset.cross_end(constants.dir)
-                        - final_size.cross(constants.dir)
-                        - resolved_margin.cross_end(constants.dir)
-                }
-                (AlignItemsKeyword::End, true) => {
-                    constants.content_box_inset.cross_start(constants.dir) + resolved_margin.cross_start(constants.dir)
-                }
-                (AlignItemsKeyword::Baseline | AlignItemsKeyword::Stretch | AlignItemsKeyword::FlexStart, false)
+                (AlignItemsKeyword::Stretch | AlignItemsKeyword::FlexStart, false)
                 | (AlignItemsKeyword::FlexEnd, true) => {
                     constants.content_box_inset.cross_start(constants.dir) + resolved_margin.cross_start(constants.dir)
                 }
-                (AlignItemsKeyword::Baseline | AlignItemsKeyword::Stretch | AlignItemsKeyword::FlexStart, true)
+                (AlignItemsKeyword::Stretch | AlignItemsKeyword::FlexStart, true)
                 | (AlignItemsKeyword::FlexEnd, false) => {
                     constants.container_size.cross(constants.dir)
                         - constants.content_box_inset.cross_end(constants.dir)

--- a/test_fixtures/flex/absolute_layout_align_self_baseline_wrap_reverse.html
+++ b/test_fixtures/flex/absolute_layout_align_self_baseline_wrap_reverse.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 100px; height: 100px; flex-wrap: wrap-reverse;">
+  <div style="position: absolute; width: 20px; height: 20px; align-self: baseline;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/absolute_layout_align_self_end_wrap_reverse.html
+++ b/test_fixtures/flex/absolute_layout_align_self_end_wrap_reverse.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 100px; height: 100px; flex-wrap: wrap-reverse;">
+  <div style="position: absolute; width: 20px; height: 20px; align-self: end;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/absolute_layout_align_self_start_wrap_reverse.html
+++ b/test_fixtures/flex/absolute_layout_align_self_start_wrap_reverse.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 100px; height: 100px; flex-wrap: wrap-reverse;">
+  <div style="position: absolute; width: 20px; height: 20px; align-self: start;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/absolute_layout_in_row_reverse_container.html
+++ b/test_fixtures/flex/absolute_layout_in_row_reverse_container.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="flex-direction: row-reverse; width: 100px; height: 100px;">
+  <div style="position: absolute; width: 20px; height: 20px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/absolute_layout_justify_content_end_row_reverse.html
+++ b/test_fixtures/flex/absolute_layout_justify_content_end_row_reverse.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="flex-direction: row-reverse; justify-content: end; width: 100px; height: 100px;">
+  <div style="position: absolute; width: 20px; height: 20px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/absolute_layout_justify_content_end_rtl.html
+++ b/test_fixtures/flex/absolute_layout_justify_content_end_rtl.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="direction: rtl; width: 100px; height: 100px; justify-content: end;">
+  <div style="position: absolute; width: 20px; height: 20px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/absolute_layout_justify_content_space_between_row_reverse.html
+++ b/test_fixtures/flex/absolute_layout_justify_content_space_between_row_reverse.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="flex-direction: row-reverse; justify-content: space-between; width: 100px; height: 100px;">
+  <div style="position: absolute; width: 20px; height: 20px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/absolute_layout_justify_content_start_row_reverse.html
+++ b/test_fixtures/flex/absolute_layout_justify_content_start_row_reverse.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="flex-direction: row-reverse; justify-content: start; width: 100px; height: 100px;">
+  <div style="position: absolute; width: 20px; height: 20px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/absolute_layout_justify_content_start_rtl.html
+++ b/test_fixtures/flex/absolute_layout_justify_content_start_rtl.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="direction: rtl; width: 100px; height: 100px; justify-content: start;">
+  <div style="position: absolute; width: 20px; height: 20px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/absolute_layout_no_inset_margin_auto.html
+++ b/test_fixtures/flex/absolute_layout_no_inset_margin_auto.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 100px; height: 100px;">
+  <div style="position: absolute; width: 20px; height: 20px; margin: auto;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/absolute_layout_no_inset_margin_left_auto.html
+++ b/test_fixtures/flex/absolute_layout_no_inset_margin_left_auto.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 100px; height: 100px;">
+  <div style="position: absolute; width: 20px; height: 20px; margin-left: auto; margin-top: auto;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/absolute_layout_no_inset_margins.html
+++ b/test_fixtures/flex/absolute_layout_no_inset_margins.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 100px; height: 100px;">
+  <div style="position: absolute; width: 20px; height: 20px; margin: 1px 2px 3px 4px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/flex/absolute_layout_align_self_baseline_wrap_reverse__border_box_ltr.xml
+++ b/tests/xml/flex/absolute_layout_align_self_baseline_wrap_reverse__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_align_self_baseline_wrap_reverse__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" flex-wrap="wrap-reverse" width="100px" height="100px">
+      <div direction="ltr" position="absolute" align-self="baseline" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_align_self_baseline_wrap_reverse__border_box_rtl.xml
+++ b/tests/xml/flex/absolute_layout_align_self_baseline_wrap_reverse__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_align_self_baseline_wrap_reverse__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" flex-wrap="wrap-reverse" width="100px" height="100px">
+      <div direction="rtl" position="absolute" align-self="baseline" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="80" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_align_self_baseline_wrap_reverse__content_box_ltr.xml
+++ b/tests/xml/flex/absolute_layout_align_self_baseline_wrap_reverse__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_align_self_baseline_wrap_reverse__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" flex-wrap="wrap-reverse" width="100px" height="100px">
+      <div box-sizing="content-box" direction="ltr" position="absolute" align-self="baseline" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_align_self_baseline_wrap_reverse__content_box_rtl.xml
+++ b/tests/xml/flex/absolute_layout_align_self_baseline_wrap_reverse__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_align_self_baseline_wrap_reverse__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" flex-wrap="wrap-reverse" width="100px" height="100px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" align-self="baseline" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="80" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_align_self_end_wrap_reverse__border_box_ltr.xml
+++ b/tests/xml/flex/absolute_layout_align_self_end_wrap_reverse__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_align_self_end_wrap_reverse__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" flex-wrap="wrap-reverse" width="100px" height="100px">
+      <div direction="ltr" position="absolute" align-self="end" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="80" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_align_self_end_wrap_reverse__border_box_rtl.xml
+++ b/tests/xml/flex/absolute_layout_align_self_end_wrap_reverse__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_align_self_end_wrap_reverse__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" flex-wrap="wrap-reverse" width="100px" height="100px">
+      <div direction="rtl" position="absolute" align-self="end" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="80" y="80" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_align_self_end_wrap_reverse__content_box_ltr.xml
+++ b/tests/xml/flex/absolute_layout_align_self_end_wrap_reverse__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_align_self_end_wrap_reverse__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" flex-wrap="wrap-reverse" width="100px" height="100px">
+      <div box-sizing="content-box" direction="ltr" position="absolute" align-self="end" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="80" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_align_self_end_wrap_reverse__content_box_rtl.xml
+++ b/tests/xml/flex/absolute_layout_align_self_end_wrap_reverse__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_align_self_end_wrap_reverse__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" flex-wrap="wrap-reverse" width="100px" height="100px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" align-self="end" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="80" y="80" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_align_self_start_wrap_reverse__border_box_ltr.xml
+++ b/tests/xml/flex/absolute_layout_align_self_start_wrap_reverse__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_align_self_start_wrap_reverse__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" flex-wrap="wrap-reverse" width="100px" height="100px">
+      <div direction="ltr" position="absolute" align-self="start" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_align_self_start_wrap_reverse__border_box_rtl.xml
+++ b/tests/xml/flex/absolute_layout_align_self_start_wrap_reverse__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_align_self_start_wrap_reverse__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" flex-wrap="wrap-reverse" width="100px" height="100px">
+      <div direction="rtl" position="absolute" align-self="start" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="80" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_align_self_start_wrap_reverse__content_box_ltr.xml
+++ b/tests/xml/flex/absolute_layout_align_self_start_wrap_reverse__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_align_self_start_wrap_reverse__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" flex-wrap="wrap-reverse" width="100px" height="100px">
+      <div box-sizing="content-box" direction="ltr" position="absolute" align-self="start" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_align_self_start_wrap_reverse__content_box_rtl.xml
+++ b/tests/xml/flex/absolute_layout_align_self_start_wrap_reverse__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_align_self_start_wrap_reverse__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" flex-wrap="wrap-reverse" width="100px" height="100px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" align-self="start" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="80" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_in_row_reverse_container__border_box_ltr.xml
+++ b/tests/xml/flex/absolute_layout_in_row_reverse_container__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_in_row_reverse_container__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" flex-direction="row-reverse" width="100px" height="100px">
+      <div direction="ltr" position="absolute" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="80" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_in_row_reverse_container__border_box_rtl.xml
+++ b/tests/xml/flex/absolute_layout_in_row_reverse_container__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_in_row_reverse_container__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" flex-direction="row-reverse" width="100px" height="100px">
+      <div direction="rtl" position="absolute" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_in_row_reverse_container__content_box_ltr.xml
+++ b/tests/xml/flex/absolute_layout_in_row_reverse_container__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_in_row_reverse_container__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" flex-direction="row-reverse" width="100px" height="100px">
+      <div box-sizing="content-box" direction="ltr" position="absolute" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="80" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_in_row_reverse_container__content_box_rtl.xml
+++ b/tests/xml/flex/absolute_layout_in_row_reverse_container__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_in_row_reverse_container__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" flex-direction="row-reverse" width="100px" height="100px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_justify_content_end_row_reverse__border_box_ltr.xml
+++ b/tests/xml/flex/absolute_layout_justify_content_end_row_reverse__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_justify_content_end_row_reverse__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" flex-direction="row-reverse" justify-content="end" width="100px" height="100px">
+      <div direction="ltr" position="absolute" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="80" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_justify_content_end_row_reverse__border_box_rtl.xml
+++ b/tests/xml/flex/absolute_layout_justify_content_end_row_reverse__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_justify_content_end_row_reverse__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" flex-direction="row-reverse" justify-content="end" width="100px" height="100px">
+      <div direction="rtl" position="absolute" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_justify_content_end_row_reverse__content_box_ltr.xml
+++ b/tests/xml/flex/absolute_layout_justify_content_end_row_reverse__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_justify_content_end_row_reverse__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" flex-direction="row-reverse" justify-content="end" width="100px" height="100px">
+      <div box-sizing="content-box" direction="ltr" position="absolute" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="80" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_justify_content_end_row_reverse__content_box_rtl.xml
+++ b/tests/xml/flex/absolute_layout_justify_content_end_row_reverse__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_justify_content_end_row_reverse__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" flex-direction="row-reverse" justify-content="end" width="100px" height="100px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_justify_content_end_rtl__border_box_ltr.xml
+++ b/tests/xml/flex/absolute_layout_justify_content_end_rtl__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_justify_content_end_rtl__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" justify-content="end" width="100px" height="100px">
+      <div direction="ltr" position="absolute" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_justify_content_end_rtl__border_box_rtl.xml
+++ b/tests/xml/flex/absolute_layout_justify_content_end_rtl__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_justify_content_end_rtl__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" justify-content="end" width="100px" height="100px">
+      <div direction="rtl" position="absolute" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_justify_content_end_rtl__content_box_ltr.xml
+++ b/tests/xml/flex/absolute_layout_justify_content_end_rtl__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_justify_content_end_rtl__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" justify-content="end" width="100px" height="100px">
+      <div box-sizing="content-box" direction="ltr" position="absolute" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_justify_content_end_rtl__content_box_rtl.xml
+++ b/tests/xml/flex/absolute_layout_justify_content_end_rtl__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_justify_content_end_rtl__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" justify-content="end" width="100px" height="100px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_justify_content_space_between_row_reverse__border_box_ltr.xml
+++ b/tests/xml/flex/absolute_layout_justify_content_space_between_row_reverse__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_justify_content_space_between_row_reverse__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" flex-direction="row-reverse" justify-content="space-between" width="100px" height="100px">
+      <div direction="ltr" position="absolute" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="80" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_justify_content_space_between_row_reverse__border_box_rtl.xml
+++ b/tests/xml/flex/absolute_layout_justify_content_space_between_row_reverse__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_justify_content_space_between_row_reverse__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" flex-direction="row-reverse" justify-content="space-between" width="100px" height="100px">
+      <div direction="rtl" position="absolute" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_justify_content_space_between_row_reverse__content_box_ltr.xml
+++ b/tests/xml/flex/absolute_layout_justify_content_space_between_row_reverse__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_justify_content_space_between_row_reverse__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" flex-direction="row-reverse" justify-content="space-between" width="100px" height="100px">
+      <div box-sizing="content-box" direction="ltr" position="absolute" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="80" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_justify_content_space_between_row_reverse__content_box_rtl.xml
+++ b/tests/xml/flex/absolute_layout_justify_content_space_between_row_reverse__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_justify_content_space_between_row_reverse__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" flex-direction="row-reverse" justify-content="space-between" width="100px" height="100px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_justify_content_start_row_reverse__border_box_ltr.xml
+++ b/tests/xml/flex/absolute_layout_justify_content_start_row_reverse__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_justify_content_start_row_reverse__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" flex-direction="row-reverse" justify-content="start" width="100px" height="100px">
+      <div direction="ltr" position="absolute" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_justify_content_start_row_reverse__border_box_rtl.xml
+++ b/tests/xml/flex/absolute_layout_justify_content_start_row_reverse__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_justify_content_start_row_reverse__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" flex-direction="row-reverse" justify-content="start" width="100px" height="100px">
+      <div direction="rtl" position="absolute" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="80" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_justify_content_start_row_reverse__content_box_ltr.xml
+++ b/tests/xml/flex/absolute_layout_justify_content_start_row_reverse__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_justify_content_start_row_reverse__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" flex-direction="row-reverse" justify-content="start" width="100px" height="100px">
+      <div box-sizing="content-box" direction="ltr" position="absolute" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_justify_content_start_row_reverse__content_box_rtl.xml
+++ b/tests/xml/flex/absolute_layout_justify_content_start_row_reverse__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_justify_content_start_row_reverse__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" flex-direction="row-reverse" justify-content="start" width="100px" height="100px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="80" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_justify_content_start_rtl__border_box_ltr.xml
+++ b/tests/xml/flex/absolute_layout_justify_content_start_rtl__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_justify_content_start_rtl__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" justify-content="start" width="100px" height="100px">
+      <div direction="ltr" position="absolute" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="80" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_justify_content_start_rtl__border_box_rtl.xml
+++ b/tests/xml/flex/absolute_layout_justify_content_start_rtl__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_justify_content_start_rtl__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" justify-content="start" width="100px" height="100px">
+      <div direction="rtl" position="absolute" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="80" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_justify_content_start_rtl__content_box_ltr.xml
+++ b/tests/xml/flex/absolute_layout_justify_content_start_rtl__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_justify_content_start_rtl__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" justify-content="start" width="100px" height="100px">
+      <div box-sizing="content-box" direction="ltr" position="absolute" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="80" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_justify_content_start_rtl__content_box_rtl.xml
+++ b/tests/xml/flex/absolute_layout_justify_content_start_rtl__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_justify_content_start_rtl__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" justify-content="start" width="100px" height="100px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="80" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_no_inset_margin_auto__border_box_ltr.xml
+++ b/tests/xml/flex/absolute_layout_no_inset_margin_auto__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_no_inset_margin_auto__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" width="100px" height="100px">
+      <div direction="ltr" position="absolute" width="20px" height="20px" margin-top="auto" margin-left="auto" margin-bottom="auto" margin-right="auto"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_no_inset_margin_auto__border_box_rtl.xml
+++ b/tests/xml/flex/absolute_layout_no_inset_margin_auto__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_no_inset_margin_auto__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" width="100px" height="100px">
+      <div direction="rtl" position="absolute" width="20px" height="20px" margin-top="auto" margin-left="auto" margin-bottom="auto" margin-right="auto"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="80" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_no_inset_margin_auto__content_box_ltr.xml
+++ b/tests/xml/flex/absolute_layout_no_inset_margin_auto__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_no_inset_margin_auto__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" width="100px" height="100px">
+      <div box-sizing="content-box" direction="ltr" position="absolute" width="20px" height="20px" margin-top="auto" margin-left="auto" margin-bottom="auto" margin-right="auto"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_no_inset_margin_auto__content_box_rtl.xml
+++ b/tests/xml/flex/absolute_layout_no_inset_margin_auto__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_no_inset_margin_auto__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" width="100px" height="100px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" width="20px" height="20px" margin-top="auto" margin-left="auto" margin-bottom="auto" margin-right="auto"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="80" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_no_inset_margin_left_auto__border_box_ltr.xml
+++ b/tests/xml/flex/absolute_layout_no_inset_margin_left_auto__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_no_inset_margin_left_auto__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" width="100px" height="100px">
+      <div direction="ltr" position="absolute" width="20px" height="20px" margin-top="auto" margin-left="auto"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_no_inset_margin_left_auto__border_box_rtl.xml
+++ b/tests/xml/flex/absolute_layout_no_inset_margin_left_auto__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_no_inset_margin_left_auto__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" width="100px" height="100px">
+      <div direction="rtl" position="absolute" width="20px" height="20px" margin-top="auto" margin-left="auto"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="80" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_no_inset_margin_left_auto__content_box_ltr.xml
+++ b/tests/xml/flex/absolute_layout_no_inset_margin_left_auto__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_no_inset_margin_left_auto__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" width="100px" height="100px">
+      <div box-sizing="content-box" direction="ltr" position="absolute" width="20px" height="20px" margin-top="auto" margin-left="auto"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_no_inset_margin_left_auto__content_box_rtl.xml
+++ b/tests/xml/flex/absolute_layout_no_inset_margin_left_auto__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_no_inset_margin_left_auto__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" width="100px" height="100px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" width="20px" height="20px" margin-top="auto" margin-left="auto"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="80" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_no_inset_margins__border_box_ltr.xml
+++ b/tests/xml/flex/absolute_layout_no_inset_margins__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_no_inset_margins__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" width="100px" height="100px">
+      <div direction="ltr" position="absolute" width="20px" height="20px" margin-top="1px" margin-left="4px" margin-bottom="3px" margin-right="2px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="4" y="1" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_no_inset_margins__border_box_rtl.xml
+++ b/tests/xml/flex/absolute_layout_no_inset_margins__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_no_inset_margins__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" width="100px" height="100px">
+      <div direction="rtl" position="absolute" width="20px" height="20px" margin-top="1px" margin-left="4px" margin-bottom="3px" margin-right="2px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="78" y="1" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_no_inset_margins__content_box_ltr.xml
+++ b/tests/xml/flex/absolute_layout_no_inset_margins__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_no_inset_margins__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" width="100px" height="100px">
+      <div box-sizing="content-box" direction="ltr" position="absolute" width="20px" height="20px" margin-top="1px" margin-left="4px" margin-bottom="3px" margin-right="2px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="4" y="1" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_no_inset_margins__content_box_rtl.xml
+++ b/tests/xml/flex/absolute_layout_no_inset_margins__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="absolute_layout_no_inset_margins__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" width="100px" height="100px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" width="20px" height="20px" margin-top="1px" margin-left="4px" margin-bottom="3px" margin-right="2px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="78" y="1" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -5604,6 +5604,66 @@ mod flex {
     }
 
     #[test]
+    fn absolute_layout_align_self_baseline_wrap_reverse__border_box_ltr() {
+        crate::run_xml_test("flex", "absolute_layout_align_self_baseline_wrap_reverse__border_box_ltr");
+    }
+
+    #[test]
+    fn absolute_layout_align_self_baseline_wrap_reverse__content_box_ltr() {
+        crate::run_xml_test("flex", "absolute_layout_align_self_baseline_wrap_reverse__content_box_ltr");
+    }
+
+    #[test]
+    fn absolute_layout_align_self_baseline_wrap_reverse__border_box_rtl() {
+        crate::run_xml_test("flex", "absolute_layout_align_self_baseline_wrap_reverse__border_box_rtl");
+    }
+
+    #[test]
+    fn absolute_layout_align_self_baseline_wrap_reverse__content_box_rtl() {
+        crate::run_xml_test("flex", "absolute_layout_align_self_baseline_wrap_reverse__content_box_rtl");
+    }
+
+    #[test]
+    fn absolute_layout_align_self_end_wrap_reverse__border_box_ltr() {
+        crate::run_xml_test("flex", "absolute_layout_align_self_end_wrap_reverse__border_box_ltr");
+    }
+
+    #[test]
+    fn absolute_layout_align_self_end_wrap_reverse__content_box_ltr() {
+        crate::run_xml_test("flex", "absolute_layout_align_self_end_wrap_reverse__content_box_ltr");
+    }
+
+    #[test]
+    fn absolute_layout_align_self_end_wrap_reverse__border_box_rtl() {
+        crate::run_xml_test("flex", "absolute_layout_align_self_end_wrap_reverse__border_box_rtl");
+    }
+
+    #[test]
+    fn absolute_layout_align_self_end_wrap_reverse__content_box_rtl() {
+        crate::run_xml_test("flex", "absolute_layout_align_self_end_wrap_reverse__content_box_rtl");
+    }
+
+    #[test]
+    fn absolute_layout_align_self_start_wrap_reverse__border_box_ltr() {
+        crate::run_xml_test("flex", "absolute_layout_align_self_start_wrap_reverse__border_box_ltr");
+    }
+
+    #[test]
+    fn absolute_layout_align_self_start_wrap_reverse__content_box_ltr() {
+        crate::run_xml_test("flex", "absolute_layout_align_self_start_wrap_reverse__content_box_ltr");
+    }
+
+    #[test]
+    fn absolute_layout_align_self_start_wrap_reverse__border_box_rtl() {
+        crate::run_xml_test("flex", "absolute_layout_align_self_start_wrap_reverse__border_box_rtl");
+    }
+
+    #[test]
+    fn absolute_layout_align_self_start_wrap_reverse__content_box_rtl() {
+        crate::run_xml_test("flex", "absolute_layout_align_self_start_wrap_reverse__content_box_rtl");
+    }
+
+    #[test]
     fn absolute_layout_child_order__border_box_ltr() {
         crate::run_xml_test("flex", "absolute_layout_child_order__border_box_ltr");
     }
@@ -5621,6 +5681,26 @@ mod flex {
     #[test]
     fn absolute_layout_child_order__content_box_rtl() {
         crate::run_xml_test("flex", "absolute_layout_child_order__content_box_rtl");
+    }
+
+    #[test]
+    fn absolute_layout_in_row_reverse_container__border_box_ltr() {
+        crate::run_xml_test("flex", "absolute_layout_in_row_reverse_container__border_box_ltr");
+    }
+
+    #[test]
+    fn absolute_layout_in_row_reverse_container__content_box_ltr() {
+        crate::run_xml_test("flex", "absolute_layout_in_row_reverse_container__content_box_ltr");
+    }
+
+    #[test]
+    fn absolute_layout_in_row_reverse_container__border_box_rtl() {
+        crate::run_xml_test("flex", "absolute_layout_in_row_reverse_container__border_box_rtl");
+    }
+
+    #[test]
+    fn absolute_layout_in_row_reverse_container__content_box_rtl() {
+        crate::run_xml_test("flex", "absolute_layout_in_row_reverse_container__content_box_rtl");
     }
 
     #[test]
@@ -5721,6 +5801,166 @@ mod flex {
     #[test]
     fn absolute_layout_justify_content_center__content_box_rtl() {
         crate::run_xml_test("flex", "absolute_layout_justify_content_center__content_box_rtl");
+    }
+
+    #[test]
+    fn absolute_layout_justify_content_end_row_reverse__border_box_ltr() {
+        crate::run_xml_test("flex", "absolute_layout_justify_content_end_row_reverse__border_box_ltr");
+    }
+
+    #[test]
+    fn absolute_layout_justify_content_end_row_reverse__content_box_ltr() {
+        crate::run_xml_test("flex", "absolute_layout_justify_content_end_row_reverse__content_box_ltr");
+    }
+
+    #[test]
+    fn absolute_layout_justify_content_end_row_reverse__border_box_rtl() {
+        crate::run_xml_test("flex", "absolute_layout_justify_content_end_row_reverse__border_box_rtl");
+    }
+
+    #[test]
+    fn absolute_layout_justify_content_end_row_reverse__content_box_rtl() {
+        crate::run_xml_test("flex", "absolute_layout_justify_content_end_row_reverse__content_box_rtl");
+    }
+
+    #[test]
+    fn absolute_layout_justify_content_end_rtl__border_box_ltr() {
+        crate::run_xml_test("flex", "absolute_layout_justify_content_end_rtl__border_box_ltr");
+    }
+
+    #[test]
+    fn absolute_layout_justify_content_end_rtl__content_box_ltr() {
+        crate::run_xml_test("flex", "absolute_layout_justify_content_end_rtl__content_box_ltr");
+    }
+
+    #[test]
+    fn absolute_layout_justify_content_end_rtl__border_box_rtl() {
+        crate::run_xml_test("flex", "absolute_layout_justify_content_end_rtl__border_box_rtl");
+    }
+
+    #[test]
+    fn absolute_layout_justify_content_end_rtl__content_box_rtl() {
+        crate::run_xml_test("flex", "absolute_layout_justify_content_end_rtl__content_box_rtl");
+    }
+
+    #[test]
+    fn absolute_layout_justify_content_space_between_row_reverse__border_box_ltr() {
+        crate::run_xml_test("flex", "absolute_layout_justify_content_space_between_row_reverse__border_box_ltr");
+    }
+
+    #[test]
+    fn absolute_layout_justify_content_space_between_row_reverse__content_box_ltr() {
+        crate::run_xml_test("flex", "absolute_layout_justify_content_space_between_row_reverse__content_box_ltr");
+    }
+
+    #[test]
+    fn absolute_layout_justify_content_space_between_row_reverse__border_box_rtl() {
+        crate::run_xml_test("flex", "absolute_layout_justify_content_space_between_row_reverse__border_box_rtl");
+    }
+
+    #[test]
+    fn absolute_layout_justify_content_space_between_row_reverse__content_box_rtl() {
+        crate::run_xml_test("flex", "absolute_layout_justify_content_space_between_row_reverse__content_box_rtl");
+    }
+
+    #[test]
+    fn absolute_layout_justify_content_start_row_reverse__border_box_ltr() {
+        crate::run_xml_test("flex", "absolute_layout_justify_content_start_row_reverse__border_box_ltr");
+    }
+
+    #[test]
+    fn absolute_layout_justify_content_start_row_reverse__content_box_ltr() {
+        crate::run_xml_test("flex", "absolute_layout_justify_content_start_row_reverse__content_box_ltr");
+    }
+
+    #[test]
+    fn absolute_layout_justify_content_start_row_reverse__border_box_rtl() {
+        crate::run_xml_test("flex", "absolute_layout_justify_content_start_row_reverse__border_box_rtl");
+    }
+
+    #[test]
+    fn absolute_layout_justify_content_start_row_reverse__content_box_rtl() {
+        crate::run_xml_test("flex", "absolute_layout_justify_content_start_row_reverse__content_box_rtl");
+    }
+
+    #[test]
+    fn absolute_layout_justify_content_start_rtl__border_box_ltr() {
+        crate::run_xml_test("flex", "absolute_layout_justify_content_start_rtl__border_box_ltr");
+    }
+
+    #[test]
+    fn absolute_layout_justify_content_start_rtl__content_box_ltr() {
+        crate::run_xml_test("flex", "absolute_layout_justify_content_start_rtl__content_box_ltr");
+    }
+
+    #[test]
+    fn absolute_layout_justify_content_start_rtl__border_box_rtl() {
+        crate::run_xml_test("flex", "absolute_layout_justify_content_start_rtl__border_box_rtl");
+    }
+
+    #[test]
+    fn absolute_layout_justify_content_start_rtl__content_box_rtl() {
+        crate::run_xml_test("flex", "absolute_layout_justify_content_start_rtl__content_box_rtl");
+    }
+
+    #[test]
+    fn absolute_layout_no_inset_margin_auto__border_box_ltr() {
+        crate::run_xml_test("flex", "absolute_layout_no_inset_margin_auto__border_box_ltr");
+    }
+
+    #[test]
+    fn absolute_layout_no_inset_margin_auto__content_box_ltr() {
+        crate::run_xml_test("flex", "absolute_layout_no_inset_margin_auto__content_box_ltr");
+    }
+
+    #[test]
+    fn absolute_layout_no_inset_margin_auto__border_box_rtl() {
+        crate::run_xml_test("flex", "absolute_layout_no_inset_margin_auto__border_box_rtl");
+    }
+
+    #[test]
+    fn absolute_layout_no_inset_margin_auto__content_box_rtl() {
+        crate::run_xml_test("flex", "absolute_layout_no_inset_margin_auto__content_box_rtl");
+    }
+
+    #[test]
+    fn absolute_layout_no_inset_margin_left_auto__border_box_ltr() {
+        crate::run_xml_test("flex", "absolute_layout_no_inset_margin_left_auto__border_box_ltr");
+    }
+
+    #[test]
+    fn absolute_layout_no_inset_margin_left_auto__content_box_ltr() {
+        crate::run_xml_test("flex", "absolute_layout_no_inset_margin_left_auto__content_box_ltr");
+    }
+
+    #[test]
+    fn absolute_layout_no_inset_margin_left_auto__border_box_rtl() {
+        crate::run_xml_test("flex", "absolute_layout_no_inset_margin_left_auto__border_box_rtl");
+    }
+
+    #[test]
+    fn absolute_layout_no_inset_margin_left_auto__content_box_rtl() {
+        crate::run_xml_test("flex", "absolute_layout_no_inset_margin_left_auto__content_box_rtl");
+    }
+
+    #[test]
+    fn absolute_layout_no_inset_margins__border_box_ltr() {
+        crate::run_xml_test("flex", "absolute_layout_no_inset_margins__border_box_ltr");
+    }
+
+    #[test]
+    fn absolute_layout_no_inset_margins__content_box_ltr() {
+        crate::run_xml_test("flex", "absolute_layout_no_inset_margins__content_box_ltr");
+    }
+
+    #[test]
+    fn absolute_layout_no_inset_margins__border_box_rtl() {
+        crate::run_xml_test("flex", "absolute_layout_no_inset_margins__border_box_rtl");
+    }
+
+    #[test]
+    fn absolute_layout_no_inset_margins__content_box_rtl() {
+        crate::run_xml_test("flex", "absolute_layout_no_inset_margins__content_box_rtl");
     }
 
     #[test]


### PR DESCRIPTION
# Objective

Fix the static position of absolutely positioned children of flex containers, debugging the WPT `css/css-flexbox/abspos/flex-abspos-staticpos-*` tests (run in Blitz). Four fixes in `perform_absolute_layout_on_absolute_children`:

- `start`/`end` (and `self-start`/`self-end`, which stylo_taffy maps to `start`/`end`) are writing-mode relative: they flip for RTL but NOT for `row-reverse`/`column-reverse` or `wrap-reverse`. Previously they were resolved via `main_axis_flex_start_reversed`/`cross_axis_flex_start_reversed`, i.e. treated as flex-relative.
- `justify-content: space-between` (and the `normal` default, changed from `JustifyContent::START` to `JustifyContent::FLEX_START`) now falls back to *flex-relative* start, so it resolves to the correct edge in reversed flex directions.
- `align-self: baseline` now uses its static-position fallback of `start` (previously grouped with `flex-start`, so it flipped under `wrap-reverse`).
- `auto` margins only absorb free space when both insets in that axis are set; otherwise they resolve to zero per CSS2 §10.3.7/§10.6.4 (fixes the `flex-abspos-staticpos-margin-*` reftests where `margin: auto` with no insets must behave as `0`).

## Context

Verified by running `just wpt css/css-flexbox` in Blitz with this branch patched in (together with DioxusLabs/blitz#624): the `flex-abspos-staticpos-*` tests go from 30→52 passing tests in `css/css-flexbox/abspos` (116 subtests fixed across the suite), with the only remaining non-vertical-writing-mode failure being `align-self-rtl-004` (`self-start`/`self-end` on items whose own direction differs from the container's, which would need dedicated self-start/self-end keywords in Taffy).

New gentest fixtures cover each fixed behavior (`absolute_layout_in_row_reverse_container`, `absolute_layout_justify_content_{start,end}_{row_reverse,rtl}`, `absolute_layout_justify_content_space_between_row_reverse`, `absolute_layout_align_self_{start,end,baseline}_wrap_reverse`, `absolute_layout_no_inset_margin*`); all pre-existing generated tests still pass. CHANGELOG.md updated.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/d0e25433ddd94622ac777e7ddbefb779
Requested by: @nicoburns