### PR TITLE
Block abs-pos: resolve auto margins against the clamped (used) size

### DIFF
--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -1615,9 +1615,7 @@ fn perform_absolute_layout_on_absolute_children(
                 // the 'direction' property of the containing block is 'rtl') or 'right' (in case 'direction' is 'ltr') and solve for that value.
                 width: {
                     let auto_margin_count = margin.left.is_none() as u8 + margin.right.is_none() as u8;
-                    if auto_margin_count == 2
-                        && (style_size.width.is_none() || style_size.width.unwrap() >= free_space.width)
-                    {
+                    if auto_margin_count == 2 && free_space.width <= 0.0 {
                         0.0
                     } else if auto_margin_count > 0 {
                         free_space.width / auto_margin_count as f32
@@ -1627,9 +1625,7 @@ fn perform_absolute_layout_on_absolute_children(
                 },
                 height: {
                     let auto_margin_count = margin.top.is_none() as u8 + margin.bottom.is_none() as u8;
-                    if auto_margin_count == 2
-                        && (style_size.height.is_none() || style_size.height.unwrap() >= free_space.height)
-                    {
+                    if auto_margin_count == 2 && free_space.height <= 0.0 {
                         0.0
                     } else if auto_margin_count > 0 {
                         free_space.height / auto_margin_count as f32

--- a/test_fixtures/block/block_absolute_margin_auto_left_and_right_max_width.html
+++ b/test_fixtures/block/block_absolute_margin_auto_left_and_right_max_width.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; position: relative; width: 200px; height: 100px;">
+  <div style="position: absolute; left: 0px; right: 0px; top: 20px; margin: auto; width: 180px; max-width: 100px; height: 40px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/block/block_absolute_margin_auto_top_and_bottom_max_height.html
+++ b/test_fixtures/block/block_absolute_margin_auto_top_and_bottom_max_height.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; position: relative; width: 200px; height: 100px;">
+  <div style="position: absolute; top: 0px; bottom: 0px; left: 20px; margin: auto; height: 90px; max-height: 40px; width: 100px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/block/block_absolute_margin_auto_left_and_right_max_width__border_box_ltr.xml
+++ b/tests/xml/block/block_absolute_margin_auto_left_and_right_max_width__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="block_absolute_margin_auto_left_and_right_max_width__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="200px" height="100px">
+      <div direction="ltr" position="absolute" width="180px" height="40px" max-width="100px" margin-top="auto" margin-left="auto" margin-bottom="auto" margin-right="auto" top="20px" left="0px" right="0px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="50" y="20" width="100" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_absolute_margin_auto_left_and_right_max_width__border_box_rtl.xml
+++ b/tests/xml/block/block_absolute_margin_auto_left_and_right_max_width__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="block_absolute_margin_auto_left_and_right_max_width__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="200px" height="100px">
+      <div direction="rtl" position="absolute" width="180px" height="40px" max-width="100px" margin-top="auto" margin-left="auto" margin-bottom="auto" margin-right="auto" top="20px" left="0px" right="0px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="50" y="20" width="100" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_absolute_margin_auto_left_and_right_max_width__content_box_ltr.xml
+++ b/tests/xml/block/block_absolute_margin_auto_left_and_right_max_width__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="block_absolute_margin_auto_left_and_right_max_width__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="200px" height="100px">
+      <div box-sizing="content-box" direction="ltr" position="absolute" width="180px" height="40px" max-width="100px" margin-top="auto" margin-left="auto" margin-bottom="auto" margin-right="auto" top="20px" left="0px" right="0px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="50" y="20" width="100" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_absolute_margin_auto_left_and_right_max_width__content_box_rtl.xml
+++ b/tests/xml/block/block_absolute_margin_auto_left_and_right_max_width__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="block_absolute_margin_auto_left_and_right_max_width__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="200px" height="100px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" width="180px" height="40px" max-width="100px" margin-top="auto" margin-left="auto" margin-bottom="auto" margin-right="auto" top="20px" left="0px" right="0px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="50" y="20" width="100" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_absolute_margin_auto_top_and_bottom_max_height__border_box_ltr.xml
+++ b/tests/xml/block/block_absolute_margin_auto_top_and_bottom_max_height__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="block_absolute_margin_auto_top_and_bottom_max_height__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="200px" height="100px">
+      <div direction="ltr" position="absolute" width="100px" height="90px" max-height="40px" margin-top="auto" margin-left="auto" margin-bottom="auto" margin-right="auto" top="0px" left="20px" bottom="0px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="20" y="30" width="100" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_absolute_margin_auto_top_and_bottom_max_height__border_box_rtl.xml
+++ b/tests/xml/block/block_absolute_margin_auto_top_and_bottom_max_height__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="block_absolute_margin_auto_top_and_bottom_max_height__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="200px" height="100px">
+      <div direction="rtl" position="absolute" width="100px" height="90px" max-height="40px" margin-top="auto" margin-left="auto" margin-bottom="auto" margin-right="auto" top="0px" left="20px" bottom="0px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="20" y="30" width="100" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_absolute_margin_auto_top_and_bottom_max_height__content_box_ltr.xml
+++ b/tests/xml/block/block_absolute_margin_auto_top_and_bottom_max_height__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="block_absolute_margin_auto_top_and_bottom_max_height__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="200px" height="100px">
+      <div box-sizing="content-box" direction="ltr" position="absolute" width="100px" height="90px" max-height="40px" margin-top="auto" margin-left="auto" margin-bottom="auto" margin-right="auto" top="0px" left="20px" bottom="0px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="20" y="30" width="100" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_absolute_margin_auto_top_and_bottom_max_height__content_box_rtl.xml
+++ b/tests/xml/block/block_absolute_margin_auto_top_and_bottom_max_height__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="block_absolute_margin_auto_top_and_bottom_max_height__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="200px" height="100px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" width="100px" height="90px" max-height="40px" margin-top="auto" margin-left="auto" margin-bottom="auto" margin-right="auto" top="0px" left="20px" bottom="0px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="20" y="30" width="100" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -594,6 +594,26 @@ mod block {
     }
 
     #[test]
+    fn block_absolute_margin_auto_left_and_right_max_width__border_box_ltr() {
+        crate::run_xml_test("block", "block_absolute_margin_auto_left_and_right_max_width__border_box_ltr");
+    }
+
+    #[test]
+    fn block_absolute_margin_auto_left_and_right_max_width__content_box_ltr() {
+        crate::run_xml_test("block", "block_absolute_margin_auto_left_and_right_max_width__content_box_ltr");
+    }
+
+    #[test]
+    fn block_absolute_margin_auto_left_and_right_max_width__border_box_rtl() {
+        crate::run_xml_test("block", "block_absolute_margin_auto_left_and_right_max_width__border_box_rtl");
+    }
+
+    #[test]
+    fn block_absolute_margin_auto_left_and_right_max_width__content_box_rtl() {
+        crate::run_xml_test("block", "block_absolute_margin_auto_left_and_right_max_width__content_box_rtl");
+    }
+
+    #[test]
     fn block_absolute_margin_auto_left_and_right_with_inset__border_box_ltr() {
         crate::run_xml_test("block", "block_absolute_margin_auto_left_and_right_with_inset__border_box_ltr");
     }
@@ -943,6 +963,26 @@ mod block {
     #[test]
     fn block_absolute_margin_auto_right_without_inset__content_box_rtl() {
         crate::run_xml_test("block", "block_absolute_margin_auto_right_without_inset__content_box_rtl");
+    }
+
+    #[test]
+    fn block_absolute_margin_auto_top_and_bottom_max_height__border_box_ltr() {
+        crate::run_xml_test("block", "block_absolute_margin_auto_top_and_bottom_max_height__border_box_ltr");
+    }
+
+    #[test]
+    fn block_absolute_margin_auto_top_and_bottom_max_height__content_box_ltr() {
+        crate::run_xml_test("block", "block_absolute_margin_auto_top_and_bottom_max_height__content_box_ltr");
+    }
+
+    #[test]
+    fn block_absolute_margin_auto_top_and_bottom_max_height__border_box_rtl() {
+        crate::run_xml_test("block", "block_absolute_margin_auto_top_and_bottom_max_height__border_box_rtl");
+    }
+
+    #[test]
+    fn block_absolute_margin_auto_top_and_bottom_max_height__content_box_rtl() {
+        crate::run_xml_test("block", "block_absolute_margin_auto_top_and_bottom_max_height__content_box_rtl");
     }
 
     #[test]


### PR DESCRIPTION
# Objective

Fixes DioxusLabs/blitz#691: an absolutely positioned box with both insets set, `margin: auto`, and a `max-width` smaller than its declared `width` was pinned to the leading edge instead of being centred (the standard modal-centring idiom `inset: 0; margin: auto; max-width: ...`).

## Context

In `perform_absolute_layout_on_absolute_children`, the both-margins-auto case zeroed the margins whenever the *declared* size was >= the free space:

```rust
if auto_margin_count == 2
    && (style_size.width.is_none() || style_size.width.unwrap() >= free_space.width)
{ 0.0 }
```

`free_space` is already computed from `final_size` (the min/max-clamped used size), so comparing against the pre-clamp `style_size` incorrectly zeroed the margins when clamping created free space. Per CSS 2.1 §10.3.7 the equal-split constraint only gives way when it would make the margins negative, so the condition is now simply:

```rust
if auto_margin_count == 2 && free_space.width <= 0.0 { 0.0 }
```

(and the analogous change for the vertical axis). This also fixes the exact-fit case (`width` equal to the available space, free space = 0 previously hit `>=` — behaviour unchanged there since the split is 0 anyway) and the `width: auto` case, where `final_size` fills the inset-defined space so free space is 0.

Added gentests `block_absolute_margin_auto_left_and_right_max_width` and `block_absolute_margin_auto_top_and_bottom_max_height` reproducing the issue; all existing generated tests still pass.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/197549ede4f24be58b33ce772c2ba198
Requested by: @nicoburns