### PR TITLE
Add generated tests for abspos grid items in grids with gaps

### DIFF
--- a/test_fixtures/grid/grid_absolute_gaps_end_lines.html
+++ b/test_fixtures/grid/grid_absolute_gaps_end_lines.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="height: 240px; width: 440px; display: grid; grid-template-columns: 40px 40px 40px 40px; grid-template-rows: 40px 40px; gap: 25px 50px; border: 5px solid black; padding: 15px; position: relative; box-sizing: border-box;">
+  <div style="position: absolute; grid-column: auto / 2; grid-row: auto / 2; background-color: red;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_absolute_gaps_end_lines_rtl.html
+++ b/test_fixtures/grid/grid_absolute_gaps_end_lines_rtl.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="height: 240px; width: 440px; display: grid; grid-template-columns: 40px 40px 40px 40px; grid-template-rows: 40px 40px; gap: 25px 50px; border: 5px solid black; padding: 15px; position: relative; box-sizing: border-box; direction: rtl;">
+  <div style="position: absolute; grid-column: auto / 2; grid-row: auto / 2; background-color: red;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_absolute_gaps_spans.html
+++ b/test_fixtures/grid/grid_absolute_gaps_spans.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="height: 240px; width: 440px; display: grid; grid-template-columns: 40px 40px 40px 40px; grid-template-rows: 40px 40px; gap: 25px 50px; border: 5px solid black; padding: 15px; position: relative; box-sizing: border-box;">
+  <div style="position: absolute; grid-column: 2 / 4; grid-row: 1 / 3; background-color: red;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_absolute_gaps_spans_rtl.html
+++ b/test_fixtures/grid/grid_absolute_gaps_spans_rtl.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="height: 240px; width: 440px; display: grid; grid-template-columns: 40px 40px 40px 40px; grid-template-rows: 40px 40px; gap: 25px 50px; border: 5px solid black; padding: 15px; position: relative; box-sizing: border-box; direction: rtl;">
+  <div style="position: absolute; grid-column: 2 / 4; grid-row: 1 / 3; background-color: red;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_absolute_gaps_start_lines.html
+++ b/test_fixtures/grid/grid_absolute_gaps_start_lines.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="height: 240px; width: 440px; display: grid; grid-template-columns: 40px 40px 40px 40px; grid-template-rows: 40px 40px; gap: 25px 50px; border: 5px solid black; padding: 15px; position: relative; box-sizing: border-box;">
+  <div style="position: absolute; grid-column: 2 / auto; grid-row: 2 / auto; background-color: red;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_absolute_gaps_start_lines_rtl.html
+++ b/test_fixtures/grid/grid_absolute_gaps_start_lines_rtl.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="height: 240px; width: 440px; display: grid; grid-template-columns: 40px 40px 40px 40px; grid-template-rows: 40px 40px; gap: 25px 50px; border: 5px solid black; padding: 15px; position: relative; box-sizing: border-box; direction: rtl;">
+  <div style="position: absolute; grid-column: 2 / auto; grid-row: 2 / auto; background-color: red;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/grid/grid_absolute_gaps_end_lines__border_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_gaps_end_lines__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_gaps_end_lines__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="440px" height="240px" row-gap="25px" column-gap="50px" padding-top="15px" padding-left="15px" padding-bottom="15px" padding-right="15px" border-top="5px" border-left="5px" border-bottom="5px" border-right="5px" grid-template-rows="40px 40px" grid-template-columns="40px 40px 40px 40px">
+      <div direction="ltr" position="absolute" grid-row-end="2" grid-column-end="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="440" height="240">
+      <node x="5" y="5" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_gaps_end_lines__border_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_gaps_end_lines__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_gaps_end_lines__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="440px" height="240px" row-gap="25px" column-gap="50px" padding-top="15px" padding-left="15px" padding-bottom="15px" padding-right="15px" border-top="5px" border-left="5px" border-bottom="5px" border-right="5px" grid-template-rows="40px 40px" grid-template-columns="40px 40px 40px 40px">
+      <div direction="rtl" position="absolute" grid-row-end="2" grid-column-end="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="440" height="240">
+      <node x="435" y="5" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_gaps_end_lines__content_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_gaps_end_lines__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_gaps_end_lines__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="440px" height="240px" row-gap="25px" column-gap="50px" padding-top="15px" padding-left="15px" padding-bottom="15px" padding-right="15px" border-top="5px" border-left="5px" border-bottom="5px" border-right="5px" grid-template-rows="40px 40px" grid-template-columns="40px 40px 40px 40px">
+      <div box-sizing="content-box" direction="ltr" position="absolute" grid-row-end="2" grid-column-end="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="440" height="240">
+      <node x="5" y="5" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_gaps_end_lines__content_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_gaps_end_lines__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_gaps_end_lines__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="440px" height="240px" row-gap="25px" column-gap="50px" padding-top="15px" padding-left="15px" padding-bottom="15px" padding-right="15px" border-top="5px" border-left="5px" border-bottom="5px" border-right="5px" grid-template-rows="40px 40px" grid-template-columns="40px 40px 40px 40px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" grid-row-end="2" grid-column-end="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="440" height="240">
+      <node x="435" y="5" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_gaps_end_lines_rtl__border_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_gaps_end_lines_rtl__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_gaps_end_lines_rtl__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="440px" height="240px" row-gap="25px" column-gap="50px" padding-top="15px" padding-left="15px" padding-bottom="15px" padding-right="15px" border-top="5px" border-left="5px" border-bottom="5px" border-right="5px" grid-template-rows="40px 40px" grid-template-columns="40px 40px 40px 40px">
+      <div direction="ltr" position="absolute" grid-row-end="2" grid-column-end="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="440" height="240">
+      <node x="435" y="5" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_gaps_end_lines_rtl__border_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_gaps_end_lines_rtl__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_gaps_end_lines_rtl__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="440px" height="240px" row-gap="25px" column-gap="50px" padding-top="15px" padding-left="15px" padding-bottom="15px" padding-right="15px" border-top="5px" border-left="5px" border-bottom="5px" border-right="5px" grid-template-rows="40px 40px" grid-template-columns="40px 40px 40px 40px">
+      <div direction="rtl" position="absolute" grid-row-end="2" grid-column-end="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="440" height="240">
+      <node x="435" y="5" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_gaps_end_lines_rtl__content_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_gaps_end_lines_rtl__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_gaps_end_lines_rtl__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="440px" height="240px" row-gap="25px" column-gap="50px" padding-top="15px" padding-left="15px" padding-bottom="15px" padding-right="15px" border-top="5px" border-left="5px" border-bottom="5px" border-right="5px" grid-template-rows="40px 40px" grid-template-columns="40px 40px 40px 40px">
+      <div box-sizing="content-box" direction="ltr" position="absolute" grid-row-end="2" grid-column-end="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="440" height="240">
+      <node x="435" y="5" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_gaps_end_lines_rtl__content_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_gaps_end_lines_rtl__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_gaps_end_lines_rtl__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="440px" height="240px" row-gap="25px" column-gap="50px" padding-top="15px" padding-left="15px" padding-bottom="15px" padding-right="15px" border-top="5px" border-left="5px" border-bottom="5px" border-right="5px" grid-template-rows="40px 40px" grid-template-columns="40px 40px 40px 40px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" grid-row-end="2" grid-column-end="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="440" height="240">
+      <node x="435" y="5" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_gaps_spans__border_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_gaps_spans__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_gaps_spans__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="440px" height="240px" row-gap="25px" column-gap="50px" padding-top="15px" padding-left="15px" padding-bottom="15px" padding-right="15px" border-top="5px" border-left="5px" border-bottom="5px" border-right="5px" grid-template-rows="40px 40px" grid-template-columns="40px 40px 40px 40px">
+      <div direction="ltr" position="absolute" grid-row-start="1" grid-row-end="3" grid-column-start="2" grid-column-end="4"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="440" height="240">
+      <node x="110" y="20" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_gaps_spans__border_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_gaps_spans__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_gaps_spans__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="440px" height="240px" row-gap="25px" column-gap="50px" padding-top="15px" padding-left="15px" padding-bottom="15px" padding-right="15px" border-top="5px" border-left="5px" border-bottom="5px" border-right="5px" grid-template-rows="40px 40px" grid-template-columns="40px 40px 40px 40px">
+      <div direction="rtl" position="absolute" grid-row-start="1" grid-row-end="3" grid-column-start="2" grid-column-end="4"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="440" height="240">
+      <node x="330" y="20" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_gaps_spans__content_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_gaps_spans__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_gaps_spans__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="440px" height="240px" row-gap="25px" column-gap="50px" padding-top="15px" padding-left="15px" padding-bottom="15px" padding-right="15px" border-top="5px" border-left="5px" border-bottom="5px" border-right="5px" grid-template-rows="40px 40px" grid-template-columns="40px 40px 40px 40px">
+      <div box-sizing="content-box" direction="ltr" position="absolute" grid-row-start="1" grid-row-end="3" grid-column-start="2" grid-column-end="4"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="440" height="240">
+      <node x="110" y="20" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_gaps_spans__content_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_gaps_spans__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_gaps_spans__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="440px" height="240px" row-gap="25px" column-gap="50px" padding-top="15px" padding-left="15px" padding-bottom="15px" padding-right="15px" border-top="5px" border-left="5px" border-bottom="5px" border-right="5px" grid-template-rows="40px 40px" grid-template-columns="40px 40px 40px 40px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" grid-row-start="1" grid-row-end="3" grid-column-start="2" grid-column-end="4"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="440" height="240">
+      <node x="330" y="20" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_gaps_spans_rtl__border_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_gaps_spans_rtl__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_gaps_spans_rtl__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="440px" height="240px" row-gap="25px" column-gap="50px" padding-top="15px" padding-left="15px" padding-bottom="15px" padding-right="15px" border-top="5px" border-left="5px" border-bottom="5px" border-right="5px" grid-template-rows="40px 40px" grid-template-columns="40px 40px 40px 40px">
+      <div direction="ltr" position="absolute" grid-row-start="1" grid-row-end="3" grid-column-start="2" grid-column-end="4"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="440" height="240">
+      <node x="330" y="20" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_gaps_spans_rtl__border_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_gaps_spans_rtl__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_gaps_spans_rtl__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="440px" height="240px" row-gap="25px" column-gap="50px" padding-top="15px" padding-left="15px" padding-bottom="15px" padding-right="15px" border-top="5px" border-left="5px" border-bottom="5px" border-right="5px" grid-template-rows="40px 40px" grid-template-columns="40px 40px 40px 40px">
+      <div direction="rtl" position="absolute" grid-row-start="1" grid-row-end="3" grid-column-start="2" grid-column-end="4"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="440" height="240">
+      <node x="330" y="20" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_gaps_spans_rtl__content_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_gaps_spans_rtl__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_gaps_spans_rtl__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="440px" height="240px" row-gap="25px" column-gap="50px" padding-top="15px" padding-left="15px" padding-bottom="15px" padding-right="15px" border-top="5px" border-left="5px" border-bottom="5px" border-right="5px" grid-template-rows="40px 40px" grid-template-columns="40px 40px 40px 40px">
+      <div box-sizing="content-box" direction="ltr" position="absolute" grid-row-start="1" grid-row-end="3" grid-column-start="2" grid-column-end="4"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="440" height="240">
+      <node x="330" y="20" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_gaps_spans_rtl__content_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_gaps_spans_rtl__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_gaps_spans_rtl__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="440px" height="240px" row-gap="25px" column-gap="50px" padding-top="15px" padding-left="15px" padding-bottom="15px" padding-right="15px" border-top="5px" border-left="5px" border-bottom="5px" border-right="5px" grid-template-rows="40px 40px" grid-template-columns="40px 40px 40px 40px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" grid-row-start="1" grid-row-end="3" grid-column-start="2" grid-column-end="4"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="440" height="240">
+      <node x="330" y="20" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_gaps_start_lines__border_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_gaps_start_lines__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_gaps_start_lines__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="440px" height="240px" row-gap="25px" column-gap="50px" padding-top="15px" padding-left="15px" padding-bottom="15px" padding-right="15px" border-top="5px" border-left="5px" border-bottom="5px" border-right="5px" grid-template-rows="40px 40px" grid-template-columns="40px 40px 40px 40px">
+      <div direction="ltr" position="absolute" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="440" height="240">
+      <node x="110" y="85" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_gaps_start_lines__border_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_gaps_start_lines__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_gaps_start_lines__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="440px" height="240px" row-gap="25px" column-gap="50px" padding-top="15px" padding-left="15px" padding-bottom="15px" padding-right="15px" border-top="5px" border-left="5px" border-bottom="5px" border-right="5px" grid-template-rows="40px 40px" grid-template-columns="40px 40px 40px 40px">
+      <div direction="rtl" position="absolute" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="440" height="240">
+      <node x="330" y="85" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_gaps_start_lines__content_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_gaps_start_lines__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_gaps_start_lines__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="440px" height="240px" row-gap="25px" column-gap="50px" padding-top="15px" padding-left="15px" padding-bottom="15px" padding-right="15px" border-top="5px" border-left="5px" border-bottom="5px" border-right="5px" grid-template-rows="40px 40px" grid-template-columns="40px 40px 40px 40px">
+      <div box-sizing="content-box" direction="ltr" position="absolute" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="440" height="240">
+      <node x="110" y="85" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_gaps_start_lines__content_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_gaps_start_lines__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_gaps_start_lines__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="440px" height="240px" row-gap="25px" column-gap="50px" padding-top="15px" padding-left="15px" padding-bottom="15px" padding-right="15px" border-top="5px" border-left="5px" border-bottom="5px" border-right="5px" grid-template-rows="40px 40px" grid-template-columns="40px 40px 40px 40px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="440" height="240">
+      <node x="330" y="85" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_gaps_start_lines_rtl__border_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_gaps_start_lines_rtl__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_gaps_start_lines_rtl__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="440px" height="240px" row-gap="25px" column-gap="50px" padding-top="15px" padding-left="15px" padding-bottom="15px" padding-right="15px" border-top="5px" border-left="5px" border-bottom="5px" border-right="5px" grid-template-rows="40px 40px" grid-template-columns="40px 40px 40px 40px">
+      <div direction="ltr" position="absolute" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="440" height="240">
+      <node x="330" y="85" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_gaps_start_lines_rtl__border_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_gaps_start_lines_rtl__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_gaps_start_lines_rtl__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="440px" height="240px" row-gap="25px" column-gap="50px" padding-top="15px" padding-left="15px" padding-bottom="15px" padding-right="15px" border-top="5px" border-left="5px" border-bottom="5px" border-right="5px" grid-template-rows="40px 40px" grid-template-columns="40px 40px 40px 40px">
+      <div direction="rtl" position="absolute" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="440" height="240">
+      <node x="330" y="85" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_gaps_start_lines_rtl__content_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_gaps_start_lines_rtl__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_gaps_start_lines_rtl__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="440px" height="240px" row-gap="25px" column-gap="50px" padding-top="15px" padding-left="15px" padding-bottom="15px" padding-right="15px" border-top="5px" border-left="5px" border-bottom="5px" border-right="5px" grid-template-rows="40px 40px" grid-template-columns="40px 40px 40px 40px">
+      <div box-sizing="content-box" direction="ltr" position="absolute" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="440" height="240">
+      <node x="330" y="85" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_gaps_start_lines_rtl__content_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_gaps_start_lines_rtl__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_gaps_start_lines_rtl__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="440px" height="240px" row-gap="25px" column-gap="50px" padding-top="15px" padding-left="15px" padding-bottom="15px" padding-right="15px" border-top="5px" border-left="5px" border-bottom="5px" border-right="5px" grid-template-rows="40px 40px" grid-template-columns="40px 40px 40px 40px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="440" height="240">
+      <node x="330" y="85" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -17695,6 +17695,150 @@ mod grid {
 
     #[cfg(feature = "grid")]
     #[test]
+    fn grid_absolute_gaps_end_lines__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_gaps_end_lines__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_gaps_end_lines__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_gaps_end_lines__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_gaps_end_lines__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_gaps_end_lines__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_gaps_end_lines__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_gaps_end_lines__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_gaps_end_lines_rtl__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_gaps_end_lines_rtl__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_gaps_end_lines_rtl__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_gaps_end_lines_rtl__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_gaps_end_lines_rtl__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_gaps_end_lines_rtl__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_gaps_end_lines_rtl__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_gaps_end_lines_rtl__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_gaps_spans__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_gaps_spans__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_gaps_spans__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_gaps_spans__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_gaps_spans__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_gaps_spans__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_gaps_spans__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_gaps_spans__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_gaps_spans_rtl__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_gaps_spans_rtl__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_gaps_spans_rtl__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_gaps_spans_rtl__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_gaps_spans_rtl__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_gaps_spans_rtl__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_gaps_spans_rtl__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_gaps_spans_rtl__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_gaps_start_lines__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_gaps_start_lines__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_gaps_start_lines__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_gaps_start_lines__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_gaps_start_lines__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_gaps_start_lines__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_gaps_start_lines__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_gaps_start_lines__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_gaps_start_lines_rtl__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_gaps_start_lines_rtl__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_gaps_start_lines_rtl__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_gaps_start_lines_rtl__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_gaps_start_lines_rtl__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_gaps_start_lines_rtl__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_gaps_start_lines_rtl__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_gaps_start_lines_rtl__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
     fn grid_absolute_justify_self_sized_all__border_box_ltr() {
         crate::run_xml_test("grid", "grid_absolute_justify_self_sized_all__border_box_ltr");
     }


### PR DESCRIPTION
# Objective

Tests-only PR: adds generated tests (`grid_absolute_gaps_start_lines`, `grid_absolute_gaps_end_lines`, `grid_absolute_gaps_spans`, LTR and RTL variants) covering absolutely positioned grid item placement in grids with gaps.

## Context

The code fixes originally in this PR were split out: gutter-aware edge resolution landed on main via #1071, and the implicit-track fix is #1075. These fixtures complement #1071's content-alignment fixtures by covering gutters (`gap`) specifically, matching the scenarios of WPT `css/css-grid/abspos/grid-positioned-items-gaps-001.html` / `-rtl-001.html`.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/9f3946d51bfa4f6ba89dc83598f3fa31
Requested by: @nicoburns