### PR TITLE
Support self-start and self-end alignment keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Support for the `self-start` and `self-end` alignment keywords (`AlignItems::SELF_START`/`SELF_END` and safe variants). These resolve against the `direction` of the item itself rather than that of its container, so they only differ from `start`/`end` when the item's direction differs from its container's. Supported for `align-self`/`align-items` and `justify-self`/`justify-items` on both in-flow and absolutely positioned Flexbox and Grid items (#1074)
+
 - Support for `display: flow-root`. The new `Display::FlowRoot` variant lays out children using the block layout algorithm but always establishes a new block formatting context (its margins do not collapse with those of its children, it contains its own floats, and it avoids external floats)
 
 ### Changed

--- a/benches/src/yoga_helpers.rs
+++ b/benches/src/yoga_helpers.rs
@@ -152,7 +152,10 @@ fn items_into_align(align: Option<tf::AlignSelf>) -> yg::Align {
         tf::AlignItemsKeyword::Center => yg::Align::Center,
         tf::AlignItemsKeyword::Baseline => yg::Align::Baseline,
         tf::AlignItemsKeyword::Stretch => yg::Align::Stretch,
-        tf::AlignItemsKeyword::Start | tf::AlignItemsKeyword::End => unimplemented!(),
+        tf::AlignItemsKeyword::Start
+        | tf::AlignItemsKeyword::End
+        | tf::AlignItemsKeyword::SelfStart
+        | tf::AlignItemsKeyword::SelfEnd => unimplemented!(),
     }
 }
 

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -567,7 +567,11 @@ fn generate_anonymous_flex_items(
                 border: child_style
                     .border()
                     .resolve_or_zero(constants.node_inner_size.width, |val, basis| tree.calc(val, basis)),
-                align_self: child_style.align_self().unwrap_or(constants.align_items),
+                align_self: child_style.align_self().unwrap_or(constants.align_items).resolve_self_relative(
+                    child_style.direction(),
+                    constants.layout_direction,
+                    constants.is_column,
+                ),
                 overflow: child_style.overflow(),
                 scrollbar_width: child_style.scrollbar_width(),
                 flex_grow: child_style.flex_grow(),
@@ -1842,7 +1846,9 @@ fn align_flex_items_along_cross_axis(
     };
 
     match align_keyword {
-        AlignItemsKeyword::Start => {
+        // SelfStart/SelfEnd are resolved to Start/End against the item's own direction when
+        // flex items are generated, so they can only reach here unresolved via a logic error.
+        AlignItemsKeyword::Start | AlignItemsKeyword::SelfStart => {
             if cross_axis_should_reverse {
                 free_space
             } else {
@@ -1856,7 +1862,7 @@ fn align_flex_items_along_cross_axis(
                 0.0
             }
         }
-        AlignItemsKeyword::End => {
+        AlignItemsKeyword::End | AlignItemsKeyword::SelfEnd => {
             if cross_axis_should_reverse {
                 0.0
             } else {
@@ -2247,7 +2253,11 @@ fn perform_absolute_layout_on_absolute_children(
         let overflow = child_style.overflow();
         let scrollbar_width = child_style.scrollbar_width();
         let aspect_ratio = child_style.aspect_ratio();
-        let align_self = child_style.align_self().unwrap_or(constants.align_items);
+        let align_self = child_style.align_self().unwrap_or(constants.align_items).resolve_self_relative(
+            child_style.direction(),
+            constants.layout_direction,
+            constants.is_column,
+        );
         let margin = child_style
             .margin()
             .map(|margin| margin.resolve_to_option(inset_relative_size.width, |val, basis| tree.calc(val, basis)));
@@ -2505,16 +2515,25 @@ fn perform_absolute_layout_on_absolute_children(
             // `start`/`end` (and `baseline`, whose static-position fallback is `start`) are
             // writing-mode relative: they flip for RTL but not for `wrap-reverse`.
             // `flex-start`/`flex-end` and the `stretch` fallback are flex-relative.
+            // SelfStart/SelfEnd are resolved to Start/End against the item's own direction
+            // where `align_self` is read above, so they can only reach here via a logic error.
             let start_position = match cross_keyword {
-                AlignItemsKeyword::Start | AlignItemsKeyword::Baseline => !cross_is_rtl,
-                AlignItemsKeyword::End => cross_is_rtl,
+                AlignItemsKeyword::Start | AlignItemsKeyword::SelfStart | AlignItemsKeyword::Baseline => !cross_is_rtl,
+                AlignItemsKeyword::End | AlignItemsKeyword::SelfEnd => cross_is_rtl,
                 _ => true,
             };
             match (cross_keyword, cross_axis_flex_start_reversed) {
                 // Stretch alignment does not apply to absolutely positioned items
                 // See "Example 3" at https://www.w3.org/TR/css-flexbox-1/#abspos-items
                 // Note: Stretch should be FlexStart not Start when we support both
-                (AlignItemsKeyword::Start | AlignItemsKeyword::End | AlignItemsKeyword::Baseline, _) => {
+                (
+                    AlignItemsKeyword::Start
+                    | AlignItemsKeyword::End
+                    | AlignItemsKeyword::SelfStart
+                    | AlignItemsKeyword::SelfEnd
+                    | AlignItemsKeyword::Baseline,
+                    _,
+                ) => {
                     if start_position {
                         constants.content_box_inset.cross_start(constants.dir)
                             + resolved_margin.cross_start(constants.dir)

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -1846,9 +1846,7 @@ fn align_flex_items_along_cross_axis(
     };
 
     match align_keyword {
-        // SelfStart/SelfEnd are resolved to Start/End against the item's own direction when
-        // flex items are generated, so they can only reach here unresolved via a logic error.
-        AlignItemsKeyword::Start | AlignItemsKeyword::SelfStart => {
+        AlignItemsKeyword::Start => {
             if cross_axis_should_reverse {
                 free_space
             } else {
@@ -1862,7 +1860,7 @@ fn align_flex_items_along_cross_axis(
                 0.0
             }
         }
-        AlignItemsKeyword::End | AlignItemsKeyword::SelfEnd => {
+        AlignItemsKeyword::End => {
             if cross_axis_should_reverse {
                 0.0
             } else {
@@ -1905,6 +1903,9 @@ fn align_flex_items_along_cross_axis(
                 0.0
             }
         }
+        // SelfStart/SelfEnd are resolved to Start/End against the item's own direction when
+        // flex items are generated.
+        AlignItemsKeyword::SelfStart | AlignItemsKeyword::SelfEnd => unreachable!(),
     }
 }
 
@@ -2515,25 +2516,16 @@ fn perform_absolute_layout_on_absolute_children(
             // `start`/`end` (and `baseline`, whose static-position fallback is `start`) are
             // writing-mode relative: they flip for RTL but not for `wrap-reverse`.
             // `flex-start`/`flex-end` and the `stretch` fallback are flex-relative.
-            // SelfStart/SelfEnd are resolved to Start/End against the item's own direction
-            // where `align_self` is read above, so they can only reach here via a logic error.
             let start_position = match cross_keyword {
-                AlignItemsKeyword::Start | AlignItemsKeyword::SelfStart | AlignItemsKeyword::Baseline => !cross_is_rtl,
-                AlignItemsKeyword::End | AlignItemsKeyword::SelfEnd => cross_is_rtl,
+                AlignItemsKeyword::Start | AlignItemsKeyword::Baseline => !cross_is_rtl,
+                AlignItemsKeyword::End => cross_is_rtl,
                 _ => true,
             };
             match (cross_keyword, cross_axis_flex_start_reversed) {
                 // Stretch alignment does not apply to absolutely positioned items
                 // See "Example 3" at https://www.w3.org/TR/css-flexbox-1/#abspos-items
                 // Note: Stretch should be FlexStart not Start when we support both
-                (
-                    AlignItemsKeyword::Start
-                    | AlignItemsKeyword::End
-                    | AlignItemsKeyword::SelfStart
-                    | AlignItemsKeyword::SelfEnd
-                    | AlignItemsKeyword::Baseline,
-                    _,
-                ) => {
+                (AlignItemsKeyword::Start | AlignItemsKeyword::End | AlignItemsKeyword::Baseline, _) => {
                     if start_position {
                         constants.content_box_inset.cross_start(constants.dir)
                             + resolved_margin.cross_start(constants.dir)
@@ -2564,6 +2556,9 @@ fn perform_absolute_layout_on_absolute_children(
                         - resolved_margin.cross_end(constants.dir))
                         / 2.0
                 }
+                // SelfStart/SelfEnd are resolved to Start/End against the item's own direction
+                // where `align_self` is read above.
+                (AlignItemsKeyword::SelfStart | AlignItemsKeyword::SelfEnd, _) => unreachable!(),
             }
         };
 

--- a/src/compute/grid/alignment.rs
+++ b/src/compute/grid/alignment.rs
@@ -95,8 +95,20 @@ pub(super) fn align_and_position_item(
     let overflow = style.overflow();
     let scrollbar_width = style.scrollbar_width();
     let aspect_ratio = style.aspect_ratio();
-    let justify_self = style.justify_self();
-    let align_self = style.align_self();
+    // Resolve writing-mode-relative self-start/self-end keywords against the item's own
+    // direction. The horizontal axis is the inline axis (Taffy only supports horizontal-tb);
+    // the vertical (block) axis resolves them to plain start/end.
+    let item_direction = style.direction();
+    let justify_self = style.justify_self().map(|align| align.resolve_self_relative(item_direction, direction, true));
+    let align_self = style.align_self().map(|align| align.resolve_self_relative(item_direction, direction, false));
+    let container_alignment_styles = InBothAbsAxis {
+        horizontal: container_alignment_styles
+            .horizontal
+            .map(|align| align.resolve_self_relative(item_direction, direction, true)),
+        vertical: container_alignment_styles
+            .vertical
+            .map(|align| align.resolve_self_relative(item_direction, direction, false)),
+    };
 
     let position = style.position();
     let inset_horizontal = style
@@ -346,7 +358,10 @@ pub(super) fn align_item_within_area(
     // Compute offset in the axis
     let alignment_based_offset = match alignment_keyword {
         // TODO: Add support for baseline alignment. For now we treat it as "start".
+        // SelfStart/SelfEnd are resolved to Start/End against the item's own direction in
+        // `align_and_position_item`, so they can only reach here unresolved via a logic error.
         AlignItemsKeyword::Start
+        | AlignItemsKeyword::SelfStart
         | AlignItemsKeyword::FlexStart
         | AlignItemsKeyword::Baseline
         | AlignItemsKeyword::Stretch => {
@@ -356,7 +371,7 @@ pub(super) fn align_item_within_area(
                 resolved_margin.start
             }
         }
-        AlignItemsKeyword::End | AlignItemsKeyword::FlexEnd => {
+        AlignItemsKeyword::End | AlignItemsKeyword::SelfEnd | AlignItemsKeyword::FlexEnd => {
             if direction.is_rtl() {
                 resolved_margin.start
             } else {

--- a/src/compute/grid/alignment.rs
+++ b/src/compute/grid/alignment.rs
@@ -358,10 +358,7 @@ pub(super) fn align_item_within_area(
     // Compute offset in the axis
     let alignment_based_offset = match alignment_keyword {
         // TODO: Add support for baseline alignment. For now we treat it as "start".
-        // SelfStart/SelfEnd are resolved to Start/End against the item's own direction in
-        // `align_and_position_item`, so they can only reach here unresolved via a logic error.
         AlignItemsKeyword::Start
-        | AlignItemsKeyword::SelfStart
         | AlignItemsKeyword::FlexStart
         | AlignItemsKeyword::Baseline
         | AlignItemsKeyword::Stretch => {
@@ -371,7 +368,7 @@ pub(super) fn align_item_within_area(
                 resolved_margin.start
             }
         }
-        AlignItemsKeyword::End | AlignItemsKeyword::SelfEnd | AlignItemsKeyword::FlexEnd => {
+        AlignItemsKeyword::End | AlignItemsKeyword::FlexEnd => {
             if direction.is_rtl() {
                 resolved_margin.start
             } else {
@@ -381,6 +378,9 @@ pub(super) fn align_item_within_area(
         AlignItemsKeyword::Center => {
             (grid_area_size - resolved_size + resolved_margin.start - resolved_margin.end) / 2.0
         }
+        // SelfStart/SelfEnd are resolved to Start/End against the item's own direction in
+        // `align_and_position_item`.
+        AlignItemsKeyword::SelfStart | AlignItemsKeyword::SelfEnd => unreachable!(),
     };
 
     let offset_within_area = if position == Position::Absolute {

--- a/src/style/alignment.rs
+++ b/src/style/alignment.rs
@@ -11,6 +11,8 @@
 #[cfg(feature = "parse")]
 use crate::util::parse::{CssParseResult, FromCss, Parser, Token};
 
+use crate::style::Direction;
+
 /// The position-keyword half of [`AlignItems`] (and its aliases `AlignSelf`,
 /// `JustifyItems`, `JustifySelf`).
 ///
@@ -34,6 +36,18 @@ pub enum AlignItemsKeyword {
     /// For flex containers with flex_direction RowReverse or ColumnReverse this is
     /// equivalent to Start. In all other cases it is equivalent to End.
     FlexEnd,
+    /// Items are packed toward the start of the axis as determined by the item's own
+    /// writing mode/direction (rather than the container's).
+    ///
+    /// Equivalent to Start when the item's `direction` matches the container's, and
+    /// to End when they differ (in the inline axis).
+    SelfStart,
+    /// Items are packed toward the end of the axis as determined by the item's own
+    /// writing mode/direction (rather than the container's).
+    ///
+    /// Equivalent to End when the item's `direction` matches the container's, and
+    /// to Start when they differ (in the inline axis).
+    SelfEnd,
     /// Items are packed along the center of the cross axis.
     Center,
     /// Items are aligned such as their baselines align.
@@ -139,6 +153,10 @@ impl AlignItems {
     pub const FLEX_START: Self = Self { keyword: AlignItemsKeyword::FlexStart, safety: AlignmentSafety::Unsafe };
     /// Items are packed towards the flex-relative end of the axis.
     pub const FLEX_END: Self = Self { keyword: AlignItemsKeyword::FlexEnd, safety: AlignmentSafety::Unsafe };
+    /// Items are packed toward the start of the axis as determined by the item's own direction.
+    pub const SELF_START: Self = Self { keyword: AlignItemsKeyword::SelfStart, safety: AlignmentSafety::Unsafe };
+    /// Items are packed toward the end of the axis as determined by the item's own direction.
+    pub const SELF_END: Self = Self { keyword: AlignItemsKeyword::SelfEnd, safety: AlignmentSafety::Unsafe };
     /// Items are packed along the center of the cross axis.
     pub const CENTER: Self = Self { keyword: AlignItemsKeyword::Center, safety: AlignmentSafety::Unsafe };
     /// Items are aligned such as their baselines align.
@@ -160,6 +178,12 @@ impl AlignItems {
     /// Like [`AlignItems::CENTER`], but falls back to [`AlignItems::START`] when the
     /// alignment subject overflows the alignment container, to avoid data loss.
     pub const SAFE_CENTER: Self = Self { keyword: AlignItemsKeyword::Center, safety: AlignmentSafety::Safe };
+    /// Like [`AlignItems::SELF_START`], but falls back to [`AlignItems::START`] when the
+    /// alignment subject overflows the alignment container, to avoid data loss.
+    pub const SAFE_SELF_START: Self = Self { keyword: AlignItemsKeyword::SelfStart, safety: AlignmentSafety::Safe };
+    /// Like [`AlignItems::SELF_END`], but falls back to [`AlignItems::START`] when the
+    /// alignment subject overflows the alignment container, to avoid data loss.
+    pub const SAFE_SELF_END: Self = Self { keyword: AlignItemsKeyword::SelfEnd, safety: AlignmentSafety::Safe };
 
     /// Returns `true` iff this carries the `safe` overflow-position modifier.
     #[inline]
@@ -171,6 +195,44 @@ impl AlignItems {
     #[inline]
     pub const fn keyword(self) -> AlignItemsKeyword {
         self.keyword
+    }
+
+    /// Resolve the writing-mode-relative `SelfStart`/`SelfEnd` keywords to `Start`/`End`
+    /// based on the item's own `direction` per CSS Box Alignment §5.2
+    /// <https://www.w3.org/TR/css-align-3/#self-alignment>. All other keywords are
+    /// returned unchanged.
+    ///
+    /// The `Start`/`End` keywords used by the compute paths are relative to the
+    /// *container's* writing mode/direction, so in the inline axis `SelfStart` resolves
+    /// to `Start` when the item's direction matches the container's and to `End` when it
+    /// differs. Taffy only supports the `horizontal-tb` writing mode, so in the block
+    /// axis `SelfStart`/`SelfEnd` always resolve to `Start`/`End` respectively.
+    #[inline]
+    pub(crate) fn resolve_self_relative(
+        self,
+        item_direction: Direction,
+        container_direction: Direction,
+        axis_is_inline: bool,
+    ) -> Self {
+        let flip = axis_is_inline && item_direction != container_direction;
+        let keyword = match self.keyword {
+            AlignItemsKeyword::SelfStart => {
+                if flip {
+                    AlignItemsKeyword::End
+                } else {
+                    AlignItemsKeyword::Start
+                }
+            }
+            AlignItemsKeyword::SelfEnd => {
+                if flip {
+                    AlignItemsKeyword::Start
+                } else {
+                    AlignItemsKeyword::End
+                }
+            }
+            other => other,
+        };
+        Self { keyword, safety: self.safety }
     }
 }
 
@@ -186,6 +248,8 @@ impl FromCss for AlignItems {
                     "end" => Ok(Self::SAFE_END),
                     "flex-start" => Ok(Self::SAFE_FLEX_START),
                     "flex-end" => Ok(Self::SAFE_FLEX_END),
+                    "self-start" => Ok(Self::SAFE_SELF_START),
+                    "self-end" => Ok(Self::SAFE_SELF_END),
                     "center" => Ok(Self::SAFE_CENTER),
                     _ => Err(input.new_unexpected_token_error(Token::Ident(pos))),
                 }
@@ -197,6 +261,8 @@ impl FromCss for AlignItems {
                     "end" => Ok(Self::END),
                     "flex-start" => Ok(Self::FLEX_START),
                     "flex-end" => Ok(Self::FLEX_END),
+                    "self-start" => Ok(Self::SELF_START),
+                    "self-end" => Ok(Self::SELF_END),
                     "center" => Ok(Self::CENTER),
                     _ => Err(input.new_unexpected_token_error(Token::Ident(pos))),
                 }
@@ -205,6 +271,8 @@ impl FromCss for AlignItems {
             "end" => Ok(Self::END),
             "flex-start" => Ok(Self::FLEX_START),
             "flex-end" => Ok(Self::FLEX_END),
+            "self-start" => Ok(Self::SELF_START),
+            "self-end" => Ok(Self::SELF_END),
             "center" => Ok(Self::CENTER),
             "baseline" => Ok(Self::BASELINE),
             "stretch" => Ok(Self::STRETCH),
@@ -366,6 +434,8 @@ const ALIGN_ITEMS_NAMES: &[&str] = &[
     "End",
     "FlexStart",
     "FlexEnd",
+    "SelfStart",
+    "SelfEnd",
     "Center",
     "Baseline",
     "Stretch",
@@ -373,6 +443,8 @@ const ALIGN_ITEMS_NAMES: &[&str] = &[
     "SafeEnd",
     "SafeFlexStart",
     "SafeFlexEnd",
+    "SafeSelfStart",
+    "SafeSelfEnd",
     "SafeCenter",
 ];
 
@@ -384,6 +456,8 @@ impl serde::Serialize for AlignItems {
             (AlignItemsKeyword::End, AlignmentSafety::Unsafe) => "End",
             (AlignItemsKeyword::FlexStart, AlignmentSafety::Unsafe) => "FlexStart",
             (AlignItemsKeyword::FlexEnd, AlignmentSafety::Unsafe) => "FlexEnd",
+            (AlignItemsKeyword::SelfStart, AlignmentSafety::Unsafe) => "SelfStart",
+            (AlignItemsKeyword::SelfEnd, AlignmentSafety::Unsafe) => "SelfEnd",
             (AlignItemsKeyword::Center, AlignmentSafety::Unsafe) => "Center",
             (AlignItemsKeyword::Baseline, _) => "Baseline",
             (AlignItemsKeyword::Stretch, _) => "Stretch",
@@ -391,6 +465,8 @@ impl serde::Serialize for AlignItems {
             (AlignItemsKeyword::End, AlignmentSafety::Safe) => "SafeEnd",
             (AlignItemsKeyword::FlexStart, AlignmentSafety::Safe) => "SafeFlexStart",
             (AlignItemsKeyword::FlexEnd, AlignmentSafety::Safe) => "SafeFlexEnd",
+            (AlignItemsKeyword::SelfStart, AlignmentSafety::Safe) => "SafeSelfStart",
+            (AlignItemsKeyword::SelfEnd, AlignmentSafety::Safe) => "SafeSelfEnd",
             (AlignItemsKeyword::Center, AlignmentSafety::Safe) => "SafeCenter",
         };
         serializer.serialize_str(name)
@@ -412,6 +488,8 @@ impl<'de> serde::Deserialize<'de> for AlignItems {
                     "End" => AlignItems::END,
                     "FlexStart" => AlignItems::FLEX_START,
                     "FlexEnd" => AlignItems::FLEX_END,
+                    "SelfStart" => AlignItems::SELF_START,
+                    "SelfEnd" => AlignItems::SELF_END,
                     "Center" => AlignItems::CENTER,
                     "Baseline" => AlignItems::BASELINE,
                     "Stretch" => AlignItems::STRETCH,
@@ -419,6 +497,8 @@ impl<'de> serde::Deserialize<'de> for AlignItems {
                     "SafeEnd" => AlignItems::SAFE_END,
                     "SafeFlexStart" => AlignItems::SAFE_FLEX_START,
                     "SafeFlexEnd" => AlignItems::SAFE_FLEX_END,
+                    "SafeSelfStart" => AlignItems::SAFE_SELF_START,
+                    "SafeSelfEnd" => AlignItems::SAFE_SELF_END,
                     "SafeCenter" => AlignItems::SAFE_CENTER,
                     other => return Err(E::unknown_variant(other, ALIGN_ITEMS_NAMES)),
                 })
@@ -533,6 +613,10 @@ mod tests {
         assert!(!AlignItems::CENTER.is_safe());
         assert!(!AlignItems::BASELINE.is_safe());
         assert!(!AlignItems::STRETCH.is_safe());
+        assert!(AlignItems::SAFE_SELF_START.is_safe());
+        assert!(AlignItems::SAFE_SELF_END.is_safe());
+        assert!(!AlignItems::SELF_START.is_safe());
+        assert!(!AlignItems::SELF_END.is_safe());
     }
 
     #[test]
@@ -542,6 +626,8 @@ mod tests {
         assert_eq!(AlignItems::SAFE_FLEX_START.keyword(), AlignItemsKeyword::FlexStart);
         assert_eq!(AlignItems::SAFE_FLEX_END.keyword(), AlignItemsKeyword::FlexEnd);
         assert_eq!(AlignItems::SAFE_CENTER.keyword(), AlignItemsKeyword::Center);
+        assert_eq!(AlignItems::SAFE_SELF_START.keyword(), AlignItemsKeyword::SelfStart);
+        assert_eq!(AlignItems::SAFE_SELF_END.keyword(), AlignItemsKeyword::SelfEnd);
     }
 
     #[test]
@@ -550,6 +636,34 @@ mod tests {
         assert_eq!(AlignItems::STRETCH.keyword(), AlignItemsKeyword::Stretch);
         assert_eq!(AlignItems::BASELINE.keyword(), AlignItemsKeyword::Baseline);
         assert_eq!(AlignItems::FLEX_START.keyword(), AlignItemsKeyword::FlexStart);
+    }
+
+    #[test]
+    fn resolve_self_relative_inline_axis() {
+        use Direction::{Ltr, Rtl};
+        // Same direction: self-start == start, self-end == end
+        assert_eq!(AlignItems::SELF_START.resolve_self_relative(Ltr, Ltr, true), AlignItems::START);
+        assert_eq!(AlignItems::SELF_END.resolve_self_relative(Ltr, Ltr, true), AlignItems::END);
+        assert_eq!(AlignItems::SELF_START.resolve_self_relative(Rtl, Rtl, true), AlignItems::START);
+        assert_eq!(AlignItems::SELF_END.resolve_self_relative(Rtl, Rtl, true), AlignItems::END);
+        // Opposite direction: self-start == end, self-end == start
+        assert_eq!(AlignItems::SELF_START.resolve_self_relative(Ltr, Rtl, true), AlignItems::END);
+        assert_eq!(AlignItems::SELF_END.resolve_self_relative(Ltr, Rtl, true), AlignItems::START);
+        assert_eq!(AlignItems::SELF_START.resolve_self_relative(Rtl, Ltr, true), AlignItems::END);
+        assert_eq!(AlignItems::SELF_END.resolve_self_relative(Rtl, Ltr, true), AlignItems::START);
+        // Safety modifier is preserved
+        assert_eq!(AlignItems::SAFE_SELF_START.resolve_self_relative(Ltr, Rtl, true), AlignItems::SAFE_END);
+        // Other keywords are unchanged
+        assert_eq!(AlignItems::START.resolve_self_relative(Ltr, Rtl, true), AlignItems::START);
+        assert_eq!(AlignItems::FLEX_END.resolve_self_relative(Ltr, Rtl, true), AlignItems::FLEX_END);
+    }
+
+    #[test]
+    fn resolve_self_relative_block_axis() {
+        use Direction::{Ltr, Rtl};
+        // In the block axis (horizontal-tb only) direction never flips self-start/self-end
+        assert_eq!(AlignItems::SELF_START.resolve_self_relative(Ltr, Rtl, false), AlignItems::START);
+        assert_eq!(AlignItems::SELF_END.resolve_self_relative(Rtl, Ltr, false), AlignItems::END);
     }
 
     #[test]
@@ -590,6 +704,8 @@ mod tests {
         assert_eq!("flex-start".parse::<AlignItems>().unwrap(), AlignItems::FLEX_START);
         assert_eq!("flex-end".parse::<AlignItems>().unwrap(), AlignItems::FLEX_END);
         assert_eq!("center".parse::<AlignItems>().unwrap(), AlignItems::CENTER);
+        assert_eq!("self-start".parse::<AlignItems>().unwrap(), AlignItems::SELF_START);
+        assert_eq!("self-end".parse::<AlignItems>().unwrap(), AlignItems::SELF_END);
         assert_eq!("baseline".parse::<AlignItems>().unwrap(), AlignItems::BASELINE);
         assert_eq!("stretch".parse::<AlignItems>().unwrap(), AlignItems::STRETCH);
     }
@@ -601,6 +717,8 @@ mod tests {
         assert_eq!("safe end".parse::<AlignItems>().unwrap(), AlignItems::SAFE_END);
         assert_eq!("safe flex-start".parse::<AlignItems>().unwrap(), AlignItems::SAFE_FLEX_START);
         assert_eq!("safe flex-end".parse::<AlignItems>().unwrap(), AlignItems::SAFE_FLEX_END);
+        assert_eq!("safe self-start".parse::<AlignItems>().unwrap(), AlignItems::SAFE_SELF_START);
+        assert_eq!("safe self-end".parse::<AlignItems>().unwrap(), AlignItems::SAFE_SELF_END);
         assert_eq!("safe center".parse::<AlignItems>().unwrap(), AlignItems::SAFE_CENTER);
     }
 
@@ -616,6 +734,8 @@ mod tests {
     fn parse_align_items_unsafe_drops_modifier() {
         assert_eq!("unsafe start".parse::<AlignItems>().unwrap(), AlignItems::START);
         assert_eq!("unsafe end".parse::<AlignItems>().unwrap(), AlignItems::END);
+        assert_eq!("unsafe self-start".parse::<AlignItems>().unwrap(), AlignItems::SELF_START);
+        assert_eq!("unsafe self-end".parse::<AlignItems>().unwrap(), AlignItems::SELF_END);
         assert_eq!("unsafe center".parse::<AlignItems>().unwrap(), AlignItems::CENTER);
     }
 
@@ -686,6 +806,10 @@ mod tests {
             (AlignItems::SAFE_FLEX_START, "\"SafeFlexStart\""),
             (AlignItems::SAFE_FLEX_END, "\"SafeFlexEnd\""),
             (AlignItems::SAFE_CENTER, "\"SafeCenter\""),
+            (AlignItems::SELF_START, "\"SelfStart\""),
+            (AlignItems::SELF_END, "\"SelfEnd\""),
+            (AlignItems::SAFE_SELF_START, "\"SafeSelfStart\""),
+            (AlignItems::SAFE_SELF_END, "\"SafeSelfEnd\""),
         ];
         for (value, expected) in cases {
             let serialized = serde_json::to_string(&value).unwrap();

--- a/test_fixtures/flex/absolute_layout_align_self_self_end_column_child_rtl.html
+++ b/test_fixtures/flex/absolute_layout_align_self_self_end_column_child_rtl.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 100px; height: 100px; flex-direction: column;">
+  <div style="position: absolute; width: 20px; height: 20px; direction: rtl; align-self: self-end;"></div>
+  <div style="position: absolute; width: 20px; height: 20px; direction: ltr; align-self: self-end;"></div>
+</div>
+</body>
+</html>

--- a/test_fixtures/flex/absolute_layout_align_self_self_start_column_child_rtl.html
+++ b/test_fixtures/flex/absolute_layout_align_self_self_start_column_child_rtl.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 100px; height: 100px; flex-direction: column;">
+  <div style="position: absolute; width: 20px; height: 20px; direction: rtl; align-self: self-start;"></div>
+  <div style="position: absolute; width: 20px; height: 20px; direction: ltr; align-self: self-start;"></div>
+</div>
+</body>
+</html>

--- a/test_fixtures/flex/align_self_self_end.html
+++ b/test_fixtures/flex/align_self_self_end.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 100px; height: 100px;">
+  <div style="height: 10px; width: 10px; align-self: self-end;"></div>
+</div>
+</body>
+</html>

--- a/test_fixtures/flex/align_self_self_end_wrap_reverse.html
+++ b/test_fixtures/flex/align_self_self_end_wrap_reverse.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 100px; height: 100px; flex-wrap: wrap-reverse;">
+  <div style="height: 10px; width: 10px; align-self: self-end;"></div>
+</div>
+</body>
+</html>

--- a/test_fixtures/flex/align_self_self_start.html
+++ b/test_fixtures/flex/align_self_self_start.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 100px; height: 100px;">
+  <div style="height: 10px; width: 10px; align-self: self-start;"></div>
+</div>
+</body>
+</html>

--- a/test_fixtures/flex/flex_column_align_items_self_start_child_rtl.html
+++ b/test_fixtures/flex/flex_column_align_items_self_start_child_rtl.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 100px; height: 100px; flex-direction: column; align-items: self-start;">
+  <div style="height: 10px; width: 10px; direction: rtl;"></div>
+  <div style="height: 10px; width: 10px; direction: ltr;"></div>
+</div>
+</body>
+</html>

--- a/test_fixtures/flex/flex_column_align_self_self_end_child_rtl.html
+++ b/test_fixtures/flex/flex_column_align_self_self_end_child_rtl.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 100px; height: 100px; flex-direction: column;">
+  <div style="height: 10px; width: 10px; direction: rtl; align-self: self-end;"></div>
+  <div style="height: 10px; width: 10px; direction: ltr; align-self: self-end;"></div>
+</div>
+</body>
+</html>

--- a/test_fixtures/flex/flex_column_align_self_self_start_child_rtl.html
+++ b/test_fixtures/flex/flex_column_align_self_self_start_child_rtl.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 100px; height: 100px; flex-direction: column;">
+  <div style="height: 10px; width: 10px; direction: rtl; align-self: self-start;"></div>
+  <div style="height: 10px; width: 10px; direction: ltr; align-self: self-start;"></div>
+</div>
+</body>
+</html>

--- a/test_fixtures/grid/grid_absolute_align_self_self_end.html
+++ b/test_fixtures/grid/grid_absolute_align_self_self_end.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="height: 120px; width: 120px; display: grid; grid-template-columns: 40px 40px 40px; grid-template-rows: 40px 40px 40px;">
+  <div style="position: absolute; width: 20px; height: 20px; align-self: self-end;"></div>
+  <div style="position: absolute; width: 20px; height: 20px; direction: rtl; align-self: self-end;"></div>
+</div>
+</body>
+</html>

--- a/test_fixtures/grid/grid_absolute_justify_self_self_start_child_rtl.html
+++ b/test_fixtures/grid/grid_absolute_justify_self_self_start_child_rtl.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="height: 120px; width: 120px; display: grid; grid-template-columns: 40px 40px 40px; grid-template-rows: 40px 40px 40px;">
+  <div style="position: absolute; width: 20px; height: 20px; direction: rtl; justify-self: self-start;"></div>
+  <div style="position: absolute; width: 20px; height: 20px; direction: ltr; justify-self: self-start;"></div>
+</div>
+</body>
+</html>

--- a/test_fixtures/grid/grid_align_self_self_start_self_end.html
+++ b/test_fixtures/grid/grid_align_self_self_start_self_end.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="height: 120px; width: 120px; display: grid; grid-template-columns: 40px 40px 40px; grid-template-rows: 40px 40px 40px;">
+  <div style="width: 20px; height: 20px; grid-row: 1; grid-column: 1; align-self: self-start;"></div>
+  <div style="width: 20px; height: 20px; grid-row: 2; grid-column: 2; direction: rtl; align-self: self-end;"></div>
+</div>
+</body>
+</html>

--- a/test_fixtures/grid/grid_justify_items_self_end_child_rtl.html
+++ b/test_fixtures/grid/grid_justify_items_self_end_child_rtl.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="height: 120px; width: 120px; display: grid; grid-template-columns: 40px 40px 40px; grid-template-rows: 40px 40px 40px; justify-items: self-end;">
+  <div style="width: 20px; height: 20px; grid-row: 1; grid-column: 1; direction: rtl;"></div>
+  <div style="width: 20px; height: 20px; grid-row: 2; grid-column: 2; direction: ltr;"></div>
+</div>
+</body>
+</html>

--- a/test_fixtures/grid/grid_justify_self_self_end.html
+++ b/test_fixtures/grid/grid_justify_self_self_end.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="height: 120px; width: 120px; display: grid; grid-template-columns: 40px 40px 40px; grid-template-rows: 40px 40px 40px;">
+  <div style="width: 20px; height: 20px; grid-row: 1; grid-column: 1; justify-self: self-end;"></div>
+  <div style="width: 20px; height: 20px; grid-row: 2; grid-column: 2; justify-self: self-end;"></div>
+</div>
+</body>
+</html>

--- a/test_fixtures/grid/grid_justify_self_self_start.html
+++ b/test_fixtures/grid/grid_justify_self_self_start.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="height: 120px; width: 120px; display: grid; grid-template-columns: 40px 40px 40px; grid-template-rows: 40px 40px 40px;">
+  <div style="width: 20px; height: 20px; grid-row: 1; grid-column: 1; justify-self: self-start;"></div>
+  <div style="width: 20px; height: 20px; grid-row: 2; grid-column: 2; justify-self: self-start;"></div>
+</div>
+</body>
+</html>

--- a/test_fixtures/grid/grid_justify_self_self_start_child_rtl.html
+++ b/test_fixtures/grid/grid_justify_self_self_start_child_rtl.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="height: 120px; width: 120px; display: grid; grid-template-columns: 40px 40px 40px; grid-template-rows: 40px 40px 40px;">
+  <div style="width: 20px; height: 20px; grid-row: 1; grid-column: 1; direction: rtl; justify-self: self-start;"></div>
+  <div style="width: 20px; height: 20px; grid-row: 2; grid-column: 2; direction: rtl; justify-self: self-end;"></div>
+  <div style="width: 20px; height: 20px; grid-row: 3; grid-column: 3; direction: ltr; justify-self: self-start;"></div>
+</div>
+</body>
+</html>

--- a/tests/xml/flex/absolute_layout_align_self_self_end_column_child_rtl__border_box_ltr.xml
+++ b/tests/xml/flex/absolute_layout_align_self_self_end_column_child_rtl__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="absolute_layout_align_self_self_end_column_child_rtl__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" flex-direction="column" width="100px" height="100px">
+      <div direction="rtl" position="absolute" align-self="self-end" width="20px" height="20px"/>
+      <div direction="ltr" position="absolute" align-self="self-end" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="80" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_align_self_self_end_column_child_rtl__border_box_rtl.xml
+++ b/tests/xml/flex/absolute_layout_align_self_self_end_column_child_rtl__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="absolute_layout_align_self_self_end_column_child_rtl__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" flex-direction="column" width="100px" height="100px">
+      <div direction="rtl" position="absolute" align-self="self-end" width="20px" height="20px"/>
+      <div direction="ltr" position="absolute" align-self="self-end" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="80" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_align_self_self_end_column_child_rtl__content_box_ltr.xml
+++ b/tests/xml/flex/absolute_layout_align_self_self_end_column_child_rtl__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="absolute_layout_align_self_self_end_column_child_rtl__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" flex-direction="column" width="100px" height="100px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" align-self="self-end" width="20px" height="20px"/>
+      <div box-sizing="content-box" direction="ltr" position="absolute" align-self="self-end" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="80" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_align_self_self_end_column_child_rtl__content_box_rtl.xml
+++ b/tests/xml/flex/absolute_layout_align_self_self_end_column_child_rtl__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="absolute_layout_align_self_self_end_column_child_rtl__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" flex-direction="column" width="100px" height="100px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" align-self="self-end" width="20px" height="20px"/>
+      <div box-sizing="content-box" direction="ltr" position="absolute" align-self="self-end" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="80" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_align_self_self_start_column_child_rtl__border_box_ltr.xml
+++ b/tests/xml/flex/absolute_layout_align_self_self_start_column_child_rtl__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="absolute_layout_align_self_self_start_column_child_rtl__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" flex-direction="column" width="100px" height="100px">
+      <div direction="rtl" position="absolute" align-self="self-start" width="20px" height="20px"/>
+      <div direction="ltr" position="absolute" align-self="self-start" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="80" y="0" width="20" height="20"/>
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_align_self_self_start_column_child_rtl__border_box_rtl.xml
+++ b/tests/xml/flex/absolute_layout_align_self_self_start_column_child_rtl__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="absolute_layout_align_self_self_start_column_child_rtl__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" flex-direction="column" width="100px" height="100px">
+      <div direction="rtl" position="absolute" align-self="self-start" width="20px" height="20px"/>
+      <div direction="ltr" position="absolute" align-self="self-start" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="80" y="0" width="20" height="20"/>
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_align_self_self_start_column_child_rtl__content_box_ltr.xml
+++ b/tests/xml/flex/absolute_layout_align_self_self_start_column_child_rtl__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="absolute_layout_align_self_self_start_column_child_rtl__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" flex-direction="column" width="100px" height="100px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" align-self="self-start" width="20px" height="20px"/>
+      <div box-sizing="content-box" direction="ltr" position="absolute" align-self="self-start" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="80" y="0" width="20" height="20"/>
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/absolute_layout_align_self_self_start_column_child_rtl__content_box_rtl.xml
+++ b/tests/xml/flex/absolute_layout_align_self_self_start_column_child_rtl__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="absolute_layout_align_self_self_start_column_child_rtl__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" flex-direction="column" width="100px" height="100px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" align-self="self-start" width="20px" height="20px"/>
+      <div box-sizing="content-box" direction="ltr" position="absolute" align-self="self-start" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="80" y="0" width="20" height="20"/>
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_self_self_end__border_box_ltr.xml
+++ b/tests/xml/flex/align_self_self_end__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="align_self_self_end__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" width="100px" height="100px">
+      <div direction="ltr" align-self="self-end" width="10px" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="90" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_self_self_end__border_box_rtl.xml
+++ b/tests/xml/flex/align_self_self_end__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="align_self_self_end__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" width="100px" height="100px">
+      <div direction="rtl" align-self="self-end" width="10px" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="90" y="90" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_self_self_end__content_box_ltr.xml
+++ b/tests/xml/flex/align_self_self_end__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="align_self_self_end__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" width="100px" height="100px">
+      <div box-sizing="content-box" direction="ltr" align-self="self-end" width="10px" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="90" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_self_self_end__content_box_rtl.xml
+++ b/tests/xml/flex/align_self_self_end__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="align_self_self_end__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" width="100px" height="100px">
+      <div box-sizing="content-box" direction="rtl" align-self="self-end" width="10px" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="90" y="90" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_self_self_end_wrap_reverse__border_box_ltr.xml
+++ b/tests/xml/flex/align_self_self_end_wrap_reverse__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="align_self_self_end_wrap_reverse__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" flex-wrap="wrap-reverse" width="100px" height="100px">
+      <div direction="ltr" align-self="self-end" width="10px" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="90" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_self_self_end_wrap_reverse__border_box_rtl.xml
+++ b/tests/xml/flex/align_self_self_end_wrap_reverse__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="align_self_self_end_wrap_reverse__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" flex-wrap="wrap-reverse" width="100px" height="100px">
+      <div direction="rtl" align-self="self-end" width="10px" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="90" y="90" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_self_self_end_wrap_reverse__content_box_ltr.xml
+++ b/tests/xml/flex/align_self_self_end_wrap_reverse__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="align_self_self_end_wrap_reverse__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" flex-wrap="wrap-reverse" width="100px" height="100px">
+      <div box-sizing="content-box" direction="ltr" align-self="self-end" width="10px" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="90" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_self_self_end_wrap_reverse__content_box_rtl.xml
+++ b/tests/xml/flex/align_self_self_end_wrap_reverse__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="align_self_self_end_wrap_reverse__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" flex-wrap="wrap-reverse" width="100px" height="100px">
+      <div box-sizing="content-box" direction="rtl" align-self="self-end" width="10px" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="90" y="90" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_self_self_start__border_box_ltr.xml
+++ b/tests/xml/flex/align_self_self_start__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="align_self_self_start__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" width="100px" height="100px">
+      <div direction="ltr" align-self="self-start" width="10px" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_self_self_start__border_box_rtl.xml
+++ b/tests/xml/flex/align_self_self_start__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="align_self_self_start__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" width="100px" height="100px">
+      <div direction="rtl" align-self="self-start" width="10px" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="90" y="0" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_self_self_start__content_box_ltr.xml
+++ b/tests/xml/flex/align_self_self_start__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="align_self_self_start__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" width="100px" height="100px">
+      <div box-sizing="content-box" direction="ltr" align-self="self-start" width="10px" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_self_self_start__content_box_rtl.xml
+++ b/tests/xml/flex/align_self_self_start__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="align_self_self_start__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" width="100px" height="100px">
+      <div box-sizing="content-box" direction="rtl" align-self="self-start" width="10px" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="90" y="0" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_column_align_items_self_start_child_rtl__border_box_ltr.xml
+++ b/tests/xml/flex/flex_column_align_items_self_start_child_rtl__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="flex_column_align_items_self_start_child_rtl__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" flex-direction="column" align-items="self-start" width="100px" height="100px">
+      <div direction="rtl" width="10px" height="10px"/>
+      <div direction="ltr" width="10px" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="90" y="0" width="10" height="10"/>
+      <node x="0" y="10" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_column_align_items_self_start_child_rtl__border_box_rtl.xml
+++ b/tests/xml/flex/flex_column_align_items_self_start_child_rtl__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="flex_column_align_items_self_start_child_rtl__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" flex-direction="column" align-items="self-start" width="100px" height="100px">
+      <div direction="rtl" width="10px" height="10px"/>
+      <div direction="ltr" width="10px" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="90" y="0" width="10" height="10"/>
+      <node x="0" y="10" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_column_align_items_self_start_child_rtl__content_box_ltr.xml
+++ b/tests/xml/flex/flex_column_align_items_self_start_child_rtl__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="flex_column_align_items_self_start_child_rtl__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" flex-direction="column" align-items="self-start" width="100px" height="100px">
+      <div box-sizing="content-box" direction="rtl" width="10px" height="10px"/>
+      <div box-sizing="content-box" direction="ltr" width="10px" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="90" y="0" width="10" height="10"/>
+      <node x="0" y="10" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_column_align_items_self_start_child_rtl__content_box_rtl.xml
+++ b/tests/xml/flex/flex_column_align_items_self_start_child_rtl__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="flex_column_align_items_self_start_child_rtl__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" flex-direction="column" align-items="self-start" width="100px" height="100px">
+      <div box-sizing="content-box" direction="rtl" width="10px" height="10px"/>
+      <div box-sizing="content-box" direction="ltr" width="10px" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="90" y="0" width="10" height="10"/>
+      <node x="0" y="10" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_column_align_self_self_end_child_rtl__border_box_ltr.xml
+++ b/tests/xml/flex/flex_column_align_self_self_end_child_rtl__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="flex_column_align_self_self_end_child_rtl__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" flex-direction="column" width="100px" height="100px">
+      <div direction="rtl" align-self="self-end" width="10px" height="10px"/>
+      <div direction="ltr" align-self="self-end" width="10px" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="10" height="10"/>
+      <node x="90" y="10" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_column_align_self_self_end_child_rtl__border_box_rtl.xml
+++ b/tests/xml/flex/flex_column_align_self_self_end_child_rtl__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="flex_column_align_self_self_end_child_rtl__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" flex-direction="column" width="100px" height="100px">
+      <div direction="rtl" align-self="self-end" width="10px" height="10px"/>
+      <div direction="ltr" align-self="self-end" width="10px" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="10" height="10"/>
+      <node x="90" y="10" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_column_align_self_self_end_child_rtl__content_box_ltr.xml
+++ b/tests/xml/flex/flex_column_align_self_self_end_child_rtl__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="flex_column_align_self_self_end_child_rtl__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" flex-direction="column" width="100px" height="100px">
+      <div box-sizing="content-box" direction="rtl" align-self="self-end" width="10px" height="10px"/>
+      <div box-sizing="content-box" direction="ltr" align-self="self-end" width="10px" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="10" height="10"/>
+      <node x="90" y="10" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_column_align_self_self_end_child_rtl__content_box_rtl.xml
+++ b/tests/xml/flex/flex_column_align_self_self_end_child_rtl__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="flex_column_align_self_self_end_child_rtl__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" flex-direction="column" width="100px" height="100px">
+      <div box-sizing="content-box" direction="rtl" align-self="self-end" width="10px" height="10px"/>
+      <div box-sizing="content-box" direction="ltr" align-self="self-end" width="10px" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="10" height="10"/>
+      <node x="90" y="10" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_column_align_self_self_start_child_rtl__border_box_ltr.xml
+++ b/tests/xml/flex/flex_column_align_self_self_start_child_rtl__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="flex_column_align_self_self_start_child_rtl__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" flex-direction="column" width="100px" height="100px">
+      <div direction="rtl" align-self="self-start" width="10px" height="10px"/>
+      <div direction="ltr" align-self="self-start" width="10px" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="90" y="0" width="10" height="10"/>
+      <node x="0" y="10" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_column_align_self_self_start_child_rtl__border_box_rtl.xml
+++ b/tests/xml/flex/flex_column_align_self_self_start_child_rtl__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="flex_column_align_self_self_start_child_rtl__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" flex-direction="column" width="100px" height="100px">
+      <div direction="rtl" align-self="self-start" width="10px" height="10px"/>
+      <div direction="ltr" align-self="self-start" width="10px" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="90" y="0" width="10" height="10"/>
+      <node x="0" y="10" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_column_align_self_self_start_child_rtl__content_box_ltr.xml
+++ b/tests/xml/flex/flex_column_align_self_self_start_child_rtl__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="flex_column_align_self_self_start_child_rtl__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" flex-direction="column" width="100px" height="100px">
+      <div box-sizing="content-box" direction="rtl" align-self="self-start" width="10px" height="10px"/>
+      <div box-sizing="content-box" direction="ltr" align-self="self-start" width="10px" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="90" y="0" width="10" height="10"/>
+      <node x="0" y="10" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_column_align_self_self_start_child_rtl__content_box_rtl.xml
+++ b/tests/xml/flex/flex_column_align_self_self_start_child_rtl__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="flex_column_align_self_self_start_child_rtl__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" flex-direction="column" width="100px" height="100px">
+      <div box-sizing="content-box" direction="rtl" align-self="self-start" width="10px" height="10px"/>
+      <div box-sizing="content-box" direction="ltr" align-self="self-start" width="10px" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="90" y="0" width="10" height="10"/>
+      <node x="0" y="10" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_align_self_self_end__border_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_align_self_self_end__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_absolute_align_self_self_end__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div direction="ltr" position="absolute" align-self="self-end" width="20px" height="20px"/>
+      <div direction="rtl" position="absolute" align-self="self-end" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="0" y="100" width="20" height="20"/>
+      <node x="0" y="100" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_align_self_self_end__border_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_align_self_self_end__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_absolute_align_self_self_end__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div direction="rtl" position="absolute" align-self="self-end" width="20px" height="20px"/>
+      <div direction="rtl" position="absolute" align-self="self-end" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="100" y="100" width="20" height="20"/>
+      <node x="100" y="100" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_align_self_self_end__content_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_align_self_self_end__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_absolute_align_self_self_end__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div box-sizing="content-box" direction="ltr" position="absolute" align-self="self-end" width="20px" height="20px"/>
+      <div box-sizing="content-box" direction="rtl" position="absolute" align-self="self-end" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="0" y="100" width="20" height="20"/>
+      <node x="0" y="100" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_align_self_self_end__content_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_align_self_self_end__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_absolute_align_self_self_end__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" align-self="self-end" width="20px" height="20px"/>
+      <div box-sizing="content-box" direction="rtl" position="absolute" align-self="self-end" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="100" y="100" width="20" height="20"/>
+      <node x="100" y="100" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_justify_self_self_start_child_rtl__border_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_justify_self_self_start_child_rtl__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_absolute_justify_self_self_start_child_rtl__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div direction="rtl" position="absolute" justify-self="self-start" width="20px" height="20px"/>
+      <div direction="ltr" position="absolute" justify-self="self-start" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="100" y="0" width="20" height="20"/>
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_justify_self_self_start_child_rtl__border_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_justify_self_self_start_child_rtl__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_absolute_justify_self_self_start_child_rtl__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div direction="rtl" position="absolute" justify-self="self-start" width="20px" height="20px"/>
+      <div direction="ltr" position="absolute" justify-self="self-start" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="100" y="0" width="20" height="20"/>
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_justify_self_self_start_child_rtl__content_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_justify_self_self_start_child_rtl__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_absolute_justify_self_self_start_child_rtl__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" justify-self="self-start" width="20px" height="20px"/>
+      <div box-sizing="content-box" direction="ltr" position="absolute" justify-self="self-start" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="100" y="0" width="20" height="20"/>
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_justify_self_self_start_child_rtl__content_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_justify_self_self_start_child_rtl__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_absolute_justify_self_self_start_child_rtl__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" justify-self="self-start" width="20px" height="20px"/>
+      <div box-sizing="content-box" direction="ltr" position="absolute" justify-self="self-start" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="100" y="0" width="20" height="20"/>
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_self_self_start_self_end__border_box_ltr.xml
+++ b/tests/xml/grid/grid_align_self_self_start_self_end__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_align_self_self_start_self_end__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div direction="ltr" align-self="self-start" width="20px" height="20px" grid-row-start="1" grid-column-start="1"/>
+      <div direction="rtl" align-self="self-end" width="20px" height="20px" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="40" y="60" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_self_self_start_self_end__border_box_rtl.xml
+++ b/tests/xml/grid/grid_align_self_self_start_self_end__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_align_self_self_start_self_end__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div direction="rtl" align-self="self-start" width="20px" height="20px" grid-row-start="1" grid-column-start="1"/>
+      <div direction="rtl" align-self="self-end" width="20px" height="20px" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="100" y="0" width="20" height="20"/>
+      <node x="60" y="60" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_self_self_start_self_end__content_box_ltr.xml
+++ b/tests/xml/grid/grid_align_self_self_start_self_end__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_align_self_self_start_self_end__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div box-sizing="content-box" direction="ltr" align-self="self-start" width="20px" height="20px" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="rtl" align-self="self-end" width="20px" height="20px" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="40" y="60" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_self_self_start_self_end__content_box_rtl.xml
+++ b/tests/xml/grid/grid_align_self_self_start_self_end__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_align_self_self_start_self_end__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div box-sizing="content-box" direction="rtl" align-self="self-start" width="20px" height="20px" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="rtl" align-self="self-end" width="20px" height="20px" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="100" y="0" width="20" height="20"/>
+      <node x="60" y="60" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_justify_items_self_end_child_rtl__border_box_ltr.xml
+++ b/tests/xml/grid/grid_justify_items_self_end_child_rtl__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_justify_items_self_end_child_rtl__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" justify-items="self-end" width="120px" height="120px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div direction="rtl" width="20px" height="20px" grid-row-start="1" grid-column-start="1"/>
+      <div direction="ltr" width="20px" height="20px" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="60" y="40" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_justify_items_self_end_child_rtl__border_box_rtl.xml
+++ b/tests/xml/grid/grid_justify_items_self_end_child_rtl__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_justify_items_self_end_child_rtl__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" justify-items="self-end" width="120px" height="120px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div direction="rtl" width="20px" height="20px" grid-row-start="1" grid-column-start="1"/>
+      <div direction="ltr" width="20px" height="20px" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="80" y="0" width="20" height="20"/>
+      <node x="60" y="40" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_justify_items_self_end_child_rtl__content_box_ltr.xml
+++ b/tests/xml/grid/grid_justify_items_self_end_child_rtl__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_justify_items_self_end_child_rtl__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" justify-items="self-end" width="120px" height="120px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div box-sizing="content-box" direction="rtl" width="20px" height="20px" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="ltr" width="20px" height="20px" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="60" y="40" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_justify_items_self_end_child_rtl__content_box_rtl.xml
+++ b/tests/xml/grid/grid_justify_items_self_end_child_rtl__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_justify_items_self_end_child_rtl__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" justify-items="self-end" width="120px" height="120px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div box-sizing="content-box" direction="rtl" width="20px" height="20px" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="ltr" width="20px" height="20px" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="80" y="0" width="20" height="20"/>
+      <node x="60" y="40" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_justify_self_self_end__border_box_ltr.xml
+++ b/tests/xml/grid/grid_justify_self_self_end__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_justify_self_self_end__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div direction="ltr" justify-self="self-end" width="20px" height="20px" grid-row-start="1" grid-column-start="1"/>
+      <div direction="ltr" justify-self="self-end" width="20px" height="20px" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="20" y="0" width="20" height="20"/>
+      <node x="60" y="40" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_justify_self_self_end__border_box_rtl.xml
+++ b/tests/xml/grid/grid_justify_self_self_end__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_justify_self_self_end__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div direction="rtl" justify-self="self-end" width="20px" height="20px" grid-row-start="1" grid-column-start="1"/>
+      <div direction="rtl" justify-self="self-end" width="20px" height="20px" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="80" y="0" width="20" height="20"/>
+      <node x="40" y="40" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_justify_self_self_end__content_box_ltr.xml
+++ b/tests/xml/grid/grid_justify_self_self_end__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_justify_self_self_end__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div box-sizing="content-box" direction="ltr" justify-self="self-end" width="20px" height="20px" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="ltr" justify-self="self-end" width="20px" height="20px" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="20" y="0" width="20" height="20"/>
+      <node x="60" y="40" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_justify_self_self_end__content_box_rtl.xml
+++ b/tests/xml/grid/grid_justify_self_self_end__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_justify_self_self_end__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div box-sizing="content-box" direction="rtl" justify-self="self-end" width="20px" height="20px" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="rtl" justify-self="self-end" width="20px" height="20px" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="80" y="0" width="20" height="20"/>
+      <node x="40" y="40" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_justify_self_self_start__border_box_ltr.xml
+++ b/tests/xml/grid/grid_justify_self_self_start__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_justify_self_self_start__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div direction="ltr" justify-self="self-start" width="20px" height="20px" grid-row-start="1" grid-column-start="1"/>
+      <div direction="ltr" justify-self="self-start" width="20px" height="20px" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="40" y="40" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_justify_self_self_start__border_box_rtl.xml
+++ b/tests/xml/grid/grid_justify_self_self_start__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_justify_self_self_start__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div direction="rtl" justify-self="self-start" width="20px" height="20px" grid-row-start="1" grid-column-start="1"/>
+      <div direction="rtl" justify-self="self-start" width="20px" height="20px" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="100" y="0" width="20" height="20"/>
+      <node x="60" y="40" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_justify_self_self_start__content_box_ltr.xml
+++ b/tests/xml/grid/grid_justify_self_self_start__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_justify_self_self_start__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div box-sizing="content-box" direction="ltr" justify-self="self-start" width="20px" height="20px" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="ltr" justify-self="self-start" width="20px" height="20px" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="40" y="40" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_justify_self_self_start__content_box_rtl.xml
+++ b/tests/xml/grid/grid_justify_self_self_start__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_justify_self_self_start__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div box-sizing="content-box" direction="rtl" justify-self="self-start" width="20px" height="20px" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="rtl" justify-self="self-start" width="20px" height="20px" grid-row-start="2" grid-column-start="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="100" y="0" width="20" height="20"/>
+      <node x="60" y="40" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_justify_self_self_start_child_rtl__border_box_ltr.xml
+++ b/tests/xml/grid/grid_justify_self_self_start_child_rtl__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_justify_self_self_start_child_rtl__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="120px" height="120px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div direction="rtl" justify-self="self-start" width="20px" height="20px" grid-row-start="1" grid-column-start="1"/>
+      <div direction="rtl" justify-self="self-end" width="20px" height="20px" grid-row-start="2" grid-column-start="2"/>
+      <div direction="ltr" justify-self="self-start" width="20px" height="20px" grid-row-start="3" grid-column-start="3"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="20" y="0" width="20" height="20"/>
+      <node x="40" y="40" width="20" height="20"/>
+      <node x="80" y="80" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_justify_self_self_start_child_rtl__border_box_rtl.xml
+++ b/tests/xml/grid/grid_justify_self_self_start_child_rtl__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_justify_self_self_start_child_rtl__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="120px" height="120px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div direction="rtl" justify-self="self-start" width="20px" height="20px" grid-row-start="1" grid-column-start="1"/>
+      <div direction="rtl" justify-self="self-end" width="20px" height="20px" grid-row-start="2" grid-column-start="2"/>
+      <div direction="ltr" justify-self="self-start" width="20px" height="20px" grid-row-start="3" grid-column-start="3"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="100" y="0" width="20" height="20"/>
+      <node x="40" y="40" width="20" height="20"/>
+      <node x="0" y="80" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_justify_self_self_start_child_rtl__content_box_ltr.xml
+++ b/tests/xml/grid/grid_justify_self_self_start_child_rtl__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_justify_self_self_start_child_rtl__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="120px" height="120px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div box-sizing="content-box" direction="rtl" justify-self="self-start" width="20px" height="20px" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="rtl" justify-self="self-end" width="20px" height="20px" grid-row-start="2" grid-column-start="2"/>
+      <div box-sizing="content-box" direction="ltr" justify-self="self-start" width="20px" height="20px" grid-row-start="3" grid-column-start="3"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="20" y="0" width="20" height="20"/>
+      <node x="40" y="40" width="20" height="20"/>
+      <node x="80" y="80" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_justify_self_self_start_child_rtl__content_box_rtl.xml
+++ b/tests/xml/grid/grid_justify_self_self_start_child_rtl__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_justify_self_self_start_child_rtl__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="120px" height="120px" grid-template-rows="40px 40px 40px" grid-template-columns="40px 40px 40px">
+      <div box-sizing="content-box" direction="rtl" justify-self="self-start" width="20px" height="20px" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="rtl" justify-self="self-end" width="20px" height="20px" grid-row-start="2" grid-column-start="2"/>
+      <div box-sizing="content-box" direction="ltr" justify-self="self-start" width="20px" height="20px" grid-row-start="3" grid-column-start="3"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="100" y="0" width="20" height="20"/>
+      <node x="40" y="40" width="20" height="20"/>
+      <node x="0" y="80" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -5644,6 +5644,46 @@ mod flex {
     }
 
     #[test]
+    fn absolute_layout_align_self_self_end_column_child_rtl__border_box_ltr() {
+        crate::run_xml_test("flex", "absolute_layout_align_self_self_end_column_child_rtl__border_box_ltr");
+    }
+
+    #[test]
+    fn absolute_layout_align_self_self_end_column_child_rtl__content_box_ltr() {
+        crate::run_xml_test("flex", "absolute_layout_align_self_self_end_column_child_rtl__content_box_ltr");
+    }
+
+    #[test]
+    fn absolute_layout_align_self_self_end_column_child_rtl__border_box_rtl() {
+        crate::run_xml_test("flex", "absolute_layout_align_self_self_end_column_child_rtl__border_box_rtl");
+    }
+
+    #[test]
+    fn absolute_layout_align_self_self_end_column_child_rtl__content_box_rtl() {
+        crate::run_xml_test("flex", "absolute_layout_align_self_self_end_column_child_rtl__content_box_rtl");
+    }
+
+    #[test]
+    fn absolute_layout_align_self_self_start_column_child_rtl__border_box_ltr() {
+        crate::run_xml_test("flex", "absolute_layout_align_self_self_start_column_child_rtl__border_box_ltr");
+    }
+
+    #[test]
+    fn absolute_layout_align_self_self_start_column_child_rtl__content_box_ltr() {
+        crate::run_xml_test("flex", "absolute_layout_align_self_self_start_column_child_rtl__content_box_ltr");
+    }
+
+    #[test]
+    fn absolute_layout_align_self_self_start_column_child_rtl__border_box_rtl() {
+        crate::run_xml_test("flex", "absolute_layout_align_self_self_start_column_child_rtl__border_box_rtl");
+    }
+
+    #[test]
+    fn absolute_layout_align_self_self_start_column_child_rtl__content_box_rtl() {
+        crate::run_xml_test("flex", "absolute_layout_align_self_self_start_column_child_rtl__content_box_rtl");
+    }
+
+    #[test]
     fn absolute_layout_align_self_start_wrap_reverse__border_box_ltr() {
         crate::run_xml_test("flex", "absolute_layout_align_self_start_wrap_reverse__border_box_ltr");
     }
@@ -8632,6 +8672,66 @@ mod flex {
     }
 
     #[test]
+    fn align_self_self_end__border_box_ltr() {
+        crate::run_xml_test("flex", "align_self_self_end__border_box_ltr");
+    }
+
+    #[test]
+    fn align_self_self_end__content_box_ltr() {
+        crate::run_xml_test("flex", "align_self_self_end__content_box_ltr");
+    }
+
+    #[test]
+    fn align_self_self_end__border_box_rtl() {
+        crate::run_xml_test("flex", "align_self_self_end__border_box_rtl");
+    }
+
+    #[test]
+    fn align_self_self_end__content_box_rtl() {
+        crate::run_xml_test("flex", "align_self_self_end__content_box_rtl");
+    }
+
+    #[test]
+    fn align_self_self_end_wrap_reverse__border_box_ltr() {
+        crate::run_xml_test("flex", "align_self_self_end_wrap_reverse__border_box_ltr");
+    }
+
+    #[test]
+    fn align_self_self_end_wrap_reverse__content_box_ltr() {
+        crate::run_xml_test("flex", "align_self_self_end_wrap_reverse__content_box_ltr");
+    }
+
+    #[test]
+    fn align_self_self_end_wrap_reverse__border_box_rtl() {
+        crate::run_xml_test("flex", "align_self_self_end_wrap_reverse__border_box_rtl");
+    }
+
+    #[test]
+    fn align_self_self_end_wrap_reverse__content_box_rtl() {
+        crate::run_xml_test("flex", "align_self_self_end_wrap_reverse__content_box_rtl");
+    }
+
+    #[test]
+    fn align_self_self_start__border_box_ltr() {
+        crate::run_xml_test("flex", "align_self_self_start__border_box_ltr");
+    }
+
+    #[test]
+    fn align_self_self_start__content_box_ltr() {
+        crate::run_xml_test("flex", "align_self_self_start__content_box_ltr");
+    }
+
+    #[test]
+    fn align_self_self_start__border_box_rtl() {
+        crate::run_xml_test("flex", "align_self_self_start__border_box_rtl");
+    }
+
+    #[test]
+    fn align_self_self_start__content_box_rtl() {
+        crate::run_xml_test("flex", "align_self_self_start__content_box_rtl");
+    }
+
+    #[test]
     fn align_stretch_should_size_based_on_parent__border_box_ltr() {
         crate::run_xml_test("flex", "align_stretch_should_size_based_on_parent__border_box_ltr");
     }
@@ -10299,6 +10399,66 @@ mod flex {
     #[test]
     fn flex_basis_zero_undefined_main_size__content_box_rtl() {
         crate::run_xml_test("flex", "flex_basis_zero_undefined_main_size__content_box_rtl");
+    }
+
+    #[test]
+    fn flex_column_align_items_self_start_child_rtl__border_box_ltr() {
+        crate::run_xml_test("flex", "flex_column_align_items_self_start_child_rtl__border_box_ltr");
+    }
+
+    #[test]
+    fn flex_column_align_items_self_start_child_rtl__content_box_ltr() {
+        crate::run_xml_test("flex", "flex_column_align_items_self_start_child_rtl__content_box_ltr");
+    }
+
+    #[test]
+    fn flex_column_align_items_self_start_child_rtl__border_box_rtl() {
+        crate::run_xml_test("flex", "flex_column_align_items_self_start_child_rtl__border_box_rtl");
+    }
+
+    #[test]
+    fn flex_column_align_items_self_start_child_rtl__content_box_rtl() {
+        crate::run_xml_test("flex", "flex_column_align_items_self_start_child_rtl__content_box_rtl");
+    }
+
+    #[test]
+    fn flex_column_align_self_self_end_child_rtl__border_box_ltr() {
+        crate::run_xml_test("flex", "flex_column_align_self_self_end_child_rtl__border_box_ltr");
+    }
+
+    #[test]
+    fn flex_column_align_self_self_end_child_rtl__content_box_ltr() {
+        crate::run_xml_test("flex", "flex_column_align_self_self_end_child_rtl__content_box_ltr");
+    }
+
+    #[test]
+    fn flex_column_align_self_self_end_child_rtl__border_box_rtl() {
+        crate::run_xml_test("flex", "flex_column_align_self_self_end_child_rtl__border_box_rtl");
+    }
+
+    #[test]
+    fn flex_column_align_self_self_end_child_rtl__content_box_rtl() {
+        crate::run_xml_test("flex", "flex_column_align_self_self_end_child_rtl__content_box_rtl");
+    }
+
+    #[test]
+    fn flex_column_align_self_self_start_child_rtl__border_box_ltr() {
+        crate::run_xml_test("flex", "flex_column_align_self_self_start_child_rtl__border_box_ltr");
+    }
+
+    #[test]
+    fn flex_column_align_self_self_start_child_rtl__content_box_ltr() {
+        crate::run_xml_test("flex", "flex_column_align_self_self_start_child_rtl__content_box_ltr");
+    }
+
+    #[test]
+    fn flex_column_align_self_self_start_child_rtl__border_box_rtl() {
+        crate::run_xml_test("flex", "flex_column_align_self_self_start_child_rtl__border_box_rtl");
+    }
+
+    #[test]
+    fn flex_column_align_self_self_start_child_rtl__content_box_rtl() {
+        crate::run_xml_test("flex", "flex_column_align_self_self_start_child_rtl__content_box_rtl");
     }
 
     #[test]
@@ -17303,6 +17463,30 @@ mod grid {
 
     #[cfg(feature = "grid")]
     #[test]
+    fn grid_absolute_align_self_self_end__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_align_self_self_end__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_align_self_self_end__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_align_self_self_end__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_align_self_self_end__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_align_self_self_end__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_align_self_self_end__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_align_self_self_end__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
     fn grid_absolute_align_self_sized_all__border_box_ltr() {
         crate::run_xml_test("grid", "grid_absolute_align_self_sized_all__border_box_ltr");
     }
@@ -17947,6 +18131,28 @@ mod grid {
     #[test]
     fn grid_absolute_gaps_start_lines_rtl__content_box_rtl() {
         crate::run_xml_test("grid", "grid_absolute_gaps_start_lines_rtl__content_box_rtl");
+    }
+
+    fn grid_absolute_justify_self_self_start_child_rtl__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_justify_self_self_start_child_rtl__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_justify_self_self_start_child_rtl__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_justify_self_self_start_child_rtl__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_justify_self_self_start_child_rtl__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_justify_self_self_start_child_rtl__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_justify_self_self_start_child_rtl__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_justify_self_self_start_child_rtl__content_box_rtl");
     }
 
     #[cfg(feature = "grid")]
@@ -19063,6 +19269,30 @@ mod grid {
     #[test]
     fn grid_align_items_sized_stretch__content_box_rtl() {
         crate::run_xml_test("grid", "grid_align_items_sized_stretch__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_self_self_start_self_end__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_align_self_self_start_self_end__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_self_self_start_self_end__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_align_self_self_start_self_end__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_self_self_start_self_end__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_align_self_self_start_self_end__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_self_self_start_self_end__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_align_self_self_start_self_end__content_box_rtl");
     }
 
     #[cfg(feature = "grid")]
@@ -26189,6 +26419,30 @@ mod grid {
 
     #[cfg(feature = "grid")]
     #[test]
+    fn grid_justify_items_self_end_child_rtl__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_justify_items_self_end_child_rtl__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_justify_items_self_end_child_rtl__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_justify_items_self_end_child_rtl__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_justify_items_self_end_child_rtl__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_justify_items_self_end_child_rtl__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_justify_items_self_end_child_rtl__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_justify_items_self_end_child_rtl__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
     fn grid_justify_items_sized_center__border_box_ltr() {
         crate::run_xml_test("grid", "grid_justify_items_sized_center__border_box_ltr");
     }
@@ -26377,6 +26631,78 @@ mod grid {
     #[test]
     fn grid_justify_self_rtl__content_box_rtl() {
         crate::run_xml_test("grid", "grid_justify_self_rtl__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_justify_self_self_end__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_justify_self_self_end__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_justify_self_self_end__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_justify_self_self_end__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_justify_self_self_end__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_justify_self_self_end__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_justify_self_self_end__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_justify_self_self_end__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_justify_self_self_start__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_justify_self_self_start__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_justify_self_self_start__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_justify_self_self_start__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_justify_self_self_start__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_justify_self_self_start__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_justify_self_self_start__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_justify_self_self_start__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_justify_self_self_start_child_rtl__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_justify_self_self_start_child_rtl__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_justify_self_self_start_child_rtl__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_justify_self_self_start_child_rtl__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_justify_self_self_start_child_rtl__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_justify_self_self_start_child_rtl__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_justify_self_self_start_child_rtl__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_justify_self_self_start_child_rtl__content_box_rtl");
     }
 
     #[cfg(feature = "grid")]

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -18157,6 +18157,30 @@ mod grid {
 
     #[cfg(feature = "grid")]
     #[test]
+    fn grid_absolute_justify_self_self_start_child_rtl__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_justify_self_self_start_child_rtl__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_justify_self_self_start_child_rtl__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_justify_self_self_start_child_rtl__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_justify_self_self_start_child_rtl__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_justify_self_self_start_child_rtl__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_justify_self_self_start_child_rtl__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_justify_self_self_start_child_rtl__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
     fn grid_absolute_justify_self_sized_all__border_box_ltr() {
         crate::run_xml_test("grid", "grid_absolute_justify_self_sized_all__border_box_ltr");
     }

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -18133,28 +18133,6 @@ mod grid {
         crate::run_xml_test("grid", "grid_absolute_gaps_start_lines_rtl__content_box_rtl");
     }
 
-    fn grid_absolute_justify_self_self_start_child_rtl__border_box_ltr() {
-        crate::run_xml_test("grid", "grid_absolute_justify_self_self_start_child_rtl__border_box_ltr");
-    }
-
-    #[cfg(feature = "grid")]
-    #[test]
-    fn grid_absolute_justify_self_self_start_child_rtl__content_box_ltr() {
-        crate::run_xml_test("grid", "grid_absolute_justify_self_self_start_child_rtl__content_box_ltr");
-    }
-
-    #[cfg(feature = "grid")]
-    #[test]
-    fn grid_absolute_justify_self_self_start_child_rtl__border_box_rtl() {
-        crate::run_xml_test("grid", "grid_absolute_justify_self_self_start_child_rtl__border_box_rtl");
-    }
-
-    #[cfg(feature = "grid")]
-    #[test]
-    fn grid_absolute_justify_self_self_start_child_rtl__content_box_rtl() {
-        crate::run_xml_test("grid", "grid_absolute_justify_self_self_start_child_rtl__content_box_rtl");
-    }
-
     #[cfg(feature = "grid")]
     #[test]
     fn grid_absolute_justify_self_self_start_child_rtl__border_box_ltr() {


### PR DESCRIPTION
# Objective

Fixes #1074

Adds support for the CSS Box Alignment `self-start`/`self-end` keywords, which resolve against the `direction` of the item itself rather than that of its container:

- New `AlignItemsKeyword::SelfStart`/`SelfEnd` variants and `AlignItems::SELF_START`/`SELF_END`/`SAFE_SELF_START`/`SAFE_SELF_END` constants, with CSS parsing (`self-start`, `safe self-end`, ...) and serde support
- New internal resolver on `AlignItems`:
  ```rust
  fn resolve_self_relative(self, item_direction: Direction, container_direction: Direction, axis_is_inline: bool) -> Self
  // SelfStart -> Start (or End when axis_is_inline && item_direction != container_direction)
  // SelfEnd   -> End   (or Start when flipped); other keywords unchanged
  ```
- Flexbox: resolved when flex items are generated (in-flow) and where `align_self` is read for absolutely positioned children. Since Taffy only supports horizontal writing modes, the cross axis is the inline axis only for `column` flex containers, so `is_column` is passed as `axis_is_inline`
- Grid: resolved in `align_and_position_item` for both in-flow and absolutely positioned items; the horizontal axis (`justify-self`) is the inline axis and can flip, the vertical axis (`align-self`) is the block axis and always resolves to plain `start`/`end`

Since only the inline axis can flip and Taffy has no vertical writing modes, `self-start`/`self-end` only differ from `start`/`end` when the item's `direction` differs from its container's.

## Context

Generated tests cover flex in-flow (`row`, `column`, `wrap-reverse`, `align-items`), flex abspos, grid `justify-self`/`align-self`/`justify-items`, and grid abspos, each with LTR/RTL container variants and explicit child `direction` mismatches.

Block layout is unaffected: Taffy's block algorithm doesn't consume `align-self`/`justify-self` at all, so there is no self-alignment path for these keywords to participate in.

`CHANGELOG.md` has been updated (the repo has no `RELEASES.md`; the changelog appears to be its successor).


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/ca2ab1b8ecbe43409053475335d0b957
Requested by: @nicoburns