### PR TITLE
Align empty grids (all tracks collapsed) within the container

### DIFF
--- a/src/compute/grid/alignment.rs
+++ b/src/compute/grid/alignment.rs
@@ -41,8 +41,17 @@ pub(super) fn align_tracks(
     let track_alignment = apply_alignment_fallback(free_space, num_tracks, track_alignment_style);
     let track_alignment = if axis_is_reversed { track_alignment.reversed() } else { track_alignment };
 
+    // If every track is collapsed then no track receives the alignment offset below, but the
+    // grid's lines should still be aligned within the container (e.g. at the inline-start edge
+    // for RTL), so apply the offset to the origin instead.
+    let empty_grid_offset = if num_tracks == 0 {
+        compute_alignment_offset(free_space, num_tracks, gap, track_alignment, layout_is_reversed, true)
+    } else {
+        0.0
+    };
+
     // Compute offsets
-    let mut total_offset = origin;
+    let mut total_offset = origin + empty_grid_offset;
     let mut seen_non_collapsed_track = false;
     tracks.iter_mut().enumerate().for_each(|(i, track)| {
         // Odd tracks are gutters (but slices are zero-indexed, so odd tracks have even indices)

--- a/test_fixtures/grid/grid_absolute_collapsed_auto_fit_tracks_rtl.html
+++ b/test_fixtures/grid/grid_absolute_collapsed_auto_fit_tracks_rtl.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="height: 330px; width: 530px; display: grid; grid-template-columns: repeat(auto-fit, 100px); grid-template-rows: repeat(auto-fit, 100px); gap: 10px; padding: 15px; position: relative; box-sizing: border-box; direction: rtl;">
+  <div style="position: absolute; grid-column: auto / 1; grid-row: auto / 1; background-color: red;"></div>
+  <div style="position: absolute; grid-column: -1 / auto; grid-row: -1 / auto; background-color: blue;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/grid/grid_absolute_collapsed_auto_fit_tracks_rtl__border_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_collapsed_auto_fit_tracks_rtl__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_absolute_collapsed_auto_fit_tracks_rtl__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="530px" height="330px" row-gap="10px" column-gap="10px" padding-top="15px" padding-left="15px" padding-bottom="15px" padding-right="15px" grid-template-rows="repeat(auto-fit, 100px)" grid-template-columns="repeat(auto-fit, 100px)">
+      <div direction="ltr" position="absolute" grid-row-end="1" grid-column-end="1"/>
+      <div direction="ltr" position="absolute" grid-row-start="-1" grid-column-start="-1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="530" height="330">
+      <node x="530" y="0" width="0" height="0"/>
+      <node x="515" y="15" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_collapsed_auto_fit_tracks_rtl__border_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_collapsed_auto_fit_tracks_rtl__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_absolute_collapsed_auto_fit_tracks_rtl__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="530px" height="330px" row-gap="10px" column-gap="10px" padding-top="15px" padding-left="15px" padding-bottom="15px" padding-right="15px" grid-template-rows="repeat(auto-fit, 100px)" grid-template-columns="repeat(auto-fit, 100px)">
+      <div direction="rtl" position="absolute" grid-row-end="1" grid-column-end="1"/>
+      <div direction="rtl" position="absolute" grid-row-start="-1" grid-column-start="-1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="530" height="330">
+      <node x="530" y="0" width="0" height="0"/>
+      <node x="515" y="15" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_collapsed_auto_fit_tracks_rtl__content_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_collapsed_auto_fit_tracks_rtl__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_absolute_collapsed_auto_fit_tracks_rtl__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="530px" height="330px" row-gap="10px" column-gap="10px" padding-top="15px" padding-left="15px" padding-bottom="15px" padding-right="15px" grid-template-rows="repeat(auto-fit, 100px)" grid-template-columns="repeat(auto-fit, 100px)">
+      <div box-sizing="content-box" direction="ltr" position="absolute" grid-row-end="1" grid-column-end="1"/>
+      <div box-sizing="content-box" direction="ltr" position="absolute" grid-row-start="-1" grid-column-start="-1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="530" height="330">
+      <node x="530" y="0" width="0" height="0"/>
+      <node x="515" y="15" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_collapsed_auto_fit_tracks_rtl__content_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_collapsed_auto_fit_tracks_rtl__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_absolute_collapsed_auto_fit_tracks_rtl__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="530px" height="330px" row-gap="10px" column-gap="10px" padding-top="15px" padding-left="15px" padding-bottom="15px" padding-right="15px" grid-template-rows="repeat(auto-fit, 100px)" grid-template-columns="repeat(auto-fit, 100px)">
+      <div box-sizing="content-box" direction="rtl" position="absolute" grid-row-end="1" grid-column-end="1"/>
+      <div box-sizing="content-box" direction="rtl" position="absolute" grid-row-start="-1" grid-column-start="-1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="530" height="330">
+      <node x="530" y="0" width="0" height="0"/>
+      <node x="515" y="15" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -17287,6 +17287,30 @@ mod grid {
 
     #[cfg(feature = "grid")]
     #[test]
+    fn grid_absolute_collapsed_auto_fit_tracks_rtl__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_collapsed_auto_fit_tracks_rtl__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_collapsed_auto_fit_tracks_rtl__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_collapsed_auto_fit_tracks_rtl__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_collapsed_auto_fit_tracks_rtl__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_collapsed_auto_fit_tracks_rtl__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_collapsed_auto_fit_tracks_rtl__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_collapsed_auto_fit_tracks_rtl__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
     fn grid_absolute_column_end__border_box_ltr() {
         crate::run_xml_test("grid", "grid_absolute_column_end__border_box_ltr");
     }


### PR DESCRIPTION
# Objective

When every track in an axis is collapsed (e.g. `repeat(auto-fit, ...)` with no in-flow items), the content-alignment offset was never applied because it is only added to the first non-collapsed track. A fully-collapsed RTL grid therefore sat at the inline-end edge instead of the inline-start edge, misplacing absolutely positioned items resolved against its grid lines.

This applies the alignment offset to the track origin when there are no non-collapsed tracks:

```rust
let empty_grid_offset = if num_tracks == 0 {
    compute_alignment_offset(free_space, num_tracks, gap, track_alignment, layout_is_reversed, true)
} else { 0.0 };
let mut total_offset = origin + empty_grid_offset;
```

## Context

Found while regression-testing #1075 against the Blitz WPT suite: this bug was previously masked by phantom implicit tracks created by abspos children. Fixes the `.grid 11` subtest of `css/css-grid/abspos/grid-positioned-items-padding-001.html`. Covered by a new generated test (`grid_absolute_collapsed_auto_fit_tracks_rtl`).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/9f3946d51bfa4f6ba89dc83598f3fa31
Requested by: @nicoburns