### PR TITLE
Grid: don't skip intrinsic track sizing when an intrinsic min has a fixed max

### DIFF
--- a/src/compute/grid/track_sizing.rs
+++ b/src/compute/grid/track_sizing.rs
@@ -295,9 +295,17 @@ pub(super) fn track_sizing_algorithm<Tree: LayoutPartialTree>(
         resolve_item_baselines(tree, axis, items, inner_node_size);
     }
 
-    // If all tracks have base_size = growth_limit, then skip the rest of this function.
-    // Note: this can only happen both track sizing function have the same fixed track sizing function
-    if axis_tracks.iter().all(|track| track.base_size == track.growth_limit) {
+    // If all tracks have a fixed min track sizing function and base_size = growth_limit,
+    // then the track sizes are already final and we can skip the rest of this function.
+    // Note that tracks with an intrinsic min track sizing function can still grow beyond
+    // a fixed growth limit (e.g. minmax(auto, 0px)), so they cannot be skipped.
+    if axis_tracks.iter().all(|track| {
+        track.base_size == track.growth_limit
+            && track
+                .min_track_sizing_function
+                .definite_value(percentage_basis, |val, basis| tree.calc(val, basis))
+                .is_some()
+    }) {
         return;
     }
 

--- a/test_fixtures/grid/grid_minmax_auto_fixed_0px_with_sized_item.html
+++ b/test_fixtures/grid/grid_minmax_auto_fixed_0px_with_sized_item.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 100px; grid-template-columns: minmax(auto, 0px); grid-template-rows: 10px 10px;">
+  <div style="width: 60px;"></div>
+  <div></div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/grid/grid_minmax_auto_fixed_0px_with_sized_item__border_box_ltr.xml
+++ b/tests/xml/grid/grid_minmax_auto_fixed_0px_with_sized_item__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_minmax_auto_fixed_0px_with_sized_item__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="100px" grid-template-rows="10px 10px" grid-template-columns="minmax(auto,0px)">
+      <div direction="ltr" width="60px"/>
+      <div direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="20">
+      <node x="0" y="0" width="60" height="10"/>
+      <node x="0" y="10" width="60" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_minmax_auto_fixed_0px_with_sized_item__border_box_rtl.xml
+++ b/tests/xml/grid/grid_minmax_auto_fixed_0px_with_sized_item__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_minmax_auto_fixed_0px_with_sized_item__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="100px" grid-template-rows="10px 10px" grid-template-columns="minmax(auto,0px)">
+      <div direction="rtl" width="60px"/>
+      <div direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="20">
+      <node x="40" y="0" width="60" height="10"/>
+      <node x="40" y="10" width="60" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_minmax_auto_fixed_0px_with_sized_item__content_box_ltr.xml
+++ b/tests/xml/grid/grid_minmax_auto_fixed_0px_with_sized_item__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_minmax_auto_fixed_0px_with_sized_item__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="100px" grid-template-rows="10px 10px" grid-template-columns="minmax(auto,0px)">
+      <div box-sizing="content-box" direction="ltr" width="60px"/>
+      <div box-sizing="content-box" direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="20">
+      <node x="0" y="0" width="60" height="10"/>
+      <node x="0" y="10" width="60" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_minmax_auto_fixed_0px_with_sized_item__content_box_rtl.xml
+++ b/tests/xml/grid/grid_minmax_auto_fixed_0px_with_sized_item__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_minmax_auto_fixed_0px_with_sized_item__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="100px" grid-template-rows="10px 10px" grid-template-columns="minmax(auto,0px)">
+      <div box-sizing="content-box" direction="rtl" width="60px"/>
+      <div box-sizing="content-box" direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="20">
+      <node x="40" y="0" width="60" height="10"/>
+      <node x="40" y="10" width="60" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -27897,6 +27897,30 @@ mod grid {
 
     #[cfg(feature = "grid")]
     #[test]
+    fn grid_minmax_auto_fixed_0px_with_sized_item__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_minmax_auto_fixed_0px_with_sized_item__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_minmax_auto_fixed_0px_with_sized_item__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_minmax_auto_fixed_0px_with_sized_item__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_minmax_auto_fixed_0px_with_sized_item__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_minmax_auto_fixed_0px_with_sized_item__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_minmax_auto_fixed_0px_with_sized_item__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_minmax_auto_fixed_0px_with_sized_item__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
     fn grid_minmax_auto_fixed_10px__border_box_ltr() {
         crate::run_xml_test("grid", "grid_minmax_auto_fixed_10px__border_box_ltr");
     }


### PR DESCRIPTION
# Objective

Fix grid tracks like `minmax(auto, 0px)` collapsing to zero instead of growing to fit items' minimum contributions. This makes Blitz pass the WPT tests `css/css-grid/grid-items/grid-items-minimum-width-001.html` / `-002.html` (and the `-orthogonal-*` variants) — previously 0/44 subtests passed, now 44/44.

## Context

`track_sizing_algorithm` has an early-exit:

```rust
// If all tracks have base_size = growth_limit, then skip the rest of this function.
if axis_tracks.iter().all(|track| track.base_size == track.growth_limit) { return; }
```

The comment claims this can only happen when both sizing functions are fixed, but `minmax(auto, 0px)` initializes to `base_size == growth_limit == 0`, so intrinsic track size resolution was skipped entirely and items' minimum contributions were never accommodated (per spec, when the growth limit is less than the base size it is increased to match, so intrinsic mins can grow past a fixed max).

The early-exit now additionally requires each track's *min* track sizing function to resolve to a definite value:

```rust
track.base_size == track.growth_limit
    && track.min_track_sizing_function.definite_value(percentage_basis, ...).is_some()
```

Includes a gentest fixture (`grid_minmax_auto_fixed_0px_with_sized_item`) covering the case. Verified no regressions in the full test suite, and no regressions across Blitz's `css/css-grid` WPT run (+9 tests, +242 subtests).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/f4389961a60946a0a3b4330b890307a0
Requested by: @nicoburns