### PR TITLE
Grid: transfer container height from width via aspect-ratio when height is indefinite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 
 ### Fixed
 
+- Grid: a grid container's automatic height is now transferred from its used width via `aspect_ratio` (and clamped by the height min/max sizes) instead of being derived from the sum of its row sizes. Previously a grid container with an `aspect_ratio` and an auto height was sized to its rows, ignoring the aspect ratio
+
 - `TaffyTree::remove` now marks the removed node's former parent as dirty, like `remove_child`, `remove_child_at_index` and `remove_children_range` already did. Previously the parent and its ancestors kept their stale cached layout, so recomputing the layout of an ancestor did not account for the removed node (#998)
 
 - Grid: fixed a subtract-with-overflow panic (in debug builds) when resolving named lines for a template containing a repetition with fewer line name sets than tracks. Any template combining line names with a repetition created by the `repeat()` style helper (or parsed from CSS such as `[a] repeat(2, 10px) [c] 10px`) could trigger this. In release builds the same bug silently mis-numbered the lines following the repetition. The length of `GridTemplateRepetition::line_names` is now part of the API contract: it must either be empty (all lines unnamed) or contain exactly `tracks.len() + 1` line name sets, and any other length panics (in all builds) during layout

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -323,6 +323,22 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
     let initial_column_sum = columns.iter().map(|track| track.base_size).sum::<f32>();
     inner_node_size.width = inner_node_size.width.or_else(|| initial_column_sum.into());
 
+    // If the container has an aspect-ratio and its height is not otherwise definite, then the height
+    // is transferred from the (now definite) width
+    let transferred_height: Option<f32> = match (inner_node_size.height, aspect_ratio, inner_node_size.width) {
+        (None, Some(ratio), Some(inner_width)) => {
+            let border_box_width = inner_width + content_box_inset.horizontal_axis_sum();
+            let border_box_height = (border_box_width / ratio)
+                .maybe_clamp(min_size.height, max_size.height)
+                .max(padding_border_size.height);
+            Some(border_box_height)
+        }
+        _ => None,
+    };
+    inner_node_size.height = inner_node_size
+        .height
+        .or_else(|| transferred_height.map(|height| height - content_box_inset.vertical_axis_sum()));
+
     items.iter_mut().for_each(|item| item.grid_area_size_cache = None);
 
     // Run track sizing algorithm for Block axis
@@ -359,6 +375,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
             .max(padding_border_size.width),
         height: resolved_style_size
             .get(AbstractAxis::Block)
+            .or(transferred_height)
             .unwrap_or_else(|| initial_row_sum + content_box_inset.vertical_axis_sum())
             .maybe_clamp(min_size.height, max_size.height)
             .max(padding_border_size.height),

--- a/test_fixtures/grid/grid_aspect_ratio_container_height_from_width.html
+++ b/test_fixtures/grid/grid_aspect_ratio_container_height_from_width.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; aspect-ratio: 2; grid-template-columns: 100px 100px;"><div></div></div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_aspect_ratio_container_height_from_width_auto_repeat.html
+++ b/test_fixtures/grid/grid_aspect_ratio_container_height_from_width_auto_repeat.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; aspect-ratio: 1; min-height: 60px; grid-template-columns: repeat(auto-fill, 50px);"><div></div></div>
+
+</body>
+</html>

--- a/tests/xml/grid/grid_aspect_ratio_container_height_from_width__border_box_ltr.xml
+++ b/tests/xml/grid/grid_aspect_ratio_container_height_from_width__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_aspect_ratio_container_height_from_width__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" aspect-ratio="2" grid-template-columns="100px 100px">
+      <div direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="0" y="0" width="100" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_aspect_ratio_container_height_from_width__border_box_rtl.xml
+++ b/tests/xml/grid/grid_aspect_ratio_container_height_from_width__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_aspect_ratio_container_height_from_width__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" aspect-ratio="2" grid-template-columns="100px 100px">
+      <div direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="100" y="0" width="100" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_aspect_ratio_container_height_from_width__content_box_ltr.xml
+++ b/tests/xml/grid/grid_aspect_ratio_container_height_from_width__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_aspect_ratio_container_height_from_width__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" aspect-ratio="2" grid-template-columns="100px 100px">
+      <div box-sizing="content-box" direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="0" y="0" width="100" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_aspect_ratio_container_height_from_width__content_box_rtl.xml
+++ b/tests/xml/grid/grid_aspect_ratio_container_height_from_width__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_aspect_ratio_container_height_from_width__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" aspect-ratio="2" grid-template-columns="100px 100px">
+      <div box-sizing="content-box" direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="100" y="0" width="100" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_aspect_ratio_container_height_from_width_auto_repeat__border_box_ltr.xml
+++ b/tests/xml/grid/grid_aspect_ratio_container_height_from_width_auto_repeat__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_aspect_ratio_container_height_from_width_auto_repeat__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" min-height="60px" aspect-ratio="1" grid-template-columns="repeat(auto-fill, 50px)">
+      <div direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="50" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_aspect_ratio_container_height_from_width_auto_repeat__border_box_rtl.xml
+++ b/tests/xml/grid/grid_aspect_ratio_container_height_from_width_auto_repeat__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_aspect_ratio_container_height_from_width_auto_repeat__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" min-height="60px" aspect-ratio="1" grid-template-columns="repeat(auto-fill, 50px)">
+      <div direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="50" y="0" width="50" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_aspect_ratio_container_height_from_width_auto_repeat__content_box_ltr.xml
+++ b/tests/xml/grid/grid_aspect_ratio_container_height_from_width_auto_repeat__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_aspect_ratio_container_height_from_width_auto_repeat__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" min-height="60px" aspect-ratio="1" grid-template-columns="repeat(auto-fill, 50px)">
+      <div box-sizing="content-box" direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="50" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_aspect_ratio_container_height_from_width_auto_repeat__content_box_rtl.xml
+++ b/tests/xml/grid/grid_aspect_ratio_container_height_from_width_auto_repeat__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_aspect_ratio_container_height_from_width_auto_repeat__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" min-height="60px" aspect-ratio="1" grid-template-columns="repeat(auto-fill, 50px)">
+      <div box-sizing="content-box" direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="50" y="0" width="50" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -19847,6 +19847,54 @@ mod grid {
 
     #[cfg(feature = "grid")]
     #[test]
+    fn grid_aspect_ratio_container_height_from_width__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_aspect_ratio_container_height_from_width__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_aspect_ratio_container_height_from_width__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_aspect_ratio_container_height_from_width__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_aspect_ratio_container_height_from_width__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_aspect_ratio_container_height_from_width__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_aspect_ratio_container_height_from_width__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_aspect_ratio_container_height_from_width__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_aspect_ratio_container_height_from_width_auto_repeat__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_aspect_ratio_container_height_from_width_auto_repeat__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_aspect_ratio_container_height_from_width_auto_repeat__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_aspect_ratio_container_height_from_width_auto_repeat__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_aspect_ratio_container_height_from_width_auto_repeat__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_aspect_ratio_container_height_from_width_auto_repeat__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_aspect_ratio_container_height_from_width_auto_repeat__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_aspect_ratio_container_height_from_width_auto_repeat__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
     fn grid_aspect_ratio_fill_child_height__border_box_ltr() {
         crate::run_xml_test("grid", "grid_aspect_ratio_fill_child_height__border_box_ltr");
     }


### PR DESCRIPTION
# Objective

Fix grid container sizing when the container has an `aspect_ratio` and an automatic height: the height should be transferred from the used width (then clamped by min/max height), rather than derived from the sum of row sizes.

This fixes the WPT test `css/css-grid/grid-definition/grid-auto-repeat-aspect-ratio-001.html` in Blitz:

```html
<div style="display: inline-grid; aspect-ratio: 1/1; min-height: 60px;
            grid-template-columns: repeat(auto-fill, 50px);"></div>
```

`min-height: 60px` transfers to a 60px min-width through the aspect ratio (already handled), giving 2 auto-fill repetitions and a 100px used width — but the used height then came out as `max(row sum = 0, min-height) = 60px` instead of the 100px transferred from the width.

## Context

In `compute_grid_layout`, once the inline-axis track sizing has produced a definite width, the height (if not otherwise definite) is now computed as:

```text
transferred_height = clamp(border_box_width / aspect_ratio, min_height, max_height)
```

This is applied both to `inner_node_size.height` before block-axis track sizing (so percentage rows resolve against it) and to the final container height (taking priority over the row-sum fallback, matching how `compute_leaf_layout` transfers height at line 149).

Gentest fixtures `grid_aspect_ratio_container_height_from_width{,_auto_repeat}` added; generated tests regenerated with Chrome via `just gentest`. All existing tests pass unchanged.

Note: the fixtures include a trivial empty child because childless nodes are dispatched to the leaf algorithm and never reach the grid code (empty grids with fixed tracks currently size to 0x0 rather than the track sum — a separate pre-existing issue).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/d23708053506499cbb8d4515549f1753
Requested by: @nicoburns