### PR TITLE
Block: apply align-content to floated children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ A large number of miscelaneous bug fixes are included in this release:
 - Block/float: apply CSS2 §9.5.1 rule 5 (float ceiling) and `clear` past zero-sized floats, which occupy no float segment and so were previously ignored when positioning later floats and cleared elements (#1056)
 - Block/float: sum float contributions when computing a float container's intrinsic width under definite available space (clamped between the widest single float and the available width), instead of dropping them entirely (#1055)
 - Block: a block container with a non-`normal` `align-content` establishes an independent formatting context (its margins do not collapse with its children's, it cannot be collapsed through, and it contains its own floats)
+- Block/float: `align-content` shifts a block container's floated children along with its in-flow content
 
 ## 0.12.2
 

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -700,7 +700,7 @@ fn compute_inner(
         return output;
     }
 
-    // Commit deferred in-flow layouts to the tree. Floated items already wrote their own layouts.
+    // Commit deferred child layouts to the tree.
     for item in items.iter() {
         if let Some(layout) = item.final_layout.as_ref() {
             tree.set_unrounded_layout(item.node_id, layout);
@@ -1025,20 +1025,19 @@ fn perform_final_layout_on_in_flow_children(
                 // println!("BLOCK FLOATED BOX ({:?}) {:?}", item.node_id, float_direction);
                 // println!("w:{} h:{} x:{}, y:{}", margin_box.width, margin_box.height, location.x, location.y);
 
-                tree.set_unrounded_layout(
-                    item.node_id,
-                    &Layout {
-                        order: item.order,
-                        size: item_layout.size,
-                        #[cfg(feature = "content_size")]
-                        content_size: item_layout.content_size,
-                        scrollbar_size,
-                        location,
-                        padding: item.padding,
-                        border: item.border,
-                        margin: item_non_auto_margin,
-                    },
-                );
+                // Deferred to the post-loop pass in `compute_inner` (like in-flow items) so that
+                // `align-content` can shift `location.y` before the layout is committed.
+                item.final_layout = Some(Layout {
+                    order: item.order,
+                    size: item_layout.size,
+                    #[cfg(feature = "content_size")]
+                    content_size: item_layout.content_size,
+                    scrollbar_size,
+                    location,
+                    padding: item.padding,
+                    border: item.border,
+                    margin: item_non_auto_margin,
+                });
 
                 #[cfg(feature = "content_size")]
                 {


### PR DESCRIPTION
# Objective

`align-content` moved a block container's in-flow children but left its floats where they were, because floated items wrote their layout to the tree inline, before the alignment pass runs:

```diff
-tree.set_unrounded_layout(item.node_id, &Layout { .. });
+item.final_layout = Some(Layout { .. });
```

They now defer into `item.final_layout` like in-flow items, so the single commit loop in `compute_inner` runs after `align-content` has shifted `location.y`.

## Context

Split out of #1087, and stacked on it (a container with a non-`normal` `align-content` must contain its floats for this to be meaningful). Exercised by `css/css-align/blocks/align-content-block-004`/`005` in Blitz.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/6eddbbb1f3e146858a3d9299376dc716
Requested by: @nicoburns