### PR TITLE
Support justify-self on block-level boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The MSRV for this release is 1.71.
 
 - Support for the `self-start` and `self-end` alignment keywords (`AlignItems::SELF_START`/`SELF_END` and safe variants). These resolve against the `direction` of the item itself rather than that of its container, so they only differ from `start`/`end` when the item's direction differs from its container's. Supported for `align-self`/`align-items` and `justify-self`/`justify-items` on both in-flow and absolutely positioned Flexbox and Grid items (#1074)
 
+- Block: support for `justify-self` on block-level boxes. A positional `justify-self` aligns the box's margin box within its containing block (or within the space beside floats for a box that avoids floats), fit-content sizes an `auto` inline size, and takes precedence over the legacy `text-align` alignment. It also applies to absolutely positioned children whose inline insets are both `auto`, which are aligned within their static-position rectangle. Requires the new `BlockItemStyle::justify_self` style accessor
+
 - Support for `display: flow-root`. The new `Display::FlowRoot` variant lays out children using the block layout algorithm but always establishes a new block formatting context (its margins do not collapse with those of its children, it contains its own floats, and it avoids external floats)
 
 ### Changed

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -1,6 +1,8 @@
 //! Computes the CSS block layout algorithm in the case that the block container being laid out contains only block-level boxes
 use crate::geometry::{Line, Point, Rect, Size};
-use crate::style::{AvailableSpace, CoreStyle, LengthPercentageAuto, Overflow, Position};
+use crate::style::{
+    AlignItems, AlignItemsKeyword, AvailableSpace, CoreStyle, LengthPercentageAuto, Overflow, Position,
+};
 use crate::style_helpers::TaffyMaxContent;
 use crate::tree::{CollapsibleMarginSet, Layout, LayoutInput, LayoutOutput, RunMode, SizingMode};
 use crate::tree::{LayoutPartialTree, LayoutPartialTreeExt, NodeId};
@@ -262,7 +264,7 @@ impl BlockContext<'_> {
     }
 }
 
-use super::common::alignment::{apply_alignment_fallback, compute_alignment_offset};
+use super::common::alignment::{apply_alignment_fallback, compute_alignment_offset, resolve_self_alignment_safety};
 #[cfg(feature = "content_size")]
 use super::common::content_size::compute_content_size_contribution;
 
@@ -285,6 +287,11 @@ struct BlockItem {
 
     /// Whether the child is a non-independent block or inline node
     is_in_same_bfc: bool,
+
+    /// The `justify-self` style of the node (`None` meaning `normal`)
+    justify_self: Option<AlignItems>,
+    /// The `direction` style of the node, used to resolve `self-start`/`self-end`
+    own_direction: Direction,
 
     #[cfg(feature = "float_layout")]
     /// The `float` style of the node
@@ -790,6 +797,8 @@ fn generate_item_list(
                 is_table,
                 is_replaced,
                 is_in_same_bfc,
+                justify_self: child_style.justify_self(),
+                own_direction: child_style.direction(),
                 #[cfg(feature = "float_layout")]
                 float,
                 #[cfg(feature = "float_layout")]
@@ -1135,11 +1144,35 @@ fn perform_final_layout_on_in_flow_children(
                 }
             };
 
+            // Resolve `justify-self` for the item. `justify-self` does not apply to floated boxes
+            // (which are handled above). `Stretch` is treated as `normal` (the default block-level
+            // behaviour) so that it neither triggers fit-content sizing nor overrides `text-align`.
+            let justify_self = item
+                .justify_self
+                .map(|align| align.resolve_self_relative(item.own_direction, direction, true))
+                .filter(|align| align.keyword != AlignItemsKeyword::Stretch);
+
             // Tables and replaced elements are not stretch-sized: they resolve their own
             // size (for replaced elements an auto width resolves to the intrinsic size
             // <https://www.w3.org/TR/CSS22/visudet.html#block-replaced-width>)
             let known_dimensions = if item.is_table || item.is_replaced {
                 Size::NONE
+            } else if item.size.width.is_none() && justify_self.is_some() {
+                // A block-level box with a positional `justify-self` is not stretched to fill its
+                // containing block: an auto inline size is fit-content sized instead
+                // <https://www.w3.org/TR/css-align-3/#justify-block>
+                let fit_content_width = tree.measure_child_size(
+                    item.node_id,
+                    Size::NONE,
+                    parent_size,
+                    Size { width: AvailableSpace::Definite(stretch_width), height: available_space.height },
+                    SizingMode::InherentSize,
+                    crate::AbsoluteAxis::Horizontal,
+                    if item.is_in_same_bfc { Line::TRUE } else { Line::FALSE },
+                );
+                item.size
+                    .map_width(|_| Some(fit_content_width.maybe_clamp(item.min_size.width, item.max_size.width)))
+                    .maybe_clamp(item.min_size, item.max_size)
             } else {
                 item.size
                     .map_width(|width| {
@@ -1344,9 +1377,21 @@ fn perform_final_layout_on_in_flow_children(
                 }
             };
 
-            // Apply alignment
+            // Apply `justify-self` alignment. The alignment container is the item's containing
+            // block, except for items that avoid floats which are aligned within the space that
+            // remains beside the floats. Auto margins have already absorbed the free space, so
+            // there is nothing left to align when they are present.
+            // <https://www.w3.org/TR/css-align-3/#justify-block>
             let item_outer_width = item_layout.size.width + resolved_margin.horizontal_axis_sum();
-            if item_outer_width < container_inner_width {
+            if let Some(justify_self) = justify_self {
+                let alignment_container_width =
+                    if item.is_in_same_bfc { container_inner_width } else { float_avoiding_width };
+                let offset = justify_self_offset(justify_self, alignment_container_width - item_outer_width);
+                match direction {
+                    Direction::Ltr => location.x += offset,
+                    Direction::Rtl => location.x -= offset,
+                }
+            } else if item_outer_width < container_inner_width {
                 let free_x_space = container_inner_width - item_outer_width;
                 match (text_align, direction) {
                     (TextAlign::Auto, _) => {
@@ -1472,6 +1517,28 @@ fn perform_final_layout_on_in_flow_children(
     committed_y_offset += resolved_content_box_inset.bottom + bottom_y_margin_offset;
     let content_height = f32_max(0.0, committed_y_offset);
     (inflow_content_size, content_height, first_child_top_margin_set, last_child_bottom_margin_set, first_baseline)
+}
+
+/// Resolve a block-level box's `justify-self` alignment into an offset from the inline-start edge
+/// of its alignment container.
+///
+/// `justify_self` must already have had `self-start`/`self-end` resolved against the item's own
+/// direction. `Stretch` is treated as `normal` (start-edge alignment) by the callers.
+/// <https://www.w3.org/TR/css-align-3/#justify-block>
+#[inline]
+fn justify_self_offset(justify_self: AlignItems, free_space: f32) -> f32 {
+    match resolve_self_alignment_safety(justify_self, free_space < 0.0) {
+        AlignItemsKeyword::End | AlignItemsKeyword::FlexEnd => free_space,
+        AlignItemsKeyword::Center => free_space / 2.0,
+        // Start-edge aligned by default
+        AlignItemsKeyword::Start
+        | AlignItemsKeyword::FlexStart
+        | AlignItemsKeyword::Baseline
+        | AlignItemsKeyword::Stretch => 0.0,
+        AlignItemsKeyword::SelfStart | AlignItemsKeyword::SelfEnd => {
+            unreachable!("SelfStart/SelfEnd are resolved against the item's own direction by callers")
+        }
+    }
 }
 
 /// Perform absolute layout on all absolutely positioned children.
@@ -1662,10 +1729,30 @@ fn perform_absolute_layout_on_absolute_children(
             (Some(left), None) => left + resolved_margin.left,
             (None, Some(right)) => area_size.width - final_size.width - right - resolved_margin.right,
             (None, None) => {
-                if direction.is_rtl() {
-                    item.static_position.x - final_size.width - resolved_margin.right - area_offset.x
-                } else {
-                    item.static_position.x + resolved_margin.left - area_offset.x
+                // With both inline insets auto the box is aligned within its static-position
+                // rectangle, which spans the inline axis of the containing block.
+                // <https://www.w3.org/TR/css-align-3/#justify-abspos>
+                let justify_self = item
+                    .justify_self
+                    .map(|align| align.resolve_self_relative(item.own_direction, direction, true))
+                    .filter(|align| align.keyword != AlignItemsKeyword::Stretch);
+                match justify_self {
+                    Some(justify_self) => {
+                        let free_space = area_size.width - final_size.width - resolved_margin.horizontal_axis_sum();
+                        let offset = justify_self_offset(justify_self, free_space);
+                        if direction.is_rtl() {
+                            area_size.width - final_size.width - resolved_margin.right - offset
+                        } else {
+                            resolved_margin.left + offset
+                        }
+                    }
+                    None => {
+                        if direction.is_rtl() {
+                            item.static_position.x - final_size.width - resolved_margin.right - area_offset.x
+                        } else {
+                            item.static_position.x + resolved_margin.left - area_offset.x
+                        }
+                    }
                 }
             }
         };

--- a/src/style/block.rs
+++ b/src/style/block.rs
@@ -25,6 +25,15 @@ pub trait BlockItemStyle: CoreStyle {
         false
     }
 
+    /// How this item should be aligned within its containing block in the inline axis.
+    ///
+    /// `None` corresponds to the `normal` behaviour of stretch-sizing an auto inline size and
+    /// otherwise aligning the item at the inline-start edge.
+    #[inline(always)]
+    fn justify_self(&self) -> Option<super::AlignSelf> {
+        None
+    }
+
     /// Whether the item is a floated
     #[cfg(feature = "float_layout")]
     #[inline(always)]

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -853,6 +853,12 @@ impl<S: CheapCloneStr> BlockItemStyle for Style<S> {
         self.item_is_table
     }
 
+    #[cfg(feature = "grid")]
+    #[inline(always)]
+    fn justify_self(&self) -> Option<AlignSelf> {
+        self.justify_self
+    }
+
     #[cfg(feature = "float_layout")]
     #[inline(always)]
     fn float(&self) -> Float {
@@ -871,6 +877,11 @@ impl<T: BlockItemStyle> BlockItemStyle for &'_ T {
     #[inline(always)]
     fn is_table(&self) -> bool {
         (*self).is_table()
+    }
+
+    #[inline(always)]
+    fn justify_self(&self) -> Option<AlignSelf> {
+        (*self).justify_self()
     }
 
     #[cfg(feature = "float_layout")]

--- a/test_fixtures/block/block_absolute_justify_self_end.html
+++ b/test_fixtures/block/block_absolute_justify_self_end.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    justify-self aligns absolutely positioned children with auto insets
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px; height: 100px; position: relative;">
+  <div style="width: 100px; height: 20px; position: absolute; justify-self: end;"></div>
+  <div style="width: 100px; height: 20px; position: absolute; top: 20px; justify-self: center;"></div>
+  <div style="width: 100px; height: 20px; position: absolute; top: 40px; left: 0px; justify-self: end;"></div>
+  <div style="width: 100px; height: 20px; position: absolute; top: 60px; justify-self: normal;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/block/block_absolute_justify_self_end_rtl.html
+++ b/test_fixtures/block/block_absolute_justify_self_end_rtl.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    justify-self aligns absolutely positioned children in an rtl container
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px; height: 100px; position: relative; direction: rtl;">
+  <div style="width: 100px; height: 20px; position: absolute; justify-self: end;"></div>
+  <div style="width: 100px; height: 20px; position: absolute; top: 20px; justify-self: center;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/block/block_justify_self_auto_width_is_fit_content.html
+++ b/test_fixtures/block/block_justify_self_auto_width_is_fit_content.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    a positional justify-self makes an auto inline size fit-content sized
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px;">
+  <div style="height: 20px; justify-self: center;">
+    <div style="width: 40px; height: 20px;"></div>
+  </div>
+  <div style="height: 20px; justify-self: end;">
+    <div style="width: 40px; height: 20px;"></div>
+  </div>
+  <div style="height: 20px; justify-self: normal;">
+    <div style="width: 40px; height: 20px;"></div>
+  </div>
+  <div style="height: 20px; justify-self: center; min-width: 150px;">
+    <div style="width: 40px; height: 20px;"></div>
+  </div>
+  <div style="height: 20px; justify-self: center; max-width: 20px;">
+    <div style="width: 40px; height: 20px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/block/block_justify_self_end.html
+++ b/test_fixtures/block/block_justify_self_end.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    justify-self: end on a block-level box
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px;">
+  <div style="width: 100px; height: 20px; justify-self: end;"></div>
+  <div style="width: 100px; height: 20px; justify-self: center;"></div>
+  <div style="width: 100px; height: 20px; justify-self: start;"></div>
+  <div style="width: 100px; height: 20px; justify-self: flex-end;"></div>
+  <div style="width: 100px; height: 20px; justify-self: stretch;"></div>
+  <div style="width: 100px; height: 20px; justify-self: normal;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/block/block_justify_self_end_child_rtl.html
+++ b/test_fixtures/block/block_justify_self_end_child_rtl.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    justify-self: start/end with a block-level item whose direction differs from the container's
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px;">
+  <div style="width: 100px; height: 20px; justify-self: end; direction: rtl;"></div>
+  <div style="width: 100px; height: 20px; justify-self: start; direction: rtl;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/block/block_justify_self_end_rtl.html
+++ b/test_fixtures/block/block_justify_self_end_rtl.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    justify-self on block-level boxes in an rtl container
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px; direction: rtl;">
+  <div style="width: 100px; height: 20px; justify-self: end;"></div>
+  <div style="width: 100px; height: 20px; justify-self: center;"></div>
+  <div style="width: 100px; height: 20px; justify-self: start;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/block/block_justify_self_overflow.html
+++ b/test_fixtures/block/block_justify_self_overflow.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    safe justify-self falls back to start when the item overflows
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px;">
+  <div style="width: 200px; height: 20px; justify-self: safe center;"></div>
+  <div style="width: 200px; height: 20px; justify-self: unsafe center;"></div>
+  <div style="width: 200px; height: 20px; justify-self: end;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/block/block_justify_self_self_start_child_rtl.html
+++ b/test_fixtures/block/block_justify_self_self_start_child_rtl.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    justify-self: self-start/self-end resolve against the item's own direction
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px;">
+  <div style="width: 100px; height: 20px; justify-self: self-start; direction: rtl;"></div>
+  <div style="width: 100px; height: 20px; justify-self: self-end; direction: rtl;"></div>
+  <div style="width: 100px; height: 20px; justify-self: self-start;"></div>
+  <div style="width: 100px; height: 20px; justify-self: self-end;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/block/block_justify_self_with_margins.html
+++ b/test_fixtures/block/block_justify_self_with_margins.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    justify-self aligns the margin box, and auto margins take precedence
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px;">
+  <div style="width: 100px; height: 20px; justify-self: center; margin-left: 20px;"></div>
+  <div style="width: 100px; height: 20px; justify-self: end; margin-right: 30px;"></div>
+  <div style="width: 100px; height: 20px; justify-self: end; margin-left: auto; margin-right: 40px;"></div>
+  <div style="width: 100px; height: 20px; justify-self: start; margin-left: auto; margin-right: auto;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/block/block_justify_self_with_text_align.html
+++ b/test_fixtures/block/block_justify_self_with_text_align.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    justify-self overrides legacy text-align alignment of block-level boxes
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px; text-align: -webkit-center;">
+  <div style="width: 100px; height: 20px; justify-self: end;"></div>
+  <div style="width: 100px; height: 20px; justify-self: normal;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/float/float_justify_self_float_avoiding_box.html
+++ b/test_fixtures/float/float_justify_self_float_avoiding_box.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    a float-avoiding box is justify-self aligned beside the float
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px;">
+  <div style="display: block; float: left; width: 50px; height: 40px;"></div>
+  <div style="display: flow-root; width: 40px; height: 20px; justify-self: center;"></div>
+  <div style="display: flow-root; height: 20px; justify-self: center;">
+    <div style="width: 20px; height: 20px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/float/float_justify_self_ignored_on_float.html
+++ b/test_fixtures/float/float_justify_self_ignored_on_float.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    justify-self does not apply to floated boxes
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px;">
+  <div style="display: block; float: left; width: 50px; height: 20px; justify-self: center;"></div>
+  <div style="display: block; float: right; width: 50px; height: 20px; justify-self: center;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_justify_self_end_child_rtl.html
+++ b/test_fixtures/grid/grid_justify_self_end_child_rtl.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    justify-self: start/end with an item whose direction differs from the container's
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-columns: 200px; width: 200px;">
+  <div style="width: 100px; height: 20px; justify-self: end; direction: rtl;"></div>
+  <div style="width: 100px; height: 20px; justify-self: start; direction: rtl;"></div>
+  <div style="width: 100px; height: 20px; justify-self: self-end; direction: rtl;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/block/block_absolute_justify_self_end__border_box_ltr.xml
+++ b/tests/xml/block/block_absolute_justify_self_end__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="block_absolute_justify_self_end__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="200px" height="100px">
+      <div direction="ltr" position="absolute" justify-self="end" width="100px" height="20px"/>
+      <div direction="ltr" position="absolute" justify-self="center" width="100px" height="20px" top="20px"/>
+      <div direction="ltr" position="absolute" justify-self="end" width="100px" height="20px" top="40px" left="0px"/>
+      <div direction="ltr" position="absolute" justify-self="normal" width="100px" height="20px" top="60px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="100" y="0" width="100" height="20"/>
+      <node x="50" y="20" width="100" height="20"/>
+      <node x="0" y="40" width="100" height="20"/>
+      <node x="0" y="60" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_absolute_justify_self_end__border_box_rtl.xml
+++ b/tests/xml/block/block_absolute_justify_self_end__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="block_absolute_justify_self_end__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="200px" height="100px">
+      <div direction="rtl" position="absolute" justify-self="end" width="100px" height="20px"/>
+      <div direction="rtl" position="absolute" justify-self="center" width="100px" height="20px" top="20px"/>
+      <div direction="rtl" position="absolute" justify-self="end" width="100px" height="20px" top="40px" left="0px"/>
+      <div direction="rtl" position="absolute" justify-self="normal" width="100px" height="20px" top="60px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="0" y="0" width="100" height="20"/>
+      <node x="50" y="20" width="100" height="20"/>
+      <node x="0" y="40" width="100" height="20"/>
+      <node x="100" y="60" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_absolute_justify_self_end__content_box_ltr.xml
+++ b/tests/xml/block/block_absolute_justify_self_end__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="block_absolute_justify_self_end__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="200px" height="100px">
+      <div box-sizing="content-box" direction="ltr" position="absolute" justify-self="end" width="100px" height="20px"/>
+      <div box-sizing="content-box" direction="ltr" position="absolute" justify-self="center" width="100px" height="20px" top="20px"/>
+      <div box-sizing="content-box" direction="ltr" position="absolute" justify-self="end" width="100px" height="20px" top="40px" left="0px"/>
+      <div box-sizing="content-box" direction="ltr" position="absolute" justify-self="normal" width="100px" height="20px" top="60px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="100" y="0" width="100" height="20"/>
+      <node x="50" y="20" width="100" height="20"/>
+      <node x="0" y="40" width="100" height="20"/>
+      <node x="0" y="60" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_absolute_justify_self_end__content_box_rtl.xml
+++ b/tests/xml/block/block_absolute_justify_self_end__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="block_absolute_justify_self_end__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="200px" height="100px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" justify-self="end" width="100px" height="20px"/>
+      <div box-sizing="content-box" direction="rtl" position="absolute" justify-self="center" width="100px" height="20px" top="20px"/>
+      <div box-sizing="content-box" direction="rtl" position="absolute" justify-self="end" width="100px" height="20px" top="40px" left="0px"/>
+      <div box-sizing="content-box" direction="rtl" position="absolute" justify-self="normal" width="100px" height="20px" top="60px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="0" y="0" width="100" height="20"/>
+      <node x="50" y="20" width="100" height="20"/>
+      <node x="0" y="40" width="100" height="20"/>
+      <node x="100" y="60" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_absolute_justify_self_end_rtl__border_box_ltr.xml
+++ b/tests/xml/block/block_absolute_justify_self_end_rtl__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="block_absolute_justify_self_end_rtl__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="200px" height="100px">
+      <div direction="ltr" position="absolute" justify-self="end" width="100px" height="20px"/>
+      <div direction="ltr" position="absolute" justify-self="center" width="100px" height="20px" top="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="0" y="0" width="100" height="20"/>
+      <node x="50" y="20" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_absolute_justify_self_end_rtl__border_box_rtl.xml
+++ b/tests/xml/block/block_absolute_justify_self_end_rtl__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="block_absolute_justify_self_end_rtl__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="200px" height="100px">
+      <div direction="rtl" position="absolute" justify-self="end" width="100px" height="20px"/>
+      <div direction="rtl" position="absolute" justify-self="center" width="100px" height="20px" top="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="0" y="0" width="100" height="20"/>
+      <node x="50" y="20" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_absolute_justify_self_end_rtl__content_box_ltr.xml
+++ b/tests/xml/block/block_absolute_justify_self_end_rtl__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="block_absolute_justify_self_end_rtl__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="200px" height="100px">
+      <div box-sizing="content-box" direction="ltr" position="absolute" justify-self="end" width="100px" height="20px"/>
+      <div box-sizing="content-box" direction="ltr" position="absolute" justify-self="center" width="100px" height="20px" top="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="0" y="0" width="100" height="20"/>
+      <node x="50" y="20" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_absolute_justify_self_end_rtl__content_box_rtl.xml
+++ b/tests/xml/block/block_absolute_justify_self_end_rtl__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="block_absolute_justify_self_end_rtl__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="200px" height="100px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" justify-self="end" width="100px" height="20px"/>
+      <div box-sizing="content-box" direction="rtl" position="absolute" justify-self="center" width="100px" height="20px" top="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="0" y="0" width="100" height="20"/>
+      <node x="50" y="20" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_justify_self_auto_width_is_fit_content__border_box_ltr.xml
+++ b/tests/xml/block/block_justify_self_auto_width_is_fit_content__border_box_ltr.xml
@@ -1,0 +1,41 @@
+<test name="block_justify_self_auto_width_is_fit_content__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="200px">
+      <div direction="ltr" justify-self="center" height="20px">
+        <div direction="ltr" width="40px" height="20px"/>
+      </div>
+      <div direction="ltr" justify-self="end" height="20px">
+        <div direction="ltr" width="40px" height="20px"/>
+      </div>
+      <div direction="ltr" justify-self="normal" height="20px">
+        <div direction="ltr" width="40px" height="20px"/>
+      </div>
+      <div direction="ltr" justify-self="center" height="20px" min-width="150px">
+        <div direction="ltr" width="40px" height="20px"/>
+      </div>
+      <div direction="ltr" justify-self="center" height="20px" max-width="20px">
+        <div direction="ltr" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="80" y="0" width="40" height="20">
+        <node x="0" y="0" width="40" height="20"/>
+      </node>
+      <node x="160" y="20" width="40" height="20">
+        <node x="0" y="0" width="40" height="20"/>
+      </node>
+      <node x="0" y="40" width="200" height="20">
+        <node x="0" y="0" width="40" height="20"/>
+      </node>
+      <node x="25" y="60" width="150" height="20">
+        <node x="0" y="0" width="40" height="20"/>
+      </node>
+      <node x="90" y="80" width="20" height="20">
+        <node x="0" y="0" width="20" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_justify_self_auto_width_is_fit_content__border_box_rtl.xml
+++ b/tests/xml/block/block_justify_self_auto_width_is_fit_content__border_box_rtl.xml
@@ -1,0 +1,41 @@
+<test name="block_justify_self_auto_width_is_fit_content__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="200px">
+      <div direction="rtl" justify-self="center" height="20px">
+        <div direction="rtl" width="40px" height="20px"/>
+      </div>
+      <div direction="rtl" justify-self="end" height="20px">
+        <div direction="rtl" width="40px" height="20px"/>
+      </div>
+      <div direction="rtl" justify-self="normal" height="20px">
+        <div direction="rtl" width="40px" height="20px"/>
+      </div>
+      <div direction="rtl" justify-self="center" height="20px" min-width="150px">
+        <div direction="rtl" width="40px" height="20px"/>
+      </div>
+      <div direction="rtl" justify-self="center" height="20px" max-width="20px">
+        <div direction="rtl" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="80" y="0" width="40" height="20">
+        <node x="0" y="0" width="40" height="20"/>
+      </node>
+      <node x="0" y="20" width="40" height="20">
+        <node x="0" y="0" width="40" height="20"/>
+      </node>
+      <node x="0" y="40" width="200" height="20">
+        <node x="160" y="0" width="40" height="20"/>
+      </node>
+      <node x="25" y="60" width="150" height="20">
+        <node x="110" y="0" width="40" height="20"/>
+      </node>
+      <node x="90" y="80" width="20" height="20">
+        <node x="0" y="0" width="20" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_justify_self_auto_width_is_fit_content__content_box_ltr.xml
+++ b/tests/xml/block/block_justify_self_auto_width_is_fit_content__content_box_ltr.xml
@@ -1,0 +1,41 @@
+<test name="block_justify_self_auto_width_is_fit_content__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="200px">
+      <div box-sizing="content-box" direction="ltr" justify-self="center" height="20px">
+        <div box-sizing="content-box" direction="ltr" width="40px" height="20px"/>
+      </div>
+      <div box-sizing="content-box" direction="ltr" justify-self="end" height="20px">
+        <div box-sizing="content-box" direction="ltr" width="40px" height="20px"/>
+      </div>
+      <div box-sizing="content-box" direction="ltr" justify-self="normal" height="20px">
+        <div box-sizing="content-box" direction="ltr" width="40px" height="20px"/>
+      </div>
+      <div box-sizing="content-box" direction="ltr" justify-self="center" height="20px" min-width="150px">
+        <div box-sizing="content-box" direction="ltr" width="40px" height="20px"/>
+      </div>
+      <div box-sizing="content-box" direction="ltr" justify-self="center" height="20px" max-width="20px">
+        <div box-sizing="content-box" direction="ltr" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="80" y="0" width="40" height="20">
+        <node x="0" y="0" width="40" height="20"/>
+      </node>
+      <node x="160" y="20" width="40" height="20">
+        <node x="0" y="0" width="40" height="20"/>
+      </node>
+      <node x="0" y="40" width="200" height="20">
+        <node x="0" y="0" width="40" height="20"/>
+      </node>
+      <node x="25" y="60" width="150" height="20">
+        <node x="0" y="0" width="40" height="20"/>
+      </node>
+      <node x="90" y="80" width="20" height="20">
+        <node x="0" y="0" width="20" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_justify_self_auto_width_is_fit_content__content_box_rtl.xml
+++ b/tests/xml/block/block_justify_self_auto_width_is_fit_content__content_box_rtl.xml
@@ -1,0 +1,41 @@
+<test name="block_justify_self_auto_width_is_fit_content__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="200px">
+      <div box-sizing="content-box" direction="rtl" justify-self="center" height="20px">
+        <div box-sizing="content-box" direction="rtl" width="40px" height="20px"/>
+      </div>
+      <div box-sizing="content-box" direction="rtl" justify-self="end" height="20px">
+        <div box-sizing="content-box" direction="rtl" width="40px" height="20px"/>
+      </div>
+      <div box-sizing="content-box" direction="rtl" justify-self="normal" height="20px">
+        <div box-sizing="content-box" direction="rtl" width="40px" height="20px"/>
+      </div>
+      <div box-sizing="content-box" direction="rtl" justify-self="center" height="20px" min-width="150px">
+        <div box-sizing="content-box" direction="rtl" width="40px" height="20px"/>
+      </div>
+      <div box-sizing="content-box" direction="rtl" justify-self="center" height="20px" max-width="20px">
+        <div box-sizing="content-box" direction="rtl" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="80" y="0" width="40" height="20">
+        <node x="0" y="0" width="40" height="20"/>
+      </node>
+      <node x="0" y="20" width="40" height="20">
+        <node x="0" y="0" width="40" height="20"/>
+      </node>
+      <node x="0" y="40" width="200" height="20">
+        <node x="160" y="0" width="40" height="20"/>
+      </node>
+      <node x="25" y="60" width="150" height="20">
+        <node x="110" y="0" width="40" height="20"/>
+      </node>
+      <node x="90" y="80" width="20" height="20">
+        <node x="0" y="0" width="20" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_justify_self_end__border_box_ltr.xml
+++ b/tests/xml/block/block_justify_self_end__border_box_ltr.xml
@@ -1,0 +1,23 @@
+<test name="block_justify_self_end__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="200px">
+      <div direction="ltr" justify-self="end" width="100px" height="20px"/>
+      <div direction="ltr" justify-self="center" width="100px" height="20px"/>
+      <div direction="ltr" justify-self="start" width="100px" height="20px"/>
+      <div direction="ltr" justify-self="flex-end" width="100px" height="20px"/>
+      <div direction="ltr" justify-self="stretch" width="100px" height="20px"/>
+      <div direction="ltr" justify-self="normal" width="100px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="120">
+      <node x="100" y="0" width="100" height="20"/>
+      <node x="50" y="20" width="100" height="20"/>
+      <node x="0" y="40" width="100" height="20"/>
+      <node x="100" y="60" width="100" height="20"/>
+      <node x="0" y="80" width="100" height="20"/>
+      <node x="0" y="100" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_justify_self_end__border_box_rtl.xml
+++ b/tests/xml/block/block_justify_self_end__border_box_rtl.xml
@@ -1,0 +1,23 @@
+<test name="block_justify_self_end__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="200px">
+      <div direction="rtl" justify-self="end" width="100px" height="20px"/>
+      <div direction="rtl" justify-self="center" width="100px" height="20px"/>
+      <div direction="rtl" justify-self="start" width="100px" height="20px"/>
+      <div direction="rtl" justify-self="flex-end" width="100px" height="20px"/>
+      <div direction="rtl" justify-self="stretch" width="100px" height="20px"/>
+      <div direction="rtl" justify-self="normal" width="100px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="120">
+      <node x="0" y="0" width="100" height="20"/>
+      <node x="50" y="20" width="100" height="20"/>
+      <node x="100" y="40" width="100" height="20"/>
+      <node x="0" y="60" width="100" height="20"/>
+      <node x="100" y="80" width="100" height="20"/>
+      <node x="100" y="100" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_justify_self_end__content_box_ltr.xml
+++ b/tests/xml/block/block_justify_self_end__content_box_ltr.xml
@@ -1,0 +1,23 @@
+<test name="block_justify_self_end__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="200px">
+      <div box-sizing="content-box" direction="ltr" justify-self="end" width="100px" height="20px"/>
+      <div box-sizing="content-box" direction="ltr" justify-self="center" width="100px" height="20px"/>
+      <div box-sizing="content-box" direction="ltr" justify-self="start" width="100px" height="20px"/>
+      <div box-sizing="content-box" direction="ltr" justify-self="flex-end" width="100px" height="20px"/>
+      <div box-sizing="content-box" direction="ltr" justify-self="stretch" width="100px" height="20px"/>
+      <div box-sizing="content-box" direction="ltr" justify-self="normal" width="100px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="120">
+      <node x="100" y="0" width="100" height="20"/>
+      <node x="50" y="20" width="100" height="20"/>
+      <node x="0" y="40" width="100" height="20"/>
+      <node x="100" y="60" width="100" height="20"/>
+      <node x="0" y="80" width="100" height="20"/>
+      <node x="0" y="100" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_justify_self_end__content_box_rtl.xml
+++ b/tests/xml/block/block_justify_self_end__content_box_rtl.xml
@@ -1,0 +1,23 @@
+<test name="block_justify_self_end__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="200px">
+      <div box-sizing="content-box" direction="rtl" justify-self="end" width="100px" height="20px"/>
+      <div box-sizing="content-box" direction="rtl" justify-self="center" width="100px" height="20px"/>
+      <div box-sizing="content-box" direction="rtl" justify-self="start" width="100px" height="20px"/>
+      <div box-sizing="content-box" direction="rtl" justify-self="flex-end" width="100px" height="20px"/>
+      <div box-sizing="content-box" direction="rtl" justify-self="stretch" width="100px" height="20px"/>
+      <div box-sizing="content-box" direction="rtl" justify-self="normal" width="100px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="120">
+      <node x="0" y="0" width="100" height="20"/>
+      <node x="50" y="20" width="100" height="20"/>
+      <node x="100" y="40" width="100" height="20"/>
+      <node x="0" y="60" width="100" height="20"/>
+      <node x="100" y="80" width="100" height="20"/>
+      <node x="100" y="100" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_justify_self_end_child_rtl__border_box_ltr.xml
+++ b/tests/xml/block/block_justify_self_end_child_rtl__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="block_justify_self_end_child_rtl__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="200px">
+      <div direction="rtl" justify-self="end" width="100px" height="20px"/>
+      <div direction="rtl" justify-self="start" width="100px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="40">
+      <node x="100" y="0" width="100" height="20"/>
+      <node x="0" y="20" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_justify_self_end_child_rtl__border_box_rtl.xml
+++ b/tests/xml/block/block_justify_self_end_child_rtl__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="block_justify_self_end_child_rtl__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="200px">
+      <div direction="rtl" justify-self="end" width="100px" height="20px"/>
+      <div direction="rtl" justify-self="start" width="100px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="40">
+      <node x="0" y="0" width="100" height="20"/>
+      <node x="100" y="20" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_justify_self_end_child_rtl__content_box_ltr.xml
+++ b/tests/xml/block/block_justify_self_end_child_rtl__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="block_justify_self_end_child_rtl__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="200px">
+      <div box-sizing="content-box" direction="rtl" justify-self="end" width="100px" height="20px"/>
+      <div box-sizing="content-box" direction="rtl" justify-self="start" width="100px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="40">
+      <node x="100" y="0" width="100" height="20"/>
+      <node x="0" y="20" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_justify_self_end_child_rtl__content_box_rtl.xml
+++ b/tests/xml/block/block_justify_self_end_child_rtl__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="block_justify_self_end_child_rtl__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="200px">
+      <div box-sizing="content-box" direction="rtl" justify-self="end" width="100px" height="20px"/>
+      <div box-sizing="content-box" direction="rtl" justify-self="start" width="100px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="40">
+      <node x="0" y="0" width="100" height="20"/>
+      <node x="100" y="20" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_justify_self_end_rtl__border_box_ltr.xml
+++ b/tests/xml/block/block_justify_self_end_rtl__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="block_justify_self_end_rtl__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="200px">
+      <div direction="ltr" justify-self="end" width="100px" height="20px"/>
+      <div direction="ltr" justify-self="center" width="100px" height="20px"/>
+      <div direction="ltr" justify-self="start" width="100px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="60">
+      <node x="0" y="0" width="100" height="20"/>
+      <node x="50" y="20" width="100" height="20"/>
+      <node x="100" y="40" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_justify_self_end_rtl__border_box_rtl.xml
+++ b/tests/xml/block/block_justify_self_end_rtl__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="block_justify_self_end_rtl__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="200px">
+      <div direction="rtl" justify-self="end" width="100px" height="20px"/>
+      <div direction="rtl" justify-self="center" width="100px" height="20px"/>
+      <div direction="rtl" justify-self="start" width="100px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="60">
+      <node x="0" y="0" width="100" height="20"/>
+      <node x="50" y="20" width="100" height="20"/>
+      <node x="100" y="40" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_justify_self_end_rtl__content_box_ltr.xml
+++ b/tests/xml/block/block_justify_self_end_rtl__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="block_justify_self_end_rtl__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="200px">
+      <div box-sizing="content-box" direction="ltr" justify-self="end" width="100px" height="20px"/>
+      <div box-sizing="content-box" direction="ltr" justify-self="center" width="100px" height="20px"/>
+      <div box-sizing="content-box" direction="ltr" justify-self="start" width="100px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="60">
+      <node x="0" y="0" width="100" height="20"/>
+      <node x="50" y="20" width="100" height="20"/>
+      <node x="100" y="40" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_justify_self_end_rtl__content_box_rtl.xml
+++ b/tests/xml/block/block_justify_self_end_rtl__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="block_justify_self_end_rtl__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="200px">
+      <div box-sizing="content-box" direction="rtl" justify-self="end" width="100px" height="20px"/>
+      <div box-sizing="content-box" direction="rtl" justify-self="center" width="100px" height="20px"/>
+      <div box-sizing="content-box" direction="rtl" justify-self="start" width="100px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="60">
+      <node x="0" y="0" width="100" height="20"/>
+      <node x="50" y="20" width="100" height="20"/>
+      <node x="100" y="40" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_justify_self_overflow__border_box_ltr.xml
+++ b/tests/xml/block/block_justify_self_overflow__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="block_justify_self_overflow__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px">
+      <div direction="ltr" justify-self="safe center" width="200px" height="20px"/>
+      <div direction="ltr" justify-self="unsafe center" width="200px" height="20px"/>
+      <div direction="ltr" justify-self="end" width="200px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="60">
+      <node x="0" y="0" width="200" height="20"/>
+      <node x="-50" y="20" width="200" height="20"/>
+      <node x="-100" y="40" width="200" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_justify_self_overflow__border_box_rtl.xml
+++ b/tests/xml/block/block_justify_self_overflow__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="block_justify_self_overflow__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px">
+      <div direction="rtl" justify-self="safe center" width="200px" height="20px"/>
+      <div direction="rtl" justify-self="unsafe center" width="200px" height="20px"/>
+      <div direction="rtl" justify-self="end" width="200px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="60">
+      <node x="-100" y="0" width="200" height="20"/>
+      <node x="-50" y="20" width="200" height="20"/>
+      <node x="0" y="40" width="200" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_justify_self_overflow__content_box_ltr.xml
+++ b/tests/xml/block/block_justify_self_overflow__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="block_justify_self_overflow__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px">
+      <div box-sizing="content-box" direction="ltr" justify-self="safe center" width="200px" height="20px"/>
+      <div box-sizing="content-box" direction="ltr" justify-self="unsafe center" width="200px" height="20px"/>
+      <div box-sizing="content-box" direction="ltr" justify-self="end" width="200px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="60">
+      <node x="0" y="0" width="200" height="20"/>
+      <node x="-50" y="20" width="200" height="20"/>
+      <node x="-100" y="40" width="200" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_justify_self_overflow__content_box_rtl.xml
+++ b/tests/xml/block/block_justify_self_overflow__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="block_justify_self_overflow__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px">
+      <div box-sizing="content-box" direction="rtl" justify-self="safe center" width="200px" height="20px"/>
+      <div box-sizing="content-box" direction="rtl" justify-self="unsafe center" width="200px" height="20px"/>
+      <div box-sizing="content-box" direction="rtl" justify-self="end" width="200px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="60">
+      <node x="-100" y="0" width="200" height="20"/>
+      <node x="-50" y="20" width="200" height="20"/>
+      <node x="0" y="40" width="200" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_justify_self_self_start_child_rtl__border_box_ltr.xml
+++ b/tests/xml/block/block_justify_self_self_start_child_rtl__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="block_justify_self_self_start_child_rtl__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="200px">
+      <div direction="rtl" justify-self="self-start" width="100px" height="20px"/>
+      <div direction="rtl" justify-self="self-end" width="100px" height="20px"/>
+      <div direction="ltr" justify-self="self-start" width="100px" height="20px"/>
+      <div direction="ltr" justify-self="self-end" width="100px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="80">
+      <node x="100" y="0" width="100" height="20"/>
+      <node x="0" y="20" width="100" height="20"/>
+      <node x="0" y="40" width="100" height="20"/>
+      <node x="100" y="60" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_justify_self_self_start_child_rtl__border_box_rtl.xml
+++ b/tests/xml/block/block_justify_self_self_start_child_rtl__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="block_justify_self_self_start_child_rtl__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="200px">
+      <div direction="rtl" justify-self="self-start" width="100px" height="20px"/>
+      <div direction="rtl" justify-self="self-end" width="100px" height="20px"/>
+      <div direction="rtl" justify-self="self-start" width="100px" height="20px"/>
+      <div direction="rtl" justify-self="self-end" width="100px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="80">
+      <node x="100" y="0" width="100" height="20"/>
+      <node x="0" y="20" width="100" height="20"/>
+      <node x="100" y="40" width="100" height="20"/>
+      <node x="0" y="60" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_justify_self_self_start_child_rtl__content_box_ltr.xml
+++ b/tests/xml/block/block_justify_self_self_start_child_rtl__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="block_justify_self_self_start_child_rtl__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="200px">
+      <div box-sizing="content-box" direction="rtl" justify-self="self-start" width="100px" height="20px"/>
+      <div box-sizing="content-box" direction="rtl" justify-self="self-end" width="100px" height="20px"/>
+      <div box-sizing="content-box" direction="ltr" justify-self="self-start" width="100px" height="20px"/>
+      <div box-sizing="content-box" direction="ltr" justify-self="self-end" width="100px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="80">
+      <node x="100" y="0" width="100" height="20"/>
+      <node x="0" y="20" width="100" height="20"/>
+      <node x="0" y="40" width="100" height="20"/>
+      <node x="100" y="60" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_justify_self_self_start_child_rtl__content_box_rtl.xml
+++ b/tests/xml/block/block_justify_self_self_start_child_rtl__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="block_justify_self_self_start_child_rtl__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="200px">
+      <div box-sizing="content-box" direction="rtl" justify-self="self-start" width="100px" height="20px"/>
+      <div box-sizing="content-box" direction="rtl" justify-self="self-end" width="100px" height="20px"/>
+      <div box-sizing="content-box" direction="rtl" justify-self="self-start" width="100px" height="20px"/>
+      <div box-sizing="content-box" direction="rtl" justify-self="self-end" width="100px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="80">
+      <node x="100" y="0" width="100" height="20"/>
+      <node x="0" y="20" width="100" height="20"/>
+      <node x="100" y="40" width="100" height="20"/>
+      <node x="0" y="60" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_justify_self_with_margins__border_box_ltr.xml
+++ b/tests/xml/block/block_justify_self_with_margins__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="block_justify_self_with_margins__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="200px">
+      <div direction="ltr" justify-self="center" width="100px" height="20px" margin-left="20px"/>
+      <div direction="ltr" justify-self="end" width="100px" height="20px" margin-right="30px"/>
+      <div direction="ltr" justify-self="end" width="100px" height="20px" margin-left="auto" margin-right="40px"/>
+      <div direction="ltr" justify-self="start" width="100px" height="20px" margin-left="auto" margin-right="auto"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="80">
+      <node x="60" y="0" width="100" height="20"/>
+      <node x="70" y="20" width="100" height="20"/>
+      <node x="60" y="40" width="100" height="20"/>
+      <node x="50" y="60" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_justify_self_with_margins__border_box_rtl.xml
+++ b/tests/xml/block/block_justify_self_with_margins__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="block_justify_self_with_margins__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="200px">
+      <div direction="rtl" justify-self="center" width="100px" height="20px" margin-left="20px"/>
+      <div direction="rtl" justify-self="end" width="100px" height="20px" margin-right="30px"/>
+      <div direction="rtl" justify-self="end" width="100px" height="20px" margin-left="auto" margin-right="40px"/>
+      <div direction="rtl" justify-self="start" width="100px" height="20px" margin-left="auto" margin-right="auto"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="80">
+      <node x="60" y="0" width="100" height="20"/>
+      <node x="0" y="20" width="100" height="20"/>
+      <node x="60" y="40" width="100" height="20"/>
+      <node x="50" y="60" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_justify_self_with_margins__content_box_ltr.xml
+++ b/tests/xml/block/block_justify_self_with_margins__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="block_justify_self_with_margins__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="200px">
+      <div box-sizing="content-box" direction="ltr" justify-self="center" width="100px" height="20px" margin-left="20px"/>
+      <div box-sizing="content-box" direction="ltr" justify-self="end" width="100px" height="20px" margin-right="30px"/>
+      <div box-sizing="content-box" direction="ltr" justify-self="end" width="100px" height="20px" margin-left="auto" margin-right="40px"/>
+      <div box-sizing="content-box" direction="ltr" justify-self="start" width="100px" height="20px" margin-left="auto" margin-right="auto"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="80">
+      <node x="60" y="0" width="100" height="20"/>
+      <node x="70" y="20" width="100" height="20"/>
+      <node x="60" y="40" width="100" height="20"/>
+      <node x="50" y="60" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_justify_self_with_margins__content_box_rtl.xml
+++ b/tests/xml/block/block_justify_self_with_margins__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="block_justify_self_with_margins__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="200px">
+      <div box-sizing="content-box" direction="rtl" justify-self="center" width="100px" height="20px" margin-left="20px"/>
+      <div box-sizing="content-box" direction="rtl" justify-self="end" width="100px" height="20px" margin-right="30px"/>
+      <div box-sizing="content-box" direction="rtl" justify-self="end" width="100px" height="20px" margin-left="auto" margin-right="40px"/>
+      <div box-sizing="content-box" direction="rtl" justify-self="start" width="100px" height="20px" margin-left="auto" margin-right="auto"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="80">
+      <node x="60" y="0" width="100" height="20"/>
+      <node x="0" y="20" width="100" height="20"/>
+      <node x="60" y="40" width="100" height="20"/>
+      <node x="50" y="60" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_justify_self_with_text_align__border_box_ltr.xml
+++ b/tests/xml/block/block_justify_self_with_text_align__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="block_justify_self_with_text_align__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" text-align="-webkit-center" width="200px">
+      <div direction="ltr" justify-self="end" width="100px" height="20px"/>
+      <div direction="ltr" justify-self="normal" width="100px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="40">
+      <node x="100" y="0" width="100" height="20"/>
+      <node x="50" y="20" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_justify_self_with_text_align__border_box_rtl.xml
+++ b/tests/xml/block/block_justify_self_with_text_align__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="block_justify_self_with_text_align__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" text-align="-webkit-center" width="200px">
+      <div direction="rtl" justify-self="end" width="100px" height="20px"/>
+      <div direction="rtl" justify-self="normal" width="100px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="40">
+      <node x="0" y="0" width="100" height="20"/>
+      <node x="50" y="20" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_justify_self_with_text_align__content_box_ltr.xml
+++ b/tests/xml/block/block_justify_self_with_text_align__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="block_justify_self_with_text_align__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" text-align="-webkit-center" width="200px">
+      <div box-sizing="content-box" direction="ltr" justify-self="end" width="100px" height="20px"/>
+      <div box-sizing="content-box" direction="ltr" justify-self="normal" width="100px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="40">
+      <node x="100" y="0" width="100" height="20"/>
+      <node x="50" y="20" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_justify_self_with_text_align__content_box_rtl.xml
+++ b/tests/xml/block/block_justify_self_with_text_align__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="block_justify_self_with_text_align__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" text-align="-webkit-center" width="200px">
+      <div box-sizing="content-box" direction="rtl" justify-self="end" width="100px" height="20px"/>
+      <div box-sizing="content-box" direction="rtl" justify-self="normal" width="100px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="40">
+      <node x="0" y="0" width="100" height="20"/>
+      <node x="50" y="20" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_justify_self_float_avoiding_box__border_box_ltr.xml
+++ b/tests/xml/float/float_justify_self_float_avoiding_box__border_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="float_justify_self_float_avoiding_box__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="200px">
+      <div display="block" direction="ltr" float="left" width="50px" height="40px"/>
+      <div display="flow-root" direction="ltr" justify-self="center" width="40px" height="20px"/>
+      <div display="flow-root" direction="ltr" justify-self="center" height="20px">
+        <div direction="ltr" width="20px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="40">
+      <node x="0" y="0" width="50" height="40"/>
+      <node x="105" y="0" width="40" height="20"/>
+      <node x="115" y="20" width="20" height="20">
+        <node x="0" y="0" width="20" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_justify_self_float_avoiding_box__border_box_rtl.xml
+++ b/tests/xml/float/float_justify_self_float_avoiding_box__border_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="float_justify_self_float_avoiding_box__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="200px">
+      <div display="block" direction="rtl" float="left" width="50px" height="40px"/>
+      <div display="flow-root" direction="rtl" justify-self="center" width="40px" height="20px"/>
+      <div display="flow-root" direction="rtl" justify-self="center" height="20px">
+        <div direction="rtl" width="20px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="40">
+      <node x="0" y="0" width="50" height="40"/>
+      <node x="105" y="0" width="40" height="20"/>
+      <node x="115" y="20" width="20" height="20">
+        <node x="0" y="0" width="20" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_justify_self_float_avoiding_box__content_box_ltr.xml
+++ b/tests/xml/float/float_justify_self_float_avoiding_box__content_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="float_justify_self_float_avoiding_box__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="200px">
+      <div display="block" box-sizing="content-box" direction="ltr" float="left" width="50px" height="40px"/>
+      <div display="flow-root" box-sizing="content-box" direction="ltr" justify-self="center" width="40px" height="20px"/>
+      <div display="flow-root" box-sizing="content-box" direction="ltr" justify-self="center" height="20px">
+        <div box-sizing="content-box" direction="ltr" width="20px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="40">
+      <node x="0" y="0" width="50" height="40"/>
+      <node x="105" y="0" width="40" height="20"/>
+      <node x="115" y="20" width="20" height="20">
+        <node x="0" y="0" width="20" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_justify_self_float_avoiding_box__content_box_rtl.xml
+++ b/tests/xml/float/float_justify_self_float_avoiding_box__content_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="float_justify_self_float_avoiding_box__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="200px">
+      <div display="block" box-sizing="content-box" direction="rtl" float="left" width="50px" height="40px"/>
+      <div display="flow-root" box-sizing="content-box" direction="rtl" justify-self="center" width="40px" height="20px"/>
+      <div display="flow-root" box-sizing="content-box" direction="rtl" justify-self="center" height="20px">
+        <div box-sizing="content-box" direction="rtl" width="20px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="40">
+      <node x="0" y="0" width="50" height="40"/>
+      <node x="105" y="0" width="40" height="20"/>
+      <node x="115" y="20" width="20" height="20">
+        <node x="0" y="0" width="20" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_justify_self_ignored_on_float__border_box_ltr.xml
+++ b/tests/xml/float/float_justify_self_ignored_on_float__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="float_justify_self_ignored_on_float__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="200px">
+      <div display="block" direction="ltr" float="left" justify-self="center" width="50px" height="20px"/>
+      <div display="block" direction="ltr" float="right" justify-self="center" width="50px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="20">
+      <node x="0" y="0" width="50" height="20"/>
+      <node x="150" y="0" width="50" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_justify_self_ignored_on_float__border_box_rtl.xml
+++ b/tests/xml/float/float_justify_self_ignored_on_float__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="float_justify_self_ignored_on_float__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="200px">
+      <div display="block" direction="rtl" float="left" justify-self="center" width="50px" height="20px"/>
+      <div display="block" direction="rtl" float="right" justify-self="center" width="50px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="20">
+      <node x="0" y="0" width="50" height="20"/>
+      <node x="150" y="0" width="50" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_justify_self_ignored_on_float__content_box_ltr.xml
+++ b/tests/xml/float/float_justify_self_ignored_on_float__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="float_justify_self_ignored_on_float__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="200px">
+      <div display="block" box-sizing="content-box" direction="ltr" float="left" justify-self="center" width="50px" height="20px"/>
+      <div display="block" box-sizing="content-box" direction="ltr" float="right" justify-self="center" width="50px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="20">
+      <node x="0" y="0" width="50" height="20"/>
+      <node x="150" y="0" width="50" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_justify_self_ignored_on_float__content_box_rtl.xml
+++ b/tests/xml/float/float_justify_self_ignored_on_float__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="float_justify_self_ignored_on_float__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="200px">
+      <div display="block" box-sizing="content-box" direction="rtl" float="left" justify-self="center" width="50px" height="20px"/>
+      <div display="block" box-sizing="content-box" direction="rtl" float="right" justify-self="center" width="50px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="20">
+      <node x="0" y="0" width="50" height="20"/>
+      <node x="150" y="0" width="50" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_justify_self_end_child_rtl__border_box_ltr.xml
+++ b/tests/xml/grid/grid_justify_self_end_child_rtl__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_justify_self_end_child_rtl__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="200px" grid-template-columns="200px">
+      <div direction="rtl" justify-self="end" width="100px" height="20px"/>
+      <div direction="rtl" justify-self="start" width="100px" height="20px"/>
+      <div direction="rtl" justify-self="self-end" width="100px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="60">
+      <node x="100" y="0" width="100" height="20"/>
+      <node x="0" y="20" width="100" height="20"/>
+      <node x="0" y="40" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_justify_self_end_child_rtl__border_box_rtl.xml
+++ b/tests/xml/grid/grid_justify_self_end_child_rtl__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_justify_self_end_child_rtl__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="200px" grid-template-columns="200px">
+      <div direction="rtl" justify-self="end" width="100px" height="20px"/>
+      <div direction="rtl" justify-self="start" width="100px" height="20px"/>
+      <div direction="rtl" justify-self="self-end" width="100px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="60">
+      <node x="0" y="0" width="100" height="20"/>
+      <node x="100" y="20" width="100" height="20"/>
+      <node x="0" y="40" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_justify_self_end_child_rtl__content_box_ltr.xml
+++ b/tests/xml/grid/grid_justify_self_end_child_rtl__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_justify_self_end_child_rtl__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="200px" grid-template-columns="200px">
+      <div box-sizing="content-box" direction="rtl" justify-self="end" width="100px" height="20px"/>
+      <div box-sizing="content-box" direction="rtl" justify-self="start" width="100px" height="20px"/>
+      <div box-sizing="content-box" direction="rtl" justify-self="self-end" width="100px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="60">
+      <node x="100" y="0" width="100" height="20"/>
+      <node x="0" y="20" width="100" height="20"/>
+      <node x="0" y="40" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_justify_self_end_child_rtl__content_box_rtl.xml
+++ b/tests/xml/grid/grid_justify_self_end_child_rtl__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_justify_self_end_child_rtl__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="200px" grid-template-columns="200px">
+      <div box-sizing="content-box" direction="rtl" justify-self="end" width="100px" height="20px"/>
+      <div box-sizing="content-box" direction="rtl" justify-self="start" width="100px" height="20px"/>
+      <div box-sizing="content-box" direction="rtl" justify-self="self-end" width="100px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="60">
+      <node x="0" y="0" width="100" height="20"/>
+      <node x="100" y="20" width="100" height="20"/>
+      <node x="0" y="40" width="100" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -314,6 +314,46 @@ mod block {
     }
 
     #[test]
+    fn block_absolute_justify_self_end__border_box_ltr() {
+        crate::run_xml_test("block", "block_absolute_justify_self_end__border_box_ltr");
+    }
+
+    #[test]
+    fn block_absolute_justify_self_end__content_box_ltr() {
+        crate::run_xml_test("block", "block_absolute_justify_self_end__content_box_ltr");
+    }
+
+    #[test]
+    fn block_absolute_justify_self_end__border_box_rtl() {
+        crate::run_xml_test("block", "block_absolute_justify_self_end__border_box_rtl");
+    }
+
+    #[test]
+    fn block_absolute_justify_self_end__content_box_rtl() {
+        crate::run_xml_test("block", "block_absolute_justify_self_end__content_box_rtl");
+    }
+
+    #[test]
+    fn block_absolute_justify_self_end_rtl__border_box_ltr() {
+        crate::run_xml_test("block", "block_absolute_justify_self_end_rtl__border_box_ltr");
+    }
+
+    #[test]
+    fn block_absolute_justify_self_end_rtl__content_box_ltr() {
+        crate::run_xml_test("block", "block_absolute_justify_self_end_rtl__content_box_ltr");
+    }
+
+    #[test]
+    fn block_absolute_justify_self_end_rtl__border_box_rtl() {
+        crate::run_xml_test("block", "block_absolute_justify_self_end_rtl__border_box_rtl");
+    }
+
+    #[test]
+    fn block_absolute_justify_self_end_rtl__content_box_rtl() {
+        crate::run_xml_test("block", "block_absolute_justify_self_end_rtl__content_box_rtl");
+    }
+
+    #[test]
     fn block_absolute_layout_child_order__border_box_ltr() {
         crate::run_xml_test("block", "block_absolute_layout_child_order__border_box_ltr");
     }
@@ -2183,6 +2223,166 @@ mod block {
     #[test]
     fn block_item_text_align_right__content_box_rtl() {
         crate::run_xml_test("block", "block_item_text_align_right__content_box_rtl");
+    }
+
+    #[test]
+    fn block_justify_self_auto_width_is_fit_content__border_box_ltr() {
+        crate::run_xml_test("block", "block_justify_self_auto_width_is_fit_content__border_box_ltr");
+    }
+
+    #[test]
+    fn block_justify_self_auto_width_is_fit_content__content_box_ltr() {
+        crate::run_xml_test("block", "block_justify_self_auto_width_is_fit_content__content_box_ltr");
+    }
+
+    #[test]
+    fn block_justify_self_auto_width_is_fit_content__border_box_rtl() {
+        crate::run_xml_test("block", "block_justify_self_auto_width_is_fit_content__border_box_rtl");
+    }
+
+    #[test]
+    fn block_justify_self_auto_width_is_fit_content__content_box_rtl() {
+        crate::run_xml_test("block", "block_justify_self_auto_width_is_fit_content__content_box_rtl");
+    }
+
+    #[test]
+    fn block_justify_self_end__border_box_ltr() {
+        crate::run_xml_test("block", "block_justify_self_end__border_box_ltr");
+    }
+
+    #[test]
+    fn block_justify_self_end__content_box_ltr() {
+        crate::run_xml_test("block", "block_justify_self_end__content_box_ltr");
+    }
+
+    #[test]
+    fn block_justify_self_end__border_box_rtl() {
+        crate::run_xml_test("block", "block_justify_self_end__border_box_rtl");
+    }
+
+    #[test]
+    fn block_justify_self_end__content_box_rtl() {
+        crate::run_xml_test("block", "block_justify_self_end__content_box_rtl");
+    }
+
+    #[test]
+    fn block_justify_self_end_child_rtl__border_box_ltr() {
+        crate::run_xml_test("block", "block_justify_self_end_child_rtl__border_box_ltr");
+    }
+
+    #[test]
+    fn block_justify_self_end_child_rtl__content_box_ltr() {
+        crate::run_xml_test("block", "block_justify_self_end_child_rtl__content_box_ltr");
+    }
+
+    #[test]
+    fn block_justify_self_end_child_rtl__border_box_rtl() {
+        crate::run_xml_test("block", "block_justify_self_end_child_rtl__border_box_rtl");
+    }
+
+    #[test]
+    fn block_justify_self_end_child_rtl__content_box_rtl() {
+        crate::run_xml_test("block", "block_justify_self_end_child_rtl__content_box_rtl");
+    }
+
+    #[test]
+    fn block_justify_self_end_rtl__border_box_ltr() {
+        crate::run_xml_test("block", "block_justify_self_end_rtl__border_box_ltr");
+    }
+
+    #[test]
+    fn block_justify_self_end_rtl__content_box_ltr() {
+        crate::run_xml_test("block", "block_justify_self_end_rtl__content_box_ltr");
+    }
+
+    #[test]
+    fn block_justify_self_end_rtl__border_box_rtl() {
+        crate::run_xml_test("block", "block_justify_self_end_rtl__border_box_rtl");
+    }
+
+    #[test]
+    fn block_justify_self_end_rtl__content_box_rtl() {
+        crate::run_xml_test("block", "block_justify_self_end_rtl__content_box_rtl");
+    }
+
+    #[test]
+    fn block_justify_self_overflow__border_box_ltr() {
+        crate::run_xml_test("block", "block_justify_self_overflow__border_box_ltr");
+    }
+
+    #[test]
+    fn block_justify_self_overflow__content_box_ltr() {
+        crate::run_xml_test("block", "block_justify_self_overflow__content_box_ltr");
+    }
+
+    #[test]
+    fn block_justify_self_overflow__border_box_rtl() {
+        crate::run_xml_test("block", "block_justify_self_overflow__border_box_rtl");
+    }
+
+    #[test]
+    fn block_justify_self_overflow__content_box_rtl() {
+        crate::run_xml_test("block", "block_justify_self_overflow__content_box_rtl");
+    }
+
+    #[test]
+    fn block_justify_self_self_start_child_rtl__border_box_ltr() {
+        crate::run_xml_test("block", "block_justify_self_self_start_child_rtl__border_box_ltr");
+    }
+
+    #[test]
+    fn block_justify_self_self_start_child_rtl__content_box_ltr() {
+        crate::run_xml_test("block", "block_justify_self_self_start_child_rtl__content_box_ltr");
+    }
+
+    #[test]
+    fn block_justify_self_self_start_child_rtl__border_box_rtl() {
+        crate::run_xml_test("block", "block_justify_self_self_start_child_rtl__border_box_rtl");
+    }
+
+    #[test]
+    fn block_justify_self_self_start_child_rtl__content_box_rtl() {
+        crate::run_xml_test("block", "block_justify_self_self_start_child_rtl__content_box_rtl");
+    }
+
+    #[test]
+    fn block_justify_self_with_margins__border_box_ltr() {
+        crate::run_xml_test("block", "block_justify_self_with_margins__border_box_ltr");
+    }
+
+    #[test]
+    fn block_justify_self_with_margins__content_box_ltr() {
+        crate::run_xml_test("block", "block_justify_self_with_margins__content_box_ltr");
+    }
+
+    #[test]
+    fn block_justify_self_with_margins__border_box_rtl() {
+        crate::run_xml_test("block", "block_justify_self_with_margins__border_box_rtl");
+    }
+
+    #[test]
+    fn block_justify_self_with_margins__content_box_rtl() {
+        crate::run_xml_test("block", "block_justify_self_with_margins__content_box_rtl");
+    }
+
+    #[test]
+    fn block_justify_self_with_text_align__border_box_ltr() {
+        crate::run_xml_test("block", "block_justify_self_with_text_align__border_box_ltr");
+    }
+
+    #[test]
+    fn block_justify_self_with_text_align__content_box_ltr() {
+        crate::run_xml_test("block", "block_justify_self_with_text_align__content_box_ltr");
+    }
+
+    #[test]
+    fn block_justify_self_with_text_align__border_box_rtl() {
+        crate::run_xml_test("block", "block_justify_self_with_text_align__border_box_rtl");
+    }
+
+    #[test]
+    fn block_justify_self_with_text_align__content_box_rtl() {
+        crate::run_xml_test("block", "block_justify_self_with_text_align__content_box_rtl");
     }
 
     #[test]
@@ -17444,6 +17644,46 @@ mod float {
     }
 
     #[test]
+    fn float_justify_self_float_avoiding_box__border_box_ltr() {
+        crate::run_xml_test("float", "float_justify_self_float_avoiding_box__border_box_ltr");
+    }
+
+    #[test]
+    fn float_justify_self_float_avoiding_box__content_box_ltr() {
+        crate::run_xml_test("float", "float_justify_self_float_avoiding_box__content_box_ltr");
+    }
+
+    #[test]
+    fn float_justify_self_float_avoiding_box__border_box_rtl() {
+        crate::run_xml_test("float", "float_justify_self_float_avoiding_box__border_box_rtl");
+    }
+
+    #[test]
+    fn float_justify_self_float_avoiding_box__content_box_rtl() {
+        crate::run_xml_test("float", "float_justify_self_float_avoiding_box__content_box_rtl");
+    }
+
+    #[test]
+    fn float_justify_self_ignored_on_float__border_box_ltr() {
+        crate::run_xml_test("float", "float_justify_self_ignored_on_float__border_box_ltr");
+    }
+
+    #[test]
+    fn float_justify_self_ignored_on_float__content_box_ltr() {
+        crate::run_xml_test("float", "float_justify_self_ignored_on_float__content_box_ltr");
+    }
+
+    #[test]
+    fn float_justify_self_ignored_on_float__border_box_rtl() {
+        crate::run_xml_test("float", "float_justify_self_ignored_on_float__border_box_rtl");
+    }
+
+    #[test]
+    fn float_justify_self_ignored_on_float__content_box_rtl() {
+        crate::run_xml_test("float", "float_justify_self_ignored_on_float__content_box_rtl");
+    }
+
+    #[test]
     fn float_negative_clearance_adjoining_float__border_box_ltr() {
         crate::run_xml_test("float", "float_negative_clearance_adjoining_float__border_box_ltr");
     }
@@ -26713,6 +26953,30 @@ mod grid {
     #[test]
     fn grid_justify_self_direction_rtl__content_box_rtl() {
         crate::run_xml_test("grid", "grid_justify_self_direction_rtl__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_justify_self_end_child_rtl__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_justify_self_end_child_rtl__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_justify_self_end_child_rtl__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_justify_self_end_child_rtl__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_justify_self_end_child_rtl__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_justify_self_end_child_rtl__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_justify_self_end_child_rtl__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_justify_self_end_child_rtl__content_box_rtl");
     }
 
     #[cfg(feature = "grid")]


### PR DESCRIPTION
# Objective

Implement `justify-self` for block-level boxes (<https://www.w3.org/TR/css-align-3/#justify-block>), so that consumers such as Blitz can align block-level children within their containing block.

## Context

`justify-self` was previously only honoured for grid items. This adds it to block layout:

- New `BlockItemStyle::justify_self` accessor (defaults to `None`, i.e. `normal`), implemented for `Style` behind the `grid` feature (where the `justify_self` field lives).
- In-flow block-level boxes: a positional `justify-self` aligns the item's margin box within the containing block (or within the space beside floats for a float-avoiding box), fit-content sizes an `auto` inline size instead of stretching it, and takes precedence over the legacy `text-align` alignment. Auto margins still win, `stretch`/`normal` keep the existing behaviour, and `self-start`/`self-end` resolve against the item's own `direction` (as in grid).
- Absolutely positioned children with both inline insets `auto` are aligned within their static-position rectangle.
- `justify-self` is ignored on floats (they are placed by the float context).

Test fixtures cover LTR/RTL containers, direction-differing children, auto/explicit widths, margins, overflow (safe/unsafe), interaction with `text-align`, floats, and absolutely positioned children; a grid fixture pins the existing direction-resolution behaviour. All expectations were generated from Chrome via `just gentest`.

RELEASES/CHANGELOG updated.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/49e63862a7874317af1f714bb5da599a
Requested by: @nicoburns