### PR TITLE
Grid: don't create implicit tracks for absolutely positioned items

### DIFF
--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -154,8 +154,14 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
         }
     }
 
-    let get_child_styles_iter =
-        |node| tree.child_ids(node).map(|child_node: NodeId| tree.get_grid_child_style(child_node));
+    // Absolutely positioned children do not take up space in the grid and do not create
+    // implicit tracks, so they are excluded from the implicit grid size estimate.
+    // https://www.w3.org/TR/css-grid-1/#abspos-items
+    let get_child_styles_iter = |node| {
+        tree.child_ids(node).map(|child_node: NodeId| tree.get_grid_child_style(child_node)).filter(|style| {
+            style.box_generation_mode() != BoxGenerationMode::None && style.position() != Position::Absolute
+        })
+    };
     let child_styles_iter = get_child_styles_iter(node);
 
     // 2. Resolve the explicit grid

--- a/test_fixtures/grid/grid_absolute_no_implicit_tracks.html
+++ b/test_fixtures/grid/grid_absolute_no_implicit_tracks.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-columns: 40px 40px; grid-template-rows: 40px 40px; gap: 10px; width: 200px; height: 200px; position: relative;">
+  <div style="background-color: red; position: absolute; grid-column: 3 / 5; grid-row: 3 / 5; width: 100%; height: 100%;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_absolute_row_start_beyond_last_line_gap.html
+++ b/test_fixtures/grid/grid_absolute_row_start_beyond_last_line_gap.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-columns: 40px 40px; grid-template-rows: 40px 40px; gap: 10px; width: 200px; height: 200px; position: relative;">
+  <div style="background-color: red; position: absolute; grid-column: 3 / auto; grid-row: 3 / auto; width: 100%; height: 100%;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/grid/grid_absolute_no_implicit_tracks__border_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_no_implicit_tracks__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_no_implicit_tracks__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="200px" height="200px" row-gap="10px" column-gap="10px" grid-template-rows="40px 40px" grid-template-columns="40px 40px">
+      <div direction="ltr" position="absolute" width="100%" height="100%" grid-row-start="3" grid-row-end="5" grid-column-start="3" grid-column-end="5"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="90" y="90" width="110" height="110"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_no_implicit_tracks__border_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_no_implicit_tracks__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_no_implicit_tracks__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="200px" height="200px" row-gap="10px" column-gap="10px" grid-template-rows="40px 40px" grid-template-columns="40px 40px">
+      <div direction="rtl" position="absolute" width="100%" height="100%" grid-row-start="3" grid-row-end="5" grid-column-start="3" grid-column-end="5"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="0" y="90" width="110" height="110"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_no_implicit_tracks__content_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_no_implicit_tracks__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_no_implicit_tracks__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="200px" height="200px" row-gap="10px" column-gap="10px" grid-template-rows="40px 40px" grid-template-columns="40px 40px">
+      <div box-sizing="content-box" direction="ltr" position="absolute" width="100%" height="100%" grid-row-start="3" grid-row-end="5" grid-column-start="3" grid-column-end="5"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="90" y="90" width="110" height="110"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_no_implicit_tracks__content_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_no_implicit_tracks__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_no_implicit_tracks__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="200px" height="200px" row-gap="10px" column-gap="10px" grid-template-rows="40px 40px" grid-template-columns="40px 40px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" width="100%" height="100%" grid-row-start="3" grid-row-end="5" grid-column-start="3" grid-column-end="5"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="0" y="90" width="110" height="110"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_row_start_beyond_last_line_gap__border_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_row_start_beyond_last_line_gap__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_row_start_beyond_last_line_gap__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="200px" height="200px" row-gap="10px" column-gap="10px" grid-template-rows="40px 40px" grid-template-columns="40px 40px">
+      <div direction="ltr" position="absolute" width="100%" height="100%" grid-row-start="3" grid-column-start="3"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="90" y="90" width="110" height="110"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_row_start_beyond_last_line_gap__border_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_row_start_beyond_last_line_gap__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_row_start_beyond_last_line_gap__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="200px" height="200px" row-gap="10px" column-gap="10px" grid-template-rows="40px 40px" grid-template-columns="40px 40px">
+      <div direction="rtl" position="absolute" width="100%" height="100%" grid-row-start="3" grid-column-start="3"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="0" y="90" width="110" height="110"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_row_start_beyond_last_line_gap__content_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_row_start_beyond_last_line_gap__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_row_start_beyond_last_line_gap__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="200px" height="200px" row-gap="10px" column-gap="10px" grid-template-rows="40px 40px" grid-template-columns="40px 40px">
+      <div box-sizing="content-box" direction="ltr" position="absolute" width="100%" height="100%" grid-row-start="3" grid-column-start="3"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="90" y="90" width="110" height="110"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_row_start_beyond_last_line_gap__content_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_row_start_beyond_last_line_gap__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_absolute_row_start_beyond_last_line_gap__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="200px" height="200px" row-gap="10px" column-gap="10px" grid-template-rows="40px 40px" grid-template-columns="40px 40px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" width="100%" height="100%" grid-row-start="3" grid-column-start="3"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="0" y="90" width="110" height="110"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -17527,6 +17527,30 @@ mod grid {
 
     #[cfg(feature = "grid")]
     #[test]
+    fn grid_absolute_no_implicit_tracks__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_no_implicit_tracks__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_no_implicit_tracks__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_no_implicit_tracks__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_no_implicit_tracks__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_no_implicit_tracks__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_no_implicit_tracks__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_no_implicit_tracks__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
     fn grid_absolute_resolved_insets__border_box_ltr() {
         crate::run_xml_test("grid", "grid_absolute_resolved_insets__border_box_ltr");
     }
@@ -17595,6 +17619,30 @@ mod grid {
     #[test]
     fn grid_absolute_row_start__content_box_rtl() {
         crate::run_xml_test("grid", "grid_absolute_row_start__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_row_start_beyond_last_line_gap__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_row_start_beyond_last_line_gap__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_row_start_beyond_last_line_gap__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_row_start_beyond_last_line_gap__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_row_start_beyond_last_line_gap__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_row_start_beyond_last_line_gap__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_row_start_beyond_last_line_gap__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_row_start_beyond_last_line_gap__content_box_rtl");
     }
 
     #[cfg(feature = "grid")]


### PR DESCRIPTION
# Objective

Fix a regression introduced by the interaction of #1071 with a pre-existing bug: absolutely positioned grid items were creating implicit tracks, contrary to [css-grid-1 §9 abspos](https://www.w3.org/TR/css-grid-1/#abspos-items). With #1071's "start edge = start of following track" rule, an abspos item placed at the last explicit grid line (e.g. `grid-row: 3 / auto` in a 2-row grid with gaps) jumped across the gap to the spurious implicit track, regressing WPT `grid-positioned-items-gaps-rtl-001` subtests `.grid 25/26`.

Fix: exclude `position: absolute` (and `display: none`) children from the implicit grid size estimate in `compute_grid_layout`, so abspos placements beyond the existing grid are treated as `auto` instead of creating tracks.

Full WPT run vs current main:
- Now fully pass: `grid-positioned-items-gaps-001` and `-rtl-001` (including the two subtests regressed by #1071), `grid-positioned-items-implicit-grid-001`, `grid-positioned-items-implicit-grid-line-001`, `positioned-grid-items-should-not-create-implicit-tracks-001`; `grid-positioned-items-padding-001` improves 7→2 failing subtests. Net +67/-1 subtests.
- Two subgrid reftests (`css/css-grid/subgrid/writing-directions-003` and its grid-lanes copy) flip PASS→FAIL: they only passed by accident because abspos items in an (unsupported) subgrid created implicit tracks that mimicked the subgridded tracks. Proper support requires subgrid.

## Context

Follow-up to #1071. Generated tests added: `grid_absolute_no_implicit_tracks`, `grid_absolute_row_start_beyond_last_line_gap`. No public API change, so no RELEASES.md entry.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/66f228c7e94242d6a8e704aa8953ae20
Requested by: @nicoburns