### PR TITLE
Flexbox: wrap against max main size when the main size is indefinite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@
 
 - Flexbox: percentage heights of block descendants no longer resolve against a flex item's post-flexing main size when that size is indefinite (#950)
 
+- Flexbox: a wrapping container with an indefinite main size now wraps its items against its max main size (e.g. `max-width` for a row container) when the available space exceeds it. Previously items were collected into flex lines using the raw available space, so a fit-content sized container (such as a float) with a `max-width` smaller than the available space never wrapped
+
 ## 0.13.0
 
 The MSRV for this release is 1.71.

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -967,13 +967,13 @@ fn collect_flex_lines<'a>(
         lines
     } else {
         let main_axis_available_space = match constants.max_size.main(constants.dir) {
-            Some(max_size) => AvailableSpace::Definite(
-                available_space
-                    .main(constants.dir)
-                    .into_option()
-                    .unwrap_or(max_size)
-                    .maybe_max(constants.min_size.main(constants.dir)),
-            ),
+            Some(max_size) => AvailableSpace::Definite({
+                let available = available_space.main(constants.dir).into_option().unwrap_or(max_size);
+                // If the container's main size is not definite then it is at most the max main size,
+                // so the max size (and not the available space) is the limit that items wrap against.
+                let available = if constants.has_definite_main_size { available } else { available.min(max_size) };
+                available.maybe_max(constants.min_size.main(constants.dir))
+            }),
             None => available_space.main(constants.dir),
         };
 

--- a/test_fixtures/flex/wrap_row_max_width_indefinite_width.html
+++ b/test_fixtures/flex/wrap_row_max_width_indefinite_width.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div class="viewport" style="width: 200px;">
+  <div id="test-root" style="max-width: 20px; height: 110px; flex-direction: row; flex-wrap: wrap;">
+    <div style="height: 10px; width: 20px;"></div>
+    <div style="height: 40px; width: 20px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/flex/wrap_row_max_width_indefinite_width__border_box_ltr.xml
+++ b/tests/xml/flex/wrap_row_max_width_indefinite_width__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="wrap_row_max_width_indefinite_width__border_box_ltr" use-rounding="true">
+  <viewport width="200px" height="max-content"/>
+  <input>
+    <div direction="ltr" flex-wrap="wrap" height="110px" max-width="20px">
+      <div direction="ltr" width="20px" height="10px"/>
+      <div direction="ltr" width="20px" height="40px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="110">
+      <node x="0" y="0" width="20" height="10"/>
+      <node x="0" y="40" width="20" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/wrap_row_max_width_indefinite_width__border_box_rtl.xml
+++ b/tests/xml/flex/wrap_row_max_width_indefinite_width__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="wrap_row_max_width_indefinite_width__border_box_rtl" use-rounding="true">
+  <viewport width="200px" height="max-content"/>
+  <input>
+    <div direction="rtl" flex-wrap="wrap" height="110px" max-width="20px">
+      <div direction="rtl" width="20px" height="10px"/>
+      <div direction="rtl" width="20px" height="40px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="180" y="0" width="20" height="110">
+      <node x="0" y="0" width="20" height="10"/>
+      <node x="0" y="40" width="20" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/wrap_row_max_width_indefinite_width__content_box_ltr.xml
+++ b/tests/xml/flex/wrap_row_max_width_indefinite_width__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="wrap_row_max_width_indefinite_width__content_box_ltr" use-rounding="true">
+  <viewport width="200px" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" flex-wrap="wrap" height="110px" max-width="20px">
+      <div box-sizing="content-box" direction="ltr" width="20px" height="10px"/>
+      <div box-sizing="content-box" direction="ltr" width="20px" height="40px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="110">
+      <node x="0" y="0" width="20" height="10"/>
+      <node x="0" y="40" width="20" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/wrap_row_max_width_indefinite_width__content_box_rtl.xml
+++ b/tests/xml/flex/wrap_row_max_width_indefinite_width__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="wrap_row_max_width_indefinite_width__content_box_rtl" use-rounding="true">
+  <viewport width="200px" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" flex-wrap="wrap" height="110px" max-width="20px">
+      <div box-sizing="content-box" direction="rtl" width="20px" height="10px"/>
+      <div box-sizing="content-box" direction="rtl" width="20px" height="40px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="180" y="0" width="20" height="110">
+      <node x="0" y="0" width="20" height="10"/>
+      <node x="0" y="40" width="20" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -17222,6 +17222,26 @@ mod flex {
     }
 
     #[test]
+    fn wrap_row_max_width_indefinite_width__border_box_ltr() {
+        crate::run_xml_test("flex", "wrap_row_max_width_indefinite_width__border_box_ltr");
+    }
+
+    #[test]
+    fn wrap_row_max_width_indefinite_width__content_box_ltr() {
+        crate::run_xml_test("flex", "wrap_row_max_width_indefinite_width__content_box_ltr");
+    }
+
+    #[test]
+    fn wrap_row_max_width_indefinite_width__border_box_rtl() {
+        crate::run_xml_test("flex", "wrap_row_max_width_indefinite_width__border_box_rtl");
+    }
+
+    #[test]
+    fn wrap_row_max_width_indefinite_width__content_box_rtl() {
+        crate::run_xml_test("flex", "wrap_row_max_width_indefinite_width__content_box_rtl");
+    }
+
+    #[test]
     fn wrapped_column_max_height__border_box_ltr() {
         crate::run_xml_test("flex", "wrapped_column_max_height__border_box_ltr");
     }


### PR DESCRIPTION
# Objective

Fix flex wrapping for containers whose main size is indefinite but capped by a max main size (e.g. a fit-content sized float with `max-width`). This is the remaining root cause of Blitz's WPT failures in `css/css-flexbox/align-content-horiz-001b.html` (and the equivalent `-vert-` tests), whose flex containers are floats with `width: auto; max-width: 20px`.

## Context

In `collect_flex_lines`, when the container's known main size is content-derived-definite (`known_main_size_is_definite`) but not an actual known dimension, the wrap limit was taken from the raw available space:

```rust
// before: items wrap against available_space (e.g. Definite(800)) even though
// the container's used main size can be at most max-width (20)
Some(max_size) => AvailableSpace::Definite(
    available_space.main(dir).into_option().unwrap_or(max_size).maybe_max(min_size),
),
```

Since a fit-content sized container is clamped by its max main size, the max size — not the available space — is the limit items wrap against when the container's own main size is indefinite:

```rust
// after
let available = available_space.main(dir).into_option().unwrap_or(max_size);
let available = if constants.has_definite_main_size { available } else { available.min(max_size) };
AvailableSpace::Definite(available.maybe_max(min_size))
```

Containers with a truly definite main size (`has_definite_main_size`) keep the previous behavior.

Added a generated test (`test_fixtures/flex/wrap_row_max_width_indefinite_width.html`, Chrome agrees with the new behavior) and a CHANGELOG entry. Verified against Blitz's WPT runner: `align-content-horiz-001b.html` goes 17/72 → 72/72, full `css/css-flexbox` suite subtest pass rate 56.7% → 69.8% with zero per-test regressions (in combination with DioxusLabs/blitz#711).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/71b2a4272c6846039ac4d12a586ecc6c
Requested by: @nicoburns