### PR TITLE
Exclude absolutely positioned children from implicit grid size estimate

### DIFF
--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -154,8 +154,13 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
         }
     }
 
-    let get_child_styles_iter =
-        |node| tree.child_ids(node).map(|child_node: NodeId| tree.get_grid_child_style(child_node));
+    // Absolutely positioned children do not take part in grid placement and do not create
+    // implicit tracks, so they are excluded from the grid size estimate.
+    let get_child_styles_iter = |node| {
+        tree.child_ids(node).map(|child_node: NodeId| tree.get_grid_child_style(child_node)).filter(|style| {
+            style.box_generation_mode() != BoxGenerationMode::None && style.position() != Position::Absolute
+        })
+    };
     let child_styles_iter = get_child_styles_iter(node);
 
     // 2. Resolve the explicit grid

--- a/test_fixtures/grid/grid_absolute_gaps_out_of_range_lines.html
+++ b/test_fixtures/grid/grid_absolute_gaps_out_of_range_lines.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="height: 240px; width: 440px; display: grid; grid-template-columns: 40px 40px 40px 40px; grid-template-rows: 40px 40px; gap: 25px 50px; border: 5px solid black; padding: 15px; position: relative; box-sizing: border-box;">
+  <div style="position: absolute; grid-column: 1 / 6; grid-row: 1 / 5; background-color: red;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_absolute_gaps_out_of_range_lines_rtl.html
+++ b/test_fixtures/grid/grid_absolute_gaps_out_of_range_lines_rtl.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="height: 240px; width: 440px; display: grid; grid-template-columns: 40px 40px 40px 40px; grid-template-rows: 40px 40px; gap: 25px 50px; border: 5px solid black; padding: 15px; position: relative; box-sizing: border-box; direction: rtl;">
+  <div style="position: absolute; grid-column: 1 / 6; grid-row: 5 / auto; background-color: red;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/grid/grid_absolute_gaps_out_of_range_lines__border_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_gaps_out_of_range_lines__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_gaps_out_of_range_lines__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="440px" height="240px" row-gap="25px" column-gap="50px" padding-top="15px" padding-left="15px" padding-bottom="15px" padding-right="15px" border-top="5px" border-left="5px" border-bottom="5px" border-right="5px" grid-template-rows="40px 40px" grid-template-columns="40px 40px 40px 40px">
+      <div direction="ltr" position="absolute" grid-row-start="1" grid-row-end="5" grid-column-start="1" grid-column-end="6"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="440" height="240">
+      <node x="20" y="20" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_gaps_out_of_range_lines__border_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_gaps_out_of_range_lines__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_gaps_out_of_range_lines__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="440px" height="240px" row-gap="25px" column-gap="50px" padding-top="15px" padding-left="15px" padding-bottom="15px" padding-right="15px" border-top="5px" border-left="5px" border-bottom="5px" border-right="5px" grid-template-rows="40px 40px" grid-template-columns="40px 40px 40px 40px">
+      <div direction="rtl" position="absolute" grid-row-start="1" grid-row-end="5" grid-column-start="1" grid-column-end="6"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="440" height="240">
+      <node x="420" y="20" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_gaps_out_of_range_lines__content_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_gaps_out_of_range_lines__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_gaps_out_of_range_lines__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="440px" height="240px" row-gap="25px" column-gap="50px" padding-top="15px" padding-left="15px" padding-bottom="15px" padding-right="15px" border-top="5px" border-left="5px" border-bottom="5px" border-right="5px" grid-template-rows="40px 40px" grid-template-columns="40px 40px 40px 40px">
+      <div box-sizing="content-box" direction="ltr" position="absolute" grid-row-start="1" grid-row-end="5" grid-column-start="1" grid-column-end="6"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="440" height="240">
+      <node x="20" y="20" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_gaps_out_of_range_lines__content_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_gaps_out_of_range_lines__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_gaps_out_of_range_lines__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="440px" height="240px" row-gap="25px" column-gap="50px" padding-top="15px" padding-left="15px" padding-bottom="15px" padding-right="15px" border-top="5px" border-left="5px" border-bottom="5px" border-right="5px" grid-template-rows="40px 40px" grid-template-columns="40px 40px 40px 40px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" grid-row-start="1" grid-row-end="5" grid-column-start="1" grid-column-end="6"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="440" height="240">
+      <node x="420" y="20" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_gaps_out_of_range_lines_rtl__border_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_gaps_out_of_range_lines_rtl__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_gaps_out_of_range_lines_rtl__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="440px" height="240px" row-gap="25px" column-gap="50px" padding-top="15px" padding-left="15px" padding-bottom="15px" padding-right="15px" border-top="5px" border-left="5px" border-bottom="5px" border-right="5px" grid-template-rows="40px 40px" grid-template-columns="40px 40px 40px 40px">
+      <div direction="ltr" position="absolute" grid-row-start="5" grid-column-start="1" grid-column-end="6"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="440" height="240">
+      <node x="420" y="5" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_gaps_out_of_range_lines_rtl__border_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_gaps_out_of_range_lines_rtl__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_gaps_out_of_range_lines_rtl__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="440px" height="240px" row-gap="25px" column-gap="50px" padding-top="15px" padding-left="15px" padding-bottom="15px" padding-right="15px" border-top="5px" border-left="5px" border-bottom="5px" border-right="5px" grid-template-rows="40px 40px" grid-template-columns="40px 40px 40px 40px">
+      <div direction="rtl" position="absolute" grid-row-start="5" grid-column-start="1" grid-column-end="6"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="440" height="240">
+      <node x="420" y="5" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_gaps_out_of_range_lines_rtl__content_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_gaps_out_of_range_lines_rtl__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_gaps_out_of_range_lines_rtl__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="440px" height="240px" row-gap="25px" column-gap="50px" padding-top="15px" padding-left="15px" padding-bottom="15px" padding-right="15px" border-top="5px" border-left="5px" border-bottom="5px" border-right="5px" grid-template-rows="40px 40px" grid-template-columns="40px 40px 40px 40px">
+      <div box-sizing="content-box" direction="ltr" position="absolute" grid-row-start="5" grid-column-start="1" grid-column-end="6"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="440" height="240">
+      <node x="420" y="5" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_gaps_out_of_range_lines_rtl__content_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_gaps_out_of_range_lines_rtl__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_gaps_out_of_range_lines_rtl__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="440px" height="240px" row-gap="25px" column-gap="50px" padding-top="15px" padding-left="15px" padding-bottom="15px" padding-right="15px" border-top="5px" border-left="5px" border-bottom="5px" border-right="5px" grid-template-rows="40px 40px" grid-template-columns="40px 40px 40px 40px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" grid-row-start="5" grid-column-start="1" grid-column-end="6"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="440" height="240">
+      <node x="420" y="5" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -17743,6 +17743,54 @@ mod grid {
 
     #[cfg(feature = "grid")]
     #[test]
+    fn grid_absolute_gaps_out_of_range_lines__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_gaps_out_of_range_lines__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_gaps_out_of_range_lines__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_gaps_out_of_range_lines__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_gaps_out_of_range_lines__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_gaps_out_of_range_lines__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_gaps_out_of_range_lines__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_gaps_out_of_range_lines__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_gaps_out_of_range_lines_rtl__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_gaps_out_of_range_lines_rtl__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_gaps_out_of_range_lines_rtl__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_gaps_out_of_range_lines_rtl__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_gaps_out_of_range_lines_rtl__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_gaps_out_of_range_lines_rtl__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_gaps_out_of_range_lines_rtl__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_gaps_out_of_range_lines_rtl__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
     fn grid_absolute_gaps_spans__border_box_ltr() {
         crate::run_xml_test("grid", "grid_absolute_gaps_spans__border_box_ltr");
     }


### PR DESCRIPTION
# Objective

Absolutely positioned children do not take part in grid placement and should not create implicit tracks, but they were included in the implicit grid size estimate, producing phantom implicit tracks that shifted track offsets and abspos grid areas. This fixes the failing WPT tests `css/css-grid/abspos/grid-positioned-items-gaps-001.html` and `grid-positioned-items-gaps-rtl-001.html` (both now 44/44 in the Blitz WPT runner).

Changes:
- Exclude `position: absolute` (and `display: none`) children from `compute_grid_size_estimate`.
- Align empty grids (all tracks collapsed, e.g. `repeat(auto-fit, ...)` with no in-flow items) within the container by applying the content-alignment offset to the track origin. Previously the offset was only applied to the first non-collapsed track, so a fully-collapsed RTL grid sat at the inline-end instead of the inline-start edge. This case was previously masked by the phantom implicit tracks; fixes `grid-positioned-items-padding-001.html` `.grid 11`.

## Context

Verified against the full Blitz WPT css-flexbox + css-grid suites: 6 tests go FAIL→PASS, 0 subtests regress vs main (two subgrid reftests flip, but subgrid is unsupported and they only passed coincidentally). Generated tests cover out-of-range abspos lines with gaps and collapsed auto-fit RTL tracks. Follow-up to #1071 and #1073.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/9f3946d51bfa4f6ba89dc83598f3fa31
Requested by: @nicoburns