### PR TITLE
Refactor compute_layout_with_measure to return LayoutOutput directly (rebase of #953)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- `TaffyTree::compute_layout_with_measure`'s measure function now takes the full `LayoutInput` (plus `NodeId`, `Option<&mut NodeContext>` and `&Style`) and returns a `LayoutOutput` directly instead of a `Size<f32>`, allowing measure functions to set baselines (and other `LayoutOutput` fields) on leaf nodes. `compute_leaf_layout` is no longer called implicitly: to retain the previous behaviour, wrap your existing measure logic in an explicit call to `compute_leaf_layout` (#953)
+
 ## 0.13.0
 
 The MSRV for this release is 1.71.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,23 @@
 
 ### Changed
 
-- `TaffyTree::compute_layout_with_measure`'s measure function now takes the full `LayoutInput` (plus `NodeId`, `Option<&mut NodeContext>` and `&Style`) and returns a `LayoutOutput` directly instead of a `Size<f32>`, allowing measure functions to set baselines (and other `LayoutOutput` fields) on leaf nodes. `compute_leaf_layout` is no longer called implicitly: to retain the previous behaviour, wrap your existing measure logic in an explicit call to `compute_leaf_layout` (#953)
+- `TaffyTree::compute_layout_with_measure`'s measure function now takes the full `LayoutInput` (plus `NodeId`, `Option<&mut NodeContext>` and `&Style`) and returns a `LayoutOutput` directly instead of a `Size<f32>`, allowing measure functions to set baselines (and other `LayoutOutput` fields) on leaf nodes. `compute_leaf_layout` is no longer called implicitly (#953)
+
+  Migration: to retain the previous behaviour, wrap your existing measure logic in an explicit call to `compute_leaf_layout` within the new-style measure function:
+
+  ```rust
+  // Before
+  tree.compute_layout_with_measure(node, available_space, |known_dimensions, available_space, node_id, node_context, style| {
+      my_measure_logic(known_dimensions, available_space, node_id, node_context, style)
+  })?;
+
+  // After
+  tree.compute_layout_with_measure(node, available_space, |inputs, node_id, node_context, style| {
+      taffy::compute_leaf_layout(inputs, style, |_, _| 0.0, |known_dimensions, available_space| {
+          my_measure_logic(known_dimensions, available_space, node_id, node_context, style)
+      })
+  })?;
+  ```
 
 ## 0.13.0
 

--- a/benches/benches/mixed.rs
+++ b/benches/benches/mixed.rs
@@ -158,8 +158,15 @@ fn mixed_benchmark(c: &mut Criterion) {
                             .compute_layout_with_measure(
                                 root,
                                 Size::MAX_CONTENT,
-                                |known_dimensions, available_space, _node_id, node_context, _style| {
-                                    measure_function(known_dimensions, available_space, node_context)
+                                |inputs, _node_id, node_context, style| {
+                                    taffy::compute_leaf_layout(
+                                        inputs,
+                                        style,
+                                        |_, _| 0.0,
+                                        |known_dimensions, available_space| {
+                                            measure_function(known_dimensions, available_space, node_context)
+                                        },
+                                    )
                                 },
                             )
                             .unwrap();

--- a/examples/cosmic_text/src/main.rs
+++ b/examples/cosmic_text/src/main.rs
@@ -108,8 +108,10 @@ fn main() -> Result<(), taffy::TaffyError> {
         Size::MAX_CONTENT,
         // Note: this closure is a FnMut closure and can be used to borrow external context for the duration of layout
         // For example, you may wish to borrow a global font registry and pass it into your text measuring function
-        |known_dimensions, available_space, _node_id, node_context, _style| {
-            measure_function(known_dimensions, available_space, node_context, &mut font_system)
+        |inputs, _node_id, node_context, style| {
+            taffy::compute_leaf_layout(inputs, style, |_, _| 0.0, |known_dimensions, available_space| {
+                measure_function(known_dimensions, available_space, node_context, &mut font_system)
+            })
         },
     )?;
     taffy.print_tree(root);

--- a/examples/measure.rs
+++ b/examples/measure.rs
@@ -59,8 +59,15 @@ fn main() -> Result<(), taffy::TaffyError> {
         Size::MAX_CONTENT,
         // Note: this closure is a FnMut closure and can be used to borrow external context for the duration of layout
         // For example, you may wish to borrow a global font registry and pass it into your text measuring function
-        |known_dimensions, available_space, _node_id, node_context, _style| {
-            measure_function(known_dimensions, available_space, node_context, &font_metrics)
+        |inputs, _node_id, node_context, style| {
+            taffy::compute_leaf_layout(
+                inputs,
+                style,
+                |_, _| 0.0,
+                |known_dimensions, available_space| {
+                    measure_function(known_dimensions, available_space, node_context, &font_metrics)
+                },
+            )
         },
     )?;
     taffy.print_tree(root);

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -266,8 +266,7 @@ impl<NodeContext> PrintTree for TaffyTree<NodeContext> {
 /// which makes the lifetimes of the context much more flexible.
 pub(crate) struct TaffyView<'t, NodeContext, MeasureFunction>
 where
-    MeasureFunction:
-        FnMut(Size<Option<f32>>, Size<AvailableSpace>, NodeId, Option<&mut NodeContext>, &Style) -> Size<f32>,
+    MeasureFunction: FnMut(LayoutInput, NodeId, Option<&mut NodeContext>, &Style) -> LayoutOutput,
 {
     /// A reference to the TaffyTree
     pub(crate) taffy: &'t mut TaffyTree<NodeContext>,
@@ -277,8 +276,7 @@ where
 
 impl<NodeContext, MeasureFunction> TaffyView<'_, NodeContext, MeasureFunction>
 where
-    MeasureFunction:
-        FnMut(Size<Option<f32>>, Size<AvailableSpace>, NodeId, Option<&mut NodeContext>, &Style) -> Size<f32>,
+    MeasureFunction: FnMut(LayoutInput, NodeId, Option<&mut NodeContext>, &Style) -> LayoutOutput,
 {
     #[inline(always)]
     /// Unified implementation that both `LayoutPartialTree::compute_child_layout`
@@ -324,10 +322,7 @@ where
                     let style = &tree.taffy.nodes[node_key].style;
                     let has_context = tree.taffy.nodes[node_key].has_context;
                     let node_context = has_context.then(|| tree.taffy.node_context_data.get_mut(node_key)).flatten();
-                    let measure_function = |known_dimensions, available_space| {
-                        (tree.measure_function)(known_dimensions, available_space, node_id, node_context, style)
-                    };
-                    compute_leaf_layout(inputs, style, |_, _| 0.0, measure_function)
+                    (tree.measure_function)(inputs, node_id, node_context, style)
                 }
             }
         })
@@ -337,8 +332,7 @@ where
 // TraversePartialTree impl for TaffyView
 impl<NodeContext, MeasureFunction> TraversePartialTree for TaffyView<'_, NodeContext, MeasureFunction>
 where
-    MeasureFunction:
-        FnMut(Size<Option<f32>>, Size<AvailableSpace>, NodeId, Option<&mut NodeContext>, &Style) -> Size<f32>,
+    MeasureFunction: FnMut(LayoutInput, NodeId, Option<&mut NodeContext>, &Style) -> LayoutOutput,
 {
     type ChildIter<'a>
         = TaffyTreeChildIter<'a>
@@ -363,16 +357,14 @@ where
 
 // TraverseTree impl for TaffyView
 impl<NodeContext, MeasureFunction> TraverseTree for TaffyView<'_, NodeContext, MeasureFunction> where
-    MeasureFunction:
-        FnMut(Size<Option<f32>>, Size<AvailableSpace>, NodeId, Option<&mut NodeContext>, &Style) -> Size<f32>
+    MeasureFunction: FnMut(LayoutInput, NodeId, Option<&mut NodeContext>, &Style) -> LayoutOutput
 {
 }
 
 // LayoutPartialTree impl for TaffyView
 impl<NodeContext, MeasureFunction> LayoutPartialTree for TaffyView<'_, NodeContext, MeasureFunction>
 where
-    MeasureFunction:
-        FnMut(Size<Option<f32>>, Size<AvailableSpace>, NodeId, Option<&mut NodeContext>, &Style) -> Size<f32>,
+    MeasureFunction: FnMut(LayoutInput, NodeId, Option<&mut NodeContext>, &Style) -> LayoutOutput,
 {
     type CoreContainerStyle<'a>
         = &'a Style
@@ -409,8 +401,7 @@ where
 
 impl<NodeContext, MeasureFunction> CacheTree for TaffyView<'_, NodeContext, MeasureFunction>
 where
-    MeasureFunction:
-        FnMut(Size<Option<f32>>, Size<AvailableSpace>, NodeId, Option<&mut NodeContext>, &Style) -> Size<f32>,
+    MeasureFunction: FnMut(LayoutInput, NodeId, Option<&mut NodeContext>, &Style) -> LayoutOutput,
 {
     fn cache_get(&self, node_id: NodeId, input: &LayoutInput) -> Option<LayoutOutput> {
         self.taffy.nodes[node_id.into()].cache.get(input)
@@ -428,8 +419,7 @@ where
 #[cfg(feature = "block_layout")]
 impl<NodeContext, MeasureFunction> LayoutBlockContainer for TaffyView<'_, NodeContext, MeasureFunction>
 where
-    MeasureFunction:
-        FnMut(Size<Option<f32>>, Size<AvailableSpace>, NodeId, Option<&mut NodeContext>, &Style) -> Size<f32>,
+    MeasureFunction: FnMut(LayoutInput, NodeId, Option<&mut NodeContext>, &Style) -> LayoutOutput,
 {
     type BlockContainerStyle<'a>
         = &'a Style
@@ -464,8 +454,7 @@ where
 #[cfg(feature = "flexbox")]
 impl<NodeContext, MeasureFunction> LayoutFlexboxContainer for TaffyView<'_, NodeContext, MeasureFunction>
 where
-    MeasureFunction:
-        FnMut(Size<Option<f32>>, Size<AvailableSpace>, NodeId, Option<&mut NodeContext>, &Style) -> Size<f32>,
+    MeasureFunction: FnMut(LayoutInput, NodeId, Option<&mut NodeContext>, &Style) -> LayoutOutput,
 {
     type FlexboxContainerStyle<'a>
         = &'a Style
@@ -490,8 +479,7 @@ where
 #[cfg(feature = "grid")]
 impl<NodeContext, MeasureFunction> LayoutGridContainer for TaffyView<'_, NodeContext, MeasureFunction>
 where
-    MeasureFunction:
-        FnMut(Size<Option<f32>>, Size<AvailableSpace>, NodeId, Option<&mut NodeContext>, &Style) -> Size<f32>,
+    MeasureFunction: FnMut(LayoutInput, NodeId, Option<&mut NodeContext>, &Style) -> LayoutOutput,
 {
     type GridContainerStyle<'a>
         = &'a Style
@@ -522,8 +510,7 @@ where
 // RoundTree impl for TaffyView
 impl<NodeContext, MeasureFunction> RoundTree for TaffyView<'_, NodeContext, MeasureFunction>
 where
-    MeasureFunction:
-        FnMut(Size<Option<f32>>, Size<AvailableSpace>, NodeId, Option<&mut NodeContext>, &Style) -> Size<f32>,
+    MeasureFunction: FnMut(LayoutInput, NodeId, Option<&mut NodeContext>, &Style) -> LayoutOutput,
 {
     #[inline(always)]
     fn get_unrounded_layout(&self, node: NodeId) -> Layout {
@@ -913,8 +900,7 @@ impl<NodeContext> TaffyTree<NodeContext> {
         measure_function: MeasureFunction,
     ) -> Result<(), TaffyError>
     where
-        MeasureFunction:
-            FnMut(Size<Option<f32>>, Size<AvailableSpace>, NodeId, Option<&mut NodeContext>, &Style) -> Size<f32>,
+        MeasureFunction: FnMut(LayoutInput, NodeId, Option<&mut NodeContext>, &Style) -> LayoutOutput,
     {
         let use_rounding = self.config.use_rounding;
         let mut taffy_view = TaffyView { taffy: self, measure_function };
@@ -927,7 +913,9 @@ impl<NodeContext> TaffyTree<NodeContext> {
 
     /// Updates the stored layout of the provided `node` and its children
     pub fn compute_layout(&mut self, node: NodeId, available_space: Size<AvailableSpace>) -> Result<(), TaffyError> {
-        self.compute_layout_with_measure(node, available_space, |_, _, _, _, _| Size::ZERO)
+        self.compute_layout_with_measure(node, available_space, |inputs, _, _, style| {
+            compute_leaf_layout(inputs, style, |_, _| 0.0, |_, _| Size::ZERO)
+        })
     }
 
     /// Prints a debug representation of the tree's layout
@@ -939,7 +927,10 @@ impl<NodeContext> TaffyTree<NodeContext> {
     /// Returns an instance of LayoutTree representing the TaffyTree
     #[cfg(test)]
     pub(crate) fn as_layout_tree(&mut self) -> impl LayoutPartialTree + CacheTree + '_ {
-        TaffyView { taffy: self, measure_function: |_, _, _, _, _| Size::ZERO }
+        TaffyView {
+            taffy: self,
+            measure_function: |inputs, _, _, style| compute_leaf_layout(inputs, style, |_, _| 0.0, |_, _| Size::ZERO),
+        }
     }
 }
 
@@ -952,13 +943,19 @@ mod tests {
     use crate::util::sys;
 
     fn size_measure_function(
-        known_dimensions: Size<Option<f32>>,
-        _available_space: Size<AvailableSpace>,
+        inputs: LayoutInput,
         _node_id: NodeId,
         node_context: Option<&mut Size<f32>>,
-        _style: &Style,
-    ) -> Size<f32> {
-        known_dimensions.unwrap_or(node_context.cloned().unwrap_or(Size::ZERO))
+        style: &Style,
+    ) -> LayoutOutput {
+        compute_leaf_layout(
+            inputs,
+            style,
+            |_, _| 0.0,
+            |known_dimensions, _available_space| {
+                known_dimensions.unwrap_or(node_context.cloned().unwrap_or(Size::ZERO))
+            },
+        )
     }
 
     #[test]

--- a/tests/common/src/lib.rs
+++ b/tests/common/src/lib.rs
@@ -1,4 +1,4 @@
-use taffy::{AvailableSpace, NodeId, Size, Style, TaffyTree};
+use taffy::{compute_leaf_layout, LayoutInput, LayoutOutput, NodeId, Size, Style, TaffyTree};
 
 /// Creates a `TaffyTree` that uses `TestNodeContext`. The purpose of this function is
 /// to allow `TaffyTree` to be monomophised once in this crate rather than separately for
@@ -61,32 +61,38 @@ pub enum TestMeasureData {
 
 /// A measure function for tests that works with `TestNodeContext`
 pub fn test_measure_function(
-    known_dimensions: Size<Option<f32>>,
-    available_space: Size<AvailableSpace>,
+    inputs: LayoutInput,
     _node_id: NodeId,
     context: Option<&mut TestNodeContext>,
-    _style: &Style,
-) -> Size<f32> {
-    if let Size { width: Some(width), height: Some(height) } = known_dimensions {
-        return Size { width, height };
-    }
+    style: &Style,
+) -> LayoutOutput {
+    compute_leaf_layout(
+        inputs,
+        style,
+        |_, _| 0.0,
+        |known_dimensions, available_space| {
+            if let Size { width: Some(width), height: Some(height) } = known_dimensions {
+                return Size { width, height };
+            }
 
-    let Some(context) = context else { return known_dimensions.map(|d| d.unwrap_or(0.0)) };
+            let Some(context) = context else { return known_dimensions.map(|d| d.unwrap_or(0.0)) };
 
-    // Increment count
-    context.count += 1;
+            // Increment count
+            context.count += 1;
 
-    let compute_size = match &context.measure_data {
-        TestMeasureData::Zero => Size::ZERO,
-        TestMeasureData::Fixed(size) => *size,
-        TestMeasureData::AspectRatio(data) => data.measure(known_dimensions),
-        TestMeasureData::AhemText(data) => data.measure(known_dimensions, available_space),
-    };
+            let compute_size = match &context.measure_data {
+                TestMeasureData::Zero => Size::ZERO,
+                TestMeasureData::Fixed(size) => *size,
+                TestMeasureData::AspectRatio(data) => data.measure(known_dimensions),
+                TestMeasureData::AhemText(data) => data.measure(known_dimensions, available_space),
+            };
 
-    Size {
-        width: known_dimensions.width.unwrap_or(compute_size.width),
-        height: known_dimensions.height.unwrap_or(compute_size.height),
-    }
+            Size {
+                width: known_dimensions.width.unwrap_or(compute_size.width),
+                height: known_dimensions.height.unwrap_or(compute_size.height),
+            }
+        },
+    )
 }
 
 /// Measure data for nodes that returns results based on an intrinsic aspect ratio

--- a/tests/hand_written.rs
+++ b/tests/hand_written.rs
@@ -1,5 +1,6 @@
 mod hand_written {
     mod adversarial_styles;
+    mod baseline;
     mod block_replaced;
     mod border_and_padding;
     mod caching;

--- a/tests/hand_written/baseline.rs
+++ b/tests/hand_written/baseline.rs
@@ -1,0 +1,111 @@
+#[cfg(test)]
+mod baseline {
+    use taffy::prelude::*;
+    use taffy::{LayoutInput, LayoutOutput, Point};
+
+    /// A node context that pairs an intrinsic size with a first-baseline offset
+    /// (measured from the node's top edge in the block axis).
+    #[derive(Debug, Clone, Copy)]
+    struct BaselineContext {
+        size: Size<f32>,
+        baseline_y: f32,
+    }
+
+    fn baseline_measure_function(
+        _inputs: LayoutInput,
+        _node_id: NodeId,
+        context: Option<&mut BaselineContext>,
+        _style: &Style,
+    ) -> LayoutOutput {
+        let Some(context) = context else { return LayoutOutput::DEFAULT };
+        LayoutOutput::from_sizes_and_baselines(context.size, Size::ZERO, Point { x: None, y: Some(context.baseline_y) })
+    }
+
+    /// Two flex items with different intrinsic baselines are aligned along their baselines
+    /// when the container uses `align-items: baseline`. The item with the smaller distance
+    /// from its top to its baseline should be shifted down so that both baselines coincide.
+    #[test]
+    fn flex_baseline_alignment_uses_measure_function_baseline() {
+        let mut taffy: TaffyTree<BaselineContext> = TaffyTree::new();
+
+        // Child A: 50x50 box with baseline 40px from the top
+        let child_a = taffy
+            .new_leaf_with_context(
+                Style::default(),
+                BaselineContext { size: Size { width: 50.0, height: 50.0 }, baseline_y: 40.0 },
+            )
+            .unwrap();
+
+        // Child B: 30x30 box with baseline 20px from the top
+        let child_b = taffy
+            .new_leaf_with_context(
+                Style::default(),
+                BaselineContext { size: Size { width: 30.0, height: 30.0 }, baseline_y: 20.0 },
+            )
+            .unwrap();
+
+        let root = taffy
+            .new_with_children(
+                Style {
+                    display: Display::Flex,
+                    flex_direction: FlexDirection::Row,
+                    align_items: Some(AlignItems::BASELINE),
+                    size: Size { width: length(200.0), height: length(100.0) },
+                    ..Default::default()
+                },
+                &[child_a, child_b],
+            )
+            .unwrap();
+
+        taffy.compute_layout_with_measure(root, Size::MAX_CONTENT, baseline_measure_function).unwrap();
+
+        let layout_a = taffy.layout(child_a).unwrap();
+        let layout_b = taffy.layout(child_b).unwrap();
+
+        // Child A sets the max baseline (40 px from its top), so it sits at the top of the line.
+        assert_eq!(layout_a.location.y, 0.0);
+        // Child B is shifted down by (40 - 20) = 20 px so its baseline aligns with child A's.
+        assert_eq!(layout_b.location.y, 20.0);
+
+        // Sanity-check: both children's baselines now sit at y = 40 in the container.
+        assert_eq!(layout_a.location.y + 40.0, layout_b.location.y + 20.0);
+    }
+
+    /// Sanity-check: without `align-items: baseline`, items align at the cross-start edge
+    /// regardless of the baseline reported by the measure function.
+    #[test]
+    fn flex_baseline_is_ignored_when_alignment_is_not_baseline() {
+        let mut taffy: TaffyTree<BaselineContext> = TaffyTree::new();
+
+        let child_a = taffy
+            .new_leaf_with_context(
+                Style::default(),
+                BaselineContext { size: Size { width: 50.0, height: 50.0 }, baseline_y: 40.0 },
+            )
+            .unwrap();
+        let child_b = taffy
+            .new_leaf_with_context(
+                Style::default(),
+                BaselineContext { size: Size { width: 30.0, height: 30.0 }, baseline_y: 20.0 },
+            )
+            .unwrap();
+
+        let root = taffy
+            .new_with_children(
+                Style {
+                    display: Display::Flex,
+                    flex_direction: FlexDirection::Row,
+                    align_items: Some(AlignItems::FLEX_START),
+                    size: Size { width: length(200.0), height: length(100.0) },
+                    ..Default::default()
+                },
+                &[child_a, child_b],
+            )
+            .unwrap();
+
+        taffy.compute_layout_with_measure(root, Size::MAX_CONTENT, baseline_measure_function).unwrap();
+
+        assert_eq!(taffy.layout(child_a).unwrap().location.y, 0.0);
+        assert_eq!(taffy.layout(child_b).unwrap().location.y, 0.0);
+    }
+}

--- a/tests/hand_written/measure.rs
+++ b/tests/hand_written/measure.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod measure {
     use taffy::prelude::*;
+    use taffy::{LayoutInput, LayoutOutput};
     use taffy_test_helpers::{new_test_tree, test_measure_function, TestNodeContext};
 
     const HUNDRED_HUNDRED: TestNodeContext = TestNodeContext::fixed(100.0, 100.0);
@@ -209,15 +210,21 @@ mod measure {
         let mut taffy: TaffyTree<()> = TaffyTree::new();
 
         fn custom_measure_function(
-            known_dimensions: Size<Option<f32>>,
-            _available_space: Size<AvailableSpace>,
+            inputs: LayoutInput,
             _node_id: NodeId,
             _node_context: Option<&mut ()>,
-            _style: &Style,
-        ) -> taffy::geometry::Size<f32> {
-            let height = known_dimensions.height.unwrap_or(50.0);
-            let width = known_dimensions.width.unwrap_or(height);
-            Size { width, height }
+            style: &Style,
+        ) -> LayoutOutput {
+            taffy::compute_leaf_layout(
+                inputs,
+                style,
+                |_, _| 0.0,
+                |known_dimensions, _available_space| {
+                    let height = known_dimensions.height.unwrap_or(50.0);
+                    let width = known_dimensions.width.unwrap_or(height);
+                    Size { width, height }
+                },
+            )
         }
 
         let child = taffy.new_leaf_with_context(Style::default(), ()).unwrap();


### PR DESCRIPTION
# Objective

Fixes #199. Rebase of @josephg's #953 onto latest main, so that `TaffyTree` users can set baselines (and other `LayoutOutput` fields) on leaf nodes.

The measure closure passed to `compute_layout_with_measure` now takes the full `LayoutInput` (plus `NodeId`, `Option<&mut NodeContext>`, `&Style`) and returns a `LayoutOutput` directly:

```rust
MeasureFunction: FnMut(LayoutInput, NodeId, Option<&mut NodeContext>, &Style) -> LayoutOutput
```

`compute_leaf_layout` is no longer called implicitly; to keep the old behaviour a measure function wraps its existing logic in an explicit call:

```rust
|inputs, _node_id, node_context, style| {
    compute_leaf_layout(inputs, style, |_, _| 0.0, |known_dimensions, available_space| {
        // old measure logic
    })
}
```

## Context

- Original PR: #953 (all commits preserved with original authorship). Changes on top of it:
  - Resolved the `tests/hand_written.rs` module-list conflict with main
  - Updated `tests/hand_written/baseline.rs` for the `AlignItems` variant→const change from #1077 (`Baseline`→`BASELINE`, `FlexStart`→`FLEX_START`)
  - Fixed the rustfmt failure in `tests/hand_written/baseline.rs` that was failing CI on #953
  - Added a CHANGELOG entry for the breaking signature change
- `cargo test --workspace` (5541 generated + hand-written), `cargo clippy --workspace` and `cargo fmt --all --check` all pass locally.

## Feedback wanted

Same open question as #953: whether to additionally ship a back-compat convenience for the old `-> Size<f32>` closure signature, or leave migration to the documented `compute_leaf_layout` wrapping pattern.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/f56e7e3126624c57927a9f48dabcdc67
Requested by: @nicoburns