### PR TITLE
Add generated tests for float placement after sibling margins

### DIFF
--- a/test_fixtures/float/float_after_sibling_bottom_margin.html
+++ b/test_fixtures/float/float_after_sibling_bottom_margin.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    A float following an in-flow sibling with a bottom margin is placed below that margin.
+    Reduced from WPT css/CSS2/margin-padding-clear/margin-right-004.xht
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px;">
+  <div style="display: block; height: 20px; margin-bottom: 16px;"></div>
+  <div style="display: block; float: left; width: 50px; height: 50px;"></div>
+  <div style="display: block; height: 30px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/float/float_between_collapsing_margins.html
+++ b/test_fixtures/float/float_between_collapsing_margins.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    A float placed between two in-flow siblings whose vertical margins collapse is
+    positioned as if it had an otherwise empty anonymous block parent taking part
+    in the flow: the preceding sibling's bottom margin contributes to its position.
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px;">
+  <div style="display: block; height: 20px; margin-bottom: 16px;"></div>
+  <div style="display: block; float: left; width: 50px; height: 50px;"></div>
+  <div style="display: block; height: 30px; margin-top: 40px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/float/float_after_sibling_bottom_margin__border_box_ltr.xml
+++ b/tests/xml/float/float_after_sibling_bottom_margin__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="float_after_sibling_bottom_margin__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="200px">
+      <div display="block" direction="ltr" height="20px" margin-bottom="16px"/>
+      <div display="block" direction="ltr" float="left" width="50px" height="50px"/>
+      <div display="block" direction="ltr" height="30px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="86">
+      <node x="0" y="0" width="200" height="20"/>
+      <node x="0" y="36" width="50" height="50"/>
+      <node x="0" y="36" width="200" height="30"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_after_sibling_bottom_margin__border_box_rtl.xml
+++ b/tests/xml/float/float_after_sibling_bottom_margin__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="float_after_sibling_bottom_margin__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="200px">
+      <div display="block" direction="rtl" height="20px" margin-bottom="16px"/>
+      <div display="block" direction="rtl" float="left" width="50px" height="50px"/>
+      <div display="block" direction="rtl" height="30px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="86">
+      <node x="0" y="0" width="200" height="20"/>
+      <node x="0" y="36" width="50" height="50"/>
+      <node x="0" y="36" width="200" height="30"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_after_sibling_bottom_margin__content_box_ltr.xml
+++ b/tests/xml/float/float_after_sibling_bottom_margin__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="float_after_sibling_bottom_margin__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="200px">
+      <div display="block" box-sizing="content-box" direction="ltr" height="20px" margin-bottom="16px"/>
+      <div display="block" box-sizing="content-box" direction="ltr" float="left" width="50px" height="50px"/>
+      <div display="block" box-sizing="content-box" direction="ltr" height="30px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="86">
+      <node x="0" y="0" width="200" height="20"/>
+      <node x="0" y="36" width="50" height="50"/>
+      <node x="0" y="36" width="200" height="30"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_after_sibling_bottom_margin__content_box_rtl.xml
+++ b/tests/xml/float/float_after_sibling_bottom_margin__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="float_after_sibling_bottom_margin__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="200px">
+      <div display="block" box-sizing="content-box" direction="rtl" height="20px" margin-bottom="16px"/>
+      <div display="block" box-sizing="content-box" direction="rtl" float="left" width="50px" height="50px"/>
+      <div display="block" box-sizing="content-box" direction="rtl" height="30px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="86">
+      <node x="0" y="0" width="200" height="20"/>
+      <node x="0" y="36" width="50" height="50"/>
+      <node x="0" y="36" width="200" height="30"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_between_collapsing_margins__border_box_ltr.xml
+++ b/tests/xml/float/float_between_collapsing_margins__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="float_between_collapsing_margins__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="200px">
+      <div display="block" direction="ltr" height="20px" margin-bottom="16px"/>
+      <div display="block" direction="ltr" float="left" width="50px" height="50px"/>
+      <div display="block" direction="ltr" height="30px" margin-top="40px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="90">
+      <node x="0" y="0" width="200" height="20"/>
+      <node x="0" y="36" width="50" height="50"/>
+      <node x="0" y="60" width="200" height="30"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_between_collapsing_margins__border_box_rtl.xml
+++ b/tests/xml/float/float_between_collapsing_margins__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="float_between_collapsing_margins__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="200px">
+      <div display="block" direction="rtl" height="20px" margin-bottom="16px"/>
+      <div display="block" direction="rtl" float="left" width="50px" height="50px"/>
+      <div display="block" direction="rtl" height="30px" margin-top="40px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="90">
+      <node x="0" y="0" width="200" height="20"/>
+      <node x="0" y="36" width="50" height="50"/>
+      <node x="0" y="60" width="200" height="30"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_between_collapsing_margins__content_box_ltr.xml
+++ b/tests/xml/float/float_between_collapsing_margins__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="float_between_collapsing_margins__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="200px">
+      <div display="block" box-sizing="content-box" direction="ltr" height="20px" margin-bottom="16px"/>
+      <div display="block" box-sizing="content-box" direction="ltr" float="left" width="50px" height="50px"/>
+      <div display="block" box-sizing="content-box" direction="ltr" height="30px" margin-top="40px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="90">
+      <node x="0" y="0" width="200" height="20"/>
+      <node x="0" y="36" width="50" height="50"/>
+      <node x="0" y="60" width="200" height="30"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_between_collapsing_margins__content_box_rtl.xml
+++ b/tests/xml/float/float_between_collapsing_margins__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="float_between_collapsing_margins__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="200px">
+      <div display="block" box-sizing="content-box" direction="rtl" height="20px" margin-bottom="16px"/>
+      <div display="block" box-sizing="content-box" direction="rtl" float="left" width="50px" height="50px"/>
+      <div display="block" box-sizing="content-box" direction="rtl" height="30px" margin-top="40px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="90">
+      <node x="0" y="0" width="200" height="20"/>
+      <node x="0" y="36" width="50" height="50"/>
+      <node x="0" y="60" width="200" height="30"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -16840,6 +16840,46 @@ mod flex {
 
 mod float {
     #[test]
+    fn float_after_sibling_bottom_margin__border_box_ltr() {
+        crate::run_xml_test("float", "float_after_sibling_bottom_margin__border_box_ltr");
+    }
+
+    #[test]
+    fn float_after_sibling_bottom_margin__content_box_ltr() {
+        crate::run_xml_test("float", "float_after_sibling_bottom_margin__content_box_ltr");
+    }
+
+    #[test]
+    fn float_after_sibling_bottom_margin__border_box_rtl() {
+        crate::run_xml_test("float", "float_after_sibling_bottom_margin__border_box_rtl");
+    }
+
+    #[test]
+    fn float_after_sibling_bottom_margin__content_box_rtl() {
+        crate::run_xml_test("float", "float_after_sibling_bottom_margin__content_box_rtl");
+    }
+
+    #[test]
+    fn float_between_collapsing_margins__border_box_ltr() {
+        crate::run_xml_test("float", "float_between_collapsing_margins__border_box_ltr");
+    }
+
+    #[test]
+    fn float_between_collapsing_margins__content_box_ltr() {
+        crate::run_xml_test("float", "float_between_collapsing_margins__content_box_ltr");
+    }
+
+    #[test]
+    fn float_between_collapsing_margins__border_box_rtl() {
+        crate::run_xml_test("float", "float_between_collapsing_margins__border_box_rtl");
+    }
+
+    #[test]
+    fn float_between_collapsing_margins__content_box_rtl() {
+        crate::run_xml_test("float", "float_between_collapsing_margins__content_box_rtl");
+    }
+
+    #[test]
     fn float_bfc_avoids_float_from_sibling_subtree__border_box_ltr() {
         crate::run_xml_test("float", "float_bfc_avoids_float_from_sibling_subtree__border_box_ltr");
     }


### PR DESCRIPTION
# Objective

Add regression tests for float placement relative to a preceding in-flow sibling's bottom margin. This was fixed in #990 (`y_offset_for_float` now includes the active collapsible margin set), but that PR landed without tests — released taffy 0.12.2 predates it and misplaces such floats by the margin amount, which is the root cause of ~85 failing `margin-right-*`/`padding-right-*` tests in Blitz's WPT `css/CSS2/margin-padding-clear` subsuite (they pass with taffy `main`).

## Context

Two new generated test fixtures (each generating ltr/rtl × border-box/content-box variants):

- `float_after_sibling_bottom_margin`: a float following a sibling with `margin-bottom` must be placed below that margin. Reduced from WPT `css/CSS2/margin-padding-clear/margin-right-004.xht`.
- `float_between_collapsing_margins`: a float between two siblings whose vertical margins collapse is positioned as if it had an otherwise empty anonymous block parent in the flow, so the preceding sibling's bottom margin contributes to its position.

Test-only change; no `RELEASES.md` update needed.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/efb54af05dba48ffbbdce7f1035f857a
Requested by: @nicoburns