### PR TITLE
Distribute only the flex-factor proportion of content excess to flexible grid tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,8 @@
 
 - Flexbox: a wrapping container with an indefinite main size now wraps its items against its max main size (e.g. `max-width` for a row container) when the available space exceeds it. Previously items were collected into flex lines using the raw available space, so a fit-content sized container (such as a float) with a `max-width` smaller than the available space never wrapped
 
+- Grid: distribute only the crossed flex factor sum's proportion (clamped at one) of an item's content-derived contribution to the flexible tracks it spans, floored by the item's minimum contribution. A `0fr` track holding a `min-height: 0` item now collapses to zero under an intrinsic sizing constraint, as browsers do (#1084)
+
 ## 0.13.0
 
 The MSRV for this release is 1.71.

--- a/src/compute/grid/track_sizing.rs
+++ b/src/compute/grid/track_sizing.rs
@@ -729,7 +729,29 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                     let limit = item.spanned_track_limit(axis, axis_tracks, axis_inner_node_size, &|val, basis| {
                         item_sizer.calc(val, basis)
                     });
-                    axis_min_content_size.maybe_min(limit).max(axis_minimum_size)
+                    let limited_min_content = axis_min_content_size.maybe_min(limit).max(axis_minimum_size);
+
+                    // For items crossing flexible tracks, browsers hand the content-derived contribution to
+                    // the flexible tracks only in proportion to the crossed flex factor sum, clamped at one
+                    // (CSS Grid 2, 12.5: "if the sum is less than one, distribute that proportion of
+                    // space"). The proportion applies to the space left after covering the spanned
+                    // inflexible tracks, and the item's minimum contribution acts as a floor on the result:
+                    // a definite size still spreads over `0fr` tracks in full. This is what lets a `0fr`
+                    // track holding a `min-height: 0` item collapse to zero, which the
+                    // `grid-template-rows: 0fr` to `1fr` collapse animation pattern relies on.
+                    if is_flex {
+                        let spanned_tracks = &axis_tracks[item.track_range_excluding_lines(axis)];
+                        let inflexible_sizes: f32 = spanned_tracks
+                            .iter()
+                            .filter(|track| !track.is_flexible())
+                            .map(|track| track.base_size)
+                            .sum();
+                        let scale = f32_min(crossed_flex_factor_sum(spanned_tracks), 1.0);
+                        let excess = f32_max(limited_min_content - inflexible_sizes, 0.0);
+                        f32_max(axis_minimum_size, inflexible_sizes + excess * scale)
+                    } else {
+                        limited_min_content
+                    }
                 }
                 _ => item_sizer.minimum_contribution(item, axis_tracks),
             };
@@ -838,7 +860,19 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                 let limit = item.spanned_track_limit(axis, axis_tracks, axis_inner_node_size, &|val, basis| {
                     item_sizer.calc(val, basis)
                 });
-                let space = axis_max_content_size.maybe_min(limit);
+                let mut space = axis_max_content_size.maybe_min(limit);
+
+                // As for the intrinsic minimums above: scale the space beyond the spanned inflexible
+                // tracks by the crossed flex factor sum, clamped at one. Anchoring at the inflexible
+                // track sizes rather than the current base sizes keeps this pass from compounding with
+                // the scaling already applied to the min-content contribution.
+                if is_flex {
+                    let spanned_tracks = &axis_tracks[item.track_range_excluding_lines(axis)];
+                    let inflexible_sizes: f32 =
+                        spanned_tracks.iter().filter(|track| !track.is_flexible()).map(|track| track.base_size).sum();
+                    let scale = f32_min(crossed_flex_factor_sum(spanned_tracks), 1.0);
+                    space = inflexible_sizes + f32_max(space - inflexible_sizes, 0.0) * scale;
+                }
                 let tracks = &mut axis_tracks[item.track_range_excluding_lines(axis)];
                 if space > 0.0 {
                     // If any of the tracks spanned by the item have a MaxContent min track sizing function then
@@ -963,6 +997,12 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
         .iter_mut()
         .filter(|track| track.growth_limit == f32::INFINITY)
         .for_each(|track| track.growth_limit = track.base_size);
+}
+
+/// The sum of the flex factors of the flexible tracks in an item's spanned track range
+#[inline(always)]
+fn crossed_flex_factor_sum(tracks: &[GridTrack]) -> f32 {
+    tracks.iter().filter(|track| track.is_flexible()).map(|track| track.flex_factor()).sum()
 }
 
 /// 11.5.1. Distributing Extra Space Across Spanned Tracks

--- a/test_fixtures/grid/grid_fr_content_proportion_sub_1_sum.html
+++ b/test_fixtures/grid/grid_fr_content_proportion_sub_1_sum.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    A 0.5fr row takes half of a min-height:0 item's 100px content: the grid is 50px tall
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; align-items: start; width: 20px; height: 150px;">
+  <div style="display: grid; grid-template-rows: 0.5fr; grid-template-columns: 20px;">
+    <div style="min-height: 0;"><div style="width: 20px; height: 100px;"></div></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_fr_content_proportion_sub_1_sum_minimum_above_share.html
+++ b/test_fixtures/grid/grid_fr_content_proportion_sub_1_sum_minimum_above_share.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    An 80px min-height above the 0.5fr share of the item's 100px content floors the row: the grid is 80px tall
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-rows: 0.5fr; grid-template-columns: 20px;">
+  <div style="min-height: 80px;"><div style="width: 20px; height: 100px;"></div></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_fr_content_proportion_sub_1_sum_minimum_below_share.html
+++ b/test_fixtures/grid/grid_fr_content_proportion_sub_1_sum_minimum_below_share.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    A 40px min-height below the 0.5fr share of the item's 100px content changes nothing: the grid is 50px tall
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; align-items: start; width: 20px; height: 150px;">
+  <div style="display: grid; grid-template-rows: 0.5fr; grid-template-columns: 20px;">
+    <div style="min-height: 40px;"><div style="width: 20px; height: 100px;"></div></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_fr_content_proportion_sub_1_sum_span_fixed_track.html
+++ b/test_fixtures/grid/grid_fr_content_proportion_sub_1_sum_span_fixed_track.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    An item spanning a 50px and a 0.5fr row: only the 50px of content beyond the fixed row is halved, so the grid is 75px tall
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; align-items: start; width: 20px; height: 150px;">
+  <div style="display: grid; grid-template-rows: 50px 0.5fr; grid-template-columns: 20px;">
+    <div style="grid-row: 1 / 3; min-height: 0;"><div style="width: 20px; height: 100px;"></div></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_fr_content_proportion_sub_1_sum_with_non_spanned_track.html
+++ b/test_fixtures/grid/grid_fr_content_proportion_sub_1_sum_with_non_spanned_track.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    A 60px item spanning 0.2fr and 0.3fr columns is scaled by those crossed factors alone, not by the non-spanned 0.5fr column
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; align-items: start; width: 150px; height: 100px;">
+  <div style="display: grid; grid-template-rows: 40px 40px; grid-template-columns: 0.2fr 0.3fr 0.5fr;">
+    <div style="width: 60px; grid-column: span 2;"></div>
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_fr_content_proportion_sum_above_1.html
+++ b/test_fixtures/grid/grid_fr_content_proportion_sum_above_1.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    A 2fr row takes the whole 100px content of a min-height:0 item: the grid is 100px tall
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-rows: 2fr; grid-template-columns: 20px;">
+  <div style="min-height: 0;"><div style="width: 20px; height: 100px;"></div></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_fr_content_proportion_zero_fr_collapse.html
+++ b/test_fixtures/grid/grid_fr_content_proportion_zero_fr_collapse.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    A 0fr row collapses under a min-height:0 item with 100px of content: the grid is 0px tall
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-rows: 0fr; grid-template-columns: 20px;">
+  <div style="min-height: 0;"><div style="width: 20px; height: 100px;"></div></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_fr_minimum_zero_sum_with_other_flex_track.html
+++ b/test_fixtures/grid/grid_fr_minimum_zero_sum_with_other_flex_track.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    A definite 100px item still sizes its 0fr row, and the sibling 1fr row follows the same fr unit: the grid is 200px tall
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-rows: 0fr 1fr; grid-template-columns: 20px;">
+  <div style="grid-row: 1 / 2; height: 100px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_fr_minimum_zero_sum_with_other_flex_track_definite.html
+++ b/test_fixtures/grid/grid_fr_minimum_zero_sum_with_other_flex_track_definite.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    In a 500px tall grid, a definite 100px item sizes its 0fr row and the 1fr row takes the remaining 400px
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-rows: 0fr 1fr; grid-template-columns: 20px; height: 500px;">
+  <div style="grid-row: 1 / 2; height: 100px;"></div>
+  <div style="grid-row: 2 / 3;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/grid/grid_fr_content_proportion_sub_1_sum__border_box_ltr.xml
+++ b/tests/xml/grid/grid_fr_content_proportion_sub_1_sum__border_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="grid_fr_content_proportion_sub_1_sum__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" align-items="start" width="20px" height="150px">
+      <div display="grid" direction="ltr" grid-template-rows="0.5fr" grid-template-columns="20px">
+        <div direction="ltr" min-height="0px">
+          <div direction="ltr" width="20px" height="100px"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="150">
+      <node x="0" y="0" width="20" height="50">
+        <node x="0" y="0" width="20" height="25">
+          <node x="0" y="0" width="20" height="100"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_content_proportion_sub_1_sum__border_box_rtl.xml
+++ b/tests/xml/grid/grid_fr_content_proportion_sub_1_sum__border_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="grid_fr_content_proportion_sub_1_sum__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" align-items="start" width="20px" height="150px">
+      <div display="grid" direction="rtl" grid-template-rows="0.5fr" grid-template-columns="20px">
+        <div direction="rtl" min-height="0px">
+          <div direction="rtl" width="20px" height="100px"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="150">
+      <node x="0" y="0" width="20" height="50">
+        <node x="0" y="0" width="20" height="25">
+          <node x="0" y="0" width="20" height="100"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_content_proportion_sub_1_sum__content_box_ltr.xml
+++ b/tests/xml/grid/grid_fr_content_proportion_sub_1_sum__content_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="grid_fr_content_proportion_sub_1_sum__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" align-items="start" width="20px" height="150px">
+      <div display="grid" box-sizing="content-box" direction="ltr" grid-template-rows="0.5fr" grid-template-columns="20px">
+        <div box-sizing="content-box" direction="ltr" min-height="0px">
+          <div box-sizing="content-box" direction="ltr" width="20px" height="100px"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="150">
+      <node x="0" y="0" width="20" height="50">
+        <node x="0" y="0" width="20" height="25">
+          <node x="0" y="0" width="20" height="100"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_content_proportion_sub_1_sum__content_box_rtl.xml
+++ b/tests/xml/grid/grid_fr_content_proportion_sub_1_sum__content_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="grid_fr_content_proportion_sub_1_sum__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" align-items="start" width="20px" height="150px">
+      <div display="grid" box-sizing="content-box" direction="rtl" grid-template-rows="0.5fr" grid-template-columns="20px">
+        <div box-sizing="content-box" direction="rtl" min-height="0px">
+          <div box-sizing="content-box" direction="rtl" width="20px" height="100px"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="150">
+      <node x="0" y="0" width="20" height="50">
+        <node x="0" y="0" width="20" height="25">
+          <node x="0" y="0" width="20" height="100"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_content_proportion_sub_1_sum_minimum_above_share__border_box_ltr.xml
+++ b/tests/xml/grid/grid_fr_content_proportion_sub_1_sum_minimum_above_share__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_fr_content_proportion_sub_1_sum_minimum_above_share__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" grid-template-rows="0.5fr" grid-template-columns="20px">
+      <div direction="ltr" min-height="80px">
+        <div direction="ltr" width="20px" height="100px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="80">
+      <node x="0" y="0" width="20" height="80">
+        <node x="0" y="0" width="20" height="100"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_content_proportion_sub_1_sum_minimum_above_share__border_box_rtl.xml
+++ b/tests/xml/grid/grid_fr_content_proportion_sub_1_sum_minimum_above_share__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_fr_content_proportion_sub_1_sum_minimum_above_share__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" grid-template-rows="0.5fr" grid-template-columns="20px">
+      <div direction="rtl" min-height="80px">
+        <div direction="rtl" width="20px" height="100px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="80">
+      <node x="0" y="0" width="20" height="80">
+        <node x="0" y="0" width="20" height="100"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_content_proportion_sub_1_sum_minimum_above_share__content_box_ltr.xml
+++ b/tests/xml/grid/grid_fr_content_proportion_sub_1_sum_minimum_above_share__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_fr_content_proportion_sub_1_sum_minimum_above_share__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" grid-template-rows="0.5fr" grid-template-columns="20px">
+      <div box-sizing="content-box" direction="ltr" min-height="80px">
+        <div box-sizing="content-box" direction="ltr" width="20px" height="100px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="80">
+      <node x="0" y="0" width="20" height="80">
+        <node x="0" y="0" width="20" height="100"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_content_proportion_sub_1_sum_minimum_above_share__content_box_rtl.xml
+++ b/tests/xml/grid/grid_fr_content_proportion_sub_1_sum_minimum_above_share__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_fr_content_proportion_sub_1_sum_minimum_above_share__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" grid-template-rows="0.5fr" grid-template-columns="20px">
+      <div box-sizing="content-box" direction="rtl" min-height="80px">
+        <div box-sizing="content-box" direction="rtl" width="20px" height="100px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="80">
+      <node x="0" y="0" width="20" height="80">
+        <node x="0" y="0" width="20" height="100"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_content_proportion_sub_1_sum_minimum_below_share__border_box_ltr.xml
+++ b/tests/xml/grid/grid_fr_content_proportion_sub_1_sum_minimum_below_share__border_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="grid_fr_content_proportion_sub_1_sum_minimum_below_share__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" align-items="start" width="20px" height="150px">
+      <div display="grid" direction="ltr" grid-template-rows="0.5fr" grid-template-columns="20px">
+        <div direction="ltr" min-height="40px">
+          <div direction="ltr" width="20px" height="100px"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="150">
+      <node x="0" y="0" width="20" height="50">
+        <node x="0" y="0" width="20" height="40">
+          <node x="0" y="0" width="20" height="100"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_content_proportion_sub_1_sum_minimum_below_share__border_box_rtl.xml
+++ b/tests/xml/grid/grid_fr_content_proportion_sub_1_sum_minimum_below_share__border_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="grid_fr_content_proportion_sub_1_sum_minimum_below_share__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" align-items="start" width="20px" height="150px">
+      <div display="grid" direction="rtl" grid-template-rows="0.5fr" grid-template-columns="20px">
+        <div direction="rtl" min-height="40px">
+          <div direction="rtl" width="20px" height="100px"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="150">
+      <node x="0" y="0" width="20" height="50">
+        <node x="0" y="0" width="20" height="40">
+          <node x="0" y="0" width="20" height="100"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_content_proportion_sub_1_sum_minimum_below_share__content_box_ltr.xml
+++ b/tests/xml/grid/grid_fr_content_proportion_sub_1_sum_minimum_below_share__content_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="grid_fr_content_proportion_sub_1_sum_minimum_below_share__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" align-items="start" width="20px" height="150px">
+      <div display="grid" box-sizing="content-box" direction="ltr" grid-template-rows="0.5fr" grid-template-columns="20px">
+        <div box-sizing="content-box" direction="ltr" min-height="40px">
+          <div box-sizing="content-box" direction="ltr" width="20px" height="100px"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="150">
+      <node x="0" y="0" width="20" height="50">
+        <node x="0" y="0" width="20" height="40">
+          <node x="0" y="0" width="20" height="100"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_content_proportion_sub_1_sum_minimum_below_share__content_box_rtl.xml
+++ b/tests/xml/grid/grid_fr_content_proportion_sub_1_sum_minimum_below_share__content_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="grid_fr_content_proportion_sub_1_sum_minimum_below_share__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" align-items="start" width="20px" height="150px">
+      <div display="grid" box-sizing="content-box" direction="rtl" grid-template-rows="0.5fr" grid-template-columns="20px">
+        <div box-sizing="content-box" direction="rtl" min-height="40px">
+          <div box-sizing="content-box" direction="rtl" width="20px" height="100px"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="150">
+      <node x="0" y="0" width="20" height="50">
+        <node x="0" y="0" width="20" height="40">
+          <node x="0" y="0" width="20" height="100"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_content_proportion_sub_1_sum_span_fixed_track__border_box_ltr.xml
+++ b/tests/xml/grid/grid_fr_content_proportion_sub_1_sum_span_fixed_track__border_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="grid_fr_content_proportion_sub_1_sum_span_fixed_track__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" align-items="start" width="20px" height="150px">
+      <div display="grid" direction="ltr" grid-template-rows="50px 0.5fr" grid-template-columns="20px">
+        <div direction="ltr" min-height="0px" grid-row-start="1" grid-row-end="3">
+          <div direction="ltr" width="20px" height="100px"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="150">
+      <node x="0" y="0" width="20" height="75">
+        <node x="0" y="0" width="20" height="63">
+          <node x="0" y="0" width="20" height="100"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_content_proportion_sub_1_sum_span_fixed_track__border_box_rtl.xml
+++ b/tests/xml/grid/grid_fr_content_proportion_sub_1_sum_span_fixed_track__border_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="grid_fr_content_proportion_sub_1_sum_span_fixed_track__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" align-items="start" width="20px" height="150px">
+      <div display="grid" direction="rtl" grid-template-rows="50px 0.5fr" grid-template-columns="20px">
+        <div direction="rtl" min-height="0px" grid-row-start="1" grid-row-end="3">
+          <div direction="rtl" width="20px" height="100px"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="150">
+      <node x="0" y="0" width="20" height="75">
+        <node x="0" y="0" width="20" height="63">
+          <node x="0" y="0" width="20" height="100"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_content_proportion_sub_1_sum_span_fixed_track__content_box_ltr.xml
+++ b/tests/xml/grid/grid_fr_content_proportion_sub_1_sum_span_fixed_track__content_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="grid_fr_content_proportion_sub_1_sum_span_fixed_track__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" align-items="start" width="20px" height="150px">
+      <div display="grid" box-sizing="content-box" direction="ltr" grid-template-rows="50px 0.5fr" grid-template-columns="20px">
+        <div box-sizing="content-box" direction="ltr" min-height="0px" grid-row-start="1" grid-row-end="3">
+          <div box-sizing="content-box" direction="ltr" width="20px" height="100px"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="150">
+      <node x="0" y="0" width="20" height="75">
+        <node x="0" y="0" width="20" height="63">
+          <node x="0" y="0" width="20" height="100"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_content_proportion_sub_1_sum_span_fixed_track__content_box_rtl.xml
+++ b/tests/xml/grid/grid_fr_content_proportion_sub_1_sum_span_fixed_track__content_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="grid_fr_content_proportion_sub_1_sum_span_fixed_track__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" align-items="start" width="20px" height="150px">
+      <div display="grid" box-sizing="content-box" direction="rtl" grid-template-rows="50px 0.5fr" grid-template-columns="20px">
+        <div box-sizing="content-box" direction="rtl" min-height="0px" grid-row-start="1" grid-row-end="3">
+          <div box-sizing="content-box" direction="rtl" width="20px" height="100px"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="150">
+      <node x="0" y="0" width="20" height="75">
+        <node x="0" y="0" width="20" height="63">
+          <node x="0" y="0" width="20" height="100"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_content_proportion_sub_1_sum_with_non_spanned_track__border_box_ltr.xml
+++ b/tests/xml/grid/grid_fr_content_proportion_sub_1_sum_with_non_spanned_track__border_box_ltr.xml
@@ -1,0 +1,25 @@
+<test name="grid_fr_content_proportion_sub_1_sum_with_non_spanned_track__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" align-items="start" width="150px" height="100px">
+      <div display="grid" direction="ltr" grid-template-rows="40px 40px" grid-template-columns="0.2fr 0.3fr 0.5fr">
+        <div direction="ltr" width="60px" grid-column-start="span 2"/>
+        <div direction="ltr"/>
+        <div direction="ltr"/>
+        <div direction="ltr"/>
+        <div direction="ltr"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="150" height="100">
+      <node x="0" y="0" width="78" height="80">
+        <node x="0" y="0" width="60" height="40"/>
+        <node x="60" y="0" width="9" height="40"/>
+        <node x="0" y="40" width="24" height="40"/>
+        <node x="24" y="40" width="36" height="40"/>
+        <node x="60" y="40" width="9" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_content_proportion_sub_1_sum_with_non_spanned_track__border_box_rtl.xml
+++ b/tests/xml/grid/grid_fr_content_proportion_sub_1_sum_with_non_spanned_track__border_box_rtl.xml
@@ -1,0 +1,25 @@
+<test name="grid_fr_content_proportion_sub_1_sum_with_non_spanned_track__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" align-items="start" width="150px" height="100px">
+      <div display="grid" direction="rtl" grid-template-rows="40px 40px" grid-template-columns="0.2fr 0.3fr 0.5fr">
+        <div direction="rtl" width="60px" grid-column-start="span 2"/>
+        <div direction="rtl"/>
+        <div direction="rtl"/>
+        <div direction="rtl"/>
+        <div direction="rtl"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="150" height="100">
+      <node x="72" y="0" width="78" height="80">
+        <node x="18" y="0" width="60" height="40"/>
+        <node x="9" y="0" width="9" height="40"/>
+        <node x="54" y="40" width="24" height="40"/>
+        <node x="18" y="40" width="36" height="40"/>
+        <node x="9" y="40" width="9" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_content_proportion_sub_1_sum_with_non_spanned_track__content_box_ltr.xml
+++ b/tests/xml/grid/grid_fr_content_proportion_sub_1_sum_with_non_spanned_track__content_box_ltr.xml
@@ -1,0 +1,25 @@
+<test name="grid_fr_content_proportion_sub_1_sum_with_non_spanned_track__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" align-items="start" width="150px" height="100px">
+      <div display="grid" box-sizing="content-box" direction="ltr" grid-template-rows="40px 40px" grid-template-columns="0.2fr 0.3fr 0.5fr">
+        <div box-sizing="content-box" direction="ltr" width="60px" grid-column-start="span 2"/>
+        <div box-sizing="content-box" direction="ltr"/>
+        <div box-sizing="content-box" direction="ltr"/>
+        <div box-sizing="content-box" direction="ltr"/>
+        <div box-sizing="content-box" direction="ltr"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="150" height="100">
+      <node x="0" y="0" width="78" height="80">
+        <node x="0" y="0" width="60" height="40"/>
+        <node x="60" y="0" width="9" height="40"/>
+        <node x="0" y="40" width="24" height="40"/>
+        <node x="24" y="40" width="36" height="40"/>
+        <node x="60" y="40" width="9" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_content_proportion_sub_1_sum_with_non_spanned_track__content_box_rtl.xml
+++ b/tests/xml/grid/grid_fr_content_proportion_sub_1_sum_with_non_spanned_track__content_box_rtl.xml
@@ -1,0 +1,25 @@
+<test name="grid_fr_content_proportion_sub_1_sum_with_non_spanned_track__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" align-items="start" width="150px" height="100px">
+      <div display="grid" box-sizing="content-box" direction="rtl" grid-template-rows="40px 40px" grid-template-columns="0.2fr 0.3fr 0.5fr">
+        <div box-sizing="content-box" direction="rtl" width="60px" grid-column-start="span 2"/>
+        <div box-sizing="content-box" direction="rtl"/>
+        <div box-sizing="content-box" direction="rtl"/>
+        <div box-sizing="content-box" direction="rtl"/>
+        <div box-sizing="content-box" direction="rtl"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="150" height="100">
+      <node x="72" y="0" width="78" height="80">
+        <node x="18" y="0" width="60" height="40"/>
+        <node x="9" y="0" width="9" height="40"/>
+        <node x="54" y="40" width="24" height="40"/>
+        <node x="18" y="40" width="36" height="40"/>
+        <node x="9" y="40" width="9" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_content_proportion_sum_above_1__border_box_ltr.xml
+++ b/tests/xml/grid/grid_fr_content_proportion_sum_above_1__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_fr_content_proportion_sum_above_1__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" grid-template-rows="2fr" grid-template-columns="20px">
+      <div direction="ltr" min-height="0px">
+        <div direction="ltr" width="20px" height="100px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="100">
+      <node x="0" y="0" width="20" height="100">
+        <node x="0" y="0" width="20" height="100"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_content_proportion_sum_above_1__border_box_rtl.xml
+++ b/tests/xml/grid/grid_fr_content_proportion_sum_above_1__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_fr_content_proportion_sum_above_1__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" grid-template-rows="2fr" grid-template-columns="20px">
+      <div direction="rtl" min-height="0px">
+        <div direction="rtl" width="20px" height="100px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="100">
+      <node x="0" y="0" width="20" height="100">
+        <node x="0" y="0" width="20" height="100"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_content_proportion_sum_above_1__content_box_ltr.xml
+++ b/tests/xml/grid/grid_fr_content_proportion_sum_above_1__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_fr_content_proportion_sum_above_1__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" grid-template-rows="2fr" grid-template-columns="20px">
+      <div box-sizing="content-box" direction="ltr" min-height="0px">
+        <div box-sizing="content-box" direction="ltr" width="20px" height="100px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="100">
+      <node x="0" y="0" width="20" height="100">
+        <node x="0" y="0" width="20" height="100"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_content_proportion_sum_above_1__content_box_rtl.xml
+++ b/tests/xml/grid/grid_fr_content_proportion_sum_above_1__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_fr_content_proportion_sum_above_1__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" grid-template-rows="2fr" grid-template-columns="20px">
+      <div box-sizing="content-box" direction="rtl" min-height="0px">
+        <div box-sizing="content-box" direction="rtl" width="20px" height="100px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="100">
+      <node x="0" y="0" width="20" height="100">
+        <node x="0" y="0" width="20" height="100"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_content_proportion_zero_fr_collapse__border_box_ltr.xml
+++ b/tests/xml/grid/grid_fr_content_proportion_zero_fr_collapse__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_fr_content_proportion_zero_fr_collapse__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" grid-template-rows="0fr" grid-template-columns="20px">
+      <div direction="ltr" min-height="0px">
+        <div direction="ltr" width="20px" height="100px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="0">
+      <node x="0" y="0" width="20" height="0">
+        <node x="0" y="0" width="20" height="100"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_content_proportion_zero_fr_collapse__border_box_rtl.xml
+++ b/tests/xml/grid/grid_fr_content_proportion_zero_fr_collapse__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_fr_content_proportion_zero_fr_collapse__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" grid-template-rows="0fr" grid-template-columns="20px">
+      <div direction="rtl" min-height="0px">
+        <div direction="rtl" width="20px" height="100px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="0">
+      <node x="0" y="0" width="20" height="0">
+        <node x="0" y="0" width="20" height="100"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_content_proportion_zero_fr_collapse__content_box_ltr.xml
+++ b/tests/xml/grid/grid_fr_content_proportion_zero_fr_collapse__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_fr_content_proportion_zero_fr_collapse__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" grid-template-rows="0fr" grid-template-columns="20px">
+      <div box-sizing="content-box" direction="ltr" min-height="0px">
+        <div box-sizing="content-box" direction="ltr" width="20px" height="100px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="0">
+      <node x="0" y="0" width="20" height="0">
+        <node x="0" y="0" width="20" height="100"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_content_proportion_zero_fr_collapse__content_box_rtl.xml
+++ b/tests/xml/grid/grid_fr_content_proportion_zero_fr_collapse__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_fr_content_proportion_zero_fr_collapse__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" grid-template-rows="0fr" grid-template-columns="20px">
+      <div box-sizing="content-box" direction="rtl" min-height="0px">
+        <div box-sizing="content-box" direction="rtl" width="20px" height="100px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="0">
+      <node x="0" y="0" width="20" height="0">
+        <node x="0" y="0" width="20" height="100"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_minimum_zero_sum_with_other_flex_track__border_box_ltr.xml
+++ b/tests/xml/grid/grid_fr_minimum_zero_sum_with_other_flex_track__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_fr_minimum_zero_sum_with_other_flex_track__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" grid-template-rows="0fr 1fr" grid-template-columns="20px">
+      <div direction="ltr" height="100px" grid-row-start="1" grid-row-end="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="200">
+      <node x="0" y="0" width="20" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_minimum_zero_sum_with_other_flex_track__border_box_rtl.xml
+++ b/tests/xml/grid/grid_fr_minimum_zero_sum_with_other_flex_track__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_fr_minimum_zero_sum_with_other_flex_track__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" grid-template-rows="0fr 1fr" grid-template-columns="20px">
+      <div direction="rtl" height="100px" grid-row-start="1" grid-row-end="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="200">
+      <node x="0" y="0" width="20" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_minimum_zero_sum_with_other_flex_track__content_box_ltr.xml
+++ b/tests/xml/grid/grid_fr_minimum_zero_sum_with_other_flex_track__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_fr_minimum_zero_sum_with_other_flex_track__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" grid-template-rows="0fr 1fr" grid-template-columns="20px">
+      <div box-sizing="content-box" direction="ltr" height="100px" grid-row-start="1" grid-row-end="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="200">
+      <node x="0" y="0" width="20" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_minimum_zero_sum_with_other_flex_track__content_box_rtl.xml
+++ b/tests/xml/grid/grid_fr_minimum_zero_sum_with_other_flex_track__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_fr_minimum_zero_sum_with_other_flex_track__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" grid-template-rows="0fr 1fr" grid-template-columns="20px">
+      <div box-sizing="content-box" direction="rtl" height="100px" grid-row-start="1" grid-row-end="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="200">
+      <node x="0" y="0" width="20" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_minimum_zero_sum_with_other_flex_track_definite__border_box_ltr.xml
+++ b/tests/xml/grid/grid_fr_minimum_zero_sum_with_other_flex_track_definite__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_fr_minimum_zero_sum_with_other_flex_track_definite__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" height="500px" grid-template-rows="0fr 1fr" grid-template-columns="20px">
+      <div direction="ltr" height="100px" grid-row-start="1" grid-row-end="2"/>
+      <div direction="ltr" grid-row-start="2" grid-row-end="3"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="500">
+      <node x="0" y="0" width="20" height="100"/>
+      <node x="0" y="100" width="20" height="400"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_minimum_zero_sum_with_other_flex_track_definite__border_box_rtl.xml
+++ b/tests/xml/grid/grid_fr_minimum_zero_sum_with_other_flex_track_definite__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_fr_minimum_zero_sum_with_other_flex_track_definite__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" height="500px" grid-template-rows="0fr 1fr" grid-template-columns="20px">
+      <div direction="rtl" height="100px" grid-row-start="1" grid-row-end="2"/>
+      <div direction="rtl" grid-row-start="2" grid-row-end="3"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="500">
+      <node x="0" y="0" width="20" height="100"/>
+      <node x="0" y="100" width="20" height="400"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_minimum_zero_sum_with_other_flex_track_definite__content_box_ltr.xml
+++ b/tests/xml/grid/grid_fr_minimum_zero_sum_with_other_flex_track_definite__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_fr_minimum_zero_sum_with_other_flex_track_definite__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" height="500px" grid-template-rows="0fr 1fr" grid-template-columns="20px">
+      <div box-sizing="content-box" direction="ltr" height="100px" grid-row-start="1" grid-row-end="2"/>
+      <div box-sizing="content-box" direction="ltr" grid-row-start="2" grid-row-end="3"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="500">
+      <node x="0" y="0" width="20" height="100"/>
+      <node x="0" y="100" width="20" height="400"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_minimum_zero_sum_with_other_flex_track_definite__content_box_rtl.xml
+++ b/tests/xml/grid/grid_fr_minimum_zero_sum_with_other_flex_track_definite__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_fr_minimum_zero_sum_with_other_flex_track_definite__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" height="500px" grid-template-rows="0fr 1fr" grid-template-columns="20px">
+      <div box-sizing="content-box" direction="rtl" height="100px" grid-row-start="1" grid-row-end="2"/>
+      <div box-sizing="content-box" direction="rtl" grid-row-start="2" grid-row-end="3"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="500">
+      <node x="0" y="0" width="20" height="100"/>
+      <node x="0" y="100" width="20" height="400"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -26873,6 +26873,174 @@ mod grid {
 
     #[cfg(feature = "grid")]
     #[test]
+    fn grid_fr_content_proportion_sub_1_sum__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_fr_content_proportion_sub_1_sum__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_content_proportion_sub_1_sum__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_fr_content_proportion_sub_1_sum__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_content_proportion_sub_1_sum__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_fr_content_proportion_sub_1_sum__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_content_proportion_sub_1_sum__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_fr_content_proportion_sub_1_sum__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_content_proportion_sub_1_sum_minimum_above_share__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_fr_content_proportion_sub_1_sum_minimum_above_share__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_content_proportion_sub_1_sum_minimum_above_share__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_fr_content_proportion_sub_1_sum_minimum_above_share__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_content_proportion_sub_1_sum_minimum_above_share__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_fr_content_proportion_sub_1_sum_minimum_above_share__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_content_proportion_sub_1_sum_minimum_above_share__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_fr_content_proportion_sub_1_sum_minimum_above_share__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_content_proportion_sub_1_sum_minimum_below_share__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_fr_content_proportion_sub_1_sum_minimum_below_share__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_content_proportion_sub_1_sum_minimum_below_share__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_fr_content_proportion_sub_1_sum_minimum_below_share__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_content_proportion_sub_1_sum_minimum_below_share__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_fr_content_proportion_sub_1_sum_minimum_below_share__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_content_proportion_sub_1_sum_minimum_below_share__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_fr_content_proportion_sub_1_sum_minimum_below_share__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_content_proportion_sub_1_sum_span_fixed_track__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_fr_content_proportion_sub_1_sum_span_fixed_track__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_content_proportion_sub_1_sum_span_fixed_track__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_fr_content_proportion_sub_1_sum_span_fixed_track__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_content_proportion_sub_1_sum_span_fixed_track__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_fr_content_proportion_sub_1_sum_span_fixed_track__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_content_proportion_sub_1_sum_span_fixed_track__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_fr_content_proportion_sub_1_sum_span_fixed_track__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_content_proportion_sub_1_sum_with_non_spanned_track__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_fr_content_proportion_sub_1_sum_with_non_spanned_track__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_content_proportion_sub_1_sum_with_non_spanned_track__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_fr_content_proportion_sub_1_sum_with_non_spanned_track__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_content_proportion_sub_1_sum_with_non_spanned_track__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_fr_content_proportion_sub_1_sum_with_non_spanned_track__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_content_proportion_sub_1_sum_with_non_spanned_track__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_fr_content_proportion_sub_1_sum_with_non_spanned_track__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_content_proportion_sum_above_1__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_fr_content_proportion_sum_above_1__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_content_proportion_sum_above_1__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_fr_content_proportion_sum_above_1__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_content_proportion_sum_above_1__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_fr_content_proportion_sum_above_1__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_content_proportion_sum_above_1__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_fr_content_proportion_sum_above_1__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_content_proportion_zero_fr_collapse__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_fr_content_proportion_zero_fr_collapse__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_content_proportion_zero_fr_collapse__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_fr_content_proportion_zero_fr_collapse__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_content_proportion_zero_fr_collapse__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_fr_content_proportion_zero_fr_collapse__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_content_proportion_zero_fr_collapse__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_fr_content_proportion_zero_fr_collapse__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
     fn grid_fr_fixed_size_no_content_proportions__border_box_ltr() {
         crate::run_xml_test("grid", "grid_fr_fixed_size_no_content_proportions__border_box_ltr");
     }
@@ -26941,6 +27109,54 @@ mod grid {
     #[test]
     fn grid_fr_fixed_size_single_item__content_box_rtl() {
         crate::run_xml_test("grid", "grid_fr_fixed_size_single_item__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_minimum_zero_sum_with_other_flex_track__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_fr_minimum_zero_sum_with_other_flex_track__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_minimum_zero_sum_with_other_flex_track__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_fr_minimum_zero_sum_with_other_flex_track__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_minimum_zero_sum_with_other_flex_track__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_fr_minimum_zero_sum_with_other_flex_track__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_minimum_zero_sum_with_other_flex_track__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_fr_minimum_zero_sum_with_other_flex_track__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_minimum_zero_sum_with_other_flex_track_definite__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_fr_minimum_zero_sum_with_other_flex_track_definite__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_minimum_zero_sum_with_other_flex_track_definite__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_fr_minimum_zero_sum_with_other_flex_track_definite__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_minimum_zero_sum_with_other_flex_track_definite__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_fr_minimum_zero_sum_with_other_flex_track_definite__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_minimum_zero_sum_with_other_flex_track_definite__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_fr_minimum_zero_sum_with_other_flex_track_definite__content_box_rtl");
     }
 
     #[cfg(feature = "grid")]


### PR DESCRIPTION
An item crossing flexible tracks handed its full content-derived contribution to
those tracks whenever the grid container was sized under a min- or max-content
constraint, holding a `0fr` track open at the item's content size. Browsers scale
that contribution by the crossed flex factor sum, clamped at one (CSS Grid Level 2,
12.5: "if the sum is less than one, distribute that proportion of space"): the
proportion applies to the space left after covering the spanned inflexible tracks,
and the item's minimum contribution floors the result. A `0fr` track holding a
`min-height: 0` item thus collapses to zero under every sizing mode - which is what
makes the common `grid-template-rows` `0fr`/`1fr` collapse animation pattern work -
while an item with a definite size spanning `0fr` tracks keeps sizing them.

The hand-written tests are gone; the nine new fixtures are generated tests asserting
taffy against Chrome, each titled with the case it covers and the size it expects.
Fixtures whose fr tracks re-resolve once the container size is
definite wrap the grid in a fixed-size flex parent, so taffy takes the same
measure-then-layout path as the browser: sizing a content-sized *root* grid, taffy
resolves the tracks in one pass while browsers re-resolve fr tracks against the
resolved definite size, so a sub-1 fr sum only takes its share of the leftover space
there. That divergence is pre-existing and orthogonal to this change (it is also why
`xgrid_fr_span_2_proportion_sub_1_sum_with_non_spanned_track` is still disabled);
`grid_fr_content_proportion_sub_1_sum_with_non_spanned_track` covers the same case
nested inside a parent.
