### PR TITLE
Implement `min-content` / `max-content` / `fit-content` / `stretch` for `width` and `height`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- `Dimension` (used for `size`) now supports the intrinsic sizing keywords `min-content`, `max-content`, `fit-content` and `fit-content(<length-percentage>)` via new constructors (`Dimension::min_content()`, `Dimension::max_content()`, `Dimension::fit_content()`, `Dimension::fit_content_px()`, `Dimension::fit_content_percent()`), a new `CompactLength::FIT_CONTENT_KEYWORD_TAG` representation for the plain `fit-content` keyword, and CSS parsing support. Block layout resolves these keywords for the widths of in-flow children and floats; other layout modes do not yet support them
+
 ### Changed
 
 - `TaffyTree::compute_layout_with_measure`'s measure function now takes the full `LayoutInput` (plus `NodeId`, `Option<&mut NodeContext>` and `&Style`) and returns a `LayoutOutput` directly instead of a `Size<f32>`, allowing measure functions to set baselines (and other `LayoutOutput` fields) on leaf nodes. `compute_leaf_layout` is no longer called implicitly (#953)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,16 @@
 
 ### Added
 
-- `Dimension` (used for `size`) now supports the intrinsic sizing keywords `min-content`, `max-content`, `fit-content` and `fit-content(<length-percentage>)` via new constructors (`Dimension::min_content()`, `Dimension::max_content()`, `Dimension::fit_content()`, `Dimension::fit_content_px()`, `Dimension::fit_content_percent()`), a new `CompactLength::FIT_CONTENT_KEYWORD_TAG` representation for the plain `fit-content` keyword, and CSS parsing support. Block layout resolves these keywords for the widths of in-flow children and floats; other layout modes do not yet support them
+- `Dimension` (used for `size`) now supports the sizing keywords `min-content`, `max-content`, `fit-content`, `fit-content(<length-percentage>)` and `stretch` via new constructors (`Dimension::min_content()`, `Dimension::max_content()`, `Dimension::fit_content()`, `Dimension::fit_content_px()`, `Dimension::fit_content_percent()`, `Dimension::stretch()`), new `CompactLength::FIT_CONTENT_KEYWORD_TAG`/`CompactLength::STRETCH_TAG` representations, and CSS parsing support. These keywords are resolved:
+  - In block layout: for the widths of in-flow children and floats
+  - In flexbox layout: for the main-axis size when determining an item's flex base size, and for the cross-axis size when determining an item's hypothetical cross size
+  - In grid layout: for the width/height of grid items, both during track sizing (content contributions) and during final item sizing/alignment. A keyword-sized axis is treated as non-`auto`, so the default `normal` self-alignment resolves to `start` rather than `stretch` in that axis
+
+  In contexts where a keyword cannot be resolved it behaves as `auto`
 
 ### Changed
+
+- `Style::min_size` and `Style::max_size` (and the corresponding `CoreStyle::min_size`/`CoreStyle::max_size` trait methods) are now `Size<LengthPercentageAuto>` rather than `Size<Dimension>`, as the min/max sizing properties do not support the new sizing keywords that `Dimension` now supports
 
 - `TaffyTree::compute_layout_with_measure`'s measure function now takes the full `LayoutInput` (plus `NodeId`, `Option<&mut NodeContext>` and `&Style`) and returns a `LayoutOutput` directly instead of a `Size<f32>`, allowing measure functions to set baselines (and other `LayoutOutput` fields) on leaf nodes. `compute_leaf_layout` is no longer called implicitly (#953)
 

--- a/scripts/gentest/src/main.rs
+++ b/scripts/gentest/src/main.rs
@@ -774,6 +774,8 @@ fn serialize_dimension(obj: &serde_json::Value) -> Option<Cow<'static, str>> {
                     "auto" => Cow::from("auto"),
                     "max-content" => Cow::from("max-content"),
                     "min-content" => Cow::from("min-content"),
+                    "fit-content" => Cow::from("fit-content"),
+                    "stretch" => Cow::from("stretch"),
                     "px" => Cow::from(format!("{}px", value.expect("Expected value for px unit"))),
                     "percent" => Cow::from(format!("{}%", value.expect("Expected value for % unit") * 100.0)),
                     "fraction" => Cow::from(format!("{}fr", value.expect("Expected value for fr unit"))),

--- a/scripts/gentest/test_helper.js
+++ b/scripts/gentest/test_helper.js
@@ -118,6 +118,10 @@ function parseDimension(input, options = { allowFrUnits: false }) {
   if (input === 'auto') return { unit: 'auto' };
   if (input === 'min-content') return { unit: 'min-content' };
   if (input === 'max-content') return { unit: 'max-content' };
+  if (input === 'fit-content') return { unit: 'fit-content' };
+  if (input === 'stretch') return { unit: 'stretch' };
+  // Note: Chrome does not support `fit-content(<length-percentage>)` for width/height,
+  // so there is no need to parse it here (only for grid tracks, which are parsed separately)
   return undefined;
 }
 

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -10,7 +10,7 @@ use crate::util::sys::Vec;
 use crate::util::MaybeMath;
 use crate::util::{MaybeResolve, ResolveOrZero};
 use crate::{
-    BlockContainerStyle, BlockItemStyle, BoxGenerationMode, BoxSizing, CompactLength, Direction, LayoutBlockContainer,
+    BlockContainerStyle, BlockItemStyle, BoxGenerationMode, BoxSizing, Dimension, Direction, LayoutBlockContainer,
     RequestedAxis, TextAlign,
 };
 
@@ -265,6 +265,7 @@ impl BlockContext<'_> {
 use super::common::alignment::{apply_alignment_fallback, compute_alignment_offset};
 #[cfg(feature = "content_size")]
 use super::common::content_size::compute_content_size_contribution;
+use super::common::sizing_keyword::{resolve_sizing_keyword, SizingKeywordResolution};
 
 /// Per-child data that is accumulated and modified over the course of the layout algorithm
 struct BlockItem {
@@ -293,9 +294,9 @@ struct BlockItem {
     /// The `clear` style of the node
     clear: Clear,
 
-    /// The raw width style of this item. Used to detect and resolve intrinsic sizing
-    /// keywords (`min-content`, `max-content`, `fit-content`, and `fit-content(...)`)
-    width_style: CompactLength,
+    /// The width style of this item. Used to detect and resolve sizing
+    /// keywords (`min-content`, `max-content`, `fit-content`, `fit-content(...)`, and `stretch`)
+    width_style: Dimension,
 
     /// The base size of this item
     size: Size<Option<f32>>,
@@ -806,7 +807,7 @@ fn generate_item_list(
                 float,
                 #[cfg(feature = "float_layout")]
                 clear: child_style.clear(),
-                width_style: child_style.size().width.into_raw(),
+                width_style: child_style.size().width,
                 size: child_style
                     .size()
                     .maybe_resolve(node_inner_size, |val, basis| tree.calc(val, basis))
@@ -861,8 +862,11 @@ fn determine_content_based_container_width(
             .resolve_or_zero(available_space.width.into_option(), |val, basis| tree.calc(val, basis))
             .horizontal_axis_sum();
         let width = known_dimensions.width.unwrap_or_else(|| {
-            let item_available_width = intrinsic_sizing_keyword_available_width(item.width_style, None, None)
-                .unwrap_or_else(|| available_space.width.maybe_sub(item_x_margin_sum));
+            let item_available_width = match resolve_sizing_keyword(item.width_style, None, None) {
+                Some(SizingKeywordResolution::Measure(available_width)) => available_width,
+                Some(SizingKeywordResolution::Exact(width)) => AvailableSpace::Definite(width),
+                None => available_space.width.maybe_sub(item_x_margin_sum),
+            };
             tree.measure_child_size(
                 item.node_id,
                 known_dimensions,
@@ -891,29 +895,6 @@ fn determine_content_based_container_width(
     }
 
     max_child_width
-}
-
-/// Compute the available width against which to measure an item whose width style is an
-/// intrinsic sizing keyword (`min-content`, `max-content`, `fit-content`, or `fit-content(...)`).
-///
-/// Returns `None` if the width style is not an intrinsic sizing keyword, or if it cannot
-/// be resolved in the current context (in which case it behaves as `auto`).
-#[inline]
-fn intrinsic_sizing_keyword_available_width(
-    width_style: CompactLength,
-    stretch_width: Option<f32>,
-    percent_resolution_basis: Option<f32>,
-) -> Option<AvailableSpace> {
-    match width_style.tag() {
-        CompactLength::MIN_CONTENT_TAG => Some(AvailableSpace::MinContent),
-        CompactLength::MAX_CONTENT_TAG => Some(AvailableSpace::MaxContent),
-        CompactLength::FIT_CONTENT_PX_TAG => Some(AvailableSpace::Definite(width_style.value())),
-        CompactLength::FIT_CONTENT_PERCENT_TAG => {
-            percent_resolution_basis.map(|basis| AvailableSpace::Definite(basis * width_style.value()))
-        }
-        CompactLength::FIT_CONTENT_KEYWORD_TAG => stretch_width.map(AvailableSpace::Definite),
-        _ => None,
-    }
 }
 
 /// Compute each child's final size and position
@@ -1008,15 +989,18 @@ fn perform_final_layout_on_in_flow_children(
                 // A float with `width: auto` is shrink-to-fit (fit-content) sized: the available
                 // space clamped between its min-content and max-content sizes.
                 let available_width = container_inner_width - item_non_auto_x_margin_sum;
-                let item_available_width = intrinsic_sizing_keyword_available_width(
+                let (item_known_width, item_available_width) = match resolve_sizing_keyword(
                     item.width_style,
                     Some(available_width),
                     Some(container_inner_width),
-                )
-                .unwrap_or(AvailableSpace::Definite(available_width));
+                ) {
+                    Some(SizingKeywordResolution::Measure(available)) => (None, available),
+                    Some(SizingKeywordResolution::Exact(width)) => (Some(width), AvailableSpace::Definite(width)),
+                    None => (None, AvailableSpace::Definite(available_width)),
+                };
                 let item_layout = tree.perform_child_layout(
                     item.node_id,
-                    Size::NONE,
+                    Size { width: item_known_width, height: None },
                     parent_size,
                     Size { width: item_available_width, height: AvailableSpace::MaxContent },
                     SizingMode::InherentSize,
@@ -1184,25 +1168,24 @@ fn perform_final_layout_on_in_flow_children(
             let known_dimensions = if item.is_table || item.is_replaced {
                 Size::NONE
             } else {
-                // Items with an intrinsic sizing keyword width (min-content, max-content,
-                // fit-content, fit-content(...)) resolve their width by measuring the item
-                // under the corresponding available space constraint
-                let keyword_width = intrinsic_sizing_keyword_available_width(
-                    item.width_style,
-                    Some(stretch_width),
-                    Some(container_inner_width),
-                )
-                .map(|item_available_width| {
-                    tree.measure_child_size(
-                        item.node_id,
-                        Size::NONE,
-                        parent_size,
-                        Size { width: item_available_width, height: AvailableSpace::MaxContent },
-                        SizingMode::InherentSize,
-                        crate::AbsoluteAxis::Horizontal,
-                        Line::TRUE,
-                    )
-                });
+                // Items with a sizing keyword width (min-content, max-content, fit-content,
+                // fit-content(...), stretch) resolve their width either directly or by measuring
+                // the item under the corresponding available space constraint
+                let keyword_width =
+                    resolve_sizing_keyword(item.width_style, Some(stretch_width), Some(container_inner_width)).map(
+                        |resolution| match resolution {
+                            SizingKeywordResolution::Exact(width) => width,
+                            SizingKeywordResolution::Measure(item_available_width) => tree.measure_child_size(
+                                item.node_id,
+                                Size::NONE,
+                                parent_size,
+                                Size { width: item_available_width, height: AvailableSpace::MaxContent },
+                                SizingMode::InherentSize,
+                                crate::AbsoluteAxis::Horizontal,
+                                Line::TRUE,
+                            ),
+                        },
+                    );
 
                 item.size
                     .map_width(|width| {

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -265,7 +265,9 @@ impl BlockContext<'_> {
 use super::common::alignment::{apply_alignment_fallback, compute_alignment_offset};
 #[cfg(feature = "content_size")]
 use super::common::content_size::compute_content_size_contribution;
-use super::common::sizing_keyword::{resolve_sizing_keyword, SizingKeywordResolution};
+use super::common::sizing_keyword::{
+    resolve_absolute_sizing_keywords, resolve_sizing_keyword, SizingKeywordResolution,
+};
 
 /// Per-child data that is accumulated and modified over the course of the layout algorithm
 struct BlockItem {
@@ -1600,8 +1602,8 @@ fn perform_absolute_layout_on_absolute_children(
         let bottom = child_style.inset().bottom.maybe_resolve(area_height, |val, basis| tree.calc(val, basis));
 
         // Compute known dimensions from min/max/inherent size styles
-        let style_size = child_style
-            .size()
+        let size_style = child_style.size();
+        let style_size = size_style
             .maybe_resolve(area_size, |val, basis| tree.calc(val, basis))
             .maybe_apply_aspect_ratio(aspect_ratio)
             .maybe_add(box_sizing_adjustment);
@@ -1620,6 +1622,23 @@ fn perform_absolute_layout_on_absolute_children(
         let mut known_dimensions = style_size.maybe_clamp(min_size, max_size);
 
         drop(child_style);
+
+        // Resolve any sizing keywords (min-content, max-content, fit-content, fit-content(...),
+        // stretch) in the size styles. An explicitly sized axis takes precedence over the
+        // inset-derived size below.
+        if size_style.width.is_sizing_keyword() || size_style.height.is_sizing_keyword() {
+            resolve_absolute_sizing_keywords(
+                tree,
+                item.node_id,
+                &mut known_dimensions,
+                size_style,
+                area_size,
+                Rect { left, right, top, bottom },
+                margin,
+                SizingMode::ContentSize,
+            );
+            known_dimensions = known_dimensions.maybe_apply_aspect_ratio(aspect_ratio).maybe_clamp(min_size, max_size);
+        }
 
         // Fill in width from left/right and reapply aspect ratio if:
         //   - Width is not already known

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -298,6 +298,11 @@ struct BlockItem {
     /// keywords (`min-content`, `max-content`, `fit-content`, `fit-content(...)`, and `stretch`)
     width_style: Dimension,
 
+    /// The height style of this item. Used to detect and resolve the `stretch` sizing keyword
+    /// (in the block axis the intrinsic sizing keywords are all equal to the content size,
+    /// which is what an auto height already resolves to)
+    height_style: Dimension,
+
     /// The base size of this item
     size: Size<Option<f32>>,
     /// The minimum allowable size of this item
@@ -808,6 +813,7 @@ fn generate_item_list(
                 #[cfg(feature = "float_layout")]
                 clear: child_style.clear(),
                 width_style: child_style.size().width,
+                height_style: child_style.size().height,
                 size: child_style
                     .size()
                     .maybe_resolve(node_inner_size, |val, basis| tree.calc(val, basis))
@@ -840,6 +846,26 @@ fn generate_item_list(
             }
         })
         .collect()
+}
+
+/// Resolve the `stretch` sizing keyword for an item's height style. In the block axis the
+/// intrinsic sizing keywords (`min-content`, `max-content`, `fit-content`, `fit-content(...)`)
+/// are all equal to the content size, which is what an auto height already resolves to, so
+/// only `stretch` requires explicit resolution.
+#[inline]
+fn resolve_stretch_height(
+    height_style: Dimension,
+    container_inner_height: Option<f32>,
+    item_y_margin_sum: f32,
+) -> Option<f32> {
+    match resolve_sizing_keyword(
+        height_style,
+        container_inner_height.maybe_sub(item_y_margin_sum),
+        container_inner_height,
+    ) {
+        Some(SizingKeywordResolution::Exact(height)) => Some(height),
+        _ => None,
+    }
 }
 
 /// Compute the content-based width in the case that the width of the container is not known
@@ -998,9 +1024,14 @@ fn perform_final_layout_on_in_flow_children(
                     Some(SizingKeywordResolution::Exact(width)) => (Some(width), AvailableSpace::Definite(width)),
                     None => (None, AvailableSpace::Definite(available_width)),
                 };
+                let item_known_height = resolve_stretch_height(
+                    item.height_style,
+                    container_percentage_resolution_height,
+                    item_non_auto_margin.vertical_axis_sum(),
+                );
                 let item_layout = tree.perform_child_layout(
                     item.node_id,
-                    Size { width: item_known_width, height: None },
+                    Size { width: item_known_width, height: item_known_height },
                     parent_size,
                     Size { width: item_available_width, height: AvailableSpace::MaxContent },
                     SizingMode::InherentSize,
@@ -1187,6 +1218,12 @@ fn perform_final_layout_on_in_flow_children(
                         },
                     );
 
+                let keyword_height = resolve_stretch_height(
+                    item.height_style,
+                    container_percentage_resolution_height,
+                    item_non_auto_margin.vertical_axis_sum(),
+                );
+
                 item.size
                     .map_width(|width| {
                         Some(
@@ -1196,6 +1233,7 @@ fn perform_final_layout_on_in_flow_children(
                                 .maybe_clamp(item.min_size.width, item.max_size.width),
                         )
                     })
+                    .map_height(|height| height.or(keyword_height))
                     .maybe_clamp(item.min_size, item.max_size)
             };
 

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -294,14 +294,12 @@ struct BlockItem {
     /// The `clear` style of the node
     clear: Clear,
 
-    /// The width style of this item. Used to detect and resolve sizing
-    /// keywords (`min-content`, `max-content`, `fit-content`, `fit-content(...)`, and `stretch`)
-    width_style: Dimension,
-
-    /// The height style of this item. Used to detect and resolve the `stretch` sizing keyword
-    /// (in the block axis the intrinsic sizing keywords are all equal to the content size,
-    /// which is what an auto height already resolves to)
-    height_style: Dimension,
+    /// The size style of this item. Used to detect and resolve sizing keywords
+    /// (`min-content`, `max-content`, `fit-content`, `fit-content(...)`, and `stretch`).
+    /// In the height (block) axis only `stretch` requires resolution: the intrinsic sizing
+    /// keywords are all equal to the content size, which is what an auto height already
+    /// resolves to.
+    size_style: Size<Dimension>,
 
     /// The base size of this item
     size: Size<Option<f32>>,
@@ -812,8 +810,7 @@ fn generate_item_list(
                 float,
                 #[cfg(feature = "float_layout")]
                 clear: child_style.clear(),
-                width_style: child_style.size().width,
-                height_style: child_style.size().height,
+                size_style: child_style.size(),
                 size: child_style
                     .size()
                     .maybe_resolve(node_inner_size, |val, basis| tree.calc(val, basis))
@@ -888,7 +885,7 @@ fn determine_content_based_container_width(
             .resolve_or_zero(available_space.width.into_option(), |val, basis| tree.calc(val, basis))
             .horizontal_axis_sum();
         let width = known_dimensions.width.unwrap_or_else(|| {
-            let item_available_width = match resolve_sizing_keyword(item.width_style, None, None) {
+            let item_available_width = match resolve_sizing_keyword(item.size_style.width, None, None) {
                 Some(SizingKeywordResolution::Measure(available_width)) => available_width,
                 Some(SizingKeywordResolution::Exact(width)) => AvailableSpace::Definite(width),
                 None => available_space.width.maybe_sub(item_x_margin_sum),
@@ -1016,7 +1013,7 @@ fn perform_final_layout_on_in_flow_children(
                 // space clamped between its min-content and max-content sizes.
                 let available_width = container_inner_width - item_non_auto_x_margin_sum;
                 let (item_known_width, item_available_width) = match resolve_sizing_keyword(
-                    item.width_style,
+                    item.size_style.width,
                     Some(available_width),
                     Some(container_inner_width),
                 ) {
@@ -1025,7 +1022,7 @@ fn perform_final_layout_on_in_flow_children(
                     None => (None, AvailableSpace::Definite(available_width)),
                 };
                 let item_known_height = resolve_stretch_height(
-                    item.height_style,
+                    item.size_style.height,
                     container_percentage_resolution_height,
                     item_non_auto_margin.vertical_axis_sum(),
                 );
@@ -1203,8 +1200,8 @@ fn perform_final_layout_on_in_flow_children(
                 // fit-content(...), stretch) resolve their width either directly or by measuring
                 // the item under the corresponding available space constraint
                 let keyword_width =
-                    resolve_sizing_keyword(item.width_style, Some(stretch_width), Some(container_inner_width)).map(
-                        |resolution| match resolution {
+                    resolve_sizing_keyword(item.size_style.width, Some(stretch_width), Some(container_inner_width))
+                        .map(|resolution| match resolution {
                             SizingKeywordResolution::Exact(width) => width,
                             SizingKeywordResolution::Measure(item_available_width) => tree.measure_child_size(
                                 item.node_id,
@@ -1215,11 +1212,10 @@ fn perform_final_layout_on_in_flow_children(
                                 crate::AbsoluteAxis::Horizontal,
                                 Line::TRUE,
                             ),
-                        },
-                    );
+                        });
 
                 let keyword_height = resolve_stretch_height(
-                    item.height_style,
+                    item.size_style.height,
                     container_percentage_resolution_height,
                     item_non_auto_margin.vertical_axis_sum(),
                 );

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -10,8 +10,8 @@ use crate::util::sys::Vec;
 use crate::util::MaybeMath;
 use crate::util::{MaybeResolve, ResolveOrZero};
 use crate::{
-    BlockContainerStyle, BlockItemStyle, BoxGenerationMode, BoxSizing, Direction, LayoutBlockContainer, RequestedAxis,
-    TextAlign,
+    BlockContainerStyle, BlockItemStyle, BoxGenerationMode, BoxSizing, CompactLength, Direction, LayoutBlockContainer,
+    RequestedAxis, TextAlign,
 };
 
 #[cfg(feature = "float_layout")]
@@ -292,6 +292,10 @@ struct BlockItem {
     #[cfg(feature = "float_layout")]
     /// The `clear` style of the node
     clear: Clear,
+
+    /// The raw width style of this item. Used to detect and resolve intrinsic sizing
+    /// keywords (`min-content`, `max-content`, `fit-content`, and `fit-content(...)`)
+    width_style: CompactLength,
 
     /// The base size of this item
     size: Size<Option<f32>>,
@@ -802,6 +806,7 @@ fn generate_item_list(
                 float,
                 #[cfg(feature = "float_layout")]
                 clear: child_style.clear(),
+                width_style: child_style.size().width.into_raw(),
                 size: child_style
                     .size()
                     .maybe_resolve(node_inner_size, |val, basis| tree.calc(val, basis))
@@ -856,11 +861,13 @@ fn determine_content_based_container_width(
             .resolve_or_zero(available_space.width.into_option(), |val, basis| tree.calc(val, basis))
             .horizontal_axis_sum();
         let width = known_dimensions.width.unwrap_or_else(|| {
+            let item_available_width = intrinsic_sizing_keyword_available_width(item.width_style, None, None)
+                .unwrap_or_else(|| available_space.width.maybe_sub(item_x_margin_sum));
             tree.measure_child_size(
                 item.node_id,
                 known_dimensions,
                 Size::NONE,
-                available_space.map_width(|w| w.maybe_sub(item_x_margin_sum)),
+                Size { width: item_available_width, height: available_space.height },
                 SizingMode::InherentSize,
                 crate::AbsoluteAxis::Horizontal,
                 Line::TRUE,
@@ -884,6 +891,29 @@ fn determine_content_based_container_width(
     }
 
     max_child_width
+}
+
+/// Compute the available width against which to measure an item whose width style is an
+/// intrinsic sizing keyword (`min-content`, `max-content`, `fit-content`, or `fit-content(...)`).
+///
+/// Returns `None` if the width style is not an intrinsic sizing keyword, or if it cannot
+/// be resolved in the current context (in which case it behaves as `auto`).
+#[inline]
+fn intrinsic_sizing_keyword_available_width(
+    width_style: CompactLength,
+    stretch_width: Option<f32>,
+    percent_resolution_basis: Option<f32>,
+) -> Option<AvailableSpace> {
+    match width_style.tag() {
+        CompactLength::MIN_CONTENT_TAG => Some(AvailableSpace::MinContent),
+        CompactLength::MAX_CONTENT_TAG => Some(AvailableSpace::MaxContent),
+        CompactLength::FIT_CONTENT_PX_TAG => Some(AvailableSpace::Definite(width_style.value())),
+        CompactLength::FIT_CONTENT_PERCENT_TAG => {
+            percent_resolution_basis.map(|basis| AvailableSpace::Definite(basis * width_style.value()))
+        }
+        CompactLength::FIT_CONTENT_KEYWORD_TAG => stretch_width.map(AvailableSpace::Definite),
+        _ => None,
+    }
 }
 
 /// Compute each child's final size and position
@@ -978,11 +1008,17 @@ fn perform_final_layout_on_in_flow_children(
                 // A float with `width: auto` is shrink-to-fit (fit-content) sized: the available
                 // space clamped between its min-content and max-content sizes.
                 let available_width = container_inner_width - item_non_auto_x_margin_sum;
+                let item_available_width = intrinsic_sizing_keyword_available_width(
+                    item.width_style,
+                    Some(available_width),
+                    Some(container_inner_width),
+                )
+                .unwrap_or(AvailableSpace::Definite(available_width));
                 let item_layout = tree.perform_child_layout(
                     item.node_id,
                     Size::NONE,
                     parent_size,
-                    Size { width: AvailableSpace::Definite(available_width), height: AvailableSpace::MaxContent },
+                    Size { width: item_available_width, height: AvailableSpace::MaxContent },
                     SizingMode::InherentSize,
                     // A float establishes a new block formatting context: its margins do not
                     // collapse with the margins of its children
@@ -1148,9 +1184,34 @@ fn perform_final_layout_on_in_flow_children(
             let known_dimensions = if item.is_table || item.is_replaced {
                 Size::NONE
             } else {
+                // Items with an intrinsic sizing keyword width (min-content, max-content,
+                // fit-content, fit-content(...)) resolve their width by measuring the item
+                // under the corresponding available space constraint
+                let keyword_width = intrinsic_sizing_keyword_available_width(
+                    item.width_style,
+                    Some(stretch_width),
+                    Some(container_inner_width),
+                )
+                .map(|item_available_width| {
+                    tree.measure_child_size(
+                        item.node_id,
+                        Size::NONE,
+                        parent_size,
+                        Size { width: item_available_width, height: AvailableSpace::MaxContent },
+                        SizingMode::InherentSize,
+                        crate::AbsoluteAxis::Horizontal,
+                        Line::TRUE,
+                    )
+                });
+
                 item.size
                     .map_width(|width| {
-                        Some(width.unwrap_or(stretch_width).maybe_clamp(item.min_size.width, item.max_size.width))
+                        Some(
+                            width
+                                .or(keyword_width)
+                                .unwrap_or(stretch_width)
+                                .maybe_clamp(item.min_size.width, item.max_size.width),
+                        )
                     })
                     .maybe_clamp(item.min_size, item.max_size)
             };

--- a/src/compute/common/mod.rs
+++ b/src/compute/common/mod.rs
@@ -1,5 +1,6 @@
 //! Generic code that is shared between multiple layout algorithms
 pub(crate) mod alignment;
+pub(crate) mod sizing_keyword;
 
 #[cfg(feature = "content_size")]
 pub(crate) mod content_size;

--- a/src/compute/common/sizing_keyword.rs
+++ b/src/compute/common/sizing_keyword.rs
@@ -1,0 +1,44 @@
+//! Shared resolution logic for sizing keywords (`min-content`, `max-content`, `fit-content`,
+//! `fit-content(...)`, and `stretch`) on the `width`/`height` style properties
+use crate::style::AvailableSpace;
+use crate::{CompactLength, Dimension};
+
+/// How a sizing keyword resolves to a used size
+pub(crate) enum SizingKeywordResolution {
+    /// The size is the result of measuring the item under the given available space constraint
+    Measure(AvailableSpace),
+    /// The size resolves to an exact value without measuring the item
+    Exact(f32),
+}
+
+/// Resolve an item's size style in one axis if it is a sizing keyword (`min-content`,
+/// `max-content`, `fit-content`, `fit-content(...)`, or `stretch`).
+///
+/// - `stretch_size` is the size the item would take if stretched to fill the available space
+///   (available space minus margins). Used by `fit-content` and `stretch`.
+/// - `percent_resolution_basis` is the size that percentages resolve against in this axis.
+///   Used by `fit-content(<percentage>)`.
+///
+/// Returns `None` if the size style is not a sizing keyword, or if it cannot
+/// be resolved in the current context (in which case it behaves as `auto`).
+#[inline]
+pub(crate) fn resolve_sizing_keyword(
+    style: Dimension,
+    stretch_size: Option<f32>,
+    percent_resolution_basis: Option<f32>,
+) -> Option<SizingKeywordResolution> {
+    match style.tag() {
+        CompactLength::MIN_CONTENT_TAG => Some(SizingKeywordResolution::Measure(AvailableSpace::MinContent)),
+        CompactLength::MAX_CONTENT_TAG => Some(SizingKeywordResolution::Measure(AvailableSpace::MaxContent)),
+        CompactLength::FIT_CONTENT_PX_TAG => {
+            Some(SizingKeywordResolution::Measure(AvailableSpace::Definite(style.value())))
+        }
+        CompactLength::FIT_CONTENT_PERCENT_TAG => percent_resolution_basis
+            .map(|basis| SizingKeywordResolution::Measure(AvailableSpace::Definite(basis * style.value()))),
+        CompactLength::FIT_CONTENT_KEYWORD_TAG => {
+            stretch_size.map(|size| SizingKeywordResolution::Measure(AvailableSpace::Definite(size)))
+        }
+        CompactLength::STRETCH_TAG => stretch_size.map(SizingKeywordResolution::Exact),
+        _ => None,
+    }
+}

--- a/src/compute/common/sizing_keyword.rs
+++ b/src/compute/common/sizing_keyword.rs
@@ -1,6 +1,9 @@
 //! Shared resolution logic for sizing keywords (`min-content`, `max-content`, `fit-content`,
 //! `fit-content(...)`, and `stretch`) on the `width`/`height` style properties
+use crate::geometry::{AbsoluteAxis, Line, Rect, Size};
 use crate::style::AvailableSpace;
+use crate::tree::{LayoutPartialTree, LayoutPartialTreeExt, NodeId, SizingMode};
+use crate::util::sys::f32_max;
 use crate::{CompactLength, Dimension};
 
 /// How a sizing keyword resolves to a used size
@@ -40,5 +43,109 @@ pub(crate) fn resolve_sizing_keyword(
         }
         CompactLength::STRETCH_TAG => stretch_size.map(SizingKeywordResolution::Exact),
         _ => None,
+    }
+}
+
+/// Resolve the sizing keywords (`min-content`, `max-content`, `fit-content`, `fit-content(...)`,
+/// and `stretch`) on the size styles of an absolutely positioned item, filling in the
+/// corresponding `known_dimensions` axes.
+///
+/// - `area_size` is the size of the item's containing block (which insets and percentages
+///   resolve against).
+/// - The stretch size in each axis is the containing block minus the item's insets and margins
+///   in that axis.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn resolve_absolute_sizing_keywords(
+    tree: &mut impl LayoutPartialTree,
+    node: NodeId,
+    known_dimensions: &mut Size<Option<f32>>,
+    size_style: Size<Dimension>,
+    area_size: Size<f32>,
+    inset: Rect<Option<f32>>,
+    margin: Rect<Option<f32>>,
+    sizing_mode: SizingMode,
+) {
+    let stretch_size = Size {
+        width: f32_max(
+            area_size.width
+                - inset.left.unwrap_or(0.0)
+                - inset.right.unwrap_or(0.0)
+                - margin.left.unwrap_or(0.0)
+                - margin.right.unwrap_or(0.0),
+            0.0,
+        ),
+        height: f32_max(
+            area_size.height
+                - inset.top.unwrap_or(0.0)
+                - inset.bottom.unwrap_or(0.0)
+                - margin.top.unwrap_or(0.0)
+                - margin.bottom.unwrap_or(0.0),
+            0.0,
+        ),
+    };
+
+    let keyword_width = if known_dimensions.width.is_none() {
+        resolve_sizing_keyword(size_style.width, Some(stretch_size.width), Some(area_size.width))
+    } else {
+        None
+    };
+    let keyword_height = if known_dimensions.height.is_none() {
+        resolve_sizing_keyword(size_style.height, Some(stretch_size.height), Some(area_size.height))
+    } else {
+        None
+    };
+
+    match (keyword_width, keyword_height) {
+        // If both axes need to be measured then resolve them with a single measure call
+        (
+            Some(SizingKeywordResolution::Measure(available_width)),
+            Some(SizingKeywordResolution::Measure(available_height)),
+        ) => {
+            let measured_size = tree.measure_child_size_both(
+                node,
+                Size::NONE,
+                area_size.map(Some),
+                Size { width: available_width, height: available_height },
+                sizing_mode,
+                Line::FALSE,
+            );
+            *known_dimensions = measured_size.map(Some);
+        }
+        (keyword_width, keyword_height) => {
+            if let Some(resolution) = keyword_width {
+                known_dimensions.width = Some(match resolution {
+                    SizingKeywordResolution::Exact(width) => width,
+                    SizingKeywordResolution::Measure(available_width) => tree.measure_child_size(
+                        node,
+                        *known_dimensions,
+                        area_size.map(Some),
+                        Size { width: available_width, height: AvailableSpace::Definite(stretch_size.height) },
+                        sizing_mode,
+                        AbsoluteAxis::Horizontal,
+                        Line::FALSE,
+                    ),
+                });
+            }
+            if let Some(resolution) = keyword_height {
+                known_dimensions.height = Some(match resolution {
+                    SizingKeywordResolution::Exact(height) => height,
+                    SizingKeywordResolution::Measure(available_height) => tree.measure_child_size(
+                        node,
+                        *known_dimensions,
+                        area_size.map(Some),
+                        Size {
+                            width: known_dimensions
+                                .width
+                                .map(AvailableSpace::Definite)
+                                .unwrap_or(AvailableSpace::Definite(stretch_size.width)),
+                            height: available_height,
+                        },
+                        sizing_mode,
+                        AbsoluteAxis::Vertical,
+                        Line::FALSE,
+                    ),
+                });
+            }
+        }
     }
 }

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -1529,21 +1529,18 @@ fn determine_hypothetical_cross_size(
             .maybe_max(padding_border_sum);
 
         // A cross size that is a sizing keyword (min-content, max-content, fit-content,
-        // fit-content(...), stretch) either resolves to an exact size or determines the
-        // available space constraint the item is measured under
+        // fit-content(...)) determines the available space constraint the item is measured under.
+        // The `stretch` keyword is not resolved here: it stretches to the flex line, which is
+        // handled in `determine_used_cross_size`
         let cross_stretch_size =
             constants.node_inner_size.cross(constants.dir).maybe_sub(child.margin.cross_axis_sum(constants.dir));
-        let (child_cross, child_available_cross) = match resolve_sizing_keyword(
+        let child_available_cross = match resolve_sizing_keyword(
             child.size_style.cross(constants.dir),
             cross_stretch_size,
             constants.node_inner_size.cross(constants.dir),
         ) {
-            Some(SizingKeywordResolution::Exact(size)) => (
-                Some(size.maybe_clamp(transferred_min_cross, transferred_max_cross).max(padding_border_sum)),
-                child_available_cross,
-            ),
-            Some(SizingKeywordResolution::Measure(available)) => (child_cross, available),
-            None => (child_cross, child_available_cross),
+            Some(SizingKeywordResolution::Measure(available)) => available,
+            _ => child_available_cross,
         };
 
         let child_inner_cross = child_cross.unwrap_or_else(|| {
@@ -1780,12 +1777,16 @@ fn determine_used_cross_size(
 
         for child in line.items.iter_mut() {
             let child_style = tree.get_flexbox_child_style(child.node);
+            // A cross size of `stretch` stretches to the flex line like align-self: stretch
+            // (but regardless of the alignment style)
+            let cross_is_stretch = child.size_style.cross(constants.dir).is_stretch();
             child.target_size.set_cross(
                 constants.dir,
-                if child.align_self == AlignSelf::STRETCH
-                    && !child.margin_is_auto.cross_start(constants.dir)
+                if !child.margin_is_auto.cross_start(constants.dir)
                     && !child.margin_is_auto.cross_end(constants.dir)
-                    && child_style.size().cross(constants.dir).is_auto()
+                    && (cross_is_stretch
+                        || (child.align_self == AlignSelf::STRETCH
+                            && child_style.size().cross(constants.dir).is_auto()))
                 {
                     // For some reason this particular usage of max_width is an exception to the rule that max_width's transfer
                     // using the aspect_ratio (if set). Both Chrome and Firefox agree on this. And reading the spec, it seems like

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -18,7 +18,9 @@ use crate::{BoxGenerationMode, BoxSizing, Dimension, Direction, RequestedAxis};
 use super::common::alignment::apply_alignment_fallback;
 #[cfg(feature = "content_size")]
 use super::common::content_size::compute_content_size_contribution;
-use super::common::sizing_keyword::{resolve_sizing_keyword, SizingKeywordResolution};
+use super::common::sizing_keyword::{
+    resolve_absolute_sizing_keywords, resolve_sizing_keyword, SizingKeywordResolution,
+};
 
 /// The intermediate results of a flexbox calculation for a single item
 struct FlexItem {
@@ -2427,8 +2429,8 @@ fn perform_absolute_layout_on_absolute_children(
             child_style.inset().bottom.maybe_resolve(inset_relative_size.height, |val, basis| tree.calc(val, basis));
 
         // Compute known dimensions from min/max/inherent size styles
-        let style_size = child_style
-            .size()
+        let size_style = child_style.size();
+        let style_size = size_style
             .maybe_resolve(inset_relative_size, |val, basis| tree.calc(val, basis))
             .maybe_apply_aspect_ratio(aspect_ratio)
             .maybe_add(box_sizing_adjustment);
@@ -2447,6 +2449,23 @@ fn perform_absolute_layout_on_absolute_children(
         let mut known_dimensions = style_size.maybe_clamp(min_size, max_size);
 
         drop(child_style);
+
+        // Resolve any sizing keywords (min-content, max-content, fit-content, fit-content(...),
+        // stretch) in the size styles. An explicitly sized axis takes precedence over the
+        // inset-derived size below.
+        if size_style.width.is_sizing_keyword() || size_style.height.is_sizing_keyword() {
+            resolve_absolute_sizing_keywords(
+                tree,
+                child,
+                &mut known_dimensions,
+                size_style,
+                inset_relative_size,
+                Rect { left, right, top, bottom },
+                margin,
+                SizingMode::InherentSize,
+            );
+            known_dimensions = known_dimensions.maybe_apply_aspect_ratio(aspect_ratio).maybe_clamp(min_size, max_size);
+        }
 
         // Fill in width from left/right and reapply aspect ratio if:
         //   - Width is not already known

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -13,11 +13,12 @@ use crate::util::debug::debug_log;
 use crate::util::sys::{f32_max, new_vec_with_capacity, Vec};
 use crate::util::MaybeMath;
 use crate::util::{MaybeResolve, ResolveOrZero};
-use crate::{BoxGenerationMode, BoxSizing, Direction, RequestedAxis};
+use crate::{BoxGenerationMode, BoxSizing, Dimension, Direction, RequestedAxis};
 
 use super::common::alignment::apply_alignment_fallback;
 #[cfg(feature = "content_size")]
 use super::common::content_size::compute_content_size_contribution;
+use super::common::sizing_keyword::{resolve_sizing_keyword, SizingKeywordResolution};
 
 /// The intermediate results of a flexbox calculation for a single item
 struct FlexItem {
@@ -29,6 +30,9 @@ struct FlexItem {
 
     /// The base size of this item
     size: Size<Option<f32>>,
+    /// The raw size style of this item. Used to detect and resolve sizing
+    /// keywords (`min-content`, `max-content`, `fit-content`, `fit-content(...)`, and `stretch`)
+    size_style: Size<Dimension>,
     /// The minimum allowable size of this item
     min_size: Size<Option<f32>>,
     /// The maximum allowable size of this item
@@ -588,6 +592,7 @@ fn generate_anonymous_flex_items(
                     .maybe_resolve(percent_resolution_size, |val, basis| tree.calc(val, basis))
                     .maybe_apply_aspect_ratio(aspect_ratio)
                     .maybe_add(box_sizing_adjustment),
+                size_style: child_style.size(),
                 min_size: child_style
                     .min_size()
                     .maybe_resolve(percent_resolution_size, |val, basis| tree.calc(val, basis))
@@ -845,15 +850,34 @@ fn determine_flex_base_size(
             //    is auto and not definite, in this calculation use fit-content as the
             //    flex item’s cross size. The flex base size is the item’s resulting main size.
 
+            // A main size that is a sizing keyword (min-content, max-content, fit-content,
+            // fit-content(...), stretch) either resolves to an exact size or determines the
+            // available space constraint the item is measured under
+            let main_stretch_size = percent_resolution_main_size.maybe_sub(child.margin.main_axis_sum(dir));
+            let keyword_main_available_space = match resolve_sizing_keyword(
+                child.size_style.main(dir),
+                main_stretch_size,
+                percent_resolution_main_size,
+            ) {
+                Some(SizingKeywordResolution::Exact(size)) => {
+                    child.flex_basis_is_definite = true;
+                    break 'flex_basis size;
+                }
+                Some(SizingKeywordResolution::Measure(available)) => Some(available),
+                None => None,
+            };
+
             let child_available_space = Size::MAX_CONTENT
                 .with_main(
                     dir,
-                    // Map AvailableSpace::Definite to AvailableSpace::MaxContent
-                    if available_space.main(dir) == AvailableSpace::MinContent {
-                        AvailableSpace::MinContent
-                    } else {
-                        AvailableSpace::MaxContent
-                    },
+                    keyword_main_available_space.unwrap_or(
+                        // Map AvailableSpace::Definite to AvailableSpace::MaxContent
+                        if available_space.main(dir) == AvailableSpace::MinContent {
+                            AvailableSpace::MinContent
+                        } else {
+                            AvailableSpace::MaxContent
+                        },
+                    ),
                 )
                 .with_cross(dir, cross_axis_available_space);
 
@@ -1503,6 +1527,24 @@ fn determine_hypothetical_cross_size(
             .cross(constants.dir)
             .maybe_clamp(transferred_min_cross, transferred_max_cross)
             .maybe_max(padding_border_sum);
+
+        // A cross size that is a sizing keyword (min-content, max-content, fit-content,
+        // fit-content(...), stretch) either resolves to an exact size or determines the
+        // available space constraint the item is measured under
+        let cross_stretch_size =
+            constants.node_inner_size.cross(constants.dir).maybe_sub(child.margin.cross_axis_sum(constants.dir));
+        let (child_cross, child_available_cross) = match resolve_sizing_keyword(
+            child.size_style.cross(constants.dir),
+            cross_stretch_size,
+            constants.node_inner_size.cross(constants.dir),
+        ) {
+            Some(SizingKeywordResolution::Exact(size)) => (
+                Some(size.maybe_clamp(transferred_min_cross, transferred_max_cross).max(padding_border_sum)),
+                child_available_cross,
+            ),
+            Some(SizingKeywordResolution::Measure(available)) => (child_cross, available),
+            None => (child_cross, child_available_cross),
+        };
 
         let child_inner_cross = child_cross.unwrap_or_else(|| {
             tree.compute_child_layout(

--- a/src/compute/grid/alignment.rs
+++ b/src/compute/grid/alignment.rs
@@ -183,6 +183,42 @@ pub(super) fn align_and_position_item(
         height: grid_area_size.height.maybe_sub(margin.top).maybe_sub(margin.bottom) - baseline_shim,
     };
 
+    // A size that is a sizing keyword (min-content, max-content, fit-content,
+    // fit-content(...), stretch) either resolves to an exact size or is resolved
+    // by measuring the item under the corresponding available space constraint
+    let keyword_width = inherent_size.width.is_none().then(|| {
+        resolve_sizing_keyword(
+            size_style.width,
+            Some(grid_area_minus_item_margins_size.width),
+            Some(grid_area_size.width),
+        )
+    });
+    let keyword_height = inherent_size.height.is_none().then(|| {
+        resolve_sizing_keyword(
+            size_style.height,
+            Some(grid_area_minus_item_margins_size.height),
+            Some(grid_area_size.height),
+        )
+    });
+
+    // If both axes need to be measured then resolve them with a single measure call
+    let keyword_measured_size: Size<Option<f32>> = match (&keyword_width, &keyword_height) {
+        (
+            Some(Some(SizingKeywordResolution::Measure(available_width))),
+            Some(Some(SizingKeywordResolution::Measure(available_height))),
+        ) if position != Position::Absolute => tree
+            .measure_child_size_both(
+                node,
+                Size::NONE,
+                grid_area_size.map(Option::Some),
+                Size { width: *available_width, height: *available_height },
+                SizingMode::InherentSize,
+                Line::FALSE,
+            )
+            .map(Option::Some),
+        _ => Size::NONE,
+    };
+
     // If node is absolutely positioned and width is not set explicitly, then deduce it
     // from left, right and container_content_box if both are set.
     let width = inherent_size.width.or_else(|| {
@@ -194,29 +230,23 @@ pub(super) fn align_and_position_item(
             }
         }
 
-        // A width that is a sizing keyword (min-content, max-content, fit-content,
-        // fit-content(...), stretch) either resolves to an exact width or is resolved
-        // by measuring the item under the corresponding available space constraint
-        let keyword_width = resolve_sizing_keyword(
-            size_style.width,
-            Some(grid_area_minus_item_margins_size.width),
-            Some(grid_area_size.width),
-        );
-        if let Some(resolution) = keyword_width {
+        if let Some(Some(resolution)) = keyword_width {
             return Some(match resolution {
                 SizingKeywordResolution::Exact(width) => width,
-                SizingKeywordResolution::Measure(available_width) => tree.measure_child_size(
-                    node,
-                    Size::NONE,
-                    grid_area_size.map(Option::Some),
-                    Size {
-                        width: available_width,
-                        height: AvailableSpace::Definite(grid_area_minus_item_margins_size.height),
-                    },
-                    SizingMode::InherentSize,
-                    AbsoluteAxis::Horizontal,
-                    Line::FALSE,
-                ),
+                SizingKeywordResolution::Measure(available_width) => keyword_measured_size.width.unwrap_or_else(|| {
+                    tree.measure_child_size(
+                        node,
+                        Size::NONE,
+                        grid_area_size.map(Option::Some),
+                        Size {
+                            width: available_width,
+                            height: AvailableSpace::Definite(grid_area_minus_item_margins_size.height),
+                        },
+                        SizingMode::InherentSize,
+                        AbsoluteAxis::Horizontal,
+                        Line::FALSE,
+                    )
+                }),
             });
         }
 
@@ -245,31 +275,27 @@ pub(super) fn align_and_position_item(
             }
         }
 
-        // A height that is a sizing keyword (min-content, max-content, fit-content,
-        // fit-content(...), stretch) either resolves to an exact height or is resolved
-        // by measuring the item under the corresponding available space constraint
-        let keyword_height = resolve_sizing_keyword(
-            size_style.height,
-            Some(grid_area_minus_item_margins_size.height),
-            Some(grid_area_size.height),
-        );
-        if let Some(resolution) = keyword_height {
+        if let Some(Some(resolution)) = keyword_height {
             return Some(match resolution {
                 SizingKeywordResolution::Exact(height) => height,
-                SizingKeywordResolution::Measure(available_height) => tree.measure_child_size(
-                    node,
-                    Size { width, height: None },
-                    grid_area_size.map(Option::Some),
-                    Size {
-                        width: width
-                            .map(AvailableSpace::Definite)
-                            .unwrap_or(AvailableSpace::Definite(grid_area_minus_item_margins_size.width)),
-                        height: available_height,
-                    },
-                    SizingMode::InherentSize,
-                    AbsoluteAxis::Vertical,
-                    Line::FALSE,
-                ),
+                SizingKeywordResolution::Measure(available_height) => {
+                    keyword_measured_size.height.unwrap_or_else(|| {
+                        tree.measure_child_size(
+                            node,
+                            Size { width, height: None },
+                            grid_area_size.map(Option::Some),
+                            Size {
+                                width: width
+                                    .map(AvailableSpace::Definite)
+                                    .unwrap_or(AvailableSpace::Definite(grid_area_minus_item_margins_size.width)),
+                                height: available_height,
+                            },
+                            SizingMode::InherentSize,
+                            AbsoluteAxis::Vertical,
+                            Line::FALSE,
+                        )
+                    })
+                }
             });
         }
 

--- a/src/compute/grid/alignment.rs
+++ b/src/compute/grid/alignment.rs
@@ -14,7 +14,8 @@ use crate::util::{MaybeMath, MaybeResolve, ResolveOrZero};
 
 #[cfg(feature = "content_size")]
 use crate::compute::common::content_size::compute_content_size_contribution;
-use crate::{BoxSizing, Direction, LayoutGridContainer};
+use crate::compute::common::sizing_keyword::{resolve_sizing_keyword, SizingKeywordResolution};
+use crate::{AbsoluteAxis, BoxSizing, Direction, LayoutGridContainer};
 
 /// Align the grid tracks within the grid according to the align-content (rows) or
 /// justify-content (columns) property. This only does anything if the size of the
@@ -128,8 +129,8 @@ pub(super) fn align_and_position_item(
     let box_sizing_adjustment =
         if style.box_sizing() == BoxSizing::ContentBox { padding_border_size } else { Size::ZERO };
 
-    let inherent_size = style
-        .size()
+    let size_style = style.size();
+    let inherent_size = size_style
         .maybe_resolve(grid_area_size, |val, basis| tree.calc(val, basis))
         .maybe_apply_aspect_ratio(aspect_ratio)
         .maybe_add(box_sizing_adjustment);
@@ -152,14 +153,17 @@ pub(super) fn align_and_position_item(
     // See: https://www.w3.org/TR/css-grid-1/#grid-item-sizing
     let alignment_styles = InBothAbsAxis {
         horizontal: justify_self.or(container_alignment_styles.horizontal).unwrap_or_else(|| {
-            if inherent_size.width.is_some() {
+            if inherent_size.width.is_some() || size_style.width.is_intrinsic_sizing_keyword() {
                 AlignSelf::START
             } else {
                 AlignSelf::STRETCH
             }
         }),
         vertical: align_self.or(container_alignment_styles.vertical).unwrap_or_else(|| {
-            if inherent_size.height.is_some() || aspect_ratio.is_some() {
+            if inherent_size.height.is_some()
+                || size_style.height.is_intrinsic_sizing_keyword()
+                || aspect_ratio.is_some()
+            {
                 AlignSelf::START
             } else {
                 AlignSelf::STRETCH
@@ -171,6 +175,8 @@ pub(super) fn align_and_position_item(
     // resolve against the WIDTH of the grid area.
     let margin =
         style.margin().map(|margin| margin.resolve_to_option(grid_area_size.width, |val, basis| tree.calc(val, basis)));
+
+    drop(style);
 
     let grid_area_minus_item_margins_size = Size {
         width: grid_area_size.width.maybe_sub(margin.left).maybe_sub(margin.right),
@@ -186,6 +192,32 @@ pub(super) fn align_and_position_item(
             if let (Some(left), Some(right)) = (inset_horizontal.start, inset_horizontal.end) {
                 return Some(f32_max(grid_area_minus_item_margins_size.width - left - right, 0.0));
             }
+        }
+
+        // A width that is a sizing keyword (min-content, max-content, fit-content,
+        // fit-content(...), stretch) either resolves to an exact width or is resolved
+        // by measuring the item under the corresponding available space constraint
+        let keyword_width = resolve_sizing_keyword(
+            size_style.width,
+            Some(grid_area_minus_item_margins_size.width),
+            Some(grid_area_size.width),
+        );
+        if let Some(resolution) = keyword_width {
+            return Some(match resolution {
+                SizingKeywordResolution::Exact(width) => width,
+                SizingKeywordResolution::Measure(available_width) => tree.measure_child_size(
+                    node,
+                    Size::NONE,
+                    grid_area_size.map(Option::Some),
+                    Size {
+                        width: available_width,
+                        height: AvailableSpace::Definite(grid_area_minus_item_margins_size.height),
+                    },
+                    SizingMode::InherentSize,
+                    AbsoluteAxis::Horizontal,
+                    Line::FALSE,
+                ),
+            });
         }
 
         // Apply width based on stretch alignment if:
@@ -213,6 +245,34 @@ pub(super) fn align_and_position_item(
             }
         }
 
+        // A height that is a sizing keyword (min-content, max-content, fit-content,
+        // fit-content(...), stretch) either resolves to an exact height or is resolved
+        // by measuring the item under the corresponding available space constraint
+        let keyword_height = resolve_sizing_keyword(
+            size_style.height,
+            Some(grid_area_minus_item_margins_size.height),
+            Some(grid_area_size.height),
+        );
+        if let Some(resolution) = keyword_height {
+            return Some(match resolution {
+                SizingKeywordResolution::Exact(height) => height,
+                SizingKeywordResolution::Measure(available_height) => tree.measure_child_size(
+                    node,
+                    Size { width, height: None },
+                    grid_area_size.map(Option::Some),
+                    Size {
+                        width: width
+                            .map(AvailableSpace::Definite)
+                            .unwrap_or(AvailableSpace::Definite(grid_area_minus_item_margins_size.width)),
+                        height: available_height,
+                    },
+                    SizingMode::InherentSize,
+                    AbsoluteAxis::Vertical,
+                    Line::FALSE,
+                ),
+            });
+        }
+
         // Apply height based on stretch alignment if:
         //  - Alignment style is "stretch"
         //  - The node is not absolutely positioned
@@ -234,8 +294,6 @@ pub(super) fn align_and_position_item(
     let Size { width, height } = Size { width, height }.maybe_clamp(min_size, max_size);
 
     // Layout node
-    drop(style);
-
     let size = if position == Position::Absolute && (width.is_none() || height.is_none()) {
         tree.measure_child_size_both(
             node,

--- a/src/compute/grid/alignment.rs
+++ b/src/compute/grid/alignment.rs
@@ -153,17 +153,14 @@ pub(super) fn align_and_position_item(
     // See: https://www.w3.org/TR/css-grid-1/#grid-item-sizing
     let alignment_styles = InBothAbsAxis {
         horizontal: justify_self.or(container_alignment_styles.horizontal).unwrap_or_else(|| {
-            if inherent_size.width.is_some() || size_style.width.is_intrinsic_sizing_keyword() {
+            if inherent_size.width.is_some() || size_style.width.is_sizing_keyword() {
                 AlignSelf::START
             } else {
                 AlignSelf::STRETCH
             }
         }),
         vertical: align_self.or(container_alignment_styles.vertical).unwrap_or_else(|| {
-            if inherent_size.height.is_some()
-                || size_style.height.is_intrinsic_sizing_keyword()
-                || aspect_ratio.is_some()
-            {
+            if inherent_size.height.is_some() || size_style.height.is_sizing_keyword() || aspect_ratio.is_some() {
                 AlignSelf::START
             } else {
                 AlignSelf::STRETCH

--- a/src/compute/grid/types/grid_item.rs
+++ b/src/compute/grid/types/grid_item.rs
@@ -284,7 +284,7 @@ impl GridItem {
         let width = inherent_size.width.or_else(|| {
             // A width that is a sizing keyword is not auto, so it does not stretch. The stretch
             // keyword resolves to an exact width; the others resolve during content measurement.
-            if self.size.width.is_intrinsic_sizing_keyword() {
+            if self.size.width.is_sizing_keyword() {
                 return match resolve_sizing_keyword(
                     self.size.width,
                     grid_area_minus_item_margins_size.width,
@@ -312,7 +312,7 @@ impl GridItem {
         let height = height.or_else(|| {
             // A height that is a sizing keyword is not auto, so it does not stretch. The stretch
             // keyword resolves to an exact height; the others resolve during content measurement.
-            if self.size.height.is_intrinsic_sizing_keyword() {
+            if self.size.height.is_sizing_keyword() {
                 return match resolve_sizing_keyword(
                     self.size.height,
                     grid_area_minus_item_margins_size.height,
@@ -534,7 +534,7 @@ impl GridItem {
         tree: &impl LayoutPartialTree,
     ) -> Size<AvailableSpace> {
         let size_style = self.size.get(axis);
-        if !size_style.is_intrinsic_sizing_keyword() {
+        if !size_style.is_sizing_keyword() {
             return available_space;
         }
         let margins = self.margins_axis_sums_with_baseline_shims(grid_area_size.width, tree);

--- a/src/compute/grid/types/grid_item.rs
+++ b/src/compute/grid/types/grid_item.rs
@@ -462,7 +462,6 @@ impl GridItem {
             known_dimensions,
             grid_area_size,
             self.keyword_adjusted_available_space(
-                axis,
                 grid_area_size,
                 available_space.map(|opt| match opt {
                     Some(size) => AvailableSpace::Definite(size),
@@ -509,7 +508,6 @@ impl GridItem {
             known_dimensions,
             grid_area_size,
             self.keyword_adjusted_available_space(
-                axis,
                 grid_area_size,
                 available_space.map(|opt| match opt {
                     Some(size) => AvailableSpace::Definite(size),
@@ -523,30 +521,33 @@ impl GridItem {
         )
     }
 
-    /// Override the available space in the axis being measured when the item's size style in that
-    /// axis is a sizing keyword that measures the item under a specific available space constraint
+    /// Override the available space in each axis whose size style is a sizing keyword that
+    /// measures the item under a specific available space constraint
     /// (min-content, max-content, fit-content, fit-content(...))
     fn keyword_adjusted_available_space(
         &self,
-        axis: AbstractAxis,
         grid_area_size: Size<Option<f32>>,
         available_space: Size<AvailableSpace>,
         tree: &impl LayoutPartialTree,
     ) -> Size<AvailableSpace> {
-        let size_style = self.size.get(axis);
-        if !size_style.is_sizing_keyword() {
+        if !self.size.width.is_sizing_keyword() && !self.size.height.is_sizing_keyword() {
             return available_space;
         }
         let margins = self.margins_axis_sums_with_baseline_shims(grid_area_size.width, tree);
-        let stretch_size = grid_area_size.get(axis).maybe_sub(margins.get(axis));
-        match resolve_sizing_keyword(size_style, stretch_size, grid_area_size.get(axis)) {
-            Some(SizingKeywordResolution::Measure(available)) => {
-                let mut adjusted = available_space;
-                adjusted.set(axis, available);
-                adjusted
+        let mut adjusted = available_space;
+        for axis in [AbstractAxis::Inline, AbstractAxis::Block] {
+            let size_style = self.size.get(axis);
+            if !size_style.is_sizing_keyword() {
+                continue;
             }
-            _ => available_space,
+            let stretch_size = grid_area_size.get(axis).maybe_sub(margins.get(axis));
+            if let Some(SizingKeywordResolution::Measure(available)) =
+                resolve_sizing_keyword(size_style, stretch_size, grid_area_size.get(axis))
+            {
+                adjusted.set(axis, available);
+            }
         }
+        adjusted
     }
 
     /// Retrieve the item's max content contribution from the cache or compute it using the provided parameters

--- a/src/compute/grid/types/grid_item.rs
+++ b/src/compute/grid/types/grid_item.rs
@@ -1,5 +1,6 @@
 //! Contains GridItem used to represent a single grid item during layout
 use super::GridTrack;
+use crate::compute::common::sizing_keyword::{resolve_sizing_keyword, SizingKeywordResolution};
 use crate::compute::grid::OriginZeroLine;
 use crate::geometry::AbstractAxis;
 use crate::geometry::{Line, Point, Rect, Size};
@@ -38,9 +39,9 @@ pub(in super::super) struct GridItem {
     /// The item's size style
     pub size: Size<Dimension>,
     /// The item's min_size style
-    pub min_size: Size<Dimension>,
+    pub min_size: Size<LengthPercentageAuto>,
     /// The item's max_size style
-    pub max_size: Size<Dimension>,
+    pub max_size: Size<LengthPercentageAuto>,
     /// The item's aspect_ratio style
     pub aspect_ratio: Option<f32>,
     /// The item's padding style
@@ -281,6 +282,19 @@ impl GridItem {
         // If node is absolutely positioned and width is not set explicitly, then deduce it
         // from left, right and container_content_box if both are set.
         let width = inherent_size.width.or_else(|| {
+            // A width that is a sizing keyword is not auto, so it does not stretch. The stretch
+            // keyword resolves to an exact width; the others resolve during content measurement.
+            if self.size.width.is_intrinsic_sizing_keyword() {
+                return match resolve_sizing_keyword(
+                    self.size.width,
+                    grid_area_minus_item_margins_size.width,
+                    grid_area_size.width,
+                ) {
+                    Some(SizingKeywordResolution::Exact(width)) => Some(width),
+                    _ => None,
+                };
+            }
+
             // Apply width based on stretch alignment if:
             //  - Alignment style is "stretch"
             //  - The node is not absolutely positioned
@@ -296,6 +310,19 @@ impl GridItem {
             Size { width, height: inherent_size.height }.maybe_apply_aspect_ratio(aspect_ratio);
 
         let height = height.or_else(|| {
+            // A height that is a sizing keyword is not auto, so it does not stretch. The stretch
+            // keyword resolves to an exact height; the others resolve during content measurement.
+            if self.size.height.is_intrinsic_sizing_keyword() {
+                return match resolve_sizing_keyword(
+                    self.size.height,
+                    grid_area_minus_item_margins_size.height,
+                    grid_area_size.height,
+                ) {
+                    Some(SizingKeywordResolution::Exact(height)) => Some(height),
+                    _ => None,
+                };
+            }
+
             // Apply height based on stretch alignment if:
             //  - Alignment style is "stretch"
             //  - The node is not absolutely positioned
@@ -434,10 +461,15 @@ impl GridItem {
             self.node,
             known_dimensions,
             grid_area_size,
-            available_space.map(|opt| match opt {
-                Some(size) => AvailableSpace::Definite(size),
-                None => AvailableSpace::MinContent,
-            }),
+            self.keyword_adjusted_available_space(
+                axis,
+                grid_area_size,
+                available_space.map(|opt| match opt {
+                    Some(size) => AvailableSpace::Definite(size),
+                    None => AvailableSpace::MinContent,
+                }),
+                tree,
+            ),
             SizingMode::InherentSize,
             axis.as_abs_naive(),
             Line::FALSE,
@@ -476,14 +508,45 @@ impl GridItem {
             self.node,
             known_dimensions,
             grid_area_size,
-            available_space.map(|opt| match opt {
-                Some(size) => AvailableSpace::Definite(size),
-                None => AvailableSpace::MaxContent,
-            }),
+            self.keyword_adjusted_available_space(
+                axis,
+                grid_area_size,
+                available_space.map(|opt| match opt {
+                    Some(size) => AvailableSpace::Definite(size),
+                    None => AvailableSpace::MaxContent,
+                }),
+                tree,
+            ),
             SizingMode::InherentSize,
             axis.as_abs_naive(),
             Line::FALSE,
         )
+    }
+
+    /// Override the available space in the axis being measured when the item's size style in that
+    /// axis is a sizing keyword that measures the item under a specific available space constraint
+    /// (min-content, max-content, fit-content, fit-content(...))
+    fn keyword_adjusted_available_space(
+        &self,
+        axis: AbstractAxis,
+        grid_area_size: Size<Option<f32>>,
+        available_space: Size<AvailableSpace>,
+        tree: &impl LayoutPartialTree,
+    ) -> Size<AvailableSpace> {
+        let size_style = self.size.get(axis);
+        if !size_style.is_intrinsic_sizing_keyword() {
+            return available_space;
+        }
+        let margins = self.margins_axis_sums_with_baseline_shims(grid_area_size.width, tree);
+        let stretch_size = grid_area_size.get(axis).maybe_sub(margins.get(axis));
+        match resolve_sizing_keyword(size_style, stretch_size, grid_area_size.get(axis)) {
+            Some(SizingKeywordResolution::Measure(available)) => {
+                let mut adjusted = available_space;
+                adjusted.set(axis, available);
+                adjusted
+            }
+            _ => available_space,
+        }
     }
 
     /// Retrieve the item's max content contribution from the cache or compute it using the provided parameters

--- a/src/style/compact_length.rs
+++ b/src/style/compact_length.rs
@@ -404,7 +404,7 @@ impl CompactLength {
 
     /// Returns true if the value is min-content, max-content, fit-content, fit-content(...), or stretch
     #[inline(always)]
-    pub fn is_intrinsic_sizing_keyword(self) -> bool {
+    pub fn is_sizing_keyword(self) -> bool {
         matches!(
             self.tag(),
             Self::MIN_CONTENT_TAG

--- a/src/style/compact_length.rs
+++ b/src/style/compact_length.rs
@@ -229,6 +229,8 @@ impl CompactLength {
     pub const FIT_CONTENT_PX_TAG: usize = 0b00010111;
     /// The tag indicating a fit-content value with percent limit
     pub const FIT_CONTENT_PERCENT_TAG: usize = 0b00011111;
+    /// The tag indicating a plain fit-content keyword value (no limit)
+    pub const FIT_CONTENT_KEYWORD_TAG: usize = 0b00100111;
 }
 
 impl CompactLength {
@@ -316,6 +318,17 @@ impl CompactLength {
         Self(CompactLengthInner::from_val(limit, Self::FIT_CONTENT_PERCENT_TAG))
     }
 
+    /// The size should be computed according to the "fit content" formula:
+    ///    `max(min_content, min(max_content, stretch))`
+    /// where:
+    ///    - `min_content` is the [min-content](Self::min_content) size
+    ///    - `max_content` is the [max-content](Self::max_content) size
+    ///    - `stretch` is the "stretch-fit" size (the size the box would take if it filled the available space)
+    #[inline(always)]
+    pub const fn fit_content_keyword() -> Self {
+        Self(CompactLengthInner::from_tag(Self::FIT_CONTENT_KEYWORD_TAG))
+    }
+
     /// Get the primary tag
     #[inline(always)]
     pub fn tag(self) -> usize {
@@ -377,6 +390,19 @@ impl CompactLength {
     #[inline(always)]
     pub fn is_fit_content(self) -> bool {
         matches!(self.tag(), Self::FIT_CONTENT_PX_TAG | Self::FIT_CONTENT_PERCENT_TAG)
+    }
+
+    /// Returns true if the value is min-content, max-content, fit-content, or fit-content(...)
+    #[inline(always)]
+    pub fn is_intrinsic_sizing_keyword(self) -> bool {
+        matches!(
+            self.tag(),
+            Self::MIN_CONTENT_TAG
+                | Self::MAX_CONTENT_TAG
+                | Self::FIT_CONTENT_KEYWORD_TAG
+                | Self::FIT_CONTENT_PX_TAG
+                | Self::FIT_CONTENT_PERCENT_TAG
+        )
     }
 
     /// Returns true if the value is max-content or a fit-content(...) value
@@ -528,6 +554,7 @@ impl<'de> serde::Deserialize<'de> for CompactLength {
                 | CompactLength::AUTO_TAG
                 | CompactLength::MIN_CONTENT_TAG
                 | CompactLength::MAX_CONTENT_TAG
+                | CompactLength::FIT_CONTENT_KEYWORD_TAG
                 | CompactLength::FIT_CONTENT_PX_TAG
                 | CompactLength::FIT_CONTENT_PERCENT_TAG
                 | CompactLength::FR_TAG

--- a/src/style/compact_length.rs
+++ b/src/style/compact_length.rs
@@ -231,6 +231,8 @@ impl CompactLength {
     pub const FIT_CONTENT_PERCENT_TAG: usize = 0b00011111;
     /// The tag indicating a plain fit-content keyword value (no limit)
     pub const FIT_CONTENT_KEYWORD_TAG: usize = 0b00100111;
+    /// The tag indicating a stretch keyword value
+    pub const STRETCH_TAG: usize = 0b00101111;
 }
 
 impl CompactLength {
@@ -329,6 +331,14 @@ impl CompactLength {
         Self(CompactLengthInner::from_tag(Self::FIT_CONTENT_KEYWORD_TAG))
     }
 
+    /// The size should be the "stretch-fit" size: the size the box would take
+    /// if it filled the available space
+    /// (<https://www.w3.org/TR/css-sizing-4/#stretch-fit-sizing>)
+    #[inline(always)]
+    pub const fn stretch() -> Self {
+        Self(CompactLengthInner::from_tag(Self::STRETCH_TAG))
+    }
+
     /// Get the primary tag
     #[inline(always)]
     pub fn tag(self) -> usize {
@@ -392,7 +402,7 @@ impl CompactLength {
         matches!(self.tag(), Self::FIT_CONTENT_PX_TAG | Self::FIT_CONTENT_PERCENT_TAG)
     }
 
-    /// Returns true if the value is min-content, max-content, fit-content, or fit-content(...)
+    /// Returns true if the value is min-content, max-content, fit-content, fit-content(...), or stretch
     #[inline(always)]
     pub fn is_intrinsic_sizing_keyword(self) -> bool {
         matches!(
@@ -402,6 +412,7 @@ impl CompactLength {
                 | Self::FIT_CONTENT_KEYWORD_TAG
                 | Self::FIT_CONTENT_PX_TAG
                 | Self::FIT_CONTENT_PERCENT_TAG
+                | Self::STRETCH_TAG
         )
     }
 
@@ -557,6 +568,7 @@ impl<'de> serde::Deserialize<'de> for CompactLength {
                 | CompactLength::FIT_CONTENT_KEYWORD_TAG
                 | CompactLength::FIT_CONTENT_PX_TAG
                 | CompactLength::FIT_CONTENT_PERCENT_TAG
+                | CompactLength::STRETCH_TAG
                 | CompactLength::FR_TAG
         ) {
             Ok(value)

--- a/src/style/dimension.rs
+++ b/src/style/dimension.rs
@@ -392,8 +392,8 @@ impl Dimension {
 
     /// Returns true if value is min-content, max-content, fit-content, fit-content(...), or stretch
     #[inline(always)]
-    pub fn is_intrinsic_sizing_keyword(self) -> bool {
-        self.0.is_intrinsic_sizing_keyword()
+    pub fn is_sizing_keyword(self) -> bool {
+        self.0.is_sizing_keyword()
     }
 
     /// Returns true if value is the stretch keyword

--- a/src/style/dimension.rs
+++ b/src/style/dimension.rs
@@ -257,10 +257,25 @@ impl From<LengthPercentageAuto> for Dimension {
 #[cfg(feature = "parse")]
 impl FromCss for Dimension {
     fn from_css<'i>(parser: &mut Parser<'i, '_>) -> CssParseResult<'i, Self> {
-        match parser.next()?.clone() {
+        let token = parser.next()?.clone();
+        match token {
             Token::Percentage { unit_value, .. } => Ok(Self::percent(unit_value)),
             Token::Dimension { unit, value, .. } if unit == "px" => Ok(Self::length(value)),
-            Token::Ident(ident) if ident == "auto" => Ok(Self::auto()),
+            Token::Ident(ref ident) => match ident.as_ref() {
+                "auto" => Ok(Self::auto()),
+                "min-content" => Ok(Self::min_content()),
+                "max-content" => Ok(Self::max_content()),
+                "fit-content" => Ok(Self::fit_content()),
+                _ => Err(parser.new_unexpected_token_error(token))?,
+            },
+            Token::Function(ref name) if name.as_ref() == "fit-content" => parser.parse_nested_block(|parser| {
+                let token = parser.next()?.clone();
+                match token {
+                    Token::Percentage { unit_value, .. } => Ok(Self::fit_content_percent(unit_value)),
+                    Token::Dimension { unit, value, .. } if unit == "px" => Ok(Self::fit_content_px(value)),
+                    token => Err(parser.new_unexpected_token_error(token))?,
+                }
+            }),
             token => Err(parser.new_unexpected_token_error(token))?,
         }
     }
@@ -289,6 +304,44 @@ impl Dimension {
     #[inline(always)]
     pub const fn auto() -> Self {
         Self(CompactLength::auto())
+    }
+
+    /// The size should be the "min-content" size.
+    /// This is the smallest size that can fit the item's contents with ALL soft line-wrapping opportunities taken
+    #[inline(always)]
+    pub const fn min_content() -> Self {
+        Self(CompactLength::min_content())
+    }
+
+    /// The size should be the "max-content" size.
+    /// This is the smallest size that can fit the item's contents with NO soft line-wrapping opportunities taken
+    #[inline(always)]
+    pub const fn max_content() -> Self {
+        Self(CompactLength::max_content())
+    }
+
+    /// The size should be computed according to the "fit content" formula:
+    ///    `max(min_content, min(max_content, stretch))`
+    /// where `stretch` is the size the box would take if it filled the available space
+    #[inline(always)]
+    pub const fn fit_content() -> Self {
+        Self(CompactLength::fit_content_keyword())
+    }
+
+    /// The size should be computed according to the "fit content" formula:
+    ///    `max(min_content, min(max_content, limit))`
+    /// where `limit` is a LENGTH value
+    #[inline(always)]
+    pub const fn fit_content_px(limit: f32) -> Self {
+        Self(CompactLength::fit_content_px(limit))
+    }
+
+    /// The size should be computed according to the "fit content" formula:
+    ///    `max(min_content, min(max_content, limit))`
+    /// where `limit` is a PERCENTAGE value
+    #[inline(always)]
+    pub const fn fit_content_percent(limit: f32) -> Self {
+        Self(CompactLength::fit_content_percent(limit))
     }
 
     /// A `calc()` value. The value passed here is treated as an opaque handle to
@@ -328,6 +381,12 @@ impl Dimension {
         self.0.is_auto()
     }
 
+    /// Returns true if value is min-content, max-content, fit-content, or fit-content(...)
+    #[inline(always)]
+    pub fn is_intrinsic_sizing_keyword(self) -> bool {
+        self.0.is_intrinsic_sizing_keyword()
+    }
+
     /// Get the raw `CompactLength` tag
     pub fn tag(self) -> usize {
         self.0.tag()
@@ -347,7 +406,17 @@ impl<'de> serde::Deserialize<'de> for Dimension {
     {
         let inner = CompactLength::deserialize(deserializer)?;
         // Note: validation intentionally excludes the CALC_TAG as deserializing calc() values is not supported
-        if matches!(inner.tag(), CompactLength::LENGTH_TAG | CompactLength::PERCENT_TAG | CompactLength::AUTO_TAG) {
+        if matches!(
+            inner.tag(),
+            CompactLength::LENGTH_TAG
+                | CompactLength::PERCENT_TAG
+                | CompactLength::AUTO_TAG
+                | CompactLength::MIN_CONTENT_TAG
+                | CompactLength::MAX_CONTENT_TAG
+                | CompactLength::FIT_CONTENT_KEYWORD_TAG
+                | CompactLength::FIT_CONTENT_PX_TAG
+                | CompactLength::FIT_CONTENT_PERCENT_TAG
+        ) {
             Ok(Self(inner))
         } else {
             Err(serde::de::Error::custom("Invalid tag"))

--- a/src/style/dimension.rs
+++ b/src/style/dimension.rs
@@ -266,6 +266,7 @@ impl FromCss for Dimension {
                 "min-content" => Ok(Self::min_content()),
                 "max-content" => Ok(Self::max_content()),
                 "fit-content" => Ok(Self::fit_content()),
+                "stretch" => Ok(Self::stretch()),
                 _ => Err(parser.new_unexpected_token_error(token))?,
             },
             Token::Function(ref name) if name.as_ref() == "fit-content" => parser.parse_nested_block(|parser| {
@@ -336,6 +337,14 @@ impl Dimension {
         Self(CompactLength::fit_content_px(limit))
     }
 
+    /// The size should be the "stretch-fit" size: the size the box would take
+    /// if it filled the available space
+    /// (<https://www.w3.org/TR/css-sizing-4/#stretch-fit-sizing>)
+    #[inline(always)]
+    pub const fn stretch() -> Self {
+        Self(CompactLength::stretch())
+    }
+
     /// The size should be computed according to the "fit content" formula:
     ///    `max(min_content, min(max_content, limit))`
     /// where `limit` is a PERCENTAGE value
@@ -381,7 +390,7 @@ impl Dimension {
         self.0.is_auto()
     }
 
-    /// Returns true if value is min-content, max-content, fit-content, or fit-content(...)
+    /// Returns true if value is min-content, max-content, fit-content, fit-content(...), or stretch
     #[inline(always)]
     pub fn is_intrinsic_sizing_keyword(self) -> bool {
         self.0.is_intrinsic_sizing_keyword()
@@ -416,6 +425,7 @@ impl<'de> serde::Deserialize<'de> for Dimension {
                 | CompactLength::FIT_CONTENT_KEYWORD_TAG
                 | CompactLength::FIT_CONTENT_PX_TAG
                 | CompactLength::FIT_CONTENT_PERCENT_TAG
+                | CompactLength::STRETCH_TAG
         ) {
             Ok(Self(inner))
         } else {

--- a/src/style/dimension.rs
+++ b/src/style/dimension.rs
@@ -396,6 +396,12 @@ impl Dimension {
         self.0.is_intrinsic_sizing_keyword()
     }
 
+    /// Returns true if value is the stretch keyword
+    #[inline(always)]
+    pub fn is_stretch(self) -> bool {
+        self.0.tag() == CompactLength::STRETCH_TAG
+    }
+
     /// Get the raw `CompactLength` tag
     pub fn tag(self) -> usize {
         self.0.tag()

--- a/src/style/grid.rs
+++ b/src/style/grid.rs
@@ -769,7 +769,12 @@ impl From<LengthPercentageAuto> for MaxTrackSizingFunction {
 }
 impl From<Dimension> for MaxTrackSizingFunction {
     fn from(input: Dimension) -> Self {
-        Self(input.0)
+        // Dimension supports values that are not valid max track sizing functions.
+        // Map those to `auto`.
+        match input.0.tag() {
+            CompactLength::FIT_CONTENT_KEYWORD_TAG | CompactLength::STRETCH_TAG => Self::auto(),
+            _ => Self(input.0),
+        }
     }
 }
 impl From<MinTrackSizingFunction> for MaxTrackSizingFunction {
@@ -1089,7 +1094,15 @@ impl From<LengthPercentageAuto> for MinTrackSizingFunction {
 }
 impl From<Dimension> for MinTrackSizingFunction {
     fn from(input: Dimension) -> Self {
-        Self(input.0)
+        // Dimension supports values that are not valid min track sizing functions.
+        // Map those to `auto`.
+        match input.0.tag() {
+            CompactLength::FIT_CONTENT_PX_TAG
+            | CompactLength::FIT_CONTENT_PERCENT_TAG
+            | CompactLength::FIT_CONTENT_KEYWORD_TAG
+            | CompactLength::STRETCH_TAG => Self::auto(),
+            _ => Self(input.0),
+        }
     }
 }
 

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -147,12 +147,12 @@ pub trait CoreStyle {
     }
     /// Controls the minimum size of the item
     #[inline(always)]
-    fn min_size(&self) -> Size<Dimension> {
+    fn min_size(&self) -> Size<LengthPercentageAuto> {
         Style::<Self::CustomIdent>::DEFAULT.min_size
     }
     /// Controls the maximum size of the item
     #[inline(always)]
-    fn max_size(&self) -> Size<Dimension> {
+    fn max_size(&self) -> Size<LengthPercentageAuto> {
         Style::<Self::CustomIdent>::DEFAULT.max_size
     }
     /// Sets the preferred aspect ratio for the item
@@ -484,10 +484,10 @@ pub struct Style<S: CheapCloneStr = DefaultCheapStr> {
     pub size: Size<Dimension>,
     /// Controls the minimum size of the item
     #[cfg_attr(feature = "serde", serde(default = "style_helpers::auto"))]
-    pub min_size: Size<Dimension>,
+    pub min_size: Size<LengthPercentageAuto>,
     /// Controls the maximum size of the item
     #[cfg_attr(feature = "serde", serde(default = "style_helpers::auto"))]
-    pub max_size: Size<Dimension>,
+    pub max_size: Size<LengthPercentageAuto>,
     /// Sets the preferred aspect ratio for the item
     ///
     /// The ratio is calculated as width divided by height.
@@ -726,11 +726,11 @@ impl<S: CheapCloneStr> CoreStyle for Style<S> {
         self.size
     }
     #[inline(always)]
-    fn min_size(&self) -> Size<Dimension> {
+    fn min_size(&self) -> Size<LengthPercentageAuto> {
         self.min_size
     }
     #[inline(always)]
-    fn max_size(&self) -> Size<Dimension> {
+    fn max_size(&self) -> Size<LengthPercentageAuto> {
         self.max_size
     }
     #[inline(always)]
@@ -795,11 +795,11 @@ impl<T: CoreStyle> CoreStyle for &'_ T {
         (*self).size()
     }
     #[inline(always)]
-    fn min_size(&self) -> Size<Dimension> {
+    fn min_size(&self) -> Size<LengthPercentageAuto> {
         (*self).min_size()
     }
     #[inline(always)]
-    fn max_size(&self) -> Size<Dimension> {
+    fn max_size(&self) -> Size<LengthPercentageAuto> {
         (*self).max_size()
     }
     #[inline(always)]

--- a/src/util/resolve.rs
+++ b/src/util/resolve.rs
@@ -65,6 +65,9 @@ impl MaybeResolve<Option<f32>, Option<f32>> for Dimension {
             CompactLength::PERCENT_TAG => context.map(|dim| dim * self.0.value()),
             #[cfg(feature = "calc")]
             _ if self.0.is_calc() => context.map(|dim| calc(self.0.calc_value(), dim)),
+            // Intrinsic sizing keywords cannot be resolved to a definite size out of context.
+            // Layout algorithms that support them must handle them explicitly.
+            _ if self.0.is_intrinsic_sizing_keyword() => None,
             _ => unreachable!(),
         }
     }

--- a/src/util/resolve.rs
+++ b/src/util/resolve.rs
@@ -67,7 +67,7 @@ impl MaybeResolve<Option<f32>, Option<f32>> for Dimension {
             _ if self.0.is_calc() => context.map(|dim| calc(self.0.calc_value(), dim)),
             // Intrinsic sizing keywords cannot be resolved to a definite size out of context.
             // Layout algorithms that support them must handle them explicitly.
-            _ if self.0.is_intrinsic_sizing_keyword() => None,
+            _ if self.0.is_sizing_keyword() => None,
             _ => unreachable!(),
         }
     }

--- a/test_fixtures/block/block_absolute_width_keywords.html
+++ b/test_fixtures/block/block_absolute_width_keywords.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; position: relative; width: 120px; height: 120px;">
+  <div style="position: absolute; top: 0px; width: stretch;">HH&ZeroWidthSpace;HH</div>
+  <div style="position: absolute; top: 30px; width: fit-content;">HH&ZeroWidthSpace;HH</div>
+  <div style="position: absolute; top: 60px; width: min-content;">HH&ZeroWidthSpace;HH</div>
+  <div style="position: absolute; top: 90px; width: max-content;">HH&ZeroWidthSpace;HH</div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/block/block_absolute_width_stretch_inset_margin.html
+++ b/test_fixtures/block/block_absolute_width_stretch_inset_margin.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; position: relative; width: 120px; height: 120px;">
+  <div style="position: absolute; top: 0px; left: 10px; margin-right: 5px; width: stretch;">HH&ZeroWidthSpace;HH</div>
+  <div style="position: absolute; top: 40px; right: 20px; width: stretch;">HH&ZeroWidthSpace;HH</div>
+  <div style="position: absolute; top: 0px; left: 10px; height: stretch; width: 20px;">HH</div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/block/block_height_stretch.html
+++ b/test_fixtures/block/block_height_stretch.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px; height: 80px;">
+  <div style="height: stretch; margin: 5px 0px 10px 0px;">HH&ZeroWidthSpace;HH</div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/block/block_width_keywords.html
+++ b/test_fixtures/block/block_width_keywords.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 120px;">
+  <div style="width: stretch;">HH&ZeroWidthSpace;HH</div>
+  <div style="width: fit-content;">HH&ZeroWidthSpace;HH</div>
+  <div style="width: min-content;">HH&ZeroWidthSpace;HH</div>
+  <div style="width: max-content;">HH&ZeroWidthSpace;HH</div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/flex_absolute_width_keywords.html
+++ b/test_fixtures/flex/flex_absolute_width_keywords.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; position: relative; width: 120px; height: 120px;">
+  <div style="position: absolute; top: 0px; width: stretch;">HH&ZeroWidthSpace;HH</div>
+  <div style="position: absolute; top: 30px; width: fit-content;">HH&ZeroWidthSpace;HH</div>
+  <div style="position: absolute; top: 60px; width: min-content;">HH&ZeroWidthSpace;HH</div>
+  <div style="position: absolute; top: 90px; width: max-content;">HH&ZeroWidthSpace;HH</div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/flex_absolute_width_stretch_inset_margin.html
+++ b/test_fixtures/flex/flex_absolute_width_stretch_inset_margin.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; position: relative; width: 120px; height: 120px;">
+  <div style="position: absolute; top: 0px; left: 10px; margin-right: 5px; width: stretch;">HH&ZeroWidthSpace;HH</div>
+  <div style="position: absolute; top: 40px; right: 20px; width: stretch;">HH&ZeroWidthSpace;HH</div>
+  <div style="position: absolute; top: 0px; left: 10px; height: stretch; width: 20px;">HH</div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/flex_item_height_stretch.html
+++ b/test_fixtures/flex/flex_item_height_stretch.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; width: 120px; height: 60px; align-items: flex-start;">
+  <div style="width: 40px; height: stretch;">HH&ZeroWidthSpace;HH</div>
+  <div style="width: 40px; height: stretch; margin: 5px 0px 10px 0px;">HH&ZeroWidthSpace;HH</div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/flex_item_width_keywords.html
+++ b/test_fixtures/flex/flex_item_width_keywords.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; width: 200px; align-items: flex-start;">
+  <div style="width: min-content;">HH&ZeroWidthSpace;HH</div>
+  <div style="width: max-content;">HH&ZeroWidthSpace;HH</div>
+  <div style="width: fit-content;">HH&ZeroWidthSpace;HH</div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/flex_item_width_stretch.html
+++ b/test_fixtures/flex/flex_item_width_stretch.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; width: 150px;">
+  <div style="width: stretch;">HH&ZeroWidthSpace;HH</div>
+  <div style="width: 30px; flex-shrink: 0;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_item_height_keywords.html
+++ b/test_fixtures/grid/grid_item_height_keywords.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-columns: 40px 40px 40px 40px; grid-template-rows: 60px;">
+  <div style="height: stretch;">HH&ZeroWidthSpace;HH</div>
+  <div style="height: fit-content;">HH&ZeroWidthSpace;HH</div>
+  <div style="height: min-content;">HH&ZeroWidthSpace;HH</div>
+  <div style="height: max-content;">HH&ZeroWidthSpace;HH</div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_item_width_keywords.html
+++ b/test_fixtures/grid/grid_item_width_keywords.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-columns: 120px; grid-auto-rows: 30px;">
+  <div style="width: stretch;">HH&ZeroWidthSpace;HH</div>
+  <div style="width: fit-content;">HH&ZeroWidthSpace;HH</div>
+  <div style="width: min-content;">HH&ZeroWidthSpace;HH</div>
+  <div style="width: max-content;">HH&ZeroWidthSpace;HH</div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_item_width_stretch_margin.html
+++ b/test_fixtures/grid/grid_item_width_stretch_margin.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-columns: 120px; grid-template-rows: 40px;">
+  <div style="width: stretch; margin: 5px 10px 5px 15px;">HH&ZeroWidthSpace;HH</div>
+</div>
+
+</body>
+</html>

--- a/tests/hand_written/min_max_overrides.rs
+++ b/tests/hand_written/min_max_overrides.rs
@@ -10,8 +10,14 @@ mod min_max_overrides {
         let child = taffy
             .new_leaf(Style {
                 size: Size { width: Dimension::from_length(50.0), height: Dimension::from_length(50.0) },
-                min_size: Size { width: Dimension::from_length(100.0), height: Dimension::from_length(100.0) },
-                max_size: Size { width: Dimension::from_length(10.0), height: Dimension::from_length(10.0) },
+                min_size: Size {
+                    width: LengthPercentageAuto::from_length(100.0),
+                    height: LengthPercentageAuto::from_length(100.0),
+                },
+                max_size: Size {
+                    width: LengthPercentageAuto::from_length(10.0),
+                    height: LengthPercentageAuto::from_length(10.0),
+                },
                 ..Default::default()
             })
             .unwrap();
@@ -33,7 +39,10 @@ mod min_max_overrides {
         let child = taffy
             .new_leaf(Style {
                 size: Size { width: Dimension::from_length(50.0), height: Dimension::from_length(50.0) },
-                max_size: Size { width: Dimension::from_length(10.0), height: Dimension::from_length(10.0) },
+                max_size: Size {
+                    width: LengthPercentageAuto::from_length(10.0),
+                    height: LengthPercentageAuto::from_length(10.0),
+                },
                 ..Default::default()
             })
             .unwrap();
@@ -55,7 +64,10 @@ mod min_max_overrides {
         let child = taffy
             .new_leaf(Style {
                 size: Size { width: Dimension::from_length(50.0), height: Dimension::from_length(50.0) },
-                min_size: Size { width: Dimension::from_length(100.0), height: Dimension::from_length(100.0) },
+                min_size: Size {
+                    width: LengthPercentageAuto::from_length(100.0),
+                    height: LengthPercentageAuto::from_length(100.0),
+                },
                 ..Default::default()
             })
             .unwrap();

--- a/tests/xml.rs
+++ b/tests/xml.rs
@@ -265,12 +265,12 @@ fn build_style<S: CheapCloneStr>(xnode: roxmltree::Node) -> taffy::Style<S> {
             height: parse_or(xnode.attribute("height"), Dimension::auto()),
         },
         min_size: Size {
-            width: parse_or(xnode.attribute("min-width"), Dimension::auto()),
-            height: parse_or(xnode.attribute("min-height"), Dimension::auto()),
+            width: parse_or(xnode.attribute("min-width"), LengthPercentageAuto::auto()),
+            height: parse_or(xnode.attribute("min-height"), LengthPercentageAuto::auto()),
         },
         max_size: Size {
-            width: parse_or(xnode.attribute("max-width"), Dimension::auto()),
-            height: parse_or(xnode.attribute("max-height"), Dimension::auto()),
+            width: parse_or(xnode.attribute("max-width"), LengthPercentageAuto::auto()),
+            height: parse_or(xnode.attribute("max-height"), LengthPercentageAuto::auto()),
         },
         inset: Rect {
             top: parse_or(xnode.attribute("top"), LengthPercentageAuto::auto()),

--- a/tests/xml/block/block_absolute_width_keywords__border_box_ltr.xml
+++ b/tests/xml/block/block_absolute_width_keywords__border_box_ltr.xml
@@ -1,0 +1,27 @@
+<test name="block_absolute_width_keywords__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="120px" height="120px">
+      <text direction="ltr" position="absolute" width="stretch" top="0px">
+        HH​HH
+      </text>
+      <text direction="ltr" position="absolute" width="fit-content" top="30px">
+        HH​HH
+      </text>
+      <text direction="ltr" position="absolute" width="min-content" top="60px">
+        HH​HH
+      </text>
+      <text direction="ltr" position="absolute" width="max-content" top="90px">
+        HH​HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="0" y="0" width="120" height="10"/>
+      <node x="0" y="30" width="40" height="10"/>
+      <node x="0" y="60" width="20" height="20"/>
+      <node x="0" y="90" width="40" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_absolute_width_keywords__border_box_rtl.xml
+++ b/tests/xml/block/block_absolute_width_keywords__border_box_rtl.xml
@@ -1,0 +1,27 @@
+<test name="block_absolute_width_keywords__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="120px" height="120px">
+      <text direction="rtl" position="absolute" width="stretch" top="0px">
+        HH​HH
+      </text>
+      <text direction="rtl" position="absolute" width="fit-content" top="30px">
+        HH​HH
+      </text>
+      <text direction="rtl" position="absolute" width="min-content" top="60px">
+        HH​HH
+      </text>
+      <text direction="rtl" position="absolute" width="max-content" top="90px">
+        HH​HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="0" y="0" width="120" height="10"/>
+      <node x="80" y="30" width="40" height="10"/>
+      <node x="100" y="60" width="20" height="20"/>
+      <node x="80" y="90" width="40" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_absolute_width_keywords__content_box_ltr.xml
+++ b/tests/xml/block/block_absolute_width_keywords__content_box_ltr.xml
@@ -1,0 +1,27 @@
+<test name="block_absolute_width_keywords__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="120px" height="120px">
+      <text box-sizing="content-box" direction="ltr" position="absolute" width="stretch" top="0px">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="ltr" position="absolute" width="fit-content" top="30px">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="ltr" position="absolute" width="min-content" top="60px">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="ltr" position="absolute" width="max-content" top="90px">
+        HH​HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="0" y="0" width="120" height="10"/>
+      <node x="0" y="30" width="40" height="10"/>
+      <node x="0" y="60" width="20" height="20"/>
+      <node x="0" y="90" width="40" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_absolute_width_keywords__content_box_rtl.xml
+++ b/tests/xml/block/block_absolute_width_keywords__content_box_rtl.xml
@@ -1,0 +1,27 @@
+<test name="block_absolute_width_keywords__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="120px" height="120px">
+      <text box-sizing="content-box" direction="rtl" position="absolute" width="stretch" top="0px">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="rtl" position="absolute" width="fit-content" top="30px">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="rtl" position="absolute" width="min-content" top="60px">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="rtl" position="absolute" width="max-content" top="90px">
+        HH​HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="0" y="0" width="120" height="10"/>
+      <node x="80" y="30" width="40" height="10"/>
+      <node x="100" y="60" width="20" height="20"/>
+      <node x="80" y="90" width="40" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_absolute_width_stretch_inset_margin__border_box_ltr.xml
+++ b/tests/xml/block/block_absolute_width_stretch_inset_margin__border_box_ltr.xml
@@ -1,0 +1,23 @@
+<test name="block_absolute_width_stretch_inset_margin__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="120px" height="120px">
+      <text direction="ltr" position="absolute" width="stretch" margin-right="5px" top="0px" left="10px">
+        HH​HH
+      </text>
+      <text direction="ltr" position="absolute" width="stretch" top="40px" right="20px">
+        HH​HH
+      </text>
+      <text direction="ltr" position="absolute" width="20px" height="stretch" top="0px" left="10px">
+        HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="10" y="0" width="105" height="10"/>
+      <node x="0" y="40" width="100" height="10"/>
+      <node x="10" y="0" width="20" height="120"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_absolute_width_stretch_inset_margin__border_box_rtl.xml
+++ b/tests/xml/block/block_absolute_width_stretch_inset_margin__border_box_rtl.xml
@@ -1,0 +1,23 @@
+<test name="block_absolute_width_stretch_inset_margin__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="120px" height="120px">
+      <text direction="rtl" position="absolute" width="stretch" margin-right="5px" top="0px" left="10px">
+        HH​HH
+      </text>
+      <text direction="rtl" position="absolute" width="stretch" top="40px" right="20px">
+        HH​HH
+      </text>
+      <text direction="rtl" position="absolute" width="20px" height="stretch" top="0px" left="10px">
+        HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="10" y="0" width="105" height="10"/>
+      <node x="0" y="40" width="100" height="10"/>
+      <node x="10" y="0" width="20" height="120"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_absolute_width_stretch_inset_margin__content_box_ltr.xml
+++ b/tests/xml/block/block_absolute_width_stretch_inset_margin__content_box_ltr.xml
@@ -1,0 +1,23 @@
+<test name="block_absolute_width_stretch_inset_margin__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="120px" height="120px">
+      <text box-sizing="content-box" direction="ltr" position="absolute" width="stretch" margin-right="5px" top="0px" left="10px">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="ltr" position="absolute" width="stretch" top="40px" right="20px">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="ltr" position="absolute" width="20px" height="stretch" top="0px" left="10px">
+        HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="10" y="0" width="105" height="10"/>
+      <node x="0" y="40" width="100" height="10"/>
+      <node x="10" y="0" width="20" height="120"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_absolute_width_stretch_inset_margin__content_box_rtl.xml
+++ b/tests/xml/block/block_absolute_width_stretch_inset_margin__content_box_rtl.xml
@@ -1,0 +1,23 @@
+<test name="block_absolute_width_stretch_inset_margin__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="120px" height="120px">
+      <text box-sizing="content-box" direction="rtl" position="absolute" width="stretch" margin-right="5px" top="0px" left="10px">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="rtl" position="absolute" width="stretch" top="40px" right="20px">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="rtl" position="absolute" width="20px" height="stretch" top="0px" left="10px">
+        HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="10" y="0" width="105" height="10"/>
+      <node x="0" y="40" width="100" height="10"/>
+      <node x="10" y="0" width="20" height="120"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_height_stretch__border_box_ltr.xml
+++ b/tests/xml/block/block_height_stretch__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="block_height_stretch__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px" height="80px">
+      <text direction="ltr" height="stretch" margin-top="5px" margin-left="0px" margin-bottom="10px" margin-right="0px">
+        HH​HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="80">
+      <node x="0" y="5" width="100" height="65"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_height_stretch__border_box_rtl.xml
+++ b/tests/xml/block/block_height_stretch__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="block_height_stretch__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px" height="80px">
+      <text direction="rtl" height="stretch" margin-top="5px" margin-left="0px" margin-bottom="10px" margin-right="0px">
+        HH​HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="80">
+      <node x="0" y="5" width="100" height="65"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_height_stretch__content_box_ltr.xml
+++ b/tests/xml/block/block_height_stretch__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="block_height_stretch__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px" height="80px">
+      <text box-sizing="content-box" direction="ltr" height="stretch" margin-top="5px" margin-left="0px" margin-bottom="10px" margin-right="0px">
+        HH​HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="80">
+      <node x="0" y="5" width="100" height="65"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_height_stretch__content_box_rtl.xml
+++ b/tests/xml/block/block_height_stretch__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="block_height_stretch__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px" height="80px">
+      <text box-sizing="content-box" direction="rtl" height="stretch" margin-top="5px" margin-left="0px" margin-bottom="10px" margin-right="0px">
+        HH​HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="80">
+      <node x="0" y="5" width="100" height="65"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_width_keywords__border_box_ltr.xml
+++ b/tests/xml/block/block_width_keywords__border_box_ltr.xml
@@ -1,0 +1,27 @@
+<test name="block_width_keywords__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="120px">
+      <text direction="ltr" width="stretch">
+        HH​HH
+      </text>
+      <text direction="ltr" width="fit-content">
+        HH​HH
+      </text>
+      <text direction="ltr" width="min-content">
+        HH​HH
+      </text>
+      <text direction="ltr" width="max-content">
+        HH​HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="50">
+      <node x="0" y="0" width="120" height="10"/>
+      <node x="0" y="10" width="40" height="10"/>
+      <node x="0" y="20" width="20" height="20"/>
+      <node x="0" y="40" width="40" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_width_keywords__border_box_rtl.xml
+++ b/tests/xml/block/block_width_keywords__border_box_rtl.xml
@@ -1,0 +1,27 @@
+<test name="block_width_keywords__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="120px">
+      <text direction="rtl" width="stretch">
+        HH​HH
+      </text>
+      <text direction="rtl" width="fit-content">
+        HH​HH
+      </text>
+      <text direction="rtl" width="min-content">
+        HH​HH
+      </text>
+      <text direction="rtl" width="max-content">
+        HH​HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="50">
+      <node x="0" y="0" width="120" height="10"/>
+      <node x="80" y="10" width="40" height="10"/>
+      <node x="100" y="20" width="20" height="20"/>
+      <node x="80" y="40" width="40" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_width_keywords__content_box_ltr.xml
+++ b/tests/xml/block/block_width_keywords__content_box_ltr.xml
@@ -1,0 +1,27 @@
+<test name="block_width_keywords__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="120px">
+      <text box-sizing="content-box" direction="ltr" width="stretch">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="ltr" width="fit-content">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="ltr" width="min-content">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="ltr" width="max-content">
+        HH​HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="50">
+      <node x="0" y="0" width="120" height="10"/>
+      <node x="0" y="10" width="40" height="10"/>
+      <node x="0" y="20" width="20" height="20"/>
+      <node x="0" y="40" width="40" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_width_keywords__content_box_rtl.xml
+++ b/tests/xml/block/block_width_keywords__content_box_rtl.xml
@@ -1,0 +1,27 @@
+<test name="block_width_keywords__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="120px">
+      <text box-sizing="content-box" direction="rtl" width="stretch">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="rtl" width="fit-content">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="rtl" width="min-content">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="rtl" width="max-content">
+        HH​HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="50">
+      <node x="0" y="0" width="120" height="10"/>
+      <node x="80" y="10" width="40" height="10"/>
+      <node x="100" y="20" width="20" height="20"/>
+      <node x="80" y="40" width="40" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_absolute_width_keywords__border_box_ltr.xml
+++ b/tests/xml/flex/flex_absolute_width_keywords__border_box_ltr.xml
@@ -1,0 +1,27 @@
+<test name="flex_absolute_width_keywords__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" width="120px" height="120px">
+      <text direction="ltr" position="absolute" width="stretch" top="0px">
+        HH​HH
+      </text>
+      <text direction="ltr" position="absolute" width="fit-content" top="30px">
+        HH​HH
+      </text>
+      <text direction="ltr" position="absolute" width="min-content" top="60px">
+        HH​HH
+      </text>
+      <text direction="ltr" position="absolute" width="max-content" top="90px">
+        HH​HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="0" y="0" width="120" height="10"/>
+      <node x="0" y="30" width="40" height="10"/>
+      <node x="0" y="60" width="20" height="20"/>
+      <node x="0" y="90" width="40" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_absolute_width_keywords__border_box_rtl.xml
+++ b/tests/xml/flex/flex_absolute_width_keywords__border_box_rtl.xml
@@ -1,0 +1,27 @@
+<test name="flex_absolute_width_keywords__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" width="120px" height="120px">
+      <text direction="rtl" position="absolute" width="stretch" top="0px">
+        HH​HH
+      </text>
+      <text direction="rtl" position="absolute" width="fit-content" top="30px">
+        HH​HH
+      </text>
+      <text direction="rtl" position="absolute" width="min-content" top="60px">
+        HH​HH
+      </text>
+      <text direction="rtl" position="absolute" width="max-content" top="90px">
+        HH​HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="0" y="0" width="120" height="10"/>
+      <node x="80" y="30" width="40" height="10"/>
+      <node x="100" y="60" width="20" height="20"/>
+      <node x="80" y="90" width="40" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_absolute_width_keywords__content_box_ltr.xml
+++ b/tests/xml/flex/flex_absolute_width_keywords__content_box_ltr.xml
@@ -1,0 +1,27 @@
+<test name="flex_absolute_width_keywords__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" width="120px" height="120px">
+      <text box-sizing="content-box" direction="ltr" position="absolute" width="stretch" top="0px">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="ltr" position="absolute" width="fit-content" top="30px">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="ltr" position="absolute" width="min-content" top="60px">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="ltr" position="absolute" width="max-content" top="90px">
+        HH​HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="0" y="0" width="120" height="10"/>
+      <node x="0" y="30" width="40" height="10"/>
+      <node x="0" y="60" width="20" height="20"/>
+      <node x="0" y="90" width="40" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_absolute_width_keywords__content_box_rtl.xml
+++ b/tests/xml/flex/flex_absolute_width_keywords__content_box_rtl.xml
@@ -1,0 +1,27 @@
+<test name="flex_absolute_width_keywords__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" width="120px" height="120px">
+      <text box-sizing="content-box" direction="rtl" position="absolute" width="stretch" top="0px">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="rtl" position="absolute" width="fit-content" top="30px">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="rtl" position="absolute" width="min-content" top="60px">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="rtl" position="absolute" width="max-content" top="90px">
+        HH​HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="0" y="0" width="120" height="10"/>
+      <node x="80" y="30" width="40" height="10"/>
+      <node x="100" y="60" width="20" height="20"/>
+      <node x="80" y="90" width="40" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_absolute_width_stretch_inset_margin__border_box_ltr.xml
+++ b/tests/xml/flex/flex_absolute_width_stretch_inset_margin__border_box_ltr.xml
@@ -1,0 +1,23 @@
+<test name="flex_absolute_width_stretch_inset_margin__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" width="120px" height="120px">
+      <text direction="ltr" position="absolute" width="stretch" margin-right="5px" top="0px" left="10px">
+        HH​HH
+      </text>
+      <text direction="ltr" position="absolute" width="stretch" top="40px" right="20px">
+        HH​HH
+      </text>
+      <text direction="ltr" position="absolute" width="20px" height="stretch" top="0px" left="10px">
+        HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="10" y="0" width="105" height="10"/>
+      <node x="0" y="40" width="100" height="10"/>
+      <node x="10" y="0" width="20" height="120"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_absolute_width_stretch_inset_margin__border_box_rtl.xml
+++ b/tests/xml/flex/flex_absolute_width_stretch_inset_margin__border_box_rtl.xml
@@ -1,0 +1,23 @@
+<test name="flex_absolute_width_stretch_inset_margin__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" width="120px" height="120px">
+      <text direction="rtl" position="absolute" width="stretch" margin-right="5px" top="0px" left="10px">
+        HH​HH
+      </text>
+      <text direction="rtl" position="absolute" width="stretch" top="40px" right="20px">
+        HH​HH
+      </text>
+      <text direction="rtl" position="absolute" width="20px" height="stretch" top="0px" left="10px">
+        HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="10" y="0" width="105" height="10"/>
+      <node x="0" y="40" width="100" height="10"/>
+      <node x="10" y="0" width="20" height="120"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_absolute_width_stretch_inset_margin__content_box_ltr.xml
+++ b/tests/xml/flex/flex_absolute_width_stretch_inset_margin__content_box_ltr.xml
@@ -1,0 +1,23 @@
+<test name="flex_absolute_width_stretch_inset_margin__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" width="120px" height="120px">
+      <text box-sizing="content-box" direction="ltr" position="absolute" width="stretch" margin-right="5px" top="0px" left="10px">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="ltr" position="absolute" width="stretch" top="40px" right="20px">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="ltr" position="absolute" width="20px" height="stretch" top="0px" left="10px">
+        HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="10" y="0" width="105" height="10"/>
+      <node x="0" y="40" width="100" height="10"/>
+      <node x="10" y="0" width="20" height="120"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_absolute_width_stretch_inset_margin__content_box_rtl.xml
+++ b/tests/xml/flex/flex_absolute_width_stretch_inset_margin__content_box_rtl.xml
@@ -1,0 +1,23 @@
+<test name="flex_absolute_width_stretch_inset_margin__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" width="120px" height="120px">
+      <text box-sizing="content-box" direction="rtl" position="absolute" width="stretch" margin-right="5px" top="0px" left="10px">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="rtl" position="absolute" width="stretch" top="40px" right="20px">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="rtl" position="absolute" width="20px" height="stretch" top="0px" left="10px">
+        HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="10" y="0" width="105" height="10"/>
+      <node x="0" y="40" width="100" height="10"/>
+      <node x="10" y="0" width="20" height="120"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_item_height_stretch__border_box_ltr.xml
+++ b/tests/xml/flex/flex_item_height_stretch__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="flex_item_height_stretch__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" align-items="flex-start" width="120px" height="60px">
+      <text direction="ltr" width="40px" height="stretch">
+        HH​HH
+      </text>
+      <text direction="ltr" width="40px" height="stretch" margin-top="5px" margin-left="0px" margin-bottom="10px" margin-right="0px">
+        HH​HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="60">
+      <node x="0" y="0" width="40" height="60"/>
+      <node x="40" y="5" width="40" height="45"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_item_height_stretch__border_box_rtl.xml
+++ b/tests/xml/flex/flex_item_height_stretch__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="flex_item_height_stretch__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" align-items="flex-start" width="120px" height="60px">
+      <text direction="rtl" width="40px" height="stretch">
+        HH​HH
+      </text>
+      <text direction="rtl" width="40px" height="stretch" margin-top="5px" margin-left="0px" margin-bottom="10px" margin-right="0px">
+        HH​HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="60">
+      <node x="80" y="0" width="40" height="60"/>
+      <node x="40" y="5" width="40" height="45"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_item_height_stretch__content_box_ltr.xml
+++ b/tests/xml/flex/flex_item_height_stretch__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="flex_item_height_stretch__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" align-items="flex-start" width="120px" height="60px">
+      <text box-sizing="content-box" direction="ltr" width="40px" height="stretch">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="ltr" width="40px" height="stretch" margin-top="5px" margin-left="0px" margin-bottom="10px" margin-right="0px">
+        HH​HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="60">
+      <node x="0" y="0" width="40" height="60"/>
+      <node x="40" y="5" width="40" height="45"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_item_height_stretch__content_box_rtl.xml
+++ b/tests/xml/flex/flex_item_height_stretch__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="flex_item_height_stretch__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" align-items="flex-start" width="120px" height="60px">
+      <text box-sizing="content-box" direction="rtl" width="40px" height="stretch">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="rtl" width="40px" height="stretch" margin-top="5px" margin-left="0px" margin-bottom="10px" margin-right="0px">
+        HH​HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="60">
+      <node x="80" y="0" width="40" height="60"/>
+      <node x="40" y="5" width="40" height="45"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_item_width_keywords__border_box_ltr.xml
+++ b/tests/xml/flex/flex_item_width_keywords__border_box_ltr.xml
@@ -1,0 +1,23 @@
+<test name="flex_item_width_keywords__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" align-items="flex-start" width="200px">
+      <text direction="ltr" width="min-content">
+        HH​HH
+      </text>
+      <text direction="ltr" width="max-content">
+        HH​HH
+      </text>
+      <text direction="ltr" width="fit-content">
+        HH​HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="20">
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="20" y="0" width="40" height="10"/>
+      <node x="60" y="0" width="40" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_item_width_keywords__border_box_rtl.xml
+++ b/tests/xml/flex/flex_item_width_keywords__border_box_rtl.xml
@@ -1,0 +1,23 @@
+<test name="flex_item_width_keywords__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" align-items="flex-start" width="200px">
+      <text direction="rtl" width="min-content">
+        HH​HH
+      </text>
+      <text direction="rtl" width="max-content">
+        HH​HH
+      </text>
+      <text direction="rtl" width="fit-content">
+        HH​HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="20">
+      <node x="180" y="0" width="20" height="20"/>
+      <node x="140" y="0" width="40" height="10"/>
+      <node x="100" y="0" width="40" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_item_width_keywords__content_box_ltr.xml
+++ b/tests/xml/flex/flex_item_width_keywords__content_box_ltr.xml
@@ -1,0 +1,23 @@
+<test name="flex_item_width_keywords__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" align-items="flex-start" width="200px">
+      <text box-sizing="content-box" direction="ltr" width="min-content">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="ltr" width="max-content">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="ltr" width="fit-content">
+        HH​HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="20">
+      <node x="0" y="0" width="20" height="20"/>
+      <node x="20" y="0" width="40" height="10"/>
+      <node x="60" y="0" width="40" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_item_width_keywords__content_box_rtl.xml
+++ b/tests/xml/flex/flex_item_width_keywords__content_box_rtl.xml
@@ -1,0 +1,23 @@
+<test name="flex_item_width_keywords__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" align-items="flex-start" width="200px">
+      <text box-sizing="content-box" direction="rtl" width="min-content">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="rtl" width="max-content">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="rtl" width="fit-content">
+        HH​HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="20">
+      <node x="180" y="0" width="20" height="20"/>
+      <node x="140" y="0" width="40" height="10"/>
+      <node x="100" y="0" width="40" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_item_width_stretch__border_box_ltr.xml
+++ b/tests/xml/flex/flex_item_width_stretch__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="flex_item_width_stretch__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" width="150px">
+      <text direction="ltr" width="stretch">
+        HH​HH
+      </text>
+      <div direction="ltr" flex-shrink="0" width="30px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="150" height="10">
+      <node x="0" y="0" width="120" height="10"/>
+      <node x="120" y="0" width="30" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_item_width_stretch__border_box_rtl.xml
+++ b/tests/xml/flex/flex_item_width_stretch__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="flex_item_width_stretch__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" width="150px">
+      <text direction="rtl" width="stretch">
+        HH​HH
+      </text>
+      <div direction="rtl" flex-shrink="0" width="30px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="150" height="10">
+      <node x="30" y="0" width="120" height="10"/>
+      <node x="0" y="0" width="30" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_item_width_stretch__content_box_ltr.xml
+++ b/tests/xml/flex/flex_item_width_stretch__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="flex_item_width_stretch__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" width="150px">
+      <text box-sizing="content-box" direction="ltr" width="stretch">
+        HH​HH
+      </text>
+      <div box-sizing="content-box" direction="ltr" flex-shrink="0" width="30px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="150" height="10">
+      <node x="0" y="0" width="120" height="10"/>
+      <node x="120" y="0" width="30" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_item_width_stretch__content_box_rtl.xml
+++ b/tests/xml/flex/flex_item_width_stretch__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="flex_item_width_stretch__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" width="150px">
+      <text box-sizing="content-box" direction="rtl" width="stretch">
+        HH​HH
+      </text>
+      <div box-sizing="content-box" direction="rtl" flex-shrink="0" width="30px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="150" height="10">
+      <node x="30" y="0" width="120" height="10"/>
+      <node x="0" y="0" width="30" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_item_height_keywords__border_box_ltr.xml
+++ b/tests/xml/grid/grid_item_height_keywords__border_box_ltr.xml
@@ -1,0 +1,27 @@
+<test name="grid_item_height_keywords__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" grid-template-rows="60px" grid-template-columns="40px 40px 40px 40px">
+      <text direction="ltr" height="stretch">
+        HH​HH
+      </text>
+      <text direction="ltr" height="fit-content">
+        HH​HH
+      </text>
+      <text direction="ltr" height="min-content">
+        HH​HH
+      </text>
+      <text direction="ltr" height="max-content">
+        HH​HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="160" height="60">
+      <node x="0" y="0" width="40" height="60"/>
+      <node x="40" y="0" width="40" height="10"/>
+      <node x="80" y="0" width="40" height="10"/>
+      <node x="120" y="0" width="40" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_item_height_keywords__border_box_rtl.xml
+++ b/tests/xml/grid/grid_item_height_keywords__border_box_rtl.xml
@@ -1,0 +1,27 @@
+<test name="grid_item_height_keywords__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" grid-template-rows="60px" grid-template-columns="40px 40px 40px 40px">
+      <text direction="rtl" height="stretch">
+        HH​HH
+      </text>
+      <text direction="rtl" height="fit-content">
+        HH​HH
+      </text>
+      <text direction="rtl" height="min-content">
+        HH​HH
+      </text>
+      <text direction="rtl" height="max-content">
+        HH​HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="160" height="60">
+      <node x="120" y="0" width="40" height="60"/>
+      <node x="80" y="0" width="40" height="10"/>
+      <node x="40" y="0" width="40" height="10"/>
+      <node x="0" y="0" width="40" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_item_height_keywords__content_box_ltr.xml
+++ b/tests/xml/grid/grid_item_height_keywords__content_box_ltr.xml
@@ -1,0 +1,27 @@
+<test name="grid_item_height_keywords__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" grid-template-rows="60px" grid-template-columns="40px 40px 40px 40px">
+      <text box-sizing="content-box" direction="ltr" height="stretch">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="ltr" height="fit-content">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="ltr" height="min-content">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="ltr" height="max-content">
+        HH​HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="160" height="60">
+      <node x="0" y="0" width="40" height="60"/>
+      <node x="40" y="0" width="40" height="10"/>
+      <node x="80" y="0" width="40" height="10"/>
+      <node x="120" y="0" width="40" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_item_height_keywords__content_box_rtl.xml
+++ b/tests/xml/grid/grid_item_height_keywords__content_box_rtl.xml
@@ -1,0 +1,27 @@
+<test name="grid_item_height_keywords__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" grid-template-rows="60px" grid-template-columns="40px 40px 40px 40px">
+      <text box-sizing="content-box" direction="rtl" height="stretch">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="rtl" height="fit-content">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="rtl" height="min-content">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="rtl" height="max-content">
+        HH​HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="160" height="60">
+      <node x="120" y="0" width="40" height="60"/>
+      <node x="80" y="0" width="40" height="10"/>
+      <node x="40" y="0" width="40" height="10"/>
+      <node x="0" y="0" width="40" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_item_width_keywords__border_box_ltr.xml
+++ b/tests/xml/grid/grid_item_width_keywords__border_box_ltr.xml
@@ -1,0 +1,27 @@
+<test name="grid_item_width_keywords__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" grid-template-columns="120px" grid-auto-rows="30px">
+      <text direction="ltr" width="stretch">
+        HH​HH
+      </text>
+      <text direction="ltr" width="fit-content">
+        HH​HH
+      </text>
+      <text direction="ltr" width="min-content">
+        HH​HH
+      </text>
+      <text direction="ltr" width="max-content">
+        HH​HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="0" y="0" width="120" height="30"/>
+      <node x="0" y="30" width="40" height="30"/>
+      <node x="0" y="60" width="20" height="30"/>
+      <node x="0" y="90" width="40" height="30"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_item_width_keywords__border_box_rtl.xml
+++ b/tests/xml/grid/grid_item_width_keywords__border_box_rtl.xml
@@ -1,0 +1,27 @@
+<test name="grid_item_width_keywords__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" grid-template-columns="120px" grid-auto-rows="30px">
+      <text direction="rtl" width="stretch">
+        HH​HH
+      </text>
+      <text direction="rtl" width="fit-content">
+        HH​HH
+      </text>
+      <text direction="rtl" width="min-content">
+        HH​HH
+      </text>
+      <text direction="rtl" width="max-content">
+        HH​HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="0" y="0" width="120" height="30"/>
+      <node x="80" y="30" width="40" height="30"/>
+      <node x="100" y="60" width="20" height="30"/>
+      <node x="80" y="90" width="40" height="30"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_item_width_keywords__content_box_ltr.xml
+++ b/tests/xml/grid/grid_item_width_keywords__content_box_ltr.xml
@@ -1,0 +1,27 @@
+<test name="grid_item_width_keywords__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" grid-template-columns="120px" grid-auto-rows="30px">
+      <text box-sizing="content-box" direction="ltr" width="stretch">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="ltr" width="fit-content">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="ltr" width="min-content">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="ltr" width="max-content">
+        HH​HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="0" y="0" width="120" height="30"/>
+      <node x="0" y="30" width="40" height="30"/>
+      <node x="0" y="60" width="20" height="30"/>
+      <node x="0" y="90" width="40" height="30"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_item_width_keywords__content_box_rtl.xml
+++ b/tests/xml/grid/grid_item_width_keywords__content_box_rtl.xml
@@ -1,0 +1,27 @@
+<test name="grid_item_width_keywords__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" grid-template-columns="120px" grid-auto-rows="30px">
+      <text box-sizing="content-box" direction="rtl" width="stretch">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="rtl" width="fit-content">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="rtl" width="min-content">
+        HH​HH
+      </text>
+      <text box-sizing="content-box" direction="rtl" width="max-content">
+        HH​HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="120">
+      <node x="0" y="0" width="120" height="30"/>
+      <node x="80" y="30" width="40" height="30"/>
+      <node x="100" y="60" width="20" height="30"/>
+      <node x="80" y="90" width="40" height="30"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_item_width_stretch_margin__border_box_ltr.xml
+++ b/tests/xml/grid/grid_item_width_stretch_margin__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_item_width_stretch_margin__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" grid-template-rows="40px" grid-template-columns="120px">
+      <text direction="ltr" width="stretch" margin-top="5px" margin-left="15px" margin-bottom="5px" margin-right="10px">
+        HH​HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="40">
+      <node x="15" y="5" width="95" height="30"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_item_width_stretch_margin__border_box_rtl.xml
+++ b/tests/xml/grid/grid_item_width_stretch_margin__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_item_width_stretch_margin__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" grid-template-rows="40px" grid-template-columns="120px">
+      <text direction="rtl" width="stretch" margin-top="5px" margin-left="15px" margin-bottom="5px" margin-right="10px">
+        HH​HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="40">
+      <node x="15" y="5" width="95" height="30"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_item_width_stretch_margin__content_box_ltr.xml
+++ b/tests/xml/grid/grid_item_width_stretch_margin__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_item_width_stretch_margin__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" grid-template-rows="40px" grid-template-columns="120px">
+      <text box-sizing="content-box" direction="ltr" width="stretch" margin-top="5px" margin-left="15px" margin-bottom="5px" margin-right="10px">
+        HH​HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="40">
+      <node x="15" y="5" width="95" height="30"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_item_width_stretch_margin__content_box_rtl.xml
+++ b/tests/xml/grid/grid_item_width_stretch_margin__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_item_width_stretch_margin__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" grid-template-rows="40px" grid-template-columns="120px">
+      <text box-sizing="content-box" direction="rtl" width="stretch" margin-top="5px" margin-left="15px" margin-bottom="5px" margin-right="10px">
+        HH​HH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="40">
+      <node x="15" y="5" width="95" height="30"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -1266,6 +1266,46 @@ mod block {
     }
 
     #[test]
+    fn block_absolute_width_keywords__border_box_ltr() {
+        crate::run_xml_test("block", "block_absolute_width_keywords__border_box_ltr");
+    }
+
+    #[test]
+    fn block_absolute_width_keywords__content_box_ltr() {
+        crate::run_xml_test("block", "block_absolute_width_keywords__content_box_ltr");
+    }
+
+    #[test]
+    fn block_absolute_width_keywords__border_box_rtl() {
+        crate::run_xml_test("block", "block_absolute_width_keywords__border_box_rtl");
+    }
+
+    #[test]
+    fn block_absolute_width_keywords__content_box_rtl() {
+        crate::run_xml_test("block", "block_absolute_width_keywords__content_box_rtl");
+    }
+
+    #[test]
+    fn block_absolute_width_stretch_inset_margin__border_box_ltr() {
+        crate::run_xml_test("block", "block_absolute_width_stretch_inset_margin__border_box_ltr");
+    }
+
+    #[test]
+    fn block_absolute_width_stretch_inset_margin__content_box_ltr() {
+        crate::run_xml_test("block", "block_absolute_width_stretch_inset_margin__content_box_ltr");
+    }
+
+    #[test]
+    fn block_absolute_width_stretch_inset_margin__border_box_rtl() {
+        crate::run_xml_test("block", "block_absolute_width_stretch_inset_margin__border_box_rtl");
+    }
+
+    #[test]
+    fn block_absolute_width_stretch_inset_margin__content_box_rtl() {
+        crate::run_xml_test("block", "block_absolute_width_stretch_inset_margin__content_box_rtl");
+    }
+
+    #[test]
     fn block_align_baseline_child__border_box_ltr() {
         crate::run_xml_test("block", "block_align_baseline_child__border_box_ltr");
     }
@@ -10165,6 +10205,46 @@ mod flex {
     #[test]
     fn flex_absolute_direction_rtl__content_box_rtl() {
         crate::run_xml_test("flex", "flex_absolute_direction_rtl__content_box_rtl");
+    }
+
+    #[test]
+    fn flex_absolute_width_keywords__border_box_ltr() {
+        crate::run_xml_test("flex", "flex_absolute_width_keywords__border_box_ltr");
+    }
+
+    #[test]
+    fn flex_absolute_width_keywords__content_box_ltr() {
+        crate::run_xml_test("flex", "flex_absolute_width_keywords__content_box_ltr");
+    }
+
+    #[test]
+    fn flex_absolute_width_keywords__border_box_rtl() {
+        crate::run_xml_test("flex", "flex_absolute_width_keywords__border_box_rtl");
+    }
+
+    #[test]
+    fn flex_absolute_width_keywords__content_box_rtl() {
+        crate::run_xml_test("flex", "flex_absolute_width_keywords__content_box_rtl");
+    }
+
+    #[test]
+    fn flex_absolute_width_stretch_inset_margin__border_box_ltr() {
+        crate::run_xml_test("flex", "flex_absolute_width_stretch_inset_margin__border_box_ltr");
+    }
+
+    #[test]
+    fn flex_absolute_width_stretch_inset_margin__content_box_ltr() {
+        crate::run_xml_test("flex", "flex_absolute_width_stretch_inset_margin__content_box_ltr");
+    }
+
+    #[test]
+    fn flex_absolute_width_stretch_inset_margin__border_box_rtl() {
+        crate::run_xml_test("flex", "flex_absolute_width_stretch_inset_margin__border_box_rtl");
+    }
+
+    #[test]
+    fn flex_absolute_width_stretch_inset_margin__content_box_rtl() {
+        crate::run_xml_test("flex", "flex_absolute_width_stretch_inset_margin__content_box_rtl");
     }
 
     #[test]

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -2046,6 +2046,26 @@ mod block {
     }
 
     #[test]
+    fn block_height_stretch__border_box_ltr() {
+        crate::run_xml_test("block", "block_height_stretch__border_box_ltr");
+    }
+
+    #[test]
+    fn block_height_stretch__content_box_ltr() {
+        crate::run_xml_test("block", "block_height_stretch__content_box_ltr");
+    }
+
+    #[test]
+    fn block_height_stretch__border_box_rtl() {
+        crate::run_xml_test("block", "block_height_stretch__border_box_rtl");
+    }
+
+    #[test]
+    fn block_height_stretch__content_box_rtl() {
+        crate::run_xml_test("block", "block_height_stretch__content_box_rtl");
+    }
+
+    #[test]
     fn block_inset_direction_rtl__border_box_ltr() {
         crate::run_xml_test("block", "block_inset_direction_rtl__border_box_ltr");
     }
@@ -4779,6 +4799,26 @@ mod block {
     #[test]
     fn block_text_align_center_rtl__content_box_rtl() {
         crate::run_xml_test("block", "block_text_align_center_rtl__content_box_rtl");
+    }
+
+    #[test]
+    fn block_width_keywords__border_box_ltr() {
+        crate::run_xml_test("block", "block_width_keywords__border_box_ltr");
+    }
+
+    #[test]
+    fn block_width_keywords__content_box_ltr() {
+        crate::run_xml_test("block", "block_width_keywords__content_box_ltr");
+    }
+
+    #[test]
+    fn block_width_keywords__border_box_rtl() {
+        crate::run_xml_test("block", "block_width_keywords__border_box_rtl");
+    }
+
+    #[test]
+    fn block_width_keywords__content_box_rtl() {
+        crate::run_xml_test("block", "block_width_keywords__content_box_rtl");
     }
 }
 
@@ -11203,6 +11243,66 @@ mod flex {
     #[test]
     fn flex_grow_within_max_width__content_box_rtl() {
         crate::run_xml_test("flex", "flex_grow_within_max_width__content_box_rtl");
+    }
+
+    #[test]
+    fn flex_item_height_stretch__border_box_ltr() {
+        crate::run_xml_test("flex", "flex_item_height_stretch__border_box_ltr");
+    }
+
+    #[test]
+    fn flex_item_height_stretch__content_box_ltr() {
+        crate::run_xml_test("flex", "flex_item_height_stretch__content_box_ltr");
+    }
+
+    #[test]
+    fn flex_item_height_stretch__border_box_rtl() {
+        crate::run_xml_test("flex", "flex_item_height_stretch__border_box_rtl");
+    }
+
+    #[test]
+    fn flex_item_height_stretch__content_box_rtl() {
+        crate::run_xml_test("flex", "flex_item_height_stretch__content_box_rtl");
+    }
+
+    #[test]
+    fn flex_item_width_keywords__border_box_ltr() {
+        crate::run_xml_test("flex", "flex_item_width_keywords__border_box_ltr");
+    }
+
+    #[test]
+    fn flex_item_width_keywords__content_box_ltr() {
+        crate::run_xml_test("flex", "flex_item_width_keywords__content_box_ltr");
+    }
+
+    #[test]
+    fn flex_item_width_keywords__border_box_rtl() {
+        crate::run_xml_test("flex", "flex_item_width_keywords__border_box_rtl");
+    }
+
+    #[test]
+    fn flex_item_width_keywords__content_box_rtl() {
+        crate::run_xml_test("flex", "flex_item_width_keywords__content_box_rtl");
+    }
+
+    #[test]
+    fn flex_item_width_stretch__border_box_ltr() {
+        crate::run_xml_test("flex", "flex_item_width_stretch__border_box_ltr");
+    }
+
+    #[test]
+    fn flex_item_width_stretch__content_box_ltr() {
+        crate::run_xml_test("flex", "flex_item_width_stretch__content_box_ltr");
+    }
+
+    #[test]
+    fn flex_item_width_stretch__border_box_rtl() {
+        crate::run_xml_test("flex", "flex_item_width_stretch__border_box_rtl");
+    }
+
+    #[test]
+    fn flex_item_width_stretch__content_box_rtl() {
+        crate::run_xml_test("flex", "flex_item_width_stretch__content_box_rtl");
     }
 
     #[test]
@@ -26233,6 +26333,78 @@ mod grid {
             "grid",
             "grid_intrinsic_track_sizes_001_span2_minmax_min_content_10px_minmax_min_content_10px__content_box_rtl",
         );
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_item_height_keywords__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_item_height_keywords__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_item_height_keywords__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_item_height_keywords__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_item_height_keywords__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_item_height_keywords__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_item_height_keywords__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_item_height_keywords__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_item_width_keywords__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_item_width_keywords__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_item_width_keywords__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_item_width_keywords__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_item_width_keywords__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_item_width_keywords__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_item_width_keywords__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_item_width_keywords__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_item_width_stretch_margin__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_item_width_stretch_margin__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_item_width_stretch_margin__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_item_width_stretch_margin__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_item_width_stretch_margin__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_item_width_stretch_margin__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_item_width_stretch_margin__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_item_width_stretch_margin__content_box_rtl");
     }
 
     #[cfg(feature = "grid")]


### PR DESCRIPTION
# Objective

Allow the `width`/`height` (`Style::size`) properties to be set to the CSS sizing keywords `min-content`, `max-content`, `fit-content`, `fit-content(<length-percentage>)` and `stretch`, and resolve them in the block, flexbox and grid layout algorithms. This lets consumers like Blitz correctly lay out content using these keywords (e.g. the WPT css-grid alignment tests, which put `width: fit-content` on grid containers).

## Context

- Representation: `Dimension` gains constructors `min_content()`, `max_content()`, `fit_content()` (plain keyword, new `CompactLength::FIT_CONTENT_KEYWORD_TAG`), `fit_content_px()`, `fit_content_percent()` (reusing the existing fit-content tags used by grid track sizing), and `stretch()` (new `CompactLength::STRETCH_TAG`). CSS parsing is supported. In `resolve.rs` keywords resolve to `None` (like `auto`), so any context that doesn't explicitly handle them treats them as `auto` rather than panicking.

- Resolution is implemented per call site via a shared helper (`compute::common::sizing_keyword::resolve_sizing_keyword`), which returns either `Measure(AvailableSpace)` (measure the item under that constraint: `min-content` → `MinContent`, `max-content` → `MaxContent`, `fit-content(limit)` → `Definite(limit)`, plain `fit-content` → `Definite(stretch size)`) or `Exact(f32)` (`stretch` → available space minus margins):
  - Block: widths of in-flow children and floats (including content-based container width determination). In the height (block) axis only `stretch` needs explicit resolution (against the container's definite inner height) — the intrinsic keywords equal the content size, which an auto height already computes
  - Flexbox: main-axis size when determining the flex base size; cross-axis size when determining the hypothetical cross size (`stretch` resolves against the flex line)
  - Grid: item width/height in both track sizing (content contributions measure under the keyword's constraint, adjusting the available space for every keyword-sized axis at once) and final item sizing/alignment (both axes resolved in a single measure call where possible). A keyword-sized axis counts as non-`auto`, so the default `normal` self-alignment resolves to `start` instead of `stretch` in that axis
  - Absolutely positioned children of block and flexbox containers, via `resolve_absolute_sizing_keywords`: `stretch` resolves to the containing block minus insets and margins, and an explicit keyword size takes precedence over the inset-derived (left+right / top+bottom) size

- Breaking change: `Style::min_size`/`Style::max_size` (and `CoreStyle::min_size`/`max_size`) are now `Size<LengthPercentageAuto>` rather than `Size<Dimension>`, since the min/max sizing properties deliberately do not support the new keywords.

- `From<Dimension>` conversions to `MinTrackSizingFunction`/`MaxTrackSizingFunction` sanitize the new tags (mapping unsupported values to `auto`) so they cannot leak into grid track sizing.

- Generated tests (from Chrome) added for block/flex/grid item width & height keywords, including absolutely positioned items. Note: Chrome does not accept `fit-content(<length-percentage>)` on `width`/`height` (only on grid tracks), so those variants have no gentest coverage.

## Feedback wanted

- Plain `fit-content` is currently formulated as "measure under `Definite(stretch size)`" rather than an explicit `clamp(min-content, stretch, max-content)`.
- In contexts where a keyword can't be resolved (e.g. `fit-content`/`stretch` with an indefinite containing block size) it falls back to behaving as `auto`.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/e6b2abe65ab14b1aa2971b32ffb71c9f
Requested by: @nicoburns