### PR TITLE
Block: resolve percentage padding/border against the containing block width

### DIFF
--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -549,8 +549,16 @@ fn compute_inner(
         known_dimensions.height.or(size.height.maybe_max(min_size.height)).or(min_size.height);
 
     // 3. Perform final item layout and return content height
-    let resolved_padding = raw_padding.resolve_or_zero(Some(container_outer_width), |val, basis| tree.calc(val, basis));
-    let resolved_border = raw_border.resolve_or_zero(Some(container_outer_width), |val, basis| tree.calc(val, basis));
+    //
+    // Percentage padding and borders resolve against the *containing block's* width
+    // (`parent_size`), not the box's own width. These only differ when the box has a
+    // non-stretch width. Fall back to the box's own width when the parent size is
+    // unknown (e.g. at the root of the layout tree).
+    let percentage_resolution_width = parent_size.width.unwrap_or(container_outer_width);
+    let resolved_padding =
+        raw_padding.resolve_or_zero(Some(percentage_resolution_width), |val, basis| tree.calc(val, basis));
+    let resolved_border =
+        raw_border.resolve_or_zero(Some(percentage_resolution_width), |val, basis| tree.calc(val, basis));
     let resolved_content_box_inset = resolved_padding + resolved_border + scrollbar_gutter;
     #[cfg_attr(not(feature = "content_size"), allow(unused_mut))]
     let (

--- a/test_fixtures/block/block_padding_percentage_nonstretch_width.html
+++ b/test_fixtures/block/block_padding_percentage_nonstretch_width.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 40px;">
+  <div style="display: block; width: 100px; padding: 10%;">
+    <div style="display: block; height: 10px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/block/block_padding_percentage_nonstretch_width__border_box_ltr.xml
+++ b/tests/xml/block/block_padding_percentage_nonstretch_width__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="block_padding_percentage_nonstretch_width__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="40px">
+      <div display="block" direction="ltr" width="100px" padding-top="10%" padding-left="10%" padding-bottom="10%" padding-right="10%">
+        <div display="block" direction="ltr" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="40" height="18">
+      <node x="0" y="0" width="100" height="18">
+        <node x="4" y="4" width="92" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_padding_percentage_nonstretch_width__border_box_rtl.xml
+++ b/tests/xml/block/block_padding_percentage_nonstretch_width__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="block_padding_percentage_nonstretch_width__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="40px">
+      <div display="block" direction="rtl" width="100px" padding-top="10%" padding-left="10%" padding-bottom="10%" padding-right="10%">
+        <div display="block" direction="rtl" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="40" height="18">
+      <node x="-60" y="0" width="100" height="18">
+        <node x="4" y="4" width="92" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_padding_percentage_nonstretch_width__content_box_ltr.xml
+++ b/tests/xml/block/block_padding_percentage_nonstretch_width__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="block_padding_percentage_nonstretch_width__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="40px">
+      <div display="block" box-sizing="content-box" direction="ltr" width="100px" padding-top="10%" padding-left="10%" padding-bottom="10%" padding-right="10%">
+        <div display="block" box-sizing="content-box" direction="ltr" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="40" height="18">
+      <node x="0" y="0" width="108" height="18">
+        <node x="4" y="4" width="100" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_padding_percentage_nonstretch_width__content_box_rtl.xml
+++ b/tests/xml/block/block_padding_percentage_nonstretch_width__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="block_padding_percentage_nonstretch_width__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="40px">
+      <div display="block" box-sizing="content-box" direction="rtl" width="100px" padding-top="10%" padding-left="10%" padding-bottom="10%" padding-right="10%">
+        <div display="block" box-sizing="content-box" direction="rtl" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="40" height="18">
+      <node x="-68" y="0" width="108" height="18">
+        <node x="4" y="4" width="100" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -4578,6 +4578,26 @@ mod block {
     }
 
     #[test]
+    fn block_padding_percentage_nonstretch_width__border_box_ltr() {
+        crate::run_xml_test("block", "block_padding_percentage_nonstretch_width__border_box_ltr");
+    }
+
+    #[test]
+    fn block_padding_percentage_nonstretch_width__content_box_ltr() {
+        crate::run_xml_test("block", "block_padding_percentage_nonstretch_width__content_box_ltr");
+    }
+
+    #[test]
+    fn block_padding_percentage_nonstretch_width__border_box_rtl() {
+        crate::run_xml_test("block", "block_padding_percentage_nonstretch_width__border_box_rtl");
+    }
+
+    #[test]
+    fn block_padding_percentage_nonstretch_width__content_box_rtl() {
+        crate::run_xml_test("block", "block_padding_percentage_nonstretch_width__content_box_rtl");
+    }
+
+    #[test]
     fn block_padding_rtl__border_box_ltr() {
         crate::run_xml_test("block", "block_padding_rtl__border_box_ltr");
     }


### PR DESCRIPTION
# Objective

Fixes WPT `css/CSS2/margin-padding-clear/margin-collapse-028.xht` (via Blitz): percentage padding on a fixed-width block inside a narrower (zero-width) container resolved against the block's own width instead of its containing block's width, displacing its content.

## Context

In `compute_inner`, the padding/border used to position children (`resolved_content_box_inset`) was re-resolved against `container_outer_width` (the box's own width):

```text
- let resolved_padding = raw_padding.resolve_or_zero(Some(container_outer_width), ...);
+ let percentage_resolution_width = parent_size.width.unwrap_or(container_outer_width);
+ let resolved_padding = raw_padding.resolve_or_zero(Some(percentage_resolution_width), ...);
```

Percentage padding/border resolve against the *containing block's* width; the two only differ when the box has a non-stretch width. The box's own width is kept as a fallback when `parent_size.width` is unknown (e.g. the root of the layout tree).

Includes generated test fixture `block_padding_percentage_nonstretch_width` (a `width: 100px; padding: 10%` block inside a `width: 40px` parent) regenerated with `just gentest`.

Note: this and #1082 both touch `src/compute/block.rs` and the generated `tests/xml/mod.rs`; whichever merges second will need a trivial rebase/regen.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/19d83a7d94fb4e43a489abaa566115ba
Requested by: @nicoburns