### PR TITLE
Support sizing keywords and `content` for flex-basis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
   In contexts where a keyword cannot be resolved it behaves as `auto`
 
+- `Dimension` also supports the `content` keyword (`Dimension::content()`, CSS `content`), which indicates an automatic size based on the box's content. This keyword is only valid for `flex-basis`, where it sizes the item based on its content (ignoring its main size property) when computing its flex base size. In any other context (e.g. `width`/`height`) it behaves as `auto`
+
 ### Changed
 
 - `Style::min_size` and `Style::max_size` (and the corresponding `CoreStyle::min_size`/`CoreStyle::max_size` trait methods) are now `Size<LengthPercentageAuto>` rather than `Size<Dimension>`, as the min/max sizing properties do not support the new sizing keywords that `Dimension` now supports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - `Dimension` (used for `size`) now supports the sizing keywords `min-content`, `max-content`, `fit-content`, `fit-content(<length-percentage>)` and `stretch` via new constructors (`Dimension::min_content()`, `Dimension::max_content()`, `Dimension::fit_content()`, `Dimension::fit_content_px()`, `Dimension::fit_content_percent()`, `Dimension::stretch()`), new `CompactLength::FIT_CONTENT_KEYWORD_TAG`/`CompactLength::STRETCH_TAG` representations, and CSS parsing support. These keywords are resolved:
   - In block layout: for the widths of in-flow children and floats
-  - In flexbox layout: for the main-axis size when determining an item's flex base size, and for the cross-axis size when determining an item's hypothetical cross size
+  - In flexbox layout: for the main-axis size when determining an item's flex base size, for the cross-axis size when determining an item's hypothetical cross size, and for `flex-basis` (where `stretch` resolves to the stretch-fit main size and the other keywords determine the sizing constraint the item is measured under when computing its flex base size)
   - In grid layout: for the width/height of grid items, both during track sizing (content contributions) and during final item sizing/alignment. A keyword-sized axis is treated as non-`auto`, so the default `normal` self-alignment resolves to `start` rather than `stretch` in that axis
 
   In contexts where a keyword cannot be resolved it behaves as `auto`

--- a/scripts/gentest/src/main.rs
+++ b/scripts/gentest/src/main.rs
@@ -776,6 +776,13 @@ fn serialize_dimension(obj: &serde_json::Value) -> Option<Cow<'static, str>> {
                     "min-content" => Cow::from("min-content"),
                     "fit-content" => Cow::from("fit-content"),
                     "stretch" => Cow::from("stretch"),
+                    "fit-content-px" => {
+                        Cow::from(format!("fit-content({}px)", value.expect("Expected value for fit-content(px) unit")))
+                    }
+                    "fit-content-percent" => Cow::from(format!(
+                        "fit-content({}%)",
+                        value.expect("Expected value for fit-content(%) unit") * 100.0
+                    )),
                     "px" => Cow::from(format!("{}px", value.expect("Expected value for px unit"))),
                     "percent" => Cow::from(format!("{}%", value.expect("Expected value for % unit") * 100.0)),
                     "fraction" => Cow::from(format!("{}fr", value.expect("Expected value for fr unit"))),

--- a/scripts/gentest/src/main.rs
+++ b/scripts/gentest/src/main.rs
@@ -776,6 +776,7 @@ fn serialize_dimension(obj: &serde_json::Value) -> Option<Cow<'static, str>> {
                     "min-content" => Cow::from("min-content"),
                     "fit-content" => Cow::from("fit-content"),
                     "stretch" => Cow::from("stretch"),
+                    "content" => Cow::from("content"),
                     "fit-content-px" => {
                         Cow::from(format!("fit-content({}px)", value.expect("Expected value for fit-content(px) unit")))
                     }

--- a/scripts/gentest/test_helper.js
+++ b/scripts/gentest/test_helper.js
@@ -120,6 +120,7 @@ function parseDimension(input, options = { allowFrUnits: false }) {
   if (input === 'max-content') return { unit: 'max-content' };
   if (input === 'fit-content') return { unit: 'fit-content' };
   if (input === 'stretch') return { unit: 'stretch' };
+  if (input === 'content') return { unit: 'content' };
   const fitContentMatch = /^fit-content\((.*)\)$/.exec(input);
   if (fitContentMatch) {
     const arg = fitContentMatch[1].trim();

--- a/scripts/gentest/test_helper.js
+++ b/scripts/gentest/test_helper.js
@@ -120,8 +120,12 @@ function parseDimension(input, options = { allowFrUnits: false }) {
   if (input === 'max-content') return { unit: 'max-content' };
   if (input === 'fit-content') return { unit: 'fit-content' };
   if (input === 'stretch') return { unit: 'stretch' };
-  // Note: Chrome does not support `fit-content(<length-percentage>)` for width/height,
-  // so there is no need to parse it here (only for grid tracks, which are parsed separately)
+  const fitContentMatch = /^fit-content\((.*)\)$/.exec(input);
+  if (fitContentMatch) {
+    const arg = fitContentMatch[1].trim();
+    if (arg.endsWith('px')) return { unit: 'fit-content-px', value: parseFloat(arg) };
+    if (arg.endsWith('%')) return { unit: 'fit-content-percent', value: parseFloat(arg) / 100 };
+  }
   return undefined;
 }
 

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -829,6 +829,11 @@ fn determine_flex_base_size(
                     Some(SizingKeywordResolution::Measure(available)) => Some(available),
                     None => None,
                 }
+            } else if flex_basis_style.is_content() {
+                // A flex basis of `content` indicates an automatic size based on the item's
+                // content: the item is measured (ignoring its main size property) under the
+                // default constraint below
+                None
             } else {
                 if let Some(flex_basis) = flex_basis.or(main_size) {
                     child.flex_basis_is_definite = true;

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -795,8 +795,8 @@ fn determine_flex_base_size(
         // content is treated as indefinite here.
         let percent_resolution_main_size =
             if constants.known_main_size_is_definite { constants.node_inner_size.main(dir) } else { None };
-        let flex_basis = child_style
-            .flex_basis()
+        let flex_basis_style = child_style.flex_basis();
+        let flex_basis = flex_basis_style
             .maybe_resolve(percent_resolution_main_size, |val, basis| tree.calc(val, basis))
             .maybe_add(box_sizing_adjustment);
 
@@ -813,9 +813,42 @@ fn determine_flex_base_size(
             // Note: `child.size` has already been resolved against aspect_ratio in generate_anonymous_flex_items
             // So B will just work here by using main_size without special handling for aspect_ratio
             let main_size = child.size.main(dir);
-            if let Some(flex_basis) = flex_basis.or(main_size) {
-                child.flex_basis_is_definite = true;
-                break 'flex_basis flex_basis;
+            let main_stretch_size = percent_resolution_main_size.maybe_sub(child.margin.main_axis_sum(dir));
+
+            // A flex basis that is a sizing keyword (min-content, max-content, fit-content,
+            // fit-content(...), stretch) is used in place of the main size property: `stretch`
+            // resolves to an exact (definite) size while the other keywords determine the
+            // available space constraint the item is measured under. A keyword that cannot be
+            // resolved in the current context behaves as `content`.
+            let keyword_main_available_space = if flex_basis_style.is_intrinsic_sizing_keyword() {
+                match resolve_sizing_keyword(flex_basis_style, main_stretch_size, percent_resolution_main_size) {
+                    Some(SizingKeywordResolution::Exact(size)) => {
+                        child.flex_basis_is_definite = true;
+                        break 'flex_basis size;
+                    }
+                    Some(SizingKeywordResolution::Measure(available)) => Some(available),
+                    None => None,
+                }
+            } else {
+                if let Some(flex_basis) = flex_basis.or(main_size) {
+                    child.flex_basis_is_definite = true;
+                    break 'flex_basis flex_basis;
+                };
+
+                // A main size that is a sizing keyword either resolves to an exact size or
+                // determines the available space constraint the item is measured under
+                match resolve_sizing_keyword(
+                    child.size_style.main(dir),
+                    main_stretch_size,
+                    percent_resolution_main_size,
+                ) {
+                    Some(SizingKeywordResolution::Exact(size)) => {
+                        child.flex_basis_is_definite = true;
+                        break 'flex_basis size;
+                    }
+                    Some(SizingKeywordResolution::Measure(available)) => Some(available),
+                    None => None,
+                }
             };
 
             // C. If the used flex basis is content or depends on its available space,
@@ -851,23 +884,6 @@ fn determine_flex_base_size(
             //    flex item’s main size is in its block axis) and the flex item’s cross size
             //    is auto and not definite, in this calculation use fit-content as the
             //    flex item’s cross size. The flex base size is the item’s resulting main size.
-
-            // A main size that is a sizing keyword (min-content, max-content, fit-content,
-            // fit-content(...), stretch) either resolves to an exact size or determines the
-            // available space constraint the item is measured under
-            let main_stretch_size = percent_resolution_main_size.maybe_sub(child.margin.main_axis_sum(dir));
-            let keyword_main_available_space = match resolve_sizing_keyword(
-                child.size_style.main(dir),
-                main_stretch_size,
-                percent_resolution_main_size,
-            ) {
-                Some(SizingKeywordResolution::Exact(size)) => {
-                    child.flex_basis_is_definite = true;
-                    break 'flex_basis size;
-                }
-                Some(SizingKeywordResolution::Measure(available)) => Some(available),
-                None => None,
-            };
 
             let child_available_space = Size::MAX_CONTENT
                 .with_main(

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -820,7 +820,7 @@ fn determine_flex_base_size(
             // resolves to an exact (definite) size while the other keywords determine the
             // available space constraint the item is measured under. A keyword that cannot be
             // resolved in the current context behaves as `content`.
-            let keyword_main_available_space = if flex_basis_style.is_intrinsic_sizing_keyword() {
+            let keyword_main_available_space = if flex_basis_style.is_sizing_keyword() {
                 match resolve_sizing_keyword(flex_basis_style, main_stretch_size, percent_resolution_main_size) {
                     Some(SizingKeywordResolution::Exact(size)) => {
                         child.flex_basis_is_definite = true;

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -820,7 +820,12 @@ fn determine_flex_base_size(
             // resolves to an exact (definite) size while the other keywords determine the
             // available space constraint the item is measured under. A keyword that cannot be
             // resolved in the current context behaves as `content`.
-            let keyword_main_available_space = if flex_basis_style.is_sizing_keyword() {
+            let keyword_main_available_space = if flex_basis_style.is_content() {
+                // A flex basis of `content` indicates an automatic size based on the item's
+                // content: the item is measured (ignoring its main size property) under the
+                // default constraint below
+                None
+            } else if flex_basis_style.is_sizing_keyword() {
                 match resolve_sizing_keyword(flex_basis_style, main_stretch_size, percent_resolution_main_size) {
                     Some(SizingKeywordResolution::Exact(size)) => {
                         child.flex_basis_is_definite = true;
@@ -829,11 +834,6 @@ fn determine_flex_base_size(
                     Some(SizingKeywordResolution::Measure(available)) => Some(available),
                     None => None,
                 }
-            } else if flex_basis_style.is_content() {
-                // A flex basis of `content` indicates an automatic size based on the item's
-                // content: the item is measured (ignoring its main size property) under the
-                // default constraint below
-                None
             } else {
                 if let Some(flex_basis) = flex_basis.or(main_size) {
                     child.flex_basis_is_definite = true;

--- a/src/style/compact_length.rs
+++ b/src/style/compact_length.rs
@@ -233,6 +233,8 @@ impl CompactLength {
     pub const FIT_CONTENT_KEYWORD_TAG: usize = 0b00100111;
     /// The tag indicating a stretch keyword value
     pub const STRETCH_TAG: usize = 0b00101111;
+    /// The tag indicating a content keyword value
+    pub const CONTENT_TAG: usize = 0b00110111;
 }
 
 impl CompactLength {
@@ -339,6 +341,15 @@ impl CompactLength {
         Self(CompactLengthInner::from_tag(Self::STRETCH_TAG))
     }
 
+    /// The size should be an automatic size based on the box's content
+    /// (<https://www.w3.org/TR/css-flexbox-1/#valdef-flex-basis-content>)
+    ///
+    /// This keyword is only valid for `flex-basis`. In any other context it behaves as [`auto`](Self::auto).
+    #[inline(always)]
+    pub const fn content() -> Self {
+        Self(CompactLengthInner::from_tag(Self::CONTENT_TAG))
+    }
+
     /// Get the primary tag
     #[inline(always)]
     pub fn tag(self) -> usize {
@@ -382,6 +393,12 @@ impl CompactLength {
     #[inline(always)]
     pub fn is_auto(self) -> bool {
         self.tag() == Self::AUTO_TAG
+    }
+
+    /// Returns true if the value is the content keyword
+    #[inline(always)]
+    pub fn is_content(self) -> bool {
+        self.tag() == Self::CONTENT_TAG
     }
 
     /// Returns true if the value is min-content
@@ -569,6 +586,7 @@ impl<'de> serde::Deserialize<'de> for CompactLength {
                 | CompactLength::FIT_CONTENT_PX_TAG
                 | CompactLength::FIT_CONTENT_PERCENT_TAG
                 | CompactLength::STRETCH_TAG
+                | CompactLength::CONTENT_TAG
                 | CompactLength::FR_TAG
         ) {
             Ok(value)

--- a/src/style/dimension.rs
+++ b/src/style/dimension.rs
@@ -267,6 +267,7 @@ impl FromCss for Dimension {
                 "max-content" => Ok(Self::max_content()),
                 "fit-content" => Ok(Self::fit_content()),
                 "stretch" => Ok(Self::stretch()),
+                "content" => Ok(Self::content()),
                 _ => Err(parser.new_unexpected_token_error(token))?,
             },
             Token::Function(ref name) if name.as_ref() == "fit-content" => parser.parse_nested_block(|parser| {
@@ -345,6 +346,15 @@ impl Dimension {
         Self(CompactLength::stretch())
     }
 
+    /// The size should be an automatic size based on the box's content
+    /// (<https://www.w3.org/TR/css-flexbox-1/#valdef-flex-basis-content>)
+    ///
+    /// This keyword is only valid for `flex-basis`. In any other context it behaves as [`auto`](Self::auto).
+    #[inline(always)]
+    pub const fn content() -> Self {
+        Self(CompactLength::content())
+    }
+
     /// The size should be computed according to the "fit content" formula:
     ///    `max(min_content, min(max_content, limit))`
     /// where `limit` is a PERCENTAGE value
@@ -402,6 +412,12 @@ impl Dimension {
         self.0.tag() == CompactLength::STRETCH_TAG
     }
 
+    /// Returns true if value is the content keyword
+    #[inline(always)]
+    pub fn is_content(self) -> bool {
+        self.0.is_content()
+    }
+
     /// Get the raw `CompactLength` tag
     pub fn tag(self) -> usize {
         self.0.tag()
@@ -432,6 +448,7 @@ impl<'de> serde::Deserialize<'de> for Dimension {
                 | CompactLength::FIT_CONTENT_PX_TAG
                 | CompactLength::FIT_CONTENT_PERCENT_TAG
                 | CompactLength::STRETCH_TAG
+                | CompactLength::CONTENT_TAG
         ) {
             Ok(Self(inner))
         } else {

--- a/src/style/grid.rs
+++ b/src/style/grid.rs
@@ -772,7 +772,9 @@ impl From<Dimension> for MaxTrackSizingFunction {
         // Dimension supports values that are not valid max track sizing functions.
         // Map those to `auto`.
         match input.0.tag() {
-            CompactLength::FIT_CONTENT_KEYWORD_TAG | CompactLength::STRETCH_TAG => Self::auto(),
+            CompactLength::FIT_CONTENT_KEYWORD_TAG | CompactLength::STRETCH_TAG | CompactLength::CONTENT_TAG => {
+                Self::auto()
+            }
             _ => Self(input.0),
         }
     }
@@ -1100,7 +1102,8 @@ impl From<Dimension> for MinTrackSizingFunction {
             CompactLength::FIT_CONTENT_PX_TAG
             | CompactLength::FIT_CONTENT_PERCENT_TAG
             | CompactLength::FIT_CONTENT_KEYWORD_TAG
-            | CompactLength::STRETCH_TAG => Self::auto(),
+            | CompactLength::STRETCH_TAG
+            | CompactLength::CONTENT_TAG => Self::auto(),
             _ => Self(input.0),
         }
     }

--- a/src/util/resolve.rs
+++ b/src/util/resolve.rs
@@ -61,6 +61,8 @@ impl MaybeResolve<Option<f32>, Option<f32>> for Dimension {
     fn maybe_resolve(self, context: Option<f32>, calc: impl Fn(*const (), f32) -> f32) -> Option<f32> {
         match self.0.tag() {
             CompactLength::AUTO_TAG => None,
+            // The content keyword is only valid for flex-basis. In any other context it behaves as auto.
+            CompactLength::CONTENT_TAG => None,
             CompactLength::LENGTH_TAG => Some(self.0.value()),
             CompactLength::PERCENT_TAG => context.map(|dim| dim * self.0.value()),
             #[cfg(feature = "calc")]

--- a/test_fixtures/flex/flex_basis_content_column.html
+++ b/test_fixtures/flex/flex_basis_content_column.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="flex-direction: column; width: 50px; height: 200px;">
+  <div style="flex-basis: content; height: 100px; flex-grow: 0; flex-shrink: 0;">XXXX&ZeroWidthSpace;XXXX</div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/flex_basis_content_row.html
+++ b/test_fixtures/flex/flex_basis_content_row.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="flex-direction: row; width: 200px; height: 50px;">
+  <div style="flex-basis: content; width: 30px; flex-grow: 0; flex-shrink: 0;">XXXX&ZeroWidthSpace;XXXX</div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/flex_basis_fit_content_row.html
+++ b/test_fixtures/flex/flex_basis_fit_content_row.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="flex-direction: row; width: 60px; height: 50px;">
+  <div style="flex-basis: fit-content; flex-grow: 0; flex-shrink: 0;">XXXX&ZeroWidthSpace;XXXX</div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/flex_basis_max_content_column.html
+++ b/test_fixtures/flex/flex_basis_max_content_column.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="flex-direction: column; width: 50px; height: 200px;">
+  <div style="flex-basis: max-content; flex-grow: 0; flex-shrink: 0;">XXXX&ZeroWidthSpace;XXXX</div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/flex_basis_max_content_row.html
+++ b/test_fixtures/flex/flex_basis_max_content_row.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="flex-direction: row; width: 60px; height: 50px;">
+  <div style="flex-basis: max-content; flex-grow: 0; flex-shrink: 0;">XXXX&ZeroWidthSpace;XXXX</div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/flex_basis_min_content_column.html
+++ b/test_fixtures/flex/flex_basis_min_content_column.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="flex-direction: column; width: 50px; height: 200px;">
+  <div style="flex-basis: min-content; flex-grow: 0; flex-shrink: 0;">XXXX&ZeroWidthSpace;XXXX</div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/flex_basis_min_content_row.html
+++ b/test_fixtures/flex/flex_basis_min_content_row.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="flex-direction: row; width: 200px; height: 50px;">
+  <div style="flex-basis: min-content; flex-grow: 0; flex-shrink: 0;">XXXX&ZeroWidthSpace;XXXX</div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/flex_basis_stretch_column.html
+++ b/test_fixtures/flex/flex_basis_stretch_column.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="flex-direction: column; width: 50px; height: 200px;">
+  <div style="flex-basis: stretch; flex-grow: 0; flex-shrink: 0;">XXXX&ZeroWidthSpace;XXXX</div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/flex_basis_stretch_row.html
+++ b/test_fixtures/flex/flex_basis_stretch_row.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="flex-direction: row; width: 200px; height: 50px;">
+  <div style="flex-basis: stretch; flex-grow: 0; flex-shrink: 0;">XXXX&ZeroWidthSpace;XXXX</div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/flex/flex_basis_content_column__border_box_ltr.xml
+++ b/tests/xml/flex/flex_basis_content_column__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="flex_basis_content_column__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" flex-direction="column" width="50px" height="200px">
+      <text direction="ltr" flex-shrink="0" flex-basis="content" height="100px">
+        XXXX​XXXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="50" height="200">
+      <node x="0" y="0" width="50" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_basis_content_column__border_box_rtl.xml
+++ b/tests/xml/flex/flex_basis_content_column__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="flex_basis_content_column__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" flex-direction="column" width="50px" height="200px">
+      <text direction="rtl" flex-shrink="0" flex-basis="content" height="100px">
+        XXXX​XXXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="50" height="200">
+      <node x="0" y="0" width="50" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_basis_content_column__content_box_ltr.xml
+++ b/tests/xml/flex/flex_basis_content_column__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="flex_basis_content_column__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" flex-direction="column" width="50px" height="200px">
+      <text box-sizing="content-box" direction="ltr" flex-shrink="0" flex-basis="content" height="100px">
+        XXXX​XXXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="50" height="200">
+      <node x="0" y="0" width="50" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_basis_content_column__content_box_rtl.xml
+++ b/tests/xml/flex/flex_basis_content_column__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="flex_basis_content_column__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" flex-direction="column" width="50px" height="200px">
+      <text box-sizing="content-box" direction="rtl" flex-shrink="0" flex-basis="content" height="100px">
+        XXXX​XXXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="50" height="200">
+      <node x="0" y="0" width="50" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_basis_content_row__border_box_ltr.xml
+++ b/tests/xml/flex/flex_basis_content_row__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="flex_basis_content_row__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" width="200px" height="50px">
+      <text direction="ltr" flex-shrink="0" flex-basis="content" width="30px">
+        XXXX​XXXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="50">
+      <node x="0" y="0" width="80" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_basis_content_row__border_box_rtl.xml
+++ b/tests/xml/flex/flex_basis_content_row__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="flex_basis_content_row__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" width="200px" height="50px">
+      <text direction="rtl" flex-shrink="0" flex-basis="content" width="30px">
+        XXXX​XXXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="50">
+      <node x="120" y="0" width="80" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_basis_content_row__content_box_ltr.xml
+++ b/tests/xml/flex/flex_basis_content_row__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="flex_basis_content_row__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" width="200px" height="50px">
+      <text box-sizing="content-box" direction="ltr" flex-shrink="0" flex-basis="content" width="30px">
+        XXXX​XXXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="50">
+      <node x="0" y="0" width="80" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_basis_content_row__content_box_rtl.xml
+++ b/tests/xml/flex/flex_basis_content_row__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="flex_basis_content_row__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" width="200px" height="50px">
+      <text box-sizing="content-box" direction="rtl" flex-shrink="0" flex-basis="content" width="30px">
+        XXXX​XXXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="50">
+      <node x="120" y="0" width="80" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_basis_fit_content_row__border_box_ltr.xml
+++ b/tests/xml/flex/flex_basis_fit_content_row__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="flex_basis_fit_content_row__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" width="60px" height="50px">
+      <text direction="ltr" flex-shrink="0" flex-basis="fit-content">
+        XXXX​XXXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="60" height="50">
+      <node x="0" y="0" width="60" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_basis_fit_content_row__border_box_rtl.xml
+++ b/tests/xml/flex/flex_basis_fit_content_row__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="flex_basis_fit_content_row__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" width="60px" height="50px">
+      <text direction="rtl" flex-shrink="0" flex-basis="fit-content">
+        XXXX​XXXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="60" height="50">
+      <node x="0" y="0" width="60" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_basis_fit_content_row__content_box_ltr.xml
+++ b/tests/xml/flex/flex_basis_fit_content_row__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="flex_basis_fit_content_row__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" width="60px" height="50px">
+      <text box-sizing="content-box" direction="ltr" flex-shrink="0" flex-basis="fit-content">
+        XXXX​XXXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="60" height="50">
+      <node x="0" y="0" width="60" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_basis_fit_content_row__content_box_rtl.xml
+++ b/tests/xml/flex/flex_basis_fit_content_row__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="flex_basis_fit_content_row__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" width="60px" height="50px">
+      <text box-sizing="content-box" direction="rtl" flex-shrink="0" flex-basis="fit-content">
+        XXXX​XXXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="60" height="50">
+      <node x="0" y="0" width="60" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_basis_max_content_column__border_box_ltr.xml
+++ b/tests/xml/flex/flex_basis_max_content_column__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="flex_basis_max_content_column__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" flex-direction="column" width="50px" height="200px">
+      <text direction="ltr" flex-shrink="0" flex-basis="max-content">
+        XXXX​XXXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="50" height="200">
+      <node x="0" y="0" width="50" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_basis_max_content_column__border_box_rtl.xml
+++ b/tests/xml/flex/flex_basis_max_content_column__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="flex_basis_max_content_column__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" flex-direction="column" width="50px" height="200px">
+      <text direction="rtl" flex-shrink="0" flex-basis="max-content">
+        XXXX​XXXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="50" height="200">
+      <node x="0" y="0" width="50" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_basis_max_content_column__content_box_ltr.xml
+++ b/tests/xml/flex/flex_basis_max_content_column__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="flex_basis_max_content_column__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" flex-direction="column" width="50px" height="200px">
+      <text box-sizing="content-box" direction="ltr" flex-shrink="0" flex-basis="max-content">
+        XXXX​XXXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="50" height="200">
+      <node x="0" y="0" width="50" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_basis_max_content_column__content_box_rtl.xml
+++ b/tests/xml/flex/flex_basis_max_content_column__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="flex_basis_max_content_column__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" flex-direction="column" width="50px" height="200px">
+      <text box-sizing="content-box" direction="rtl" flex-shrink="0" flex-basis="max-content">
+        XXXX​XXXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="50" height="200">
+      <node x="0" y="0" width="50" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_basis_max_content_row__border_box_ltr.xml
+++ b/tests/xml/flex/flex_basis_max_content_row__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="flex_basis_max_content_row__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" width="60px" height="50px">
+      <text direction="ltr" flex-shrink="0" flex-basis="max-content">
+        XXXX​XXXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="60" height="50">
+      <node x="0" y="0" width="80" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_basis_max_content_row__border_box_rtl.xml
+++ b/tests/xml/flex/flex_basis_max_content_row__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="flex_basis_max_content_row__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" width="60px" height="50px">
+      <text direction="rtl" flex-shrink="0" flex-basis="max-content">
+        XXXX​XXXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="60" height="50">
+      <node x="-20" y="0" width="80" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_basis_max_content_row__content_box_ltr.xml
+++ b/tests/xml/flex/flex_basis_max_content_row__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="flex_basis_max_content_row__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" width="60px" height="50px">
+      <text box-sizing="content-box" direction="ltr" flex-shrink="0" flex-basis="max-content">
+        XXXX​XXXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="60" height="50">
+      <node x="0" y="0" width="80" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_basis_max_content_row__content_box_rtl.xml
+++ b/tests/xml/flex/flex_basis_max_content_row__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="flex_basis_max_content_row__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" width="60px" height="50px">
+      <text box-sizing="content-box" direction="rtl" flex-shrink="0" flex-basis="max-content">
+        XXXX​XXXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="60" height="50">
+      <node x="-20" y="0" width="80" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_basis_min_content_column__border_box_ltr.xml
+++ b/tests/xml/flex/flex_basis_min_content_column__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="flex_basis_min_content_column__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" flex-direction="column" width="50px" height="200px">
+      <text direction="ltr" flex-shrink="0" flex-basis="min-content">
+        XXXX​XXXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="50" height="200">
+      <node x="0" y="0" width="50" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_basis_min_content_column__border_box_rtl.xml
+++ b/tests/xml/flex/flex_basis_min_content_column__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="flex_basis_min_content_column__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" flex-direction="column" width="50px" height="200px">
+      <text direction="rtl" flex-shrink="0" flex-basis="min-content">
+        XXXX​XXXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="50" height="200">
+      <node x="0" y="0" width="50" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_basis_min_content_column__content_box_ltr.xml
+++ b/tests/xml/flex/flex_basis_min_content_column__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="flex_basis_min_content_column__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" flex-direction="column" width="50px" height="200px">
+      <text box-sizing="content-box" direction="ltr" flex-shrink="0" flex-basis="min-content">
+        XXXX​XXXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="50" height="200">
+      <node x="0" y="0" width="50" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_basis_min_content_column__content_box_rtl.xml
+++ b/tests/xml/flex/flex_basis_min_content_column__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="flex_basis_min_content_column__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" flex-direction="column" width="50px" height="200px">
+      <text box-sizing="content-box" direction="rtl" flex-shrink="0" flex-basis="min-content">
+        XXXX​XXXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="50" height="200">
+      <node x="0" y="0" width="50" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_basis_min_content_row__border_box_ltr.xml
+++ b/tests/xml/flex/flex_basis_min_content_row__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="flex_basis_min_content_row__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" width="200px" height="50px">
+      <text direction="ltr" flex-shrink="0" flex-basis="min-content">
+        XXXX​XXXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="50">
+      <node x="0" y="0" width="40" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_basis_min_content_row__border_box_rtl.xml
+++ b/tests/xml/flex/flex_basis_min_content_row__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="flex_basis_min_content_row__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" width="200px" height="50px">
+      <text direction="rtl" flex-shrink="0" flex-basis="min-content">
+        XXXX​XXXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="50">
+      <node x="160" y="0" width="40" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_basis_min_content_row__content_box_ltr.xml
+++ b/tests/xml/flex/flex_basis_min_content_row__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="flex_basis_min_content_row__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" width="200px" height="50px">
+      <text box-sizing="content-box" direction="ltr" flex-shrink="0" flex-basis="min-content">
+        XXXX​XXXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="50">
+      <node x="0" y="0" width="40" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_basis_min_content_row__content_box_rtl.xml
+++ b/tests/xml/flex/flex_basis_min_content_row__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="flex_basis_min_content_row__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" width="200px" height="50px">
+      <text box-sizing="content-box" direction="rtl" flex-shrink="0" flex-basis="min-content">
+        XXXX​XXXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="50">
+      <node x="160" y="0" width="40" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_basis_stretch_column__border_box_ltr.xml
+++ b/tests/xml/flex/flex_basis_stretch_column__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="flex_basis_stretch_column__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" flex-direction="column" width="50px" height="200px">
+      <text direction="ltr" flex-shrink="0" flex-basis="stretch">
+        XXXX​XXXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="50" height="200">
+      <node x="0" y="0" width="50" height="200"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_basis_stretch_column__border_box_rtl.xml
+++ b/tests/xml/flex/flex_basis_stretch_column__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="flex_basis_stretch_column__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" flex-direction="column" width="50px" height="200px">
+      <text direction="rtl" flex-shrink="0" flex-basis="stretch">
+        XXXX​XXXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="50" height="200">
+      <node x="0" y="0" width="50" height="200"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_basis_stretch_column__content_box_ltr.xml
+++ b/tests/xml/flex/flex_basis_stretch_column__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="flex_basis_stretch_column__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" flex-direction="column" width="50px" height="200px">
+      <text box-sizing="content-box" direction="ltr" flex-shrink="0" flex-basis="stretch">
+        XXXX​XXXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="50" height="200">
+      <node x="0" y="0" width="50" height="200"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_basis_stretch_column__content_box_rtl.xml
+++ b/tests/xml/flex/flex_basis_stretch_column__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="flex_basis_stretch_column__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" flex-direction="column" width="50px" height="200px">
+      <text box-sizing="content-box" direction="rtl" flex-shrink="0" flex-basis="stretch">
+        XXXX​XXXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="50" height="200">
+      <node x="0" y="0" width="50" height="200"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_basis_stretch_row__border_box_ltr.xml
+++ b/tests/xml/flex/flex_basis_stretch_row__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="flex_basis_stretch_row__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" width="200px" height="50px">
+      <text direction="ltr" flex-shrink="0" flex-basis="stretch">
+        XXXX​XXXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="50">
+      <node x="0" y="0" width="200" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_basis_stretch_row__border_box_rtl.xml
+++ b/tests/xml/flex/flex_basis_stretch_row__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="flex_basis_stretch_row__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" width="200px" height="50px">
+      <text direction="rtl" flex-shrink="0" flex-basis="stretch">
+        XXXX​XXXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="50">
+      <node x="0" y="0" width="200" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_basis_stretch_row__content_box_ltr.xml
+++ b/tests/xml/flex/flex_basis_stretch_row__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="flex_basis_stretch_row__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" width="200px" height="50px">
+      <text box-sizing="content-box" direction="ltr" flex-shrink="0" flex-basis="stretch">
+        XXXX​XXXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="50">
+      <node x="0" y="0" width="200" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_basis_stretch_row__content_box_rtl.xml
+++ b/tests/xml/flex/flex_basis_stretch_row__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="flex_basis_stretch_row__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" width="200px" height="50px">
+      <text box-sizing="content-box" direction="rtl" flex-shrink="0" flex-basis="stretch">
+        XXXX​XXXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="50">
+      <node x="0" y="0" width="200" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -10268,6 +10268,26 @@ mod flex {
     }
 
     #[test]
+    fn flex_basis_fit_content_row__border_box_ltr() {
+        crate::run_xml_test("flex", "flex_basis_fit_content_row__border_box_ltr");
+    }
+
+    #[test]
+    fn flex_basis_fit_content_row__content_box_ltr() {
+        crate::run_xml_test("flex", "flex_basis_fit_content_row__content_box_ltr");
+    }
+
+    #[test]
+    fn flex_basis_fit_content_row__border_box_rtl() {
+        crate::run_xml_test("flex", "flex_basis_fit_content_row__border_box_rtl");
+    }
+
+    #[test]
+    fn flex_basis_fit_content_row__content_box_rtl() {
+        crate::run_xml_test("flex", "flex_basis_fit_content_row__content_box_rtl");
+    }
+
+    #[test]
     fn flex_basis_flex_grow_column__border_box_ltr() {
         crate::run_xml_test("flex", "flex_basis_flex_grow_column__border_box_ltr");
     }
@@ -10385,6 +10405,86 @@ mod flex {
     #[test]
     fn flex_basis_larger_than_content_row__content_box_rtl() {
         crate::run_xml_test("flex", "flex_basis_larger_than_content_row__content_box_rtl");
+    }
+
+    #[test]
+    fn flex_basis_max_content_column__border_box_ltr() {
+        crate::run_xml_test("flex", "flex_basis_max_content_column__border_box_ltr");
+    }
+
+    #[test]
+    fn flex_basis_max_content_column__content_box_ltr() {
+        crate::run_xml_test("flex", "flex_basis_max_content_column__content_box_ltr");
+    }
+
+    #[test]
+    fn flex_basis_max_content_column__border_box_rtl() {
+        crate::run_xml_test("flex", "flex_basis_max_content_column__border_box_rtl");
+    }
+
+    #[test]
+    fn flex_basis_max_content_column__content_box_rtl() {
+        crate::run_xml_test("flex", "flex_basis_max_content_column__content_box_rtl");
+    }
+
+    #[test]
+    fn flex_basis_max_content_row__border_box_ltr() {
+        crate::run_xml_test("flex", "flex_basis_max_content_row__border_box_ltr");
+    }
+
+    #[test]
+    fn flex_basis_max_content_row__content_box_ltr() {
+        crate::run_xml_test("flex", "flex_basis_max_content_row__content_box_ltr");
+    }
+
+    #[test]
+    fn flex_basis_max_content_row__border_box_rtl() {
+        crate::run_xml_test("flex", "flex_basis_max_content_row__border_box_rtl");
+    }
+
+    #[test]
+    fn flex_basis_max_content_row__content_box_rtl() {
+        crate::run_xml_test("flex", "flex_basis_max_content_row__content_box_rtl");
+    }
+
+    #[test]
+    fn flex_basis_min_content_column__border_box_ltr() {
+        crate::run_xml_test("flex", "flex_basis_min_content_column__border_box_ltr");
+    }
+
+    #[test]
+    fn flex_basis_min_content_column__content_box_ltr() {
+        crate::run_xml_test("flex", "flex_basis_min_content_column__content_box_ltr");
+    }
+
+    #[test]
+    fn flex_basis_min_content_column__border_box_rtl() {
+        crate::run_xml_test("flex", "flex_basis_min_content_column__border_box_rtl");
+    }
+
+    #[test]
+    fn flex_basis_min_content_column__content_box_rtl() {
+        crate::run_xml_test("flex", "flex_basis_min_content_column__content_box_rtl");
+    }
+
+    #[test]
+    fn flex_basis_min_content_row__border_box_ltr() {
+        crate::run_xml_test("flex", "flex_basis_min_content_row__border_box_ltr");
+    }
+
+    #[test]
+    fn flex_basis_min_content_row__content_box_ltr() {
+        crate::run_xml_test("flex", "flex_basis_min_content_row__content_box_ltr");
+    }
+
+    #[test]
+    fn flex_basis_min_content_row__border_box_rtl() {
+        crate::run_xml_test("flex", "flex_basis_min_content_row__border_box_rtl");
+    }
+
+    #[test]
+    fn flex_basis_min_content_row__content_box_rtl() {
+        crate::run_xml_test("flex", "flex_basis_min_content_row__content_box_rtl");
     }
 
     #[test]
@@ -10603,6 +10703,46 @@ mod flex {
     #[test]
     fn flex_basis_smaller_then_content_with_flex_grow_very_large_size__content_box_rtl() {
         crate::run_xml_test("flex", "flex_basis_smaller_then_content_with_flex_grow_very_large_size__content_box_rtl");
+    }
+
+    #[test]
+    fn flex_basis_stretch_column__border_box_ltr() {
+        crate::run_xml_test("flex", "flex_basis_stretch_column__border_box_ltr");
+    }
+
+    #[test]
+    fn flex_basis_stretch_column__content_box_ltr() {
+        crate::run_xml_test("flex", "flex_basis_stretch_column__content_box_ltr");
+    }
+
+    #[test]
+    fn flex_basis_stretch_column__border_box_rtl() {
+        crate::run_xml_test("flex", "flex_basis_stretch_column__border_box_rtl");
+    }
+
+    #[test]
+    fn flex_basis_stretch_column__content_box_rtl() {
+        crate::run_xml_test("flex", "flex_basis_stretch_column__content_box_rtl");
+    }
+
+    #[test]
+    fn flex_basis_stretch_row__border_box_ltr() {
+        crate::run_xml_test("flex", "flex_basis_stretch_row__border_box_ltr");
+    }
+
+    #[test]
+    fn flex_basis_stretch_row__content_box_ltr() {
+        crate::run_xml_test("flex", "flex_basis_stretch_row__content_box_ltr");
+    }
+
+    #[test]
+    fn flex_basis_stretch_row__border_box_rtl() {
+        crate::run_xml_test("flex", "flex_basis_stretch_row__border_box_rtl");
+    }
+
+    #[test]
+    fn flex_basis_stretch_row__content_box_rtl() {
+        crate::run_xml_test("flex", "flex_basis_stretch_row__content_box_rtl");
     }
 
     #[test]

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -10268,6 +10268,46 @@ mod flex {
     }
 
     #[test]
+    fn flex_basis_content_column__border_box_ltr() {
+        crate::run_xml_test("flex", "flex_basis_content_column__border_box_ltr");
+    }
+
+    #[test]
+    fn flex_basis_content_column__content_box_ltr() {
+        crate::run_xml_test("flex", "flex_basis_content_column__content_box_ltr");
+    }
+
+    #[test]
+    fn flex_basis_content_column__border_box_rtl() {
+        crate::run_xml_test("flex", "flex_basis_content_column__border_box_rtl");
+    }
+
+    #[test]
+    fn flex_basis_content_column__content_box_rtl() {
+        crate::run_xml_test("flex", "flex_basis_content_column__content_box_rtl");
+    }
+
+    #[test]
+    fn flex_basis_content_row__border_box_ltr() {
+        crate::run_xml_test("flex", "flex_basis_content_row__border_box_ltr");
+    }
+
+    #[test]
+    fn flex_basis_content_row__content_box_ltr() {
+        crate::run_xml_test("flex", "flex_basis_content_row__content_box_ltr");
+    }
+
+    #[test]
+    fn flex_basis_content_row__border_box_rtl() {
+        crate::run_xml_test("flex", "flex_basis_content_row__border_box_rtl");
+    }
+
+    #[test]
+    fn flex_basis_content_row__content_box_rtl() {
+        crate::run_xml_test("flex", "flex_basis_content_row__content_box_rtl");
+    }
+
+    #[test]
     fn flex_basis_fit_content_row__border_box_ltr() {
         crate::run_xml_test("flex", "flex_basis_fit_content_row__border_box_ltr");
     }


### PR DESCRIPTION
# Objective

Extend the sizing keyword support from #1099 to `flex-basis`, so `flex-basis: min-content | max-content | fit-content | fit-content(<length-percentage>) | stretch` resolve correctly, and add a `content` keyword to `Dimension` (valid for `flex-basis`, treated as `auto` for other styles).

## Context

Stacked on #1099 (which adds the keyword representation to `Dimension` and the shared `resolve_sizing_keyword` helper).

- `determine_flex_base_size`: keyword flex-basis now resolves via `resolve_sizing_keyword` — `stretch` resolves to the definite stretch size (marking the flex basis definite), the other keywords set the available-space constraint the item is measured under. The `content` case is checked first, then keywords, then the ordinary definite/auto path.
- `CompactLength::CONTENT_TAG` / `Dimension::content()`: `flex-basis: content` uses the automatic-sizing path (case E of the flex algorithm); if `content` is set on width/height it behaves as `auto`. The `From<Dimension>` conversions to the track sizing functions treat `content` as `auto` like the other new tags.
- Generated tests added for row/column flex-basis keywords (gentest helper updated to emit the new keywords).


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/e6b2abe65ab14b1aa2971b32ffb71c9f
Requested by: @nicoburns