### PR TITLE
Fix a state corruption bug in 4 `TaffyTree` member functions that causes a crash on `TaffyTree::remove`.

### DIFF
--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -670,6 +670,11 @@ impl<NodeContext> TaffyTree<NodeContext> {
     pub fn add_child(&mut self, parent: NodeId, child: NodeId) -> TaffyResult<()> {
         let parent_key = parent.into();
         let child_key = child.into();
+
+        if let Some(old_parent) = self.parents[child_key] {
+            self.remove_child(old_parent, child);
+        }
+
         self.parents[child_key] = Some(parent);
         self.children[parent_key].push(child);
         self.mark_dirty(parent)?;
@@ -680,13 +685,18 @@ impl<NodeContext> TaffyTree<NodeContext> {
     /// Inserts a `child` node at the given `child_index` under the supplied `parent`, shifting all children after it to the right.
     pub fn insert_child_at_index(&mut self, parent: NodeId, child_index: usize, child: NodeId) -> TaffyResult<()> {
         let parent_key = parent.into();
+        let child_key = child.into();
+
+        if let Some(old_parent) = self.parents[child_key] {
+            self.remove_child(old_parent, child);
+        }
 
         let child_count = self.children[parent_key].len();
         if child_index > child_count {
             return Err(TaffyError::ChildIndexOutOfBounds { parent, child_index, child_count });
         }
 
-        self.parents[child.into()] = Some(parent);
+        self.parents[child_key] = Some(parent);
         self.children[parent_key].insert(child_index, child);
         self.mark_dirty(parent)?;
 

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -587,7 +587,13 @@ impl<NodeContext> TaffyTree<NodeContext> {
         let id = NodeId::from(self.nodes.insert(NodeData::new(layout)));
 
         for child in children {
-            self.parents[(*child).into()] = Some(id);
+            let child_key = (*child).into();
+
+            if let Some(old_parent) = self.parents[child_key] {
+                self.remove_child(old_parent, *child)?;
+            }
+
+            self.parents[child_key] = Some(id);
         }
 
         let _ = self.children.insert(children.iter().copied().collect::<_>());

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -672,7 +672,7 @@ impl<NodeContext> TaffyTree<NodeContext> {
         let child_key = child.into();
 
         if let Some(old_parent) = self.parents[child_key] {
-            self.remove_child(old_parent, child);
+            let _ = self.remove_child(old_parent, child);
         }
 
         self.parents[child_key] = Some(parent);
@@ -688,7 +688,7 @@ impl<NodeContext> TaffyTree<NodeContext> {
         let child_key = child.into();
 
         if let Some(old_parent) = self.parents[child_key] {
-            self.remove_child(old_parent, child);
+            let _ = self.remove_child(old_parent, child);
         }
 
         let child_count = self.children[parent_key].len();

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -672,7 +672,7 @@ impl<NodeContext> TaffyTree<NodeContext> {
         let child_key = child.into();
 
         if let Some(old_parent) = self.parents[child_key] {
-            let _ = self.remove_child(old_parent, child);
+            self.remove_child(old_parent, child)?;
         }
 
         self.parents[child_key] = Some(parent);
@@ -688,7 +688,7 @@ impl<NodeContext> TaffyTree<NodeContext> {
         let child_key = child.into();
 
         if let Some(old_parent) = self.parents[child_key] {
-            let _ = self.remove_child(old_parent, child);
+            self.remove_child(old_parent, child)?;
         }
 
         let child_count = self.children[parent_key].len();

--- a/src/tree/taffy_tree.rs
+++ b/src/tree/taffy_tree.rs
@@ -784,13 +784,18 @@ impl<NodeContext> TaffyTree<NodeContext> {
         new_child: NodeId,
     ) -> TaffyResult<NodeId> {
         let parent_key = parent.into();
+        let new_child_key = new_child.into();
+
+        if let Some(old_parent) = self.parents[new_child_key] {
+            self.remove_child(old_parent, new_child)?;
+        }
 
         let child_count = self.children[parent_key].len();
         if child_index >= child_count {
             return Err(TaffyError::ChildIndexOutOfBounds { parent, child_index, child_count });
         }
 
-        self.parents[new_child.into()] = Some(parent);
+        self.parents[new_child_key] = Some(parent);
         let old_child = core::mem::replace(&mut self.children[parent_key][child_index], new_child);
         self.parents[old_child.into()] = None;
 


### PR DESCRIPTION
# Objective

Remove parents of nodes passed as children to `TaffyTree::add_child`, `TaffyTree::insert_child_at_index`, `TaffyTree::new_with_children`, or `TaffyTree::replace_child_at_index` to prevent state corruption & an eventual panic.

Fixes #1100

## Context

Other functions which edit `TaffyTree`'s hierarchy (ex. `TaffyTree::set_children`) ensure the `parents` & `children` arrays are correctly updated. `TaffyTree::add_child` & friends have a slight oversight. These functions do not remove the child node from its previous parent's `children` array, which causes a crash when `TaffyTree::remove` is called.

Demo code in a gist because the extra 60 lines of code in a description is a bit much.
https://gist.github.com/CyberspaceDreamn/674cb5331fb962773299e20ce6162f9f