### PR TITLE
Block: don't collapse bottom margin with last child's when min-height determines the used height

### DIFF
--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -586,6 +586,15 @@ fn compute_inner(
         .maybe_max(Some(padding_border_size.height));
     let final_outer_size = Size { width: container_outer_width, height: container_outer_height };
 
+    // CSS2 §8.3.1: the bottom margin of a block with `height: auto` collapses with its last
+    // in-flow child's bottom margin only if the box's `min-height` is less than the box's
+    // used height. When `min-height` determines the used height, the last child's bottom
+    // margin no longer adjoins the box's bottom edge, so it stays inside the box instead of
+    // collapsing with the box's own bottom margin. (`max-height` has no such effect.)
+    let height_constrained_by_min_height = matches!(min_size.height, Some(h) if h > 0.0 && h >= container_outer_height);
+    let own_bottom_margin_collapses_with_children =
+        own_margins_collapse_with_children.end && !height_constrained_by_min_height;
+
     // Apply `align-content` to in-flow non-floated items if requested. The per-item layouts were
     // held back in `item.final_layout` so that this step can shift `location.y` before tree commit.
     //
@@ -661,7 +670,7 @@ fn compute_inner(
             let margin_top = raw_margin.top.resolve_or_zero(parent_size.width, |val, basis| tree.calc(val, basis));
             CollapsibleMarginSet::from_margin(margin_top)
         },
-        bottom_margin: if own_margins_collapse_with_children.end {
+        bottom_margin: if own_bottom_margin_collapses_with_children {
             last_child_bottom_margin_set
         } else {
             let margin_bottom =

--- a/test_fixtures/block/block_margin_y_collapse_through_child_blocked_by_parent_min_height.html
+++ b/test_fixtures/block/block_margin_y_collapse_through_child_blocked_by_parent_min_height.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; min-height: 30px;">
+    <div style="display: block; margin-bottom: 20px;"></div>
+  </div>
+  <div style="display: block; height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/block/block_margin_y_last_child_collapse_blocked_by_min_height.html
+++ b/test_fixtures/block/block_margin_y_last_child_collapse_blocked_by_min_height.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; min-height: 40px; margin-bottom: 10px;">
+    <div style="display: block; height: 10px; margin-bottom: 20px;"></div>
+  </div>
+  <div style="display: block; height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/block/block_margin_y_last_child_collapse_not_blocked_by_smaller_min_height.html
+++ b/test_fixtures/block/block_margin_y_last_child_collapse_not_blocked_by_smaller_min_height.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; min-height: 10px; margin-bottom: 10px;">
+    <div style="display: block; height: 20px; margin-bottom: 30px;"></div>
+  </div>
+  <div style="display: block; height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/block/block_margin_y_collapse_through_child_blocked_by_parent_min_height__border_box_ltr.xml
+++ b/tests/xml/block/block_margin_y_collapse_through_child_blocked_by_parent_min_height__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="block_margin_y_collapse_through_child_blocked_by_parent_min_height__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="50px">
+      <div display="block" direction="ltr" min-height="30px">
+        <div display="block" direction="ltr" margin-bottom="20px"/>
+      </div>
+      <div display="block" direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="50" height="60">
+      <node x="0" y="20" width="50" height="30">
+        <node x="0" y="0" width="50" height="0"/>
+      </node>
+      <node x="0" y="50" width="50" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_margin_y_collapse_through_child_blocked_by_parent_min_height__border_box_rtl.xml
+++ b/tests/xml/block/block_margin_y_collapse_through_child_blocked_by_parent_min_height__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="block_margin_y_collapse_through_child_blocked_by_parent_min_height__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="50px">
+      <div display="block" direction="rtl" min-height="30px">
+        <div display="block" direction="rtl" margin-bottom="20px"/>
+      </div>
+      <div display="block" direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="50" height="60">
+      <node x="0" y="20" width="50" height="30">
+        <node x="0" y="0" width="50" height="0"/>
+      </node>
+      <node x="0" y="50" width="50" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_margin_y_collapse_through_child_blocked_by_parent_min_height__content_box_ltr.xml
+++ b/tests/xml/block/block_margin_y_collapse_through_child_blocked_by_parent_min_height__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="block_margin_y_collapse_through_child_blocked_by_parent_min_height__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="50px">
+      <div display="block" box-sizing="content-box" direction="ltr" min-height="30px">
+        <div display="block" box-sizing="content-box" direction="ltr" margin-bottom="20px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="50" height="60">
+      <node x="0" y="20" width="50" height="30">
+        <node x="0" y="0" width="50" height="0"/>
+      </node>
+      <node x="0" y="50" width="50" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_margin_y_collapse_through_child_blocked_by_parent_min_height__content_box_rtl.xml
+++ b/tests/xml/block/block_margin_y_collapse_through_child_blocked_by_parent_min_height__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="block_margin_y_collapse_through_child_blocked_by_parent_min_height__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="50px">
+      <div display="block" box-sizing="content-box" direction="rtl" min-height="30px">
+        <div display="block" box-sizing="content-box" direction="rtl" margin-bottom="20px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="50" height="60">
+      <node x="0" y="20" width="50" height="30">
+        <node x="0" y="0" width="50" height="0"/>
+      </node>
+      <node x="0" y="50" width="50" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_margin_y_last_child_collapse_blocked_by_min_height__border_box_ltr.xml
+++ b/tests/xml/block/block_margin_y_last_child_collapse_blocked_by_min_height__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="block_margin_y_last_child_collapse_blocked_by_min_height__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="50px">
+      <div display="block" direction="ltr" min-height="40px" margin-bottom="10px">
+        <div display="block" direction="ltr" height="10px" margin-bottom="20px"/>
+      </div>
+      <div display="block" direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="50" height="60">
+      <node x="0" y="0" width="50" height="40">
+        <node x="0" y="0" width="50" height="10"/>
+      </node>
+      <node x="0" y="50" width="50" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_margin_y_last_child_collapse_blocked_by_min_height__border_box_rtl.xml
+++ b/tests/xml/block/block_margin_y_last_child_collapse_blocked_by_min_height__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="block_margin_y_last_child_collapse_blocked_by_min_height__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="50px">
+      <div display="block" direction="rtl" min-height="40px" margin-bottom="10px">
+        <div display="block" direction="rtl" height="10px" margin-bottom="20px"/>
+      </div>
+      <div display="block" direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="50" height="60">
+      <node x="0" y="0" width="50" height="40">
+        <node x="0" y="0" width="50" height="10"/>
+      </node>
+      <node x="0" y="50" width="50" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_margin_y_last_child_collapse_blocked_by_min_height__content_box_ltr.xml
+++ b/tests/xml/block/block_margin_y_last_child_collapse_blocked_by_min_height__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="block_margin_y_last_child_collapse_blocked_by_min_height__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="50px">
+      <div display="block" box-sizing="content-box" direction="ltr" min-height="40px" margin-bottom="10px">
+        <div display="block" box-sizing="content-box" direction="ltr" height="10px" margin-bottom="20px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="50" height="60">
+      <node x="0" y="0" width="50" height="40">
+        <node x="0" y="0" width="50" height="10"/>
+      </node>
+      <node x="0" y="50" width="50" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_margin_y_last_child_collapse_blocked_by_min_height__content_box_rtl.xml
+++ b/tests/xml/block/block_margin_y_last_child_collapse_blocked_by_min_height__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="block_margin_y_last_child_collapse_blocked_by_min_height__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="50px">
+      <div display="block" box-sizing="content-box" direction="rtl" min-height="40px" margin-bottom="10px">
+        <div display="block" box-sizing="content-box" direction="rtl" height="10px" margin-bottom="20px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="50" height="60">
+      <node x="0" y="0" width="50" height="40">
+        <node x="0" y="0" width="50" height="10"/>
+      </node>
+      <node x="0" y="50" width="50" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_margin_y_last_child_collapse_not_blocked_by_smaller_min_height__border_box_ltr.xml
+++ b/tests/xml/block/block_margin_y_last_child_collapse_not_blocked_by_smaller_min_height__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="block_margin_y_last_child_collapse_not_blocked_by_smaller_min_height__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="50px">
+      <div display="block" direction="ltr" min-height="10px" margin-bottom="10px">
+        <div display="block" direction="ltr" height="20px" margin-bottom="30px"/>
+      </div>
+      <div display="block" direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="50" height="60">
+      <node x="0" y="0" width="50" height="20">
+        <node x="0" y="0" width="50" height="20"/>
+      </node>
+      <node x="0" y="50" width="50" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_margin_y_last_child_collapse_not_blocked_by_smaller_min_height__border_box_rtl.xml
+++ b/tests/xml/block/block_margin_y_last_child_collapse_not_blocked_by_smaller_min_height__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="block_margin_y_last_child_collapse_not_blocked_by_smaller_min_height__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="50px">
+      <div display="block" direction="rtl" min-height="10px" margin-bottom="10px">
+        <div display="block" direction="rtl" height="20px" margin-bottom="30px"/>
+      </div>
+      <div display="block" direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="50" height="60">
+      <node x="0" y="0" width="50" height="20">
+        <node x="0" y="0" width="50" height="20"/>
+      </node>
+      <node x="0" y="50" width="50" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_margin_y_last_child_collapse_not_blocked_by_smaller_min_height__content_box_ltr.xml
+++ b/tests/xml/block/block_margin_y_last_child_collapse_not_blocked_by_smaller_min_height__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="block_margin_y_last_child_collapse_not_blocked_by_smaller_min_height__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="50px">
+      <div display="block" box-sizing="content-box" direction="ltr" min-height="10px" margin-bottom="10px">
+        <div display="block" box-sizing="content-box" direction="ltr" height="20px" margin-bottom="30px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="50" height="60">
+      <node x="0" y="0" width="50" height="20">
+        <node x="0" y="0" width="50" height="20"/>
+      </node>
+      <node x="0" y="50" width="50" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_margin_y_last_child_collapse_not_blocked_by_smaller_min_height__content_box_rtl.xml
+++ b/tests/xml/block/block_margin_y_last_child_collapse_not_blocked_by_smaller_min_height__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="block_margin_y_last_child_collapse_not_blocked_by_smaller_min_height__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="50px">
+      <div display="block" box-sizing="content-box" direction="rtl" min-height="10px" margin-bottom="10px">
+        <div display="block" box-sizing="content-box" direction="rtl" height="20px" margin-bottom="30px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="50" height="60">
+      <node x="0" y="0" width="50" height="20">
+        <node x="0" y="0" width="50" height="20"/>
+      </node>
+      <node x="0" y="50" width="50" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -3050,6 +3050,38 @@ mod block {
     }
 
     #[test]
+    fn block_margin_y_collapse_through_child_blocked_by_parent_min_height__border_box_ltr() {
+        crate::run_xml_test(
+            "block",
+            "block_margin_y_collapse_through_child_blocked_by_parent_min_height__border_box_ltr",
+        );
+    }
+
+    #[test]
+    fn block_margin_y_collapse_through_child_blocked_by_parent_min_height__content_box_ltr() {
+        crate::run_xml_test(
+            "block",
+            "block_margin_y_collapse_through_child_blocked_by_parent_min_height__content_box_ltr",
+        );
+    }
+
+    #[test]
+    fn block_margin_y_collapse_through_child_blocked_by_parent_min_height__border_box_rtl() {
+        crate::run_xml_test(
+            "block",
+            "block_margin_y_collapse_through_child_blocked_by_parent_min_height__border_box_rtl",
+        );
+    }
+
+    #[test]
+    fn block_margin_y_collapse_through_child_blocked_by_parent_min_height__content_box_rtl() {
+        crate::run_xml_test(
+            "block",
+            "block_margin_y_collapse_through_child_blocked_by_parent_min_height__content_box_rtl",
+        );
+    }
+
+    #[test]
     fn block_margin_y_collapse_through_negative__border_box_ltr() {
         crate::run_xml_test("block", "block_margin_y_collapse_through_negative__border_box_ltr");
     }
@@ -3562,6 +3594,26 @@ mod block {
     }
 
     #[test]
+    fn block_margin_y_last_child_collapse_blocked_by_min_height__border_box_ltr() {
+        crate::run_xml_test("block", "block_margin_y_last_child_collapse_blocked_by_min_height__border_box_ltr");
+    }
+
+    #[test]
+    fn block_margin_y_last_child_collapse_blocked_by_min_height__content_box_ltr() {
+        crate::run_xml_test("block", "block_margin_y_last_child_collapse_blocked_by_min_height__content_box_ltr");
+    }
+
+    #[test]
+    fn block_margin_y_last_child_collapse_blocked_by_min_height__border_box_rtl() {
+        crate::run_xml_test("block", "block_margin_y_last_child_collapse_blocked_by_min_height__border_box_rtl");
+    }
+
+    #[test]
+    fn block_margin_y_last_child_collapse_blocked_by_min_height__content_box_rtl() {
+        crate::run_xml_test("block", "block_margin_y_last_child_collapse_blocked_by_min_height__content_box_rtl");
+    }
+
+    #[test]
     fn block_margin_y_last_child_collapse_blocked_by_overflow_x_hidden__border_box_ltr() {
         crate::run_xml_test("block", "block_margin_y_last_child_collapse_blocked_by_overflow_x_hidden__border_box_ltr");
     }
@@ -3783,6 +3835,38 @@ mod block {
     #[test]
     fn block_margin_y_last_child_collapse_not_blocked_by_padding_top__content_box_rtl() {
         crate::run_xml_test("block", "block_margin_y_last_child_collapse_not_blocked_by_padding_top__content_box_rtl");
+    }
+
+    #[test]
+    fn block_margin_y_last_child_collapse_not_blocked_by_smaller_min_height__border_box_ltr() {
+        crate::run_xml_test(
+            "block",
+            "block_margin_y_last_child_collapse_not_blocked_by_smaller_min_height__border_box_ltr",
+        );
+    }
+
+    #[test]
+    fn block_margin_y_last_child_collapse_not_blocked_by_smaller_min_height__content_box_ltr() {
+        crate::run_xml_test(
+            "block",
+            "block_margin_y_last_child_collapse_not_blocked_by_smaller_min_height__content_box_ltr",
+        );
+    }
+
+    #[test]
+    fn block_margin_y_last_child_collapse_not_blocked_by_smaller_min_height__border_box_rtl() {
+        crate::run_xml_test(
+            "block",
+            "block_margin_y_last_child_collapse_not_blocked_by_smaller_min_height__border_box_rtl",
+        );
+    }
+
+    #[test]
+    fn block_margin_y_last_child_collapse_not_blocked_by_smaller_min_height__content_box_rtl() {
+        crate::run_xml_test(
+            "block",
+            "block_margin_y_last_child_collapse_not_blocked_by_smaller_min_height__content_box_rtl",
+        );
     }
 
     #[test]


### PR DESCRIPTION
# Objective

Fixes WPT `css/CSS2/margin-padding-clear/margin-collapse-min-height-001.xht` and `margin-collapse-min-height-002.xht` (via Blitz).

Per CSS2 §8.3.1, the bottom margin of a block with `height: auto` collapses with its last in-flow child's bottom margin *only if* the box's `min-height` is less than the box's used height. When `min-height` determines the used height, the last child's bottom margin no longer adjoins the box's bottom edge, so it must stay inside the box instead of also collapsing with the box's own bottom margin (Blitz currently double-collapses it).

## Context

In `compute_inner`, the output `bottom_margin` was gated only on `own_margins_collapse_with_children.end`:

```text
let height_constrained_by_min_height =
    matches!(min_size.height, Some(h) if h > 0.0 && h >= container_outer_height);
let own_bottom_margin_collapses_with_children =
    own_margins_collapse_with_children.end && !height_constrained_by_min_height;

bottom_margin: if own_bottom_margin_collapses_with_children { last_child_bottom_margin_set } else { /* own margin only */ }
```

`max-height` deliberately has no such effect: WPT `margin-collapse-038.xht` asserts that `max-height` must not prevent this collapse, and it still passes.

Includes generated test fixtures (`block_margin_y_last_child_collapse_blocked_by_min_height`, `block_margin_y_last_child_collapse_not_blocked_by_smaller_min_height`, `block_margin_y_collapse_through_child_blocked_by_parent_min_height`) regenerated with `just gentest`.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/19d83a7d94fb4e43a489abaa566115ba
Requested by: @nicoburns