### PR TITLE
Mark the parent as dirty when removing a node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- `TaffyTree::remove` now marks the removed node's former parent as dirty, like `remove_child`, `remove_child_at_index` and `remove_children_range` already did. Previously the parent and its ancestors kept their stale cached layout, so recomputing the layout of an ancestor did not account for the removed node (#998)
+
 ## 0.13.0
 
 The MSRV for this release is 1.71.

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -625,6 +625,7 @@ impl<NodeContext> TaffyTree<NodeContext> {
             if let Some(children) = self.children.get_mut(parent.into()) {
                 children.retain(|f| *f != node);
             }
+            self.mark_dirty(parent)?;
         }
 
         // Remove "parent" references to a node when removing that node
@@ -1059,6 +1060,30 @@ mod tests {
 
         taffy.remove(child).unwrap();
         taffy.remove(parent).unwrap();
+    }
+
+    // Related to: https://github.com/DioxusLabs/taffy/issues/998
+    #[test]
+    fn remove_node_marks_parent_dirty() {
+        use crate::prelude::*;
+
+        let mut taffy: TaffyTree<()> = TaffyTree::new();
+
+        // The root's height comes entirely from its child's 1px bottom border
+        let child = taffy
+            .new_leaf(Style { border: Rect { bottom: length(1f32), ..Rect::zero() }, ..Default::default() })
+            .unwrap();
+        let root = taffy.new_with_children(Style::default(), &[child]).unwrap();
+
+        taffy.compute_layout(root, Size::MIN_CONTENT).unwrap();
+        assert_eq!(taffy.layout(root).unwrap().size.height, 1f32);
+
+        taffy.remove(child).unwrap();
+        assert_eq!(taffy.dirty(root), Ok(true));
+
+        // The root no longer has any children, so its height should shrink back to zero
+        taffy.compute_layout(root, Size::MIN_CONTENT).unwrap();
+        assert_eq!(taffy.layout(root).unwrap().size.height, 0f32);
     }
 
     #[test]


### PR DESCRIPTION
# Objective

Fixes #998.

`TaffyTree::remove` detaches the node from its parent's children list, but never marks the ex-parent
as dirty. Its three sibling methods all do:

- `remove_child` (via `remove_child_at_index`) — `self.mark_dirty(parent)?`
- `remove_child_at_index` — `self.mark_dirty(parent)?`
- `remove_children_range` — `self.mark_dirty(parent)?`

so the parent (and its ancestors) keep their cached layout after `remove`, and a subsequent
`compute_layout` on an ancestor silently reuses a layout that still accounts for the removed node.

Reproducer from the issue — the root's height comes entirely from its one child's 1px bottom border:

```rust
use taffy::prelude::*;

fn main() {
    let mut tree: TaffyTree<()> = TaffyTree::new();

    let child = tree
        .new_leaf(Style { border: Rect { bottom: length(1.0), ..Rect::zero() }, ..Default::default() })
        .unwrap();
    let root = tree.new_with_children(Style::default(), &[child]).unwrap();

    tree.compute_layout(root, Size::MIN_CONTENT).unwrap();
    println!("height after first layout: {}", tree.layout(root).unwrap().size.height);

    let _ = tree.remove(child);
    println!("dirty(root) after remove: {:?}", tree.dirty(root));

    tree.compute_layout(root, Size::MIN_CONTENT).unwrap();
    println!("height after remove + recompute: {}", tree.layout(root).unwrap().size.height);
}
```

Before:

```text
height after first layout: 1
dirty(root) after remove: Ok(false)
height after remove + recompute: 1
```

After:

```text
height after first layout: 1
dirty(root) after remove: Ok(true)
height after remove + recompute: 0
```

## Context

The fix is a single `self.mark_dirty(parent)?` inside the existing `if let Some(parent) = ...` block
in `remove`, placed right after the node is retained out of the parent's children list. This is the
same layer the sibling methods invalidate at, and `mark_dirty` already walks up the ancestor chain,
so no other invalidation is needed. It is called while the parent's entries are still intact, and
only when the removed node actually had a parent, so the "removing a node whose parent was already
removed" case covered by `remove_child_updates_parents` is unaffected.

Regression test `remove_node_marks_parent_dirty` in `src/tree/taffy_tree.rs` asserts both that
`dirty(root)` becomes `Ok(true)` and that a recompute actually shrinks the root's height back to `0`
— the observable symptom, not just the flag.

Verification:

- Test fails on `main` with `assertion left == right failed / left: Ok(false) / right: Ok(true)`,
  and passes with the fix.
- Inverting the new call so the parent is only marked dirty when siblings remain reintroduces the
  failure; dropping the `children.retain` detachment while keeping the `mark_dirty` call is caught
  by the recompute assertion, so neither assertion is redundant.
- `cargo test -p taffy --tests`: 130 lib + 61 `hand_written` + 5541 `xml` tests pass, 0 failures.
  No generated test fixtures needed regenerating — this changes tree bookkeeping, not layout
  computation, and `test_fixtures/` and `scripts/gentest/` are untouched.
- `cargo fmt --all --check` clean, `cargo clippy -p taffy --lib -- -D warnings` clean.

I deliberately did not touch the other removal methods: `remove_child`, `remove_child_at_index`,
`remove_children_range`, `replace_child_at_index` and `set_children` all already mark the affected
parent dirty, so `remove` was the only one missing it.
