### PR TITLE
Implement the layout-affecting parts of the CSS `contain` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@
 
 - `Dimension` also supports the `content` keyword (`Dimension::content()`, CSS `content`), which indicates an automatic size based on the box's content. This keyword is only valid for `flex-basis`, where it sizes the item based on its content (ignoring its main size property) when computing its flex base size. In any other context (e.g. `width`/`height`) it behaves as `auto`
 
+- Support for the layout-affecting parts of the CSS `contain` property via a new `Contain` bitflags style type, a new `Style::contain` field and a new (defaulted) `CoreStyle::contain` trait method:
+  - `Contain::SIZE` (size containment): the box is sized as if it were empty (padding, border, aspect ratio, min/max constraints and, for grid containers, sizes of empty tracks still apply). Its children are then laid out normally inside the resulting fixed-size box
+  - `Contain::INLINE_SIZE` (inline-size containment): like size containment, but only in the inline (horizontal) axis; the box's height is still content-based
+  - `Contain::LAYOUT` (layout containment): the box establishes an independent formatting context (its margins do not collapse with those of its children, it contains its own floats, and it avoids external floats) and its baseline is suppressed (boxes requiring a baseline synthesize one from its border box)
+
+  The CSS parser (`parse` feature) accepts `none | strict | content | [ size || inline-size || layout || style || paint ]` for the `contain` property: `strict` maps to `SIZE | LAYOUT`, `content` maps to `LAYOUT`, and the `style`/`paint` keywords are accepted but ignored as they do not affect layout
+
 ### Changed
 
 - `Style::min_size` and `Style::max_size` (and the corresponding `CoreStyle::min_size`/`CoreStyle::max_size` trait methods) are now `Size<LengthPercentageAuto>` rather than `Size<Dimension>`, as the min/max sizing properties do not support the new sizing keywords that `Dimension` now supports
@@ -52,6 +59,8 @@
 - Flexbox: the definiteness of known dimensions is now tracked through nested layouts via a new `known_dimensions_are_definite` field on `LayoutInput`. A flex item's post-flexing main size is only treated as definite (for resolving percentage sizes of its children and for collecting its children into flex lines) when the container's main size is definite or the item's used flex basis is definite. Previously a wrapping flex container nested in a container with an indefinite main size could incorrectly wrap its items into multiple lines based on its own content-derived size (#999)
 
 - Flexbox: percentage heights of block descendants no longer resolve against a flex item's post-flexing main size when that size is indefinite (#950)
+
+- Block/float: the height of overflowing in-flow content of a nested block no longer contributes to the height of the block formatting context root as if it were floated content. Previously an auto-height BFC root containing a block whose in-flow content overflowed it (e.g. a fixed-height block with taller content) was incorrectly extended to contain that overflowing content
 
 - Flexbox: a wrapping container with an indefinite main size now wraps its items against its max main size (e.g. `max-width` for a row container) when the available space exceeds it. Previously items were collected into flex lines using the raw available space, so a fit-content sized container (such as a float) with a `max-width` smaller than the available space never wrapped
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
   - `Contain::INLINE_SIZE` (inline-size containment): like size containment, but only in the inline (horizontal) axis; the box's height is still content-based
   - `Contain::LAYOUT` (layout containment): the box establishes an independent formatting context (its margins do not collapse with those of its children, it contains its own floats, and it avoids external floats) and its baseline is suppressed (boxes requiring a baseline synthesize one from its border box)
   - `Contain::PAINT` (paint containment): the box establishes an independent formatting context like layout containment, but its baseline is not suppressed. Paint containment's other effects (clipping, containing absolutely-positioned descendants, stacking context) do not affect layout and are not implemented
+  - Layout and paint containment also prevent the box's overflowing content from contributing to its ancestors' `content_size` (scrollable overflow region): layout containment treats such overflow as ink overflow, and paint containment clips it. The contained box's own `content_size` still includes its overflowing content
 
   The CSS parser (`parse` feature) accepts `none | strict | content | [ size || inline-size || layout || style || paint ]` for the `contain` property: `strict` maps to `SIZE | LAYOUT | PAINT`, `content` maps to `LAYOUT | PAINT`, and the `style` keyword is accepted but ignored as it does not affect layout
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,9 @@
   - `Contain::SIZE` (size containment): the box is sized as if it were empty (padding, border, aspect ratio, min/max constraints and, for grid containers, sizes of empty tracks still apply). Its children are then laid out normally inside the resulting fixed-size box
   - `Contain::INLINE_SIZE` (inline-size containment): like size containment, but only in the inline (horizontal) axis; the box's height is still content-based
   - `Contain::LAYOUT` (layout containment): the box establishes an independent formatting context (its margins do not collapse with those of its children, it contains its own floats, and it avoids external floats) and its baseline is suppressed (boxes requiring a baseline synthesize one from its border box)
+  - `Contain::PAINT` (paint containment): the box establishes an independent formatting context like layout containment, but its baseline is not suppressed. Paint containment's other effects (clipping, containing absolutely-positioned descendants, stacking context) do not affect layout and are not implemented
 
-  The CSS parser (`parse` feature) accepts `none | strict | content | [ size || inline-size || layout || style || paint ]` for the `contain` property: `strict` maps to `SIZE | LAYOUT`, `content` maps to `LAYOUT`, and the `style`/`paint` keywords are accepted but ignored as they do not affect layout
+  The CSS parser (`parse` feature) accepts `none | strict | content | [ size || inline-size || layout || style || paint ]` for the `contain` property: `strict` maps to `SIZE | LAYOUT | PAINT`, `content` maps to `LAYOUT | PAINT`, and the `style` keyword is accepted but ignored as it does not affect layout
 
 ### Changed
 

--- a/scripts/gentest/src/main.rs
+++ b/scripts/gentest/src/main.rs
@@ -663,6 +663,8 @@ fn generate_node(w: &mut XmlWriter, node: &Value) {
         maybe_write(w, "scrollbar-width", get_num_attr(&style["scrollbarWidth"], None));
     }
 
+    maybe_write(w, "contain", get_str_attr(&style["contain"], Some("none")));
+
     maybe_write(w, "text-align", get_str_attr(&style["textAlign"], None));
     maybe_write(w, "align-items", get_str_attr(&style["alignItems"], None));
     maybe_write(w, "align-self", get_str_attr(&style["alignSelf"], None));

--- a/scripts/gentest/test_helper.js
+++ b/scripts/gentest/test_helper.js
@@ -233,6 +233,8 @@ function describeElement(e) {
       overflowY: parseEnum(e.style.overflowY),
       scrollbarWidth: getScrollBarWidth(),
 
+      contain: parseEnum(e.style.contain),
+
       alignItems: parseEnum(e.style.alignItems),
       alignSelf: parseEnum(e.style.alignSelf),
       justifyItems: parseEnum(e.style.justifyItems),

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -366,11 +366,11 @@ pub fn compute_block_layout(
             inputs,
             contain,
             size_is_definite,
-            |tree, node_id, inputs, hide_children| {
+            |tree, node_id, inputs, ignore_children| {
                 // The as-if-empty sizing pass uses a fresh formatting context so that it cannot
                 // disturb the inherited one (an empty box contributes nothing to it anyway)
-                let block_ctx = if hide_children { None } else { block_ctx.as_deref_mut() };
-                compute_block_layout_inner(tree, node_id, inputs, block_ctx, hide_children)
+                let block_ctx = if ignore_children { None } else { block_ctx.as_deref_mut() };
+                compute_block_layout_inner(tree, node_id, inputs, block_ctx, ignore_children)
             },
         )
     } else {
@@ -387,14 +387,14 @@ pub fn compute_block_layout(
 }
 
 /// The main body of the block layout algorithm. Sets up an appropriate `BlockContext` and then
-/// delegates to [`compute_inner`]. When `hide_children` is `true` the node is laid out as if it
+/// delegates to [`compute_inner`]. When `ignore_children` is `true` the node is laid out as if it
 /// had no children (used for the as-if-empty sizing pass of size containment).
 fn compute_block_layout_inner(
     tree: &mut impl LayoutBlockContainer,
     node_id: NodeId,
     inputs: LayoutInput,
     block_ctx: Option<&mut BlockContext<'_>>,
-    hide_children: bool,
+    ignore_children: bool,
 ) -> LayoutOutput {
     let LayoutInput { known_dimensions, parent_size, run_mode, .. } = inputs;
     let style = tree.get_block_container_style(node_id);
@@ -471,7 +471,7 @@ fn compute_block_layout_inner(
             node_id,
             LayoutInput { known_dimensions: styled_based_known_dimensions, ..inputs },
             inherited_bfc,
-            hide_children,
+            ignore_children,
         ),
         _ => {
             let mut root_bfc = BlockFormattingContext::new();
@@ -481,7 +481,7 @@ fn compute_block_layout_inner(
                 node_id,
                 LayoutInput { known_dimensions: styled_based_known_dimensions, ..inputs },
                 &mut root_ctx,
-                hide_children,
+                ignore_children,
             )
         }
     }
@@ -493,7 +493,7 @@ fn compute_inner(
     node_id: NodeId,
     inputs: LayoutInput,
     #[allow(unused_mut)] mut block_ctx: &mut BlockContext<'_>,
-    hide_children: bool,
+    ignore_children: bool,
 ) -> LayoutOutput {
     let LayoutInput {
         known_dimensions, parent_size, available_space, run_mode, vertical_margins_are_collapsible, ..
@@ -600,7 +600,7 @@ fn compute_inner(
     drop(style);
 
     // 1. Generate items
-    let mut items = generate_item_list(tree, node_id, container_content_box_size, hide_children);
+    let mut items = generate_item_list(tree, node_id, container_content_box_size, ignore_children);
 
     // 2. Compute container width
     let container_outer_width = known_dimensions.width.unwrap_or_else(|| {
@@ -828,9 +828,9 @@ fn generate_item_list(
     tree: &impl LayoutBlockContainer,
     node: NodeId,
     node_inner_size: Size<Option<f32>>,
-    hide_children: bool,
+    ignore_children: bool,
 ) -> Vec<BlockItem> {
-    if hide_children {
+    if ignore_children {
         return Vec::new();
     }
 

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -377,7 +377,7 @@ pub fn compute_block_layout(
     };
 
     // Layout containment suppresses the box's baseline for baseline-alignment purposes
-    if contain.contains(Contain::LAYOUT) {
+    if contain.suppresses_baseline() {
         output.first_baselines = Point::NONE;
     }
 
@@ -402,10 +402,11 @@ fn compute_block_layout_inner(
     let is_scroll_container = overflow.x.is_scroll_container() || overflow.y.is_scroll_container();
     // css-align-3 §5.1.1: a non-`normal` `align-content` makes a block container establish an
     // independent formatting context. <https://drafts.csswg.org/css-align-3/#distribution-block>
-    // Layout containment also establishes an independent formatting context.
+    // Layout and paint containment also establish an independent formatting context.
     // <https://drafts.csswg.org/css-contain-2/#containment-layout>
-    let establishes_new_bfc =
-        is_scroll_container || style.align_content().is_some() || style.contain().contains(Contain::LAYOUT);
+    let establishes_new_bfc = is_scroll_container
+        || style.align_content().is_some()
+        || style.contain().establishes_independent_formatting_context();
     let aspect_ratio = style.aspect_ratio();
     let padding = style.padding().resolve_or_zero(parent_size.width, |val, basis| tree.calc(val, basis));
     let border = style.border().resolve_or_zero(parent_size.width, |val, basis| tree.calc(val, basis));
@@ -563,8 +564,9 @@ fn compute_inner(
 
     let overflow = style.overflow();
     let is_scroll_container = overflow.x.is_scroll_container() || overflow.y.is_scroll_container();
-    let establishes_new_bfc =
-        is_scroll_container || style.align_content().is_some() || style.contain().contains(Contain::LAYOUT);
+    let establishes_new_bfc = is_scroll_container
+        || style.align_content().is_some()
+        || style.contain().establishes_independent_formatting_context();
 
     // Determine margin collapsing behaviour
     let own_margins_collapse_with_children = Line {
@@ -853,14 +855,14 @@ fn generate_item_list(
             let is_table = child_style.is_table();
             let is_replaced = child_style.is_compressible_replaced();
             let is_scroll_container = overflow.x.is_scroll_container() || overflow.y.is_scroll_container();
-            let has_layout_containment = child_style.contain().contains(Contain::LAYOUT);
+            let establishes_independent_fc = child_style.contain().establishes_independent_formatting_context();
 
             let is_in_same_bfc: bool = is_block
                 && !is_table
                 && position != Position::Absolute
                 && is_not_floated
                 && !is_scroll_container
-                && !has_layout_containment;
+                && !establishes_independent_fc;
 
             BlockItem {
                 node_id: child_node_id,

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -600,7 +600,8 @@ fn compute_inner(
     drop(style);
 
     // 1. Generate items
-    let mut items = generate_item_list(tree, node_id, container_content_box_size, ignore_children);
+    let mut items =
+        if ignore_children { Vec::new() } else { generate_item_list(tree, node_id, container_content_box_size) };
 
     // 2. Compute container width
     let container_outer_width = known_dimensions.width.unwrap_or_else(|| {
@@ -828,12 +829,7 @@ fn generate_item_list(
     tree: &impl LayoutBlockContainer,
     node: NodeId,
     node_inner_size: Size<Option<f32>>,
-    ignore_children: bool,
 ) -> Vec<BlockItem> {
-    if ignore_children {
-        return Vec::new();
-    }
-
     tree.child_ids(node)
         .map(|child_node_id| (child_node_id, tree.get_block_child_style(child_node_id)))
         .filter(|(_, style)| style.box_generation_mode() != BoxGenerationMode::None)

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -14,7 +14,7 @@ use crate::{
     LayoutBlockContainer, RequestedAxis, TextAlign,
 };
 
-use super::common::containment::compute_contained_size_layout;
+use super::common::containment::{compute_contained_size_layout, contained_size_is_definite};
 
 #[cfg(feature = "float_layout")]
 use super::float::{BfcSlot, ContentSlot, FloatContext, FloatIntrinsicWidthCalculator};
@@ -351,17 +351,28 @@ pub fn compute_block_layout(
     inputs: LayoutInput,
     block_ctx: Option<&mut BlockContext<'_>>,
 ) -> LayoutOutput {
-    let contain = tree.get_block_container_style(node_id).contain();
+    let style = tree.get_block_container_style(node_id);
+    let contain = style.contain();
 
     let mut output = if contain.intersects(Contain::SIZE.union(Contain::INLINE_SIZE)) {
+        let size_is_definite = contained_size_is_definite(&style, &inputs, |val, basis| tree.calc(val, basis));
+        drop(style);
         let mut block_ctx = block_ctx;
-        compute_contained_size_layout(tree, node_id, inputs, contain, |tree, node_id, inputs, hide_children| {
-            // The as-if-empty sizing pass uses a fresh formatting context so that it cannot
-            // disturb the inherited one (an empty box contributes nothing to it anyway)
-            let block_ctx = if hide_children { None } else { block_ctx.as_deref_mut() };
-            compute_block_layout_inner(tree, node_id, inputs, block_ctx, hide_children)
-        })
+        compute_contained_size_layout(
+            tree,
+            node_id,
+            inputs,
+            contain,
+            size_is_definite,
+            |tree, node_id, inputs, hide_children| {
+                // The as-if-empty sizing pass uses a fresh formatting context so that it cannot
+                // disturb the inherited one (an empty box contributes nothing to it anyway)
+                let block_ctx = if hide_children { None } else { block_ctx.as_deref_mut() };
+                compute_block_layout_inner(tree, node_id, inputs, block_ctx, hide_children)
+            },
+        )
     } else {
+        drop(style);
         compute_block_layout_inner(tree, node_id, inputs, block_ctx, false)
     };
 

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -830,8 +830,11 @@ fn generate_item_list(
     node_inner_size: Size<Option<f32>>,
     hide_children: bool,
 ) -> Vec<BlockItem> {
+    if hide_children {
+        return Vec::new();
+    }
+
     tree.child_ids(node)
-        .filter(move |_| !hide_children)
         .map(|child_node_id| (child_node_id, tree.get_block_child_style(child_node_id)))
         .filter(|(_, style)| style.box_generation_mode() != BoxGenerationMode::None)
         .enumerate()

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -10,9 +10,11 @@ use crate::util::sys::Vec;
 use crate::util::MaybeMath;
 use crate::util::{MaybeResolve, ResolveOrZero};
 use crate::{
-    BlockContainerStyle, BlockItemStyle, BoxGenerationMode, BoxSizing, Dimension, Direction, LayoutBlockContainer,
-    RequestedAxis, TextAlign,
+    BlockContainerStyle, BlockItemStyle, BoxGenerationMode, BoxSizing, Contain, Dimension, Direction,
+    LayoutBlockContainer, RequestedAxis, TextAlign,
 };
+
+use super::common::containment::compute_contained_size_layout;
 
 #[cfg(feature = "float_layout")]
 use super::float::{BfcSlot, ContentSlot, FloatContext, FloatIntrinsicWidthCalculator};
@@ -48,7 +50,7 @@ impl BlockFormattingContext {
             y_offset: 0.0,
             insets: [0.0, 0.0],
             content_box_insets: [0.0, 0.0],
-            float_content_contribution: 0.0,
+            float_content_contribution: f32::NEG_INFINITY,
             is_root: true,
             #[cfg(feature = "float_layout")]
             adjoining_floats: [false, false],
@@ -71,7 +73,8 @@ pub struct BlockContext<'bfc> {
     insets: [f32; 2],
     /// The x-insets of the content box
     content_box_insets: [f32; 2],
-    /// The height that floats take up in the element
+    /// The height that floats take up in the element (`f32::NEG_INFINITY` if the element's
+    /// subtree does not contain any floats)
     float_content_contribution: f32,
     /// Whether the node is the root of the Block Formatting Context is belongs to.
     is_root: bool,
@@ -97,7 +100,7 @@ impl BlockContext<'_> {
             y_offset: self.y_offset + additional_y_offset,
             insets,
             content_box_insets: insets,
-            float_content_contribution: 0.0,
+            float_content_contribution: f32::NEG_INFINITY,
             is_root: false,
             // Floats adjoining the parent's current strut also adjoin this block's top strut
             // (if this block's top margin collapses with its first child's, which is checked separately)
@@ -348,6 +351,38 @@ pub fn compute_block_layout(
     inputs: LayoutInput,
     block_ctx: Option<&mut BlockContext<'_>>,
 ) -> LayoutOutput {
+    let contain = tree.get_block_container_style(node_id).contain();
+
+    let mut output = if contain.intersects(Contain::SIZE.union(Contain::INLINE_SIZE)) {
+        let mut block_ctx = block_ctx;
+        compute_contained_size_layout(tree, node_id, inputs, contain, |tree, node_id, inputs, hide_children| {
+            // The as-if-empty sizing pass uses a fresh formatting context so that it cannot
+            // disturb the inherited one (an empty box contributes nothing to it anyway)
+            let block_ctx = if hide_children { None } else { block_ctx.as_deref_mut() };
+            compute_block_layout_inner(tree, node_id, inputs, block_ctx, hide_children)
+        })
+    } else {
+        compute_block_layout_inner(tree, node_id, inputs, block_ctx, false)
+    };
+
+    // Layout containment suppresses the box's baseline for baseline-alignment purposes
+    if contain.contains(Contain::LAYOUT) {
+        output.first_baselines = Point::NONE;
+    }
+
+    output
+}
+
+/// The main body of the block layout algorithm. Sets up an appropriate `BlockContext` and then
+/// delegates to [`compute_inner`]. When `hide_children` is `true` the node is laid out as if it
+/// had no children (used for the as-if-empty sizing pass of size containment).
+fn compute_block_layout_inner(
+    tree: &mut impl LayoutBlockContainer,
+    node_id: NodeId,
+    inputs: LayoutInput,
+    block_ctx: Option<&mut BlockContext<'_>>,
+    hide_children: bool,
+) -> LayoutOutput {
     let LayoutInput { known_dimensions, parent_size, run_mode, .. } = inputs;
     let style = tree.get_block_container_style(node_id);
 
@@ -356,7 +391,10 @@ pub fn compute_block_layout(
     let is_scroll_container = overflow.x.is_scroll_container() || overflow.y.is_scroll_container();
     // css-align-3 §5.1.1: a non-`normal` `align-content` makes a block container establish an
     // independent formatting context. <https://drafts.csswg.org/css-align-3/#distribution-block>
-    let establishes_new_bfc = is_scroll_container || style.align_content().is_some();
+    // Layout containment also establishes an independent formatting context.
+    // <https://drafts.csswg.org/css-contain-2/#containment-layout>
+    let establishes_new_bfc =
+        is_scroll_container || style.align_content().is_some() || style.contain().contains(Contain::LAYOUT);
     let aspect_ratio = style.aspect_ratio();
     let padding = style.padding().resolve_or_zero(parent_size.width, |val, basis| tree.calc(val, basis));
     let border = style.border().resolve_or_zero(parent_size.width, |val, basis| tree.calc(val, basis));
@@ -419,6 +457,7 @@ pub fn compute_block_layout(
             node_id,
             LayoutInput { known_dimensions: styled_based_known_dimensions, ..inputs },
             inherited_bfc,
+            hide_children,
         ),
         _ => {
             let mut root_bfc = BlockFormattingContext::new();
@@ -428,6 +467,7 @@ pub fn compute_block_layout(
                 node_id,
                 LayoutInput { known_dimensions: styled_based_known_dimensions, ..inputs },
                 &mut root_ctx,
+                hide_children,
             )
         }
     }
@@ -439,6 +479,7 @@ fn compute_inner(
     node_id: NodeId,
     inputs: LayoutInput,
     #[allow(unused_mut)] mut block_ctx: &mut BlockContext<'_>,
+    hide_children: bool,
 ) -> LayoutOutput {
     let LayoutInput {
         known_dimensions, parent_size, available_space, run_mode, vertical_margins_are_collapsible, ..
@@ -511,7 +552,8 @@ fn compute_inner(
 
     let overflow = style.overflow();
     let is_scroll_container = overflow.x.is_scroll_container() || overflow.y.is_scroll_container();
-    let establishes_new_bfc = is_scroll_container || style.align_content().is_some();
+    let establishes_new_bfc =
+        is_scroll_container || style.align_content().is_some() || style.contain().contains(Contain::LAYOUT);
 
     // Determine margin collapsing behaviour
     let own_margins_collapse_with_children = Line {
@@ -543,7 +585,7 @@ fn compute_inner(
     drop(style);
 
     // 1. Generate items
-    let mut items = generate_item_list(tree, node_id, container_content_box_size);
+    let mut items = generate_item_list(tree, node_id, container_content_box_size, hide_children);
 
     // 2. Compute container width
     let container_outer_width = known_dimensions.width.unwrap_or_else(|| {
@@ -770,8 +812,10 @@ fn generate_item_list(
     tree: &impl LayoutBlockContainer,
     node: NodeId,
     node_inner_size: Size<Option<f32>>,
+    hide_children: bool,
 ) -> Vec<BlockItem> {
     tree.child_ids(node)
+        .filter(move |_| !hide_children)
         .map(|child_node_id| (child_node_id, tree.get_block_child_style(child_node_id)))
         .filter(|(_, style)| style.box_generation_mode() != BoxGenerationMode::None)
         .enumerate()
@@ -798,9 +842,14 @@ fn generate_item_list(
             let is_table = child_style.is_table();
             let is_replaced = child_style.is_compressible_replaced();
             let is_scroll_container = overflow.x.is_scroll_container() || overflow.y.is_scroll_container();
+            let has_layout_containment = child_style.contain().contains(Contain::LAYOUT);
 
-            let is_in_same_bfc: bool =
-                is_block && !is_table && position != Position::Absolute && is_not_floated && !is_scroll_container;
+            let is_in_same_bfc: bool = is_block
+                && !is_table
+                && position != Position::Absolute
+                && is_not_floated
+                && !is_scroll_container
+                && !has_layout_containment;
 
             BlockItem {
                 node_id: child_node_id,

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -315,6 +315,8 @@ struct BlockItem {
 
     /// The overflow style of the item
     overflow: Point<Overflow>,
+    /// The contain style of the item
+    contain: Contain,
     /// The width of the item's scrollbars (if it has scrollbars)
     scrollbar_width: f32,
 
@@ -722,6 +724,7 @@ fn compute_inner(
                             layout.size,
                             layout.content_size,
                             item.overflow,
+                            item.contain,
                         ));
                     }
                 }
@@ -855,7 +858,8 @@ fn generate_item_list(
             let is_table = child_style.is_table();
             let is_replaced = child_style.is_compressible_replaced();
             let is_scroll_container = overflow.x.is_scroll_container() || overflow.y.is_scroll_container();
-            let establishes_independent_fc = child_style.contain().establishes_independent_formatting_context();
+            let contain = child_style.contain();
+            let establishes_independent_fc = contain.establishes_independent_formatting_context();
 
             let is_in_same_bfc: bool = is_block
                 && !is_table
@@ -891,6 +895,7 @@ fn generate_item_list(
                     .maybe_apply_aspect_ratio(aspect_ratio)
                     .maybe_add(box_sizing_adjustment),
                 overflow,
+                contain,
                 scrollbar_width: child_style.scrollbar_width(),
                 position,
                 inset: child_style.inset(),
@@ -1172,6 +1177,7 @@ fn perform_final_layout_on_in_flow_children(
                         item_layout.size,
                         item_layout.content_size,
                         item.overflow,
+                        item.contain,
                     ));
                 }
 
@@ -1550,6 +1556,7 @@ fn perform_final_layout_on_in_flow_children(
                     final_size,
                     item_layout.content_size,
                     item.overflow,
+                    item.contain,
                 ));
             }
 
@@ -1870,6 +1877,7 @@ fn perform_absolute_layout_on_absolute_children(
                 final_size,
                 layout_output.content_size,
                 item.overflow,
+                item.contain,
             ));
         }
     }

--- a/src/compute/common/containment.rs
+++ b/src/compute/common/containment.rs
@@ -1,9 +1,54 @@
 //! Shared logic for CSS size containment (`contain: size` and `contain: inline-size`)
 //! <https://drafts.csswg.org/css-contain-2/#containment-size>
 use crate::geometry::Size;
-use crate::style::Contain;
-use crate::tree::{LayoutInput, LayoutOutput, NodeId, RunMode};
+use crate::style::{Contain, CoreStyle};
+use crate::tree::{LayoutInput, LayoutOutput, NodeId, RunMode, SizingMode};
+use crate::util::MaybeResolve;
 use crate::RequestedAxis;
+
+/// Determine, from a node's own style and sizing constraints, whether the node's size is definite
+/// in each axis for the purposes of resolving its children's percentage sizes.
+///
+/// Size containment allows a used size to be computed for an `auto` sized axis (by sizing the box
+/// as if it were empty), but that does not make the axis definite: percentages resolved against it
+/// still behave as they would against an indefinite size.
+/// <https://github.com/w3c/csswg-drafts/issues/7206>
+pub(crate) fn contained_size_is_definite(
+    style: &impl CoreStyle,
+    inputs: &LayoutInput,
+    calc: impl Fn(*const (), f32) -> f32 + Copy,
+) -> Size<bool> {
+    let parent_size = inputs.parent_size;
+    let aspect_ratio = style.aspect_ratio();
+
+    let style_size = if inputs.sizing_mode == SizingMode::InherentSize {
+        style.size().maybe_resolve(parent_size, calc).maybe_apply_aspect_ratio(aspect_ratio)
+    } else {
+        Size::NONE
+    };
+    let min_size = style.min_size().maybe_resolve(parent_size, calc).maybe_apply_aspect_ratio(aspect_ratio);
+    let max_size = style.max_size().maybe_resolve(parent_size, calc).maybe_apply_aspect_ratio(aspect_ratio);
+
+    // If both min and max in a given axis are set and max <= min then this determines the size in that axis
+    let min_max_definite_size = min_size.zip_map(max_size, |min, max| match (min, max) {
+        (Some(min), Some(max)) if max <= min => Some(min),
+        _ => None,
+    });
+    let styled_size_is_definite = style_size.or(min_max_definite_size).map(|size| size.is_some());
+
+    // Sizes imposed by the parent keep the parent's definiteness; otherwise definiteness is
+    // determined by whether the node's own style resolves to a definite size.
+    Size {
+        width: match inputs.known_dimensions.width {
+            Some(_) => inputs.known_dimensions_are_definite.width,
+            None => styled_size_is_definite.width,
+        },
+        height: match inputs.known_dimensions.height {
+            Some(_) => inputs.known_dimensions_are_definite.height,
+            None => styled_size_is_definite.height,
+        },
+    }
+}
 
 /// Compute the layout of a node with size containment (`contain: size` or `contain: inline-size`)
 /// in one or both axes.
@@ -16,8 +61,10 @@ use crate::RequestedAxis;
 ///      means that padding/border, explicit grid tracks, aspect-ratio, min/max clamping etc. all
 ///      still apply.
 ///   2. **Laying out in place**: the node's contents are then laid out normally into the resulting
-///      fixed-size box by running the algorithm again with the contained size passed as definite
-///      `known_dimensions`.
+///      fixed-size box by running the algorithm again with the contained size passed as
+///      `known_dimensions`. An axis is only marked *definite* if it was already definite from the
+///      node's sizing constraints (`size_is_definite`): a used size computed for an `auto` axis by
+///      the as-if-empty pass is not definite for percentage resolution purposes.
 ///
 /// The phase 2 pass is skipped when only the box's size was requested (`RunMode::ComputeSize`),
 /// and the phase 1 pass is skipped for axes whose size is already known.
@@ -26,6 +73,7 @@ pub(crate) fn compute_contained_size_layout<Tree, ComputeInner>(
     node: NodeId,
     inputs: LayoutInput,
     contain: Contain,
+    size_is_definite: Size<bool>,
     mut compute_inner: ComputeInner,
 ) -> LayoutOutput
 where
@@ -58,11 +106,7 @@ where
         let mut output = compute_inner(
             tree,
             node,
-            LayoutInput {
-                known_dimensions: size.map(Some),
-                known_dimensions_are_definite: Size { width: true, height: true },
-                ..inputs
-            },
+            LayoutInput { known_dimensions: size.map(Some), known_dimensions_are_definite: size_is_definite, ..inputs },
             false,
         );
         output.size = size;
@@ -98,7 +142,7 @@ where
             LayoutInput {
                 known_dimensions: Size { width: Some(width), height: inputs.known_dimensions.height },
                 known_dimensions_are_definite: Size {
-                    width: true,
+                    width: size_is_definite.width,
                     height: inputs.known_dimensions_are_definite.height,
                 },
                 ..inputs

--- a/src/compute/common/containment.rs
+++ b/src/compute/common/containment.rs
@@ -44,7 +44,7 @@ pub(crate) fn contained_size_is_definite(
 
     // Sizes imposed by the parent keep the parent's definiteness; otherwise definiteness is
     // determined by whether the node's own style resolves to a definite size.
-    Size {
+    let size_is_definite = Size {
         width: match inputs.known_dimensions.width {
             Some(_) => inputs.known_dimensions_are_definite.width,
             None => styled_size_is_definite.width,
@@ -53,6 +53,20 @@ pub(crate) fn contained_size_is_definite(
             Some(_) => inputs.known_dimensions_are_definite.height,
             None => styled_size_is_definite.height,
         },
+    };
+
+    // aspect-ratio transfers definiteness across axes: an automatic size in one axis is derived
+    // from a definite size in the other axis, and is therefore also definite. Sizes imposed by
+    // the parent are used as-is (not derived through the ratio), so nothing transfers into an
+    // axis with a known dimension.
+    // <https://drafts.csswg.org/css-sizing-4/#aspect-ratio-size-transfers>
+    if aspect_ratio.is_some() {
+        Size {
+            width: size_is_definite.width || (inputs.known_dimensions.width.is_none() && size_is_definite.height),
+            height: size_is_definite.height || (inputs.known_dimensions.height.is_none() && size_is_definite.width),
+        }
+    } else {
+        size_is_definite
     }
 }
 

--- a/src/compute/common/containment.rs
+++ b/src/compute/common/containment.rs
@@ -18,6 +18,12 @@ pub(crate) fn contained_size_is_definite(
     inputs: &LayoutInput,
     calc: impl Fn(*const (), f32) -> f32 + Copy,
 ) -> Size<bool> {
+    // Sizes imposed by the parent keep the parent's definiteness, so if both dimensions are known
+    // then the node's own style never needs to be consulted.
+    if let Size { width: Some(_), height: Some(_) } = inputs.known_dimensions {
+        return inputs.known_dimensions_are_definite;
+    }
+
     let parent_size = inputs.parent_size;
     let aspect_ratio = style.aspect_ratio();
 

--- a/src/compute/common/containment.rs
+++ b/src/compute/common/containment.rs
@@ -1,0 +1,109 @@
+//! Shared logic for CSS size containment (`contain: size` and `contain: inline-size`)
+//! <https://drafts.csswg.org/css-contain-2/#containment-size>
+use crate::geometry::Size;
+use crate::style::Contain;
+use crate::tree::{LayoutInput, LayoutOutput, NodeId, RunMode};
+use crate::RequestedAxis;
+
+/// Compute the layout of a node with size containment (`contain: size` or `contain: inline-size`)
+/// in one or both axes.
+///
+/// Size containment is implemented in two phases:
+///
+///   1. **Sizing as if empty**: the size of the box in the contained axes is determined by running
+///      the node's normal layout algorithm with child enumeration suppressed (the `bool` parameter
+///      of `compute_inner`). Running the real algorithm (rather than treating the node as a leaf)
+///      means that padding/border, explicit grid tracks, aspect-ratio, min/max clamping etc. all
+///      still apply.
+///   2. **Laying out in place**: the node's contents are then laid out normally into the resulting
+///      fixed-size box by running the algorithm again with the contained size passed as definite
+///      `known_dimensions`.
+///
+/// The phase 2 pass is skipped when only the box's size was requested (`RunMode::ComputeSize`),
+/// and the phase 1 pass is skipped for axes whose size is already known.
+pub(crate) fn compute_contained_size_layout<Tree, ComputeInner>(
+    tree: &mut Tree,
+    node: NodeId,
+    inputs: LayoutInput,
+    contain: Contain,
+    mut compute_inner: ComputeInner,
+) -> LayoutOutput
+where
+    ComputeInner: FnMut(&mut Tree, NodeId, LayoutInput, bool) -> LayoutOutput,
+{
+    if contain.contains(Contain::SIZE) {
+        // Phase 1: determine the box's size as if it were empty
+        let known_dimensions = inputs.known_dimensions;
+        let size = if let Size { width: Some(width), height: Some(height) } = known_dimensions {
+            Size { width, height }
+        } else {
+            let empty_size = compute_inner(
+                tree,
+                node,
+                LayoutInput { run_mode: RunMode::ComputeSize, axis: RequestedAxis::Both, ..inputs },
+                true,
+            )
+            .size;
+            Size {
+                width: known_dimensions.width.unwrap_or(empty_size.width),
+                height: known_dimensions.height.unwrap_or(empty_size.height),
+            }
+        };
+
+        if inputs.run_mode == RunMode::ComputeSize {
+            return LayoutOutput::from_outer_size(size);
+        }
+
+        // Phase 2: lay the box's contents out into the fixed-size box
+        let mut output = compute_inner(
+            tree,
+            node,
+            LayoutInput {
+                known_dimensions: size.map(Some),
+                known_dimensions_are_definite: Size { width: true, height: true },
+                ..inputs
+            },
+            false,
+        );
+        output.size = size;
+        output
+    } else {
+        // Inline-size containment. Taffy only supports the `horizontal-tb` writing mode, so the
+        // inline axis is always the horizontal axis.
+
+        // Phase 1: determine the box's width as if it were empty
+        let width = match inputs.known_dimensions.width {
+            Some(width) => width,
+            None => {
+                compute_inner(
+                    tree,
+                    node,
+                    LayoutInput { run_mode: RunMode::ComputeSize, axis: RequestedAxis::Horizontal, ..inputs },
+                    true,
+                )
+                .size
+                .width
+            }
+        };
+
+        if inputs.run_mode == RunMode::ComputeSize && inputs.axis == RequestedAxis::Horizontal {
+            return LayoutOutput::from_outer_size(Size { width, height: 0.0 });
+        }
+
+        // Phase 2: lay the box's contents out normally with the width fixed. The height
+        // continues to depend on the box's contents.
+        compute_inner(
+            tree,
+            node,
+            LayoutInput {
+                known_dimensions: Size { width: Some(width), height: inputs.known_dimensions.height },
+                known_dimensions_are_definite: Size {
+                    width: true,
+                    height: inputs.known_dimensions_are_definite.height,
+                },
+                ..inputs
+            },
+            false,
+        )
+    }
+}

--- a/src/compute/common/content_size.rs
+++ b/src/compute/common/content_size.rs
@@ -1,6 +1,6 @@
 //! Generic CSS content size code that is shared between all CSS algorithms.
 use crate::geometry::{Point, Size};
-use crate::style::Overflow;
+use crate::style::{Contain, Overflow};
 use crate::util::sys::{f32_max, f32_min};
 
 #[inline(always)]
@@ -10,14 +10,18 @@ pub(crate) fn compute_content_size_contribution(
     size: Size<f32>,
     content_size: Size<f32>,
     overflow: Point<Overflow>,
+    contain: Contain,
 ) -> Size<f32> {
+    // A box whose containment contains its scrollable overflow contributes only its border box
+    // to its parent's content size, regardless of its overflow style
+    let overflow_contributes = !contain.contains_scrollable_overflow();
     let size_content_size_contribution = Size {
         width: match overflow.x {
-            Overflow::Visible => f32_max(size.width, content_size.width),
+            Overflow::Visible if overflow_contributes => f32_max(size.width, content_size.width),
             _ => size.width,
         },
         height: match overflow.y {
-            Overflow::Visible => f32_max(size.height, content_size.height),
+            Overflow::Visible if overflow_contributes => f32_max(size.height, content_size.height),
             _ => size.height,
         },
     };

--- a/src/compute/common/mod.rs
+++ b/src/compute/common/mod.rs
@@ -1,5 +1,7 @@
 //! Generic code that is shared between multiple layout algorithms
 pub(crate) mod alignment;
+#[cfg(any(feature = "block_layout", feature = "flexbox", feature = "grid"))]
+pub(crate) mod containment;
 pub(crate) mod sizing_keyword;
 
 #[cfg(feature = "content_size")]

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -236,13 +236,13 @@ pub fn compute_flexbox_layout(
     output
 }
 
-/// The main body of the flexbox layout algorithm. When `hide_children` is `true` the node is laid
+/// The main body of the flexbox layout algorithm. When `ignore_children` is `true` the node is laid
 /// out as if it had no children (used for the as-if-empty sizing pass of size containment).
 fn compute_flexbox_layout_inner(
     tree: &mut impl LayoutFlexboxContainer,
     node: NodeId,
     inputs: LayoutInput,
-    hide_children: bool,
+    ignore_children: bool,
 ) -> LayoutOutput {
     let LayoutInput { known_dimensions, parent_size, run_mode, .. } = inputs;
     let style = tree.get_flexbox_container_style(node);
@@ -322,7 +322,7 @@ fn compute_flexbox_layout_inner(
         tree,
         node,
         LayoutInput { known_dimensions: styled_based_known_dimensions, known_dimensions_are_definite, ..inputs },
-        hide_children,
+        ignore_children,
     )
 }
 
@@ -331,7 +331,7 @@ fn compute_preliminary(
     tree: &mut impl LayoutFlexboxContainer,
     node: NodeId,
     inputs: LayoutInput,
-    hide_children: bool,
+    ignore_children: bool,
 ) -> LayoutOutput {
     let LayoutInput { known_dimensions, parent_size, available_space, run_mode, .. } = inputs;
 
@@ -350,7 +350,7 @@ fn compute_preliminary(
 
     // 1. Generate anonymous flex items as described in §4 Flex Items.
     debug_log!("generate_anonymous_flex_items");
-    let mut flex_items = generate_anonymous_flex_items(tree, node, &constants, hide_children);
+    let mut flex_items = generate_anonymous_flex_items(tree, node, &constants, ignore_children);
 
     // 9.2. Line Length Determination
 
@@ -638,9 +638,9 @@ fn generate_anonymous_flex_items(
     tree: &impl LayoutFlexboxContainer,
     node: NodeId,
     constants: &AlgoConstants,
-    hide_children: bool,
+    ignore_children: bool,
 ) -> Vec<FlexItem> {
-    if hide_children {
+    if ignore_children {
         return Vec::new();
     }
 

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -16,7 +16,7 @@ use crate::util::{MaybeResolve, ResolveOrZero};
 use crate::{BoxGenerationMode, BoxSizing, Contain, Dimension, Direction, RequestedAxis};
 
 use super::common::alignment::apply_alignment_fallback;
-use super::common::containment::compute_contained_size_layout;
+use super::common::containment::{compute_contained_size_layout, contained_size_is_definite};
 #[cfg(feature = "content_size")]
 use super::common::content_size::compute_content_size_contribution;
 use super::common::sizing_keyword::{
@@ -214,11 +214,15 @@ pub fn compute_flexbox_layout(
     node: NodeId,
     inputs: LayoutInput,
 ) -> LayoutOutput {
-    let contain = tree.get_flexbox_container_style(node).contain();
+    let style = tree.get_flexbox_container_style(node);
+    let contain = style.contain();
 
     let mut output = if contain.intersects(Contain::SIZE.union(Contain::INLINE_SIZE)) {
-        compute_contained_size_layout(tree, node, inputs, contain, compute_flexbox_layout_inner)
+        let size_is_definite = contained_size_is_definite(&style, &inputs, |val, basis| tree.calc(val, basis));
+        drop(style);
+        compute_contained_size_layout(tree, node, inputs, contain, size_is_definite, compute_flexbox_layout_inner)
     } else {
+        drop(style);
         compute_flexbox_layout_inner(tree, node, inputs, false)
     };
 
@@ -635,12 +639,17 @@ fn generate_anonymous_flex_items(
     hide_children: bool,
 ) -> Vec<FlexItem> {
     // Percentage sizes of items resolve against the container's inner size, but only if that size
-    // is definite. A known main size which is derived from the container's own content is treated
-    // as indefinite here.
-    let percent_resolution_size = if constants.known_main_size_is_definite {
-        constants.node_inner_size
-    } else {
-        constants.node_inner_size.with_main(constants.dir, None)
+    // is definite. A known size which is derived from the container's own content (e.g. a size
+    // computed by size containment's as-if-empty pass) is treated as indefinite here.
+    let percent_resolution_size = {
+        let mut size = constants.node_inner_size;
+        if !constants.known_main_size_is_definite {
+            size.set_main(constants.dir, None);
+        }
+        if !constants.has_definite_cross_size {
+            size.set_cross(constants.dir, None);
+        }
+        size
     };
 
     tree.child_ids(node)
@@ -1872,7 +1881,7 @@ fn calculate_children_base_lines(
 fn calculate_cross_size(flex_lines: &mut [FlexLine], node_size: Size<Option<f32>>, constants: &AlgoConstants) {
     // If the flex container is single-line and has a definite cross size,
     // the cross size of the flex line is the flex container’s inner cross size.
-    if !constants.is_wrap && node_size.cross(constants.dir).is_some() {
+    if !constants.is_wrap && node_size.cross(constants.dir).is_some() && constants.has_definite_cross_size {
         let cross_axis_padding_border = constants.content_box_inset.cross_axis_sum(constants.dir);
         let cross_min_size = constants.min_size.cross(constants.dir);
         let cross_max_size = constants.max_size.cross(constants.dir);

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -350,7 +350,8 @@ fn compute_preliminary(
 
     // 1. Generate anonymous flex items as described in §4 Flex Items.
     debug_log!("generate_anonymous_flex_items");
-    let mut flex_items = generate_anonymous_flex_items(tree, node, &constants, ignore_children);
+    let mut flex_items =
+        if ignore_children { Vec::new() } else { generate_anonymous_flex_items(tree, node, &constants) };
 
     // 9.2. Line Length Determination
 
@@ -638,12 +639,7 @@ fn generate_anonymous_flex_items(
     tree: &impl LayoutFlexboxContainer,
     node: NodeId,
     constants: &AlgoConstants,
-    ignore_children: bool,
 ) -> Vec<FlexItem> {
-    if ignore_children {
-        return Vec::new();
-    }
-
     // Percentage sizes of items resolve against the container's inner size, but only if that size
     // is definite. A known size which is derived from the container's own content (e.g. a size
     // computed by size containment's as-if-empty pass) is treated as indefinite here.

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -640,6 +640,10 @@ fn generate_anonymous_flex_items(
     constants: &AlgoConstants,
     hide_children: bool,
 ) -> Vec<FlexItem> {
+    if hide_children {
+        return Vec::new();
+    }
+
     // Percentage sizes of items resolve against the container's inner size, but only if that size
     // is definite. A known size which is derived from the container's own content (e.g. a size
     // computed by size containment's as-if-empty pass) is treated as indefinite here.
@@ -655,7 +659,6 @@ fn generate_anonymous_flex_items(
     };
 
     tree.child_ids(node)
-        .filter(move |_| !hide_children)
         .enumerate()
         .map(|(index, child)| (index, child, tree.get_flexbox_child_style(child)))
         .filter(|(_, _, style)| style.position() != Position::Absolute)

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -227,7 +227,7 @@ pub fn compute_flexbox_layout(
     };
 
     // Layout containment suppresses the box's baseline for baseline-alignment purposes
-    if contain.contains(Contain::LAYOUT) {
+    if contain.suppresses_baseline() {
         output.first_baselines = Point::NONE;
     }
 

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -47,6 +47,8 @@ struct FlexItem {
 
     /// The overflow style of the item
     overflow: Point<Overflow>,
+    /// The contain style of the item
+    contain: Contain,
     /// The width of the scrollbars (if it has any)
     scrollbar_width: f32,
     /// The flex shrink style of the item
@@ -707,6 +709,7 @@ fn generate_anonymous_flex_items(
                     constants.is_column,
                 ),
                 overflow: child_style.overflow(),
+                contain: child_style.contain(),
                 scrollbar_width: child_style.scrollbar_width(),
                 flex_grow: child_style.flex_grow(),
                 flex_shrink: child_style.flex_shrink(),
@@ -2446,6 +2449,7 @@ fn calculate_flex_item(
             size,
             content_size,
             item.overflow,
+            item.contain,
         ));
     }
 }
@@ -2612,6 +2616,7 @@ fn perform_absolute_layout_on_absolute_children(
         }
 
         let overflow = child_style.overflow();
+        let contain = child_style.contain();
         let scrollbar_width = child_style.scrollbar_width();
         let aspect_ratio = child_style.aspect_ratio();
         let align_self = child_style.align_self().unwrap_or(constants.align_items).resolve_self_relative(
@@ -2964,13 +2969,18 @@ fn perform_absolute_layout_on_absolute_children(
 
         #[cfg(feature = "content_size")]
         {
+            let overflow_contributes = !contain.contains_scrollable_overflow();
             let size_content_size_contribution = Size {
                 width: match overflow.x {
-                    Overflow::Visible => f32_max(final_size.width, layout_output.content_size.width),
+                    Overflow::Visible if overflow_contributes => {
+                        f32_max(final_size.width, layout_output.content_size.width)
+                    }
                     _ => final_size.width,
                 },
                 height: match overflow.y {
-                    Overflow::Visible => f32_max(final_size.height, layout_output.content_size.height),
+                    Overflow::Visible if overflow_contributes => {
+                        f32_max(final_size.height, layout_output.content_size.height)
+                    }
                     _ => final_size.height,
                 },
             };

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -13,9 +13,10 @@ use crate::util::debug::debug_log;
 use crate::util::sys::{f32_max, f32_min, new_vec_with_capacity, Vec};
 use crate::util::MaybeMath;
 use crate::util::{MaybeResolve, ResolveOrZero};
-use crate::{BoxGenerationMode, BoxSizing, Dimension, Direction, RequestedAxis};
+use crate::{BoxGenerationMode, BoxSizing, Contain, Dimension, Direction, RequestedAxis};
 
 use super::common::alignment::apply_alignment_fallback;
+use super::common::containment::compute_contained_size_layout;
 #[cfg(feature = "content_size")]
 use super::common::content_size::compute_content_size_contribution;
 use super::common::sizing_keyword::{
@@ -213,6 +214,30 @@ pub fn compute_flexbox_layout(
     node: NodeId,
     inputs: LayoutInput,
 ) -> LayoutOutput {
+    let contain = tree.get_flexbox_container_style(node).contain();
+
+    let mut output = if contain.intersects(Contain::SIZE.union(Contain::INLINE_SIZE)) {
+        compute_contained_size_layout(tree, node, inputs, contain, compute_flexbox_layout_inner)
+    } else {
+        compute_flexbox_layout_inner(tree, node, inputs, false)
+    };
+
+    // Layout containment suppresses the box's baseline for baseline-alignment purposes
+    if contain.contains(Contain::LAYOUT) {
+        output.first_baselines = Point::NONE;
+    }
+
+    output
+}
+
+/// The main body of the flexbox layout algorithm. When `hide_children` is `true` the node is laid
+/// out as if it had no children (used for the as-if-empty sizing pass of size containment).
+fn compute_flexbox_layout_inner(
+    tree: &mut impl LayoutFlexboxContainer,
+    node: NodeId,
+    inputs: LayoutInput,
+    hide_children: bool,
+) -> LayoutOutput {
     let LayoutInput { known_dimensions, parent_size, run_mode, .. } = inputs;
     let style = tree.get_flexbox_container_style(node);
 
@@ -291,11 +316,17 @@ pub fn compute_flexbox_layout(
         tree,
         node,
         LayoutInput { known_dimensions: styled_based_known_dimensions, known_dimensions_are_definite, ..inputs },
+        hide_children,
     )
 }
 
 /// Compute a preliminary size for an item
-fn compute_preliminary(tree: &mut impl LayoutFlexboxContainer, node: NodeId, inputs: LayoutInput) -> LayoutOutput {
+fn compute_preliminary(
+    tree: &mut impl LayoutFlexboxContainer,
+    node: NodeId,
+    inputs: LayoutInput,
+    hide_children: bool,
+) -> LayoutOutput {
     let LayoutInput { known_dimensions, parent_size, available_space, run_mode, .. } = inputs;
 
     // Define some general constants we will need for the remainder of the algorithm.
@@ -313,7 +344,7 @@ fn compute_preliminary(tree: &mut impl LayoutFlexboxContainer, node: NodeId, inp
 
     // 1. Generate anonymous flex items as described in §4 Flex Items.
     debug_log!("generate_anonymous_flex_items");
-    let mut flex_items = generate_anonymous_flex_items(tree, node, &constants);
+    let mut flex_items = generate_anonymous_flex_items(tree, node, &constants, hide_children);
 
     // 9.2. Line Length Determination
 
@@ -601,6 +632,7 @@ fn generate_anonymous_flex_items(
     tree: &impl LayoutFlexboxContainer,
     node: NodeId,
     constants: &AlgoConstants,
+    hide_children: bool,
 ) -> Vec<FlexItem> {
     // Percentage sizes of items resolve against the container's inner size, but only if that size
     // is definite. A known main size which is derived from the container's own content is treated
@@ -612,6 +644,7 @@ fn generate_anonymous_flex_items(
     };
 
     tree.child_ids(node)
+        .filter(move |_| !hide_children)
         .enumerate()
         .map(|(index, child)| (index, child, tree.get_flexbox_child_style(child)))
         .filter(|(_, _, style)| style.position() != Position::Absolute)

--- a/src/compute/grid/alignment.rs
+++ b/src/compute/grid/alignment.rs
@@ -94,6 +94,7 @@ pub(super) fn align_and_position_item(
     let style = tree.get_grid_child_style(node);
 
     let overflow = style.overflow();
+    let contain = style.contain();
     let scrollbar_width = style.scrollbar_width();
     let aspect_ratio = style.aspect_ratio();
     // Resolve writing-mode-relative self-start/self-end keywords against the item's own
@@ -400,6 +401,7 @@ pub(super) fn align_and_position_item(
             Size { width, height },
             layout_output.content_size,
             overflow,
+            contain,
         )
     };
     #[cfg(not(feature = "content_size"))]

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     GridItemStyle, JustifyContent, LayoutGridContainer, RequestedAxis,
 };
 
-use super::common::containment::compute_contained_size_layout;
+use super::common::containment::{compute_contained_size_layout, contained_size_is_definite};
 use alignment::{align_and_position_item, align_tracks};
 use explicit_grid::{compute_explicit_grid_size_in_axis, initialize_grid_tracks, AutoRepeatStrategy};
 use implicit_grid::compute_grid_size_estimate;
@@ -47,11 +47,15 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
     node: NodeId,
     inputs: LayoutInput,
 ) -> LayoutOutput {
-    let contain = tree.get_grid_container_style(node).contain();
+    let style = tree.get_grid_container_style(node);
+    let contain = style.contain();
 
     let mut output = if contain.intersects(Contain::SIZE.union(Contain::INLINE_SIZE)) {
-        compute_contained_size_layout(tree, node, inputs, contain, compute_grid_layout_inner)
+        let size_is_definite = contained_size_is_definite(&style, &inputs, |val, basis| tree.calc(val, basis));
+        drop(style);
+        compute_contained_size_layout(tree, node, inputs, contain, size_is_definite, compute_grid_layout_inner)
     } else {
+        drop(style);
         compute_grid_layout_inner(tree, node, inputs, false)
     };
 

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -67,13 +67,13 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
     output
 }
 
-/// The main body of the grid layout algorithm. When `hide_children` is `true` the node is laid
+/// The main body of the grid layout algorithm. When `ignore_children` is `true` the node is laid
 /// out as if it had no children (used for the as-if-empty sizing pass of size containment).
 fn compute_grid_layout_inner<Tree: LayoutGridContainer>(
     tree: &mut Tree,
     node: NodeId,
     inputs: LayoutInput,
-    hide_children: bool,
+    ignore_children: bool,
 ) -> LayoutOutput {
     let LayoutInput { known_dimensions, parent_size, available_space, run_mode, .. } = inputs;
 
@@ -245,7 +245,7 @@ fn compute_grid_layout_inner<Tree: LayoutGridContainer>(
     // 3. Implicit Grid: Estimate Track Counts
     // Estimate the number of rows and columns in the implicit grid (= the entire grid)
     // This is necessary as part of placement. Doing it early here is a perf optimisation to reduce allocations.
-    let (est_col_counts, est_row_counts) = if hide_children {
+    let (est_col_counts, est_row_counts) = if ignore_children {
         compute_grid_size_estimate::<Tree::GridItemStyle<'_>>(
             explicit_col_count,
             explicit_row_count,
@@ -258,9 +258,9 @@ fn compute_grid_layout_inner<Tree: LayoutGridContainer>(
 
     // 4. Grid Item Placement
     // Match items (children) to a definite grid position (row start/end and column start/end position)
-    let mut items = if hide_children { Vec::new() } else { Vec::with_capacity(tree.child_count(node)) };
+    let mut items = if ignore_children { Vec::new() } else { Vec::with_capacity(tree.child_count(node)) };
     let mut cell_occupancy_matrix = CellOccupancyMatrix::with_track_counts(est_col_counts, est_row_counts);
-    if !hide_children {
+    if !ignore_children {
         let in_flow_children_iter = || {
             tree.child_ids(node)
                 .enumerate()

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -187,14 +187,10 @@ fn compute_grid_layout_inner<Tree: LayoutGridContainer>(
     // Absolutely positioned children do not take part in grid placement and do not create
     // implicit tracks, so they are excluded from the grid size estimate.
     let get_child_styles_iter = |node| {
-        tree.child_ids(node)
-            .filter(move |_| !hide_children)
-            .map(|child_node: NodeId| tree.get_grid_child_style(child_node))
-            .filter(|style| {
-                style.box_generation_mode() != BoxGenerationMode::None && style.position() != Position::Absolute
-            })
+        tree.child_ids(node).map(|child_node: NodeId| tree.get_grid_child_style(child_node)).filter(|style| {
+            style.box_generation_mode() != BoxGenerationMode::None && style.position() != Position::Absolute
+        })
     };
-    let child_styles_iter = get_child_styles_iter(node);
 
     // 2. Resolve the explicit grid
 
@@ -249,32 +245,41 @@ fn compute_grid_layout_inner<Tree: LayoutGridContainer>(
     // 3. Implicit Grid: Estimate Track Counts
     // Estimate the number of rows and columns in the implicit grid (= the entire grid)
     // This is necessary as part of placement. Doing it early here is a perf optimisation to reduce allocations.
-    let (est_col_counts, est_row_counts) =
-        compute_grid_size_estimate(explicit_col_count, explicit_row_count, direction, child_styles_iter);
+    let (est_col_counts, est_row_counts) = if hide_children {
+        compute_grid_size_estimate::<Tree::GridItemStyle<'_>>(
+            explicit_col_count,
+            explicit_row_count,
+            direction,
+            core::iter::empty(),
+        )
+    } else {
+        compute_grid_size_estimate(explicit_col_count, explicit_row_count, direction, get_child_styles_iter(node))
+    };
 
     // 4. Grid Item Placement
     // Match items (children) to a definite grid position (row start/end and column start/end position)
-    let mut items = Vec::with_capacity(tree.child_count(node));
+    let mut items = if hide_children { Vec::new() } else { Vec::with_capacity(tree.child_count(node)) };
     let mut cell_occupancy_matrix = CellOccupancyMatrix::with_track_counts(est_col_counts, est_row_counts);
-    let in_flow_children_iter = || {
-        tree.child_ids(node)
-            .filter(move |_| !hide_children)
-            .enumerate()
-            .map(|(index, child_node)| (index, child_node, tree.get_grid_child_style(child_node)))
-            .filter(|(_, _, style)| {
-                style.box_generation_mode() != BoxGenerationMode::None && style.position() != Position::Absolute
-            })
-    };
-    place_grid_items(
-        &mut cell_occupancy_matrix,
-        &mut items,
-        in_flow_children_iter,
-        direction,
-        style.grid_auto_flow(),
-        align_items.unwrap_or(AlignItems::STRETCH),
-        justify_items.unwrap_or(AlignItems::STRETCH),
-        &name_resolver,
-    );
+    if !hide_children {
+        let in_flow_children_iter = || {
+            tree.child_ids(node)
+                .enumerate()
+                .map(|(index, child_node)| (index, child_node, tree.get_grid_child_style(child_node)))
+                .filter(|(_, _, style)| {
+                    style.box_generation_mode() != BoxGenerationMode::None && style.position() != Position::Absolute
+                })
+        };
+        place_grid_items(
+            &mut cell_occupancy_matrix,
+            &mut items,
+            in_flow_children_iter,
+            direction,
+            style.grid_auto_flow(),
+            align_items.unwrap_or(AlignItems::STRETCH),
+            justify_items.unwrap_or(AlignItems::STRETCH),
+            &name_resolver,
+        );
+    }
 
     // Extract track counts from previous step (auto-placement can expand the number of tracks)
     let final_col_counts = *cell_occupancy_matrix.track_counts(AbsoluteAxis::Horizontal);

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -9,9 +9,11 @@ use crate::util::sys::{f32_max, f32_min, GridTrackVec, Vec};
 use crate::util::MaybeMath;
 use crate::util::{MaybeResolve, ResolveOrZero};
 use crate::{
-    style_helpers::*, AlignContent, BoxGenerationMode, BoxSizing, CoreStyle, Direction, GridContainerStyle,
+    style_helpers::*, AlignContent, BoxGenerationMode, BoxSizing, Contain, CoreStyle, Direction, GridContainerStyle,
     GridItemStyle, JustifyContent, LayoutGridContainer, RequestedAxis,
 };
+
+use super::common::containment::compute_contained_size_layout;
 use alignment::{align_and_position_item, align_tracks};
 use explicit_grid::{compute_explicit_grid_size_in_axis, initialize_grid_tracks, AutoRepeatStrategy};
 use implicit_grid::compute_grid_size_estimate;
@@ -44,6 +46,30 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
     tree: &mut Tree,
     node: NodeId,
     inputs: LayoutInput,
+) -> LayoutOutput {
+    let contain = tree.get_grid_container_style(node).contain();
+
+    let mut output = if contain.intersects(Contain::SIZE.union(Contain::INLINE_SIZE)) {
+        compute_contained_size_layout(tree, node, inputs, contain, compute_grid_layout_inner)
+    } else {
+        compute_grid_layout_inner(tree, node, inputs, false)
+    };
+
+    // Layout containment suppresses the box's baseline for baseline-alignment purposes
+    if contain.contains(Contain::LAYOUT) {
+        output.first_baselines = Point::NONE;
+    }
+
+    output
+}
+
+/// The main body of the grid layout algorithm. When `hide_children` is `true` the node is laid
+/// out as if it had no children (used for the as-if-empty sizing pass of size containment).
+fn compute_grid_layout_inner<Tree: LayoutGridContainer>(
+    tree: &mut Tree,
+    node: NodeId,
+    inputs: LayoutInput,
+    hide_children: bool,
 ) -> LayoutOutput {
     let LayoutInput { known_dimensions, parent_size, available_space, run_mode, .. } = inputs;
 
@@ -157,9 +183,12 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
     // Absolutely positioned children do not take part in grid placement and do not create
     // implicit tracks, so they are excluded from the grid size estimate.
     let get_child_styles_iter = |node| {
-        tree.child_ids(node).map(|child_node: NodeId| tree.get_grid_child_style(child_node)).filter(|style| {
-            style.box_generation_mode() != BoxGenerationMode::None && style.position() != Position::Absolute
-        })
+        tree.child_ids(node)
+            .filter(move |_| !hide_children)
+            .map(|child_node: NodeId| tree.get_grid_child_style(child_node))
+            .filter(|style| {
+                style.box_generation_mode() != BoxGenerationMode::None && style.position() != Position::Absolute
+            })
     };
     let child_styles_iter = get_child_styles_iter(node);
 
@@ -225,6 +254,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
     let mut cell_occupancy_matrix = CellOccupancyMatrix::with_track_counts(est_col_counts, est_row_counts);
     let in_flow_children_iter = || {
         tree.child_ids(node)
+            .filter(move |_| !hide_children)
             .enumerate()
             .map(|(index, child_node)| (index, child_node, tree.get_grid_child_style(child_node)))
             .filter(|(_, _, style)| {

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -60,7 +60,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
     };
 
     // Layout containment suppresses the box's baseline for baseline-alignment purposes
-    if contain.contains(Contain::LAYOUT) {
+    if contain.suppresses_baseline() {
         output.first_baselines = Point::NONE;
     }
 

--- a/src/compute/leaf.rs
+++ b/src/compute/leaf.rs
@@ -79,7 +79,7 @@ where
         || style.overflow().x.is_scroll_container()
         || style.overflow().y.is_scroll_container()
         || style.position() == Position::Absolute
-        || contain.contains(Contain::LAYOUT)
+        || contain.establishes_independent_formatting_context()
         || padding.top > 0.0
         || padding.bottom > 0.0
         || border.top > 0.0

--- a/src/compute/leaf.rs
+++ b/src/compute/leaf.rs
@@ -8,7 +8,7 @@ use crate::util::debug::debug_log;
 use crate::util::sys::f32_max;
 use crate::util::MaybeMath;
 use crate::util::{MaybeResolve, ResolveOrZero};
-use crate::{BoxSizing, Contain, CoreStyle};
+use crate::{BoxSizing, Contain, CoreStyle, RequestedAxis};
 use core::unreachable;
 
 /// Compute the size of a leaf node (node with no children)
@@ -174,6 +174,19 @@ where
     // content is still laid out (at that width) and continues to determine the box's height.
     // <https://drafts.csswg.org/css-contain-2/#containment-inline-size>
     let has_inline_size_containment = contain.contains(Contain::INLINE_SIZE);
+
+    // If only the width was requested then measured content cannot affect it, so the measure
+    // function does not need to be called.
+    if has_inline_size_containment && run_mode == RunMode::ComputeSize && inputs.axis == RequestedAxis::Horizontal {
+        let width = known_dimensions
+            .width
+            .or(node_size.width)
+            .unwrap_or(content_box_inset.horizontal_axis_sum())
+            .maybe_clamp(node_min_size.width, node_max_size.width);
+        let width = f32_max(width, padding_border.horizontal_axis_sum());
+        return LayoutOutput::from_outer_size(Size { width, height: 0.0 });
+    }
+
     let available_space =
         if has_inline_size_containment && known_dimensions.width.is_none() && node_size.width.is_none() {
             let empty_width =

--- a/src/compute/leaf.rs
+++ b/src/compute/leaf.rs
@@ -8,7 +8,7 @@ use crate::util::debug::debug_log;
 use crate::util::sys::f32_max;
 use crate::util::MaybeMath;
 use crate::util::{MaybeResolve, ResolveOrZero};
-use crate::{BoxSizing, CoreStyle};
+use crate::{BoxSizing, Contain, CoreStyle};
 use core::unreachable;
 
 /// Compute the size of a leaf node (node with no children)
@@ -73,10 +73,13 @@ where
     content_box_inset.right += scrollbar_gutter.x;
     content_box_inset.bottom += scrollbar_gutter.y;
 
+    let contain = style.contain();
+
     let has_styles_preventing_being_collapsed_through = !style.is_block()
         || style.overflow().x.is_scroll_container()
         || style.overflow().y.is_scroll_container()
         || style.position() == Position::Absolute
+        || contain.contains(Contain::LAYOUT)
         || padding.top > 0.0
         || padding.bottom > 0.0
         || border.top > 0.0
@@ -131,6 +134,58 @@ where
             }),
     };
 
+    // Size containment: the box is sized as if it were empty. The box's content is still laid out
+    // (into the resulting fixed-size box) for content size purposes.
+    // <https://drafts.csswg.org/css-contain-2/#containment-size>
+    if contain.contains(Contain::SIZE) {
+        let clamped_size = known_dimensions
+            .or(node_size)
+            .unwrap_or(content_box_inset.sum_axes())
+            .maybe_clamp(node_min_size, node_max_size);
+        let size = Size {
+            width: clamped_size.width,
+            height: f32_max(clamped_size.height, aspect_ratio.map(|ratio| clamped_size.width / ratio).unwrap_or(0.0)),
+        };
+        let size = size.maybe_max(padding_border.sum_axes().map(Some));
+
+        #[cfg(feature = "content_size")]
+        let content_size = if run_mode == RunMode::PerformLayout {
+            let inner_size = Size {
+                width: f32_max(size.width - content_box_inset.horizontal_axis_sum(), 0.0),
+                height: f32_max(size.height - content_box_inset.vertical_axis_sum(), 0.0),
+            };
+            measure_function(Size::NONE, inner_size.map(AvailableSpace::Definite)) + padding.sum_axes()
+        } else {
+            Size::ZERO
+        };
+
+        return LayoutOutput {
+            size,
+            #[cfg(feature = "content_size")]
+            content_size,
+            first_baselines: Point::NONE,
+            top_margin: CollapsibleMarginSet::ZERO,
+            bottom_margin: CollapsibleMarginSet::ZERO,
+            margins_can_collapse_through: !has_styles_preventing_being_collapsed_through && size.height == 0.0,
+        };
+    }
+
+    // Inline-size containment: the box's width is determined as if it were empty, but the box's
+    // content is still laid out (at that width) and continues to determine the box's height.
+    // <https://drafts.csswg.org/css-contain-2/#containment-inline-size>
+    let has_inline_size_containment = contain.contains(Contain::INLINE_SIZE);
+    let available_space =
+        if has_inline_size_containment && known_dimensions.width.is_none() && node_size.width.is_none() {
+            let empty_width =
+                content_box_inset.horizontal_axis_sum().maybe_clamp(node_min_size.width, node_max_size.width);
+            Size {
+                width: AvailableSpace::Definite(f32_max(empty_width - content_box_inset.horizontal_axis_sum(), 0.0)),
+                height: available_space.height,
+            }
+        } else {
+            available_space
+        };
+
     // Measure node
     let measured_size = measure_function(
         match run_mode {
@@ -140,9 +195,12 @@ where
         },
         available_space,
     );
+    // With inline-size containment the content does not contribute to the box's width
+    let sizing_measured_size =
+        if has_inline_size_containment { Size { width: 0.0, height: measured_size.height } } else { measured_size };
     let clamped_size = known_dimensions
         .or(node_size)
-        .unwrap_or(measured_size + content_box_inset.sum_axes())
+        .unwrap_or(sizing_measured_size + content_box_inset.sum_axes())
         .maybe_clamp(node_min_size, node_max_size);
     let size = Size {
         width: clamped_size.width,

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -483,6 +483,14 @@ impl Contain {
     pub const fn suppresses_baseline(self) -> bool {
         self.contains(Contain::LAYOUT)
     }
+
+    /// Whether this containment prevents the box's overflowing content from contributing to an
+    /// ancestor's scrollable overflow region (layout containment treats such overflow as ink
+    /// overflow; paint containment clips it)
+    #[inline(always)]
+    pub const fn contains_scrollable_overflow(self) -> bool {
+        self.intersects(Contain::LAYOUT.union(Contain::PAINT))
+    }
 }
 
 impl core::ops::BitOr for Contain {

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -414,9 +414,12 @@ crate::util::parse::impl_parse_for_keyword_enum!(Overflow,
 ///   - [`Contain::INLINE_SIZE`]: like size containment, but only in the inline (horizontal) axis.
 ///   - [`Contain::LAYOUT`]: the box establishes an independent formatting context, and is treated
 ///     as having no baseline for baseline-alignment purposes (layout containment).
+///   - [`Contain::PAINT`]: the box establishes an independent formatting context. Paint
+///     containment's other effects (clipping, containing absolutely-positioned descendants,
+///     stacking context) are outside of Taffy's scope.
 ///
-/// The `style` and `paint` containment types have no effect on layout and are therefore not
-/// represented (they are accepted and ignored when parsing).
+/// The `style` containment type has no effect on layout and is therefore not represented
+/// (it is accepted and ignored when parsing).
 ///
 /// <https://developer.mozilla.org/en-US/docs/Web/CSS/contain>
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
@@ -437,10 +440,14 @@ impl Contain {
     /// as having no baseline for baseline-alignment purposes.
     /// <https://drafts.csswg.org/css-contain-2/#containment-layout>
     pub const LAYOUT: Contain = Contain(1 << 2);
-    /// The containment implied by `contain: strict` (`size layout`, ignoring non-layout types)
-    pub const STRICT: Contain = Contain(Contain::SIZE.0 | Contain::LAYOUT.0);
-    /// The containment implied by `contain: content` (`layout`, ignoring non-layout types)
-    pub const CONTENT: Contain = Contain(Contain::LAYOUT.0);
+    /// Paint containment: the box establishes an independent formatting context. Its other
+    /// effects don't affect layout.
+    /// <https://drafts.csswg.org/css-contain-2/#containment-paint>
+    pub const PAINT: Contain = Contain(1 << 3);
+    /// The containment implied by `contain: strict` (`size layout paint`, ignoring style containment)
+    pub const STRICT: Contain = Contain(Contain::SIZE.0 | Contain::LAYOUT.0 | Contain::PAINT.0);
+    /// The containment implied by `contain: content` (`layout paint`, ignoring style containment)
+    pub const CONTENT: Contain = Contain(Contain::LAYOUT.0 | Contain::PAINT.0);
 
     /// The default containment (no containment)
     pub const DEFAULT: Contain = Contain::NONE;
@@ -462,6 +469,20 @@ impl Contain {
     pub const fn union(self, other: Contain) -> Contain {
         Contain(self.0 | other.0)
     }
+
+    /// Whether this containment causes the box to establish an independent formatting context
+    /// (both layout and paint containment do)
+    #[inline(always)]
+    pub const fn establishes_independent_formatting_context(self) -> bool {
+        self.intersects(Contain::LAYOUT.union(Contain::PAINT))
+    }
+
+    /// Whether this containment suppresses the box's baseline for baseline-alignment purposes
+    /// (layout containment does, paint containment does not)
+    #[inline(always)]
+    pub const fn suppresses_baseline(self) -> bool {
+        self.contains(Contain::LAYOUT)
+    }
 }
 
 impl core::ops::BitOr for Contain {
@@ -482,11 +503,9 @@ impl core::ops::BitOrAssign for Contain {
 #[cfg(feature = "parse")]
 impl crate::util::parse::FromCss for Contain {
     fn from_css<'i>(input: &mut crate::util::parse::Parser<'i, '_>) -> crate::util::parse::CssParseResult<'i, Self> {
-        /// Bits used to detect duplicate keywords while parsing (includes the ignored
-        /// `style` and `paint` keywords, which do not map to `Contain` flags)
+        /// Duplicate-detection bit for the ignored `style` keyword, which does not map to a
+        /// `Contain` flag
         const STYLE_BIT: u8 = 1 << 6;
-        /// Duplicate-detection bit for the ignored `paint` keyword
-        const PAINT_BIT: u8 = 1 << 7;
 
         let mut flags = Contain::NONE;
         let mut seen: u8 = 0;
@@ -510,10 +529,10 @@ impl crate::util::parse::FromCss for Contain {
                 "size" => (Contain::SIZE, Contain::SIZE.0),
                 "inline-size" => (Contain::INLINE_SIZE, Contain::INLINE_SIZE.0),
                 "layout" => (Contain::LAYOUT, Contain::LAYOUT.0),
-                // `style` and `paint` containment have no layout effect: accept and ignore
-                // them so that real CSS values round-trip
+                "paint" => (Contain::PAINT, Contain::PAINT.0),
+                // `style` containment has no layout effect: accept and ignore it so that real
+                // CSS values round-trip
                 "style" => (Contain::NONE, STYLE_BIT),
-                "paint" => (Contain::NONE, PAINT_BIT),
                 _ => {
                     return Err(input.new_unexpected_token_error(crate::util::parse::Token::Ident(ident)));
                 }
@@ -1486,17 +1505,18 @@ mod tests {
         }
 
         assert_eq!(parse("none"), Contain::NONE);
-        assert_eq!(parse("strict"), Contain::SIZE | Contain::LAYOUT);
-        assert_eq!(parse("content"), Contain::LAYOUT);
+        assert_eq!(parse("strict"), Contain::SIZE | Contain::LAYOUT | Contain::PAINT);
+        assert_eq!(parse("content"), Contain::LAYOUT | Contain::PAINT);
         assert_eq!(parse("size"), Contain::SIZE);
         assert_eq!(parse("inline-size"), Contain::INLINE_SIZE);
         assert_eq!(parse("layout"), Contain::LAYOUT);
         assert_eq!(parse("style"), Contain::NONE);
-        assert_eq!(parse("paint"), Contain::NONE);
+        assert_eq!(parse("paint"), Contain::PAINT);
         assert_eq!(parse("size layout"), Contain::SIZE | Contain::LAYOUT);
         assert_eq!(parse("layout size"), Contain::SIZE | Contain::LAYOUT);
-        assert_eq!(parse("layout paint style"), Contain::LAYOUT);
+        assert_eq!(parse("layout paint style"), Contain::LAYOUT | Contain::PAINT);
         assert_eq!(parse("SIZE Layout"), Contain::SIZE | Contain::LAYOUT);
+        assert!("paint paint".parse::<Contain>().is_err());
 
         assert!("".parse::<Contain>().is_err());
         assert!("banana".parse::<Contain>().is_err());

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -1611,12 +1611,12 @@ mod tests {
         assert_type_size::<GridTemplateComponent<String>>(56);
         assert_type_size::<GridPlacement<String>>(32);
         assert_type_size::<Line<GridPlacement<String>>>(64);
-        assert_type_size::<Style<String>>(552);
+        assert_type_size::<Style<String>>(560);
 
         // String-type dependent (Arc<str>)
         assert_type_size::<GridTemplateComponent<Arc<str>>>(56);
         assert_type_size::<GridPlacement<Arc<str>>>(24);
         assert_type_size::<Line<GridPlacement<Arc<str>>>>(48);
-        assert_type_size::<Style<Arc<str>>>(520);
+        assert_type_size::<Style<Arc<str>>>(528);
     }
 }

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -178,6 +178,12 @@ pub trait CoreStyle {
     fn border(&self) -> Rect<LengthPercentage> {
         Style::<Self::CustomIdent>::DEFAULT.border
     }
+
+    /// The layout-affecting parts of the CSS `contain` property that apply to this node
+    #[inline(always)]
+    fn contain(&self) -> Contain {
+        Contain::NONE
+    }
 }
 
 /// Sets the layout used for the children of this node
@@ -398,6 +404,137 @@ crate::util::parse::impl_parse_for_keyword_enum!(Overflow,
     "scroll" => Scroll,
 );
 
+/// The layout-affecting parts of the CSS `contain` property.
+///
+/// Containment limits the ways in which a box's contents can affect layout outside of the box
+/// (and vice versa). Taffy implements the layout-relevant containment types:
+///
+///   - [`Contain::SIZE`]: the box is sized as if it were empty, then its contents are laid out
+///     into the resulting fixed-size box (size containment).
+///   - [`Contain::INLINE_SIZE`]: like size containment, but only in the inline (horizontal) axis.
+///   - [`Contain::LAYOUT`]: the box establishes an independent formatting context, and is treated
+///     as having no baseline for baseline-alignment purposes (layout containment).
+///
+/// The `style` and `paint` containment types have no effect on layout and are therefore not
+/// represented (they are accepted and ignored when parsing).
+///
+/// <https://developer.mozilla.org/en-US/docs/Web/CSS/contain>
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct Contain(u8);
+
+impl Contain {
+    /// No containment (the default)
+    pub const NONE: Contain = Contain(0);
+    /// Size containment: the box is sized as if it were empty, then its contents are laid out
+    /// into the resulting fixed-size box.
+    /// <https://drafts.csswg.org/css-contain-2/#containment-size>
+    pub const SIZE: Contain = Contain(1 << 0);
+    /// Inline-size containment: size containment applied to the inline (horizontal) axis only.
+    /// <https://drafts.csswg.org/css-contain-2/#containment-inline-size>
+    pub const INLINE_SIZE: Contain = Contain(1 << 1);
+    /// Layout containment: the box establishes an independent formatting context and is treated
+    /// as having no baseline for baseline-alignment purposes.
+    /// <https://drafts.csswg.org/css-contain-2/#containment-layout>
+    pub const LAYOUT: Contain = Contain(1 << 2);
+    /// The containment implied by `contain: strict` (`size layout`, ignoring non-layout types)
+    pub const STRICT: Contain = Contain(Contain::SIZE.0 | Contain::LAYOUT.0);
+    /// The containment implied by `contain: content` (`layout`, ignoring non-layout types)
+    pub const CONTENT: Contain = Contain(Contain::LAYOUT.0);
+
+    /// The default containment (no containment)
+    pub const DEFAULT: Contain = Contain::NONE;
+
+    /// Returns whether `self` contains all of the containment types in `other`
+    #[inline(always)]
+    pub const fn contains(self, other: Contain) -> bool {
+        self.0 & other.0 == other.0
+    }
+
+    /// Returns whether `self` contains any of the containment types in `other`
+    #[inline(always)]
+    pub const fn intersects(self, other: Contain) -> bool {
+        self.0 & other.0 != 0
+    }
+
+    /// Returns the union of the containment types in `self` and `other`
+    #[inline(always)]
+    pub const fn union(self, other: Contain) -> Contain {
+        Contain(self.0 | other.0)
+    }
+}
+
+impl core::ops::BitOr for Contain {
+    type Output = Contain;
+    #[inline(always)]
+    fn bitor(self, rhs: Contain) -> Contain {
+        self.union(rhs)
+    }
+}
+
+impl core::ops::BitOrAssign for Contain {
+    #[inline(always)]
+    fn bitor_assign(&mut self, rhs: Contain) {
+        *self = self.union(rhs);
+    }
+}
+
+#[cfg(feature = "parse")]
+impl crate::util::parse::FromCss for Contain {
+    fn from_css<'i>(input: &mut crate::util::parse::Parser<'i, '_>) -> crate::util::parse::CssParseResult<'i, Self> {
+        /// Bits used to detect duplicate keywords while parsing (includes the ignored
+        /// `style` and `paint` keywords, which do not map to `Contain` flags)
+        const STYLE_BIT: u8 = 1 << 6;
+        /// Duplicate-detection bit for the ignored `paint` keyword
+        const PAINT_BIT: u8 = 1 << 7;
+
+        let mut flags = Contain::NONE;
+        let mut seen: u8 = 0;
+
+        loop {
+            let ident = input.expect_ident()?.clone();
+            let (flag, seen_bit) = cssparser::match_ignore_ascii_case! { &*ident,
+                // Single-keyword values (only valid on their own; `parse_entirely` in the
+                // `FromStr` impl rejects trailing keywords, and a leading keyword before them
+                // is rejected by the `seen != 0` check below)
+                "none" | "strict" | "content" => {
+                    if seen != 0 || !input.is_exhausted() {
+                        return Err(input.new_unexpected_token_error(crate::util::parse::Token::Ident(ident)));
+                    }
+                    return Ok(cssparser::match_ignore_ascii_case! { &*ident,
+                        "strict" => Contain::STRICT,
+                        "content" => Contain::CONTENT,
+                        _ => Contain::NONE,
+                    });
+                },
+                "size" => (Contain::SIZE, Contain::SIZE.0),
+                "inline-size" => (Contain::INLINE_SIZE, Contain::INLINE_SIZE.0),
+                "layout" => (Contain::LAYOUT, Contain::LAYOUT.0),
+                // `style` and `paint` containment have no layout effect: accept and ignore
+                // them so that real CSS values round-trip
+                "style" => (Contain::NONE, STYLE_BIT),
+                "paint" => (Contain::NONE, PAINT_BIT),
+                _ => {
+                    return Err(input.new_unexpected_token_error(crate::util::parse::Token::Ident(ident)));
+                }
+            };
+
+            // Reject duplicate keywords
+            if seen & seen_bit != 0 {
+                return Err(input.new_unexpected_token_error(crate::util::parse::Token::Ident(ident)));
+            }
+            seen |= seen_bit;
+            flags |= flag;
+
+            if input.is_exhausted() {
+                return Ok(flags);
+            }
+        }
+    }
+}
+#[cfg(feature = "parse")]
+crate::util::parse::from_str_from_css!(Contain);
+
 /// Sets the direction of text, table and grid columns, and horizontal overflow.
 /// <https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/direction>
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
@@ -463,6 +600,8 @@ pub struct Style<S: CheapCloneStr = DefaultCheapStr> {
     pub overflow: Point<Overflow>,
     /// How much space (in points) should be reserved for the scrollbars of `Overflow::Scroll` and `Overflow::Auto` nodes.
     pub scrollbar_width: f32,
+    /// The layout-affecting parts of the CSS `contain` property
+    pub contain: Contain,
 
     #[cfg(feature = "float_layout")]
     /// Should the box be floated
@@ -614,6 +753,7 @@ impl<S: CheapCloneStr> Style<S> {
         direction: Direction::Ltr,
         overflow: Point { x: Overflow::Visible, y: Overflow::Visible },
         scrollbar_width: 0.0,
+        contain: Contain::NONE,
         #[cfg(feature = "float_layout")]
         float: Float::None,
         #[cfg(feature = "float_layout")]
@@ -759,6 +899,10 @@ impl<S: CheapCloneStr> CoreStyle for Style<S> {
     fn border(&self) -> Rect<LengthPercentage> {
         self.border
     }
+    #[inline(always)]
+    fn contain(&self) -> Contain {
+        self.contain
+    }
 }
 
 impl<T: CoreStyle> CoreStyle for &'_ T {
@@ -827,6 +971,10 @@ impl<T: CoreStyle> CoreStyle for &'_ T {
     #[inline(always)]
     fn border(&self) -> Rect<LengthPercentage> {
         (*self).border()
+    }
+    #[inline(always)]
+    fn contain(&self) -> Contain {
+        (*self).contain()
     }
 }
 
@@ -1265,6 +1413,7 @@ mod tests {
             direction: Default::default(),
             overflow: Default::default(),
             scrollbar_width: 0.0,
+            contain: Default::default(),
             position: Default::default(),
             #[cfg(feature = "flexbox")]
             flex_direction: Default::default(),
@@ -1325,6 +1474,37 @@ mod tests {
 
         assert_eq!(Style::DEFAULT, Style::<DefaultCheapStr>::default());
         assert_eq!(Style::DEFAULT, old_defaults);
+    }
+
+    #[test]
+    #[cfg(feature = "parse")]
+    fn parse_contain() {
+        use super::Contain;
+
+        fn parse(input: &str) -> Contain {
+            input.parse().unwrap()
+        }
+
+        assert_eq!(parse("none"), Contain::NONE);
+        assert_eq!(parse("strict"), Contain::SIZE | Contain::LAYOUT);
+        assert_eq!(parse("content"), Contain::LAYOUT);
+        assert_eq!(parse("size"), Contain::SIZE);
+        assert_eq!(parse("inline-size"), Contain::INLINE_SIZE);
+        assert_eq!(parse("layout"), Contain::LAYOUT);
+        assert_eq!(parse("style"), Contain::NONE);
+        assert_eq!(parse("paint"), Contain::NONE);
+        assert_eq!(parse("size layout"), Contain::SIZE | Contain::LAYOUT);
+        assert_eq!(parse("layout size"), Contain::SIZE | Contain::LAYOUT);
+        assert_eq!(parse("layout paint style"), Contain::LAYOUT);
+        assert_eq!(parse("SIZE Layout"), Contain::SIZE | Contain::LAYOUT);
+
+        assert!("".parse::<Contain>().is_err());
+        assert!("banana".parse::<Contain>().is_err());
+        assert!("size size".parse::<Contain>().is_err());
+        assert!("none layout".parse::<Contain>().is_err());
+        assert!("layout none".parse::<Contain>().is_err());
+        assert!("strict layout".parse::<Contain>().is_err());
+        assert!("size content".parse::<Contain>().is_err());
     }
 
     // NOTE: Please feel free the update the sizes in this test as required. This test is here to prevent unintentional size changes

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -514,6 +514,9 @@ impl crate::util::parse::FromCss for Contain {
         /// Duplicate-detection bit for the ignored `style` keyword, which does not map to a
         /// `Contain` flag
         const STYLE_BIT: u8 = 1 << 6;
+        /// Shared duplicate-detection bits for the `[ size | inline-size ]` group, whose
+        /// keywords are mutually exclusive
+        const SIZE_GROUP_BITS: u8 = Contain::SIZE.0 | Contain::INLINE_SIZE.0;
 
         let mut flags = Contain::NONE;
         let mut seen: u8 = 0;
@@ -534,8 +537,8 @@ impl crate::util::parse::FromCss for Contain {
                         _ => Contain::NONE,
                     });
                 },
-                "size" => (Contain::SIZE, Contain::SIZE.0),
-                "inline-size" => (Contain::INLINE_SIZE, Contain::INLINE_SIZE.0),
+                "size" => (Contain::SIZE, SIZE_GROUP_BITS),
+                "inline-size" => (Contain::INLINE_SIZE, SIZE_GROUP_BITS),
                 "layout" => (Contain::LAYOUT, Contain::LAYOUT.0),
                 "paint" => (Contain::PAINT, Contain::PAINT.0),
                 // `style` containment has no layout effect: accept and ignore it so that real
@@ -1529,6 +1532,9 @@ mod tests {
         assert!("".parse::<Contain>().is_err());
         assert!("banana".parse::<Contain>().is_err());
         assert!("size size".parse::<Contain>().is_err());
+        assert!("size inline-size".parse::<Contain>().is_err());
+        assert!("inline-size size".parse::<Contain>().is_err());
+        assert!("size layout inline-size".parse::<Contain>().is_err());
         assert!("none layout".parse::<Contain>().is_err());
         assert!("layout none".parse::<Contain>().is_err());
         assert!("strict layout".parse::<Contain>().is_err());

--- a/test_fixtures/block/block_overflowing_content_in_fixed_height_child.html
+++ b/test_fixtures/block/block_overflowing_content_in_fixed_height_child.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px;">
+  <div style="display: block; height: 0px;">
+    <div style="display: block; height: 20px;"></div>
+    <div style="display: block; height: 20px;"></div>
+  </div>
+  <div style="display: block; height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_content_block.html
+++ b/test_fixtures/contain/contain_content_block.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px; border: 2px solid black;">
+  <div style="display: block; height: 10px; margin-bottom: 10px;"></div>
+  <div style="display: block; contain: content;">
+    <div style="display: block; height: 10px; margin-top: 20px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_inline_size_block.html
+++ b/test_fixtures/contain/contain_inline_size_block.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: max-content; border: 2px solid black;">
+  <div style="display: block; contain: inline-size;">XXX</div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_inline_size_block_height_from_content.html
+++ b/test_fixtures/contain/contain_inline_size_block_height_from_content.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: max-content; border: 2px solid black;">
+  <div style="display: block; contain: inline-size; padding: 5px;">
+    <div style="display: block; height: 20px;"></div>
+    <div style="display: block; height: 20px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_inline_size_leaf.html
+++ b/test_fixtures/contain/contain_inline_size_leaf.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: max-content; border: 2px solid black;">
+  <div style="contain: inline-size; padding: 4px;">XXX</div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_layout_block_avoids_float.html
+++ b/test_fixtures/contain/contain_layout_block_avoids_float.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px;">
+  <div style="display: block; float: left; width: 30px; height: 30px;"></div>
+  <div style="display: block; contain: layout; height: 50px;">
+    <div style="display: block; height: 10px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_layout_block_contains_floats.html
+++ b/test_fixtures/contain/contain_layout_block_contains_floats.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px;">
+  <div style="display: block; contain: layout;">
+    <div style="display: block; float: left; width: 30px; height: 30px;"></div>
+  </div>
+  <div style="display: block; height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_layout_block_margin_collapse.html
+++ b/test_fixtures/contain/contain_layout_block_margin_collapse.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px; border: 2px solid black;">
+  <div style="display: block; height: 10px; margin-bottom: 10px;"></div>
+  <div style="display: block; contain: layout;">
+    <div style="display: block; height: 10px; margin-top: 20px; margin-bottom: 20px;"></div>
+  </div>
+  <div style="display: block; height: 10px; margin-top: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_layout_block_overflow_not_propagated.html
+++ b/test_fixtures/contain/contain_layout_block_overflow_not_propagated.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; overflow: scroll; width: 100px; height: 100px;">
+  <div style="display: block; contain: layout; width: 50px; height: 50px;">
+    <div style="display: block; width: 200px; height: 200px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_layout_flex_baseline.html
+++ b/test_fixtures/contain/contain_layout_flex_baseline.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 200px; align-items: baseline;">
+  <div style="width: 50px; height: 60px;">
+    <div style="width: 50px; height: 30px;"></div>
+  </div>
+  <div style="contain: layout; width: 50px; height: 20px;">
+    <div style="width: 50px; height: 10px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_layout_flex_overflow_not_propagated.html
+++ b/test_fixtures/contain/contain_layout_flex_overflow_not_propagated.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; overflow: scroll; width: 100px; height: 100px;">
+  <div style="display: block; contain: layout; width: 50px; height: 50px; flex-shrink: 0;">
+    <div style="display: block; width: 200px; height: 200px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_layout_grid_overflow_not_propagated.html
+++ b/test_fixtures/contain/contain_layout_grid_overflow_not_propagated.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; overflow: scroll; grid-template-columns: 50px; grid-template-rows: 50px; width: 100px; height: 100px;">
+  <div style="display: block; contain: layout;">
+    <div style="display: block; width: 200px; height: 200px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_paint_block_contains_floats.html
+++ b/test_fixtures/contain/contain_paint_block_contains_floats.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px;">
+  <div style="display: block; contain: paint;">
+    <div style="display: block; float: left; width: 30px; height: 30px;"></div>
+  </div>
+  <div style="display: block; height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_paint_block_margin_collapse.html
+++ b/test_fixtures/contain/contain_paint_block_margin_collapse.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px; border: 2px solid black;">
+  <div style="display: block; height: 10px; margin-bottom: 10px;"></div>
+  <div style="display: block; contain: paint;">
+    <div style="display: block; height: 10px; margin-top: 20px; margin-bottom: 20px;"></div>
+  </div>
+  <div style="display: block; height: 10px; margin-top: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_paint_block_overflow_not_propagated.html
+++ b/test_fixtures/contain/contain_paint_block_overflow_not_propagated.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; overflow: scroll; width: 100px; height: 100px;">
+  <div style="display: block; contain: paint; width: 50px; height: 50px;">
+    <div style="display: block; width: 200px; height: 200px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_paint_flex_baseline.html
+++ b/test_fixtures/contain/contain_paint_flex_baseline.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 200px; align-items: baseline;">
+  <div style="width: 50px; height: 60px;">
+    <div style="width: 50px; height: 30px;"></div>
+  </div>
+  <div style="contain: paint; width: 50px; height: 20px;">
+    <div style="width: 50px; height: 10px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_size_aspect_ratio_percent_child.html
+++ b/test_fixtures/contain/contain_size_aspect_ratio_percent_child.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px;">
+  <div style="display: block; contain: size; aspect-ratio: 1;">
+    <div style="display: block; height: 50%;">
+      <div style="display: block; height: 20px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_size_block.html
+++ b/test_fixtures/contain/contain_size_block.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px;">
+  <div style="display: block; contain: size;">
+    <div style="display: block; height: 20px;"></div>
+    <div style="display: block; height: 20px;"></div>
+  </div>
+  <div style="display: block; height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_size_block_aspect_ratio.html
+++ b/test_fixtures/contain/contain_size_block_aspect_ratio.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px;">
+  <div style="display: block; contain: size; width: 50px; aspect-ratio: 2;">
+    <div style="display: block; height: 60px;"></div>
+  </div>
+  <div style="display: block; height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_size_block_fixed_size.html
+++ b/test_fixtures/contain/contain_size_block_fixed_size.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px;">
+  <div style="display: block; contain: size; width: 60px; height: 40px;">
+    <div style="display: block; height: 20px;"></div>
+    <div style="display: block; height: 20px;"></div>
+    <div style="display: block; height: 20px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_size_block_float_inside.html
+++ b/test_fixtures/contain/contain_size_block_float_inside.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px;">
+  <div style="display: block; contain: size;">
+    <div style="display: block; float: left; width: 30px; height: 30px;"></div>
+  </div>
+  <div style="display: block; height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_size_block_intrinsic_width.html
+++ b/test_fixtures/contain/contain_size_block_intrinsic_width.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: max-content; border: 2px solid black;">
+  <div style="display: block; contain: size;">XXX&#8203;XX&#8203;X</div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_size_block_min_size.html
+++ b/test_fixtures/contain/contain_size_block_min_size.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px;">
+  <div style="display: block; contain: size; min-width: 30px; min-height: 25px;">
+    <div style="display: block; height: 60px;"></div>
+  </div>
+  <div style="display: block; height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_size_block_padding_border.html
+++ b/test_fixtures/contain/contain_size_block_padding_border.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px;">
+  <div style="display: block; contain: size; padding: 5px 10px; border: 3px solid black;">
+    <div style="display: block; height: 20px;"></div>
+  </div>
+  <div style="display: block; height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_size_flex_basis_content.html
+++ b/test_fixtures/contain/contain_size_flex_basis_content.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; width: 200px; align-items: flex-start;">
+  <div style="contain: size; flex-basis: content;">
+    <div style="width: 40px; height: 30px;"></div>
+  </div>
+  <div style="width: 20px; height: 20px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_size_flex_container.html
+++ b/test_fixtures/contain/contain_size_flex_container.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px;">
+  <div style="display: flex; contain: size; padding: 5px;">
+    <div style="width: 40px; height: 30px;"></div>
+    <div style="width: 40px; height: 30px;"></div>
+  </div>
+  <div style="height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_size_flex_item.html
+++ b/test_fixtures/contain/contain_size_flex_item.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; width: 200px; align-items: flex-start;">
+  <div style="contain: size;">
+    <div style="width: 40px; height: 30px;"></div>
+  </div>
+  <div style="width: 20px; height: 20px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_size_flex_percent_child_auto_height.html
+++ b/test_fixtures/contain/contain_size_flex_percent_child_auto_height.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; contain: size; width: 100px;">
+  <div style="width: 30px; height: 50%;">
+    <div style="display: block; height: 20px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_size_grid_container.html
+++ b/test_fixtures/contain/contain_size_grid_container.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px;">
+  <div style="display: grid; contain: size; grid-template-columns: auto auto; padding: 5px;">
+    <div style="width: 40px; height: 30px;"></div>
+    <div style="width: 40px; height: 30px;"></div>
+  </div>
+  <div style="height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_size_grid_explicit_tracks.html
+++ b/test_fixtures/contain/contain_size_grid_explicit_tracks.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px;">
+  <div style="display: grid; contain: size; grid-template-columns: 30px 30px; grid-template-rows: 20px;">
+    <div></div>
+    <div></div>
+  </div>
+  <div style="height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_size_grid_item.html
+++ b/test_fixtures/contain/contain_size_grid_item.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-columns: auto auto; grid-template-rows: auto; width: max-content;">
+  <div style="contain: size;">
+    <div style="width: 40px; height: 30px;"></div>
+  </div>
+  <div style="width: 20px; height: 20px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_size_grid_percent_child_auto_height.html
+++ b/test_fixtures/contain/contain_size_grid_percent_child_auto_height.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; contain: size; width: 100px;">
+  <div style="display: block; height: 50%;">
+    <div style="display: block; height: 20px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_size_leaf.html
+++ b/test_fixtures/contain/contain_size_leaf.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px;">
+  <div style="contain: size;">XXX</div>
+  <div style="height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_size_percent_child_auto_height.html
+++ b/test_fixtures/contain/contain_size_percent_child_auto_height.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; contain: size; width: 100px;">
+  <div style="display: block; height: 50%;">
+    <div style="display: block; height: 20px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_size_percent_child_definite_height.html
+++ b/test_fixtures/contain/contain_size_percent_child_definite_height.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; contain: size; width: 100px; height: 40px;">
+  <div style="display: block; height: 50%;">
+    <div style="display: block; height: 20px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_size_width_fit_content.html
+++ b/test_fixtures/contain/contain_size_width_fit_content.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px;">
+  <div style="display: block; contain: size; width: fit-content; height: 10px;">
+    <div style="display: block; width: 80px; height: 20px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_size_width_max_content.html
+++ b/test_fixtures/contain/contain_size_width_max_content.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px;">
+  <div style="contain: size; width: max-content; border: 2px solid black;">XXX&#8203;XX</div>
+  <div style="height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_size_width_min_content.html
+++ b/test_fixtures/contain/contain_size_width_min_content.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px;">
+  <div style="display: block; contain: size; width: min-content; height: 10px;">
+    <div style="display: block; width: 80px; height: 20px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_strict_block.html
+++ b/test_fixtures/contain/contain_strict_block.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px;">
+  <div style="display: block; contain: strict; padding: 5px;">
+    <div style="display: block; height: 20px;"></div>
+  </div>
+  <div style="display: block; height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/xml.rs
+++ b/tests/xml.rs
@@ -256,6 +256,7 @@ fn build_style<S: CheapCloneStr>(xnode: roxmltree::Node) -> taffy::Style<S> {
             y: parse_or_default(xnode.attribute("overflow-y")),
         },
         scrollbar_width: parse_or_default(xnode.attribute("scrollbar-width")),
+        contain: parse_or_default(xnode.attribute("contain")),
         float: parse_or_default(xnode.attribute("float")),
         clear: parse_or_default(xnode.attribute("clear")),
         position: parse_or_default(xnode.attribute("position")),

--- a/tests/xml/block/block_overflowing_content_in_fixed_height_child__border_box_ltr.xml
+++ b/tests/xml/block/block_overflowing_content_in_fixed_height_child__border_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="block_overflowing_content_in_fixed_height_child__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px">
+      <div display="block" direction="ltr" height="0px">
+        <div display="block" direction="ltr" height="20px"/>
+        <div display="block" direction="ltr" height="20px"/>
+      </div>
+      <div display="block" direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="10">
+      <node x="0" y="0" width="100" height="0">
+        <node x="0" y="0" width="100" height="20"/>
+        <node x="0" y="20" width="100" height="20"/>
+      </node>
+      <node x="0" y="0" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_overflowing_content_in_fixed_height_child__border_box_rtl.xml
+++ b/tests/xml/block/block_overflowing_content_in_fixed_height_child__border_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="block_overflowing_content_in_fixed_height_child__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px">
+      <div display="block" direction="rtl" height="0px">
+        <div display="block" direction="rtl" height="20px"/>
+        <div display="block" direction="rtl" height="20px"/>
+      </div>
+      <div display="block" direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="10">
+      <node x="0" y="0" width="100" height="0">
+        <node x="0" y="0" width="100" height="20"/>
+        <node x="0" y="20" width="100" height="20"/>
+      </node>
+      <node x="0" y="0" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_overflowing_content_in_fixed_height_child__content_box_ltr.xml
+++ b/tests/xml/block/block_overflowing_content_in_fixed_height_child__content_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="block_overflowing_content_in_fixed_height_child__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" height="0px">
+        <div display="block" box-sizing="content-box" direction="ltr" height="20px"/>
+        <div display="block" box-sizing="content-box" direction="ltr" height="20px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="10">
+      <node x="0" y="0" width="100" height="0">
+        <node x="0" y="0" width="100" height="20"/>
+        <node x="0" y="20" width="100" height="20"/>
+      </node>
+      <node x="0" y="0" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_overflowing_content_in_fixed_height_child__content_box_rtl.xml
+++ b/tests/xml/block/block_overflowing_content_in_fixed_height_child__content_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="block_overflowing_content_in_fixed_height_child__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" height="0px">
+        <div display="block" box-sizing="content-box" direction="rtl" height="20px"/>
+        <div display="block" box-sizing="content-box" direction="rtl" height="20px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="10">
+      <node x="0" y="0" width="100" height="0">
+        <node x="0" y="0" width="100" height="20"/>
+        <node x="0" y="20" width="100" height="20"/>
+      </node>
+      <node x="0" y="0" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_content_block__border_box_ltr.xml
+++ b/tests/xml/contain/contain_content_block__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="contain_content_block__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <div display="block" direction="ltr" height="10px" margin-bottom="10px"/>
+      <div display="block" direction="ltr" contain="content">
+        <div display="block" direction="ltr" height="10px" margin-top="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="54">
+      <node x="2" y="2" width="96" height="10"/>
+      <node x="2" y="22" width="96" height="30">
+        <node x="0" y="20" width="96" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_content_block__border_box_rtl.xml
+++ b/tests/xml/contain/contain_content_block__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="contain_content_block__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <div display="block" direction="rtl" height="10px" margin-bottom="10px"/>
+      <div display="block" direction="rtl" contain="content">
+        <div display="block" direction="rtl" height="10px" margin-top="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="54">
+      <node x="2" y="2" width="96" height="10"/>
+      <node x="2" y="22" width="96" height="30">
+        <node x="0" y="20" width="96" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_content_block__content_box_ltr.xml
+++ b/tests/xml/contain/contain_content_block__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="contain_content_block__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <div display="block" box-sizing="content-box" direction="ltr" height="10px" margin-bottom="10px"/>
+      <div display="block" box-sizing="content-box" direction="ltr" contain="content">
+        <div display="block" box-sizing="content-box" direction="ltr" height="10px" margin-top="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="104" height="54">
+      <node x="2" y="2" width="100" height="10"/>
+      <node x="2" y="22" width="100" height="30">
+        <node x="0" y="20" width="100" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_content_block__content_box_rtl.xml
+++ b/tests/xml/contain/contain_content_block__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="contain_content_block__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <div display="block" box-sizing="content-box" direction="rtl" height="10px" margin-bottom="10px"/>
+      <div display="block" box-sizing="content-box" direction="rtl" contain="content">
+        <div display="block" box-sizing="content-box" direction="rtl" height="10px" margin-top="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="104" height="54">
+      <node x="2" y="2" width="100" height="10"/>
+      <node x="2" y="22" width="100" height="30">
+        <node x="0" y="20" width="100" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_inline_size_block__border_box_ltr.xml
+++ b/tests/xml/contain/contain_inline_size_block__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="contain_inline_size_block__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="max-content" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <text display="block" direction="ltr" contain="inline-size">
+        XXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="4" height="14">
+      <node x="2" y="2" width="0" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_inline_size_block__border_box_rtl.xml
+++ b/tests/xml/contain/contain_inline_size_block__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="contain_inline_size_block__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="max-content" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <text display="block" direction="rtl" contain="inline-size">
+        XXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="4" height="14">
+      <node x="2" y="2" width="0" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_inline_size_block__content_box_ltr.xml
+++ b/tests/xml/contain/contain_inline_size_block__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="contain_inline_size_block__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="max-content" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <text display="block" box-sizing="content-box" direction="ltr" contain="inline-size">
+        XXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="4" height="14">
+      <node x="2" y="2" width="0" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_inline_size_block__content_box_rtl.xml
+++ b/tests/xml/contain/contain_inline_size_block__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="contain_inline_size_block__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="max-content" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <text display="block" box-sizing="content-box" direction="rtl" contain="inline-size">
+        XXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="4" height="14">
+      <node x="2" y="2" width="0" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_inline_size_block_height_from_content__border_box_ltr.xml
+++ b/tests/xml/contain/contain_inline_size_block_height_from_content__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="contain_inline_size_block_height_from_content__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="max-content" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <div display="block" direction="ltr" contain="inline-size" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px">
+        <div display="block" direction="ltr" height="20px"/>
+        <div display="block" direction="ltr" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="14" height="54">
+      <node x="2" y="2" width="10" height="50">
+        <node x="5" y="5" width="0" height="20"/>
+        <node x="5" y="25" width="0" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_inline_size_block_height_from_content__border_box_rtl.xml
+++ b/tests/xml/contain/contain_inline_size_block_height_from_content__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="contain_inline_size_block_height_from_content__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="max-content" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <div display="block" direction="rtl" contain="inline-size" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px">
+        <div display="block" direction="rtl" height="20px"/>
+        <div display="block" direction="rtl" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="14" height="54">
+      <node x="2" y="2" width="10" height="50">
+        <node x="5" y="5" width="0" height="20"/>
+        <node x="5" y="25" width="0" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_inline_size_block_height_from_content__content_box_ltr.xml
+++ b/tests/xml/contain/contain_inline_size_block_height_from_content__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="contain_inline_size_block_height_from_content__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="max-content" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <div display="block" box-sizing="content-box" direction="ltr" contain="inline-size" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px">
+        <div display="block" box-sizing="content-box" direction="ltr" height="20px"/>
+        <div display="block" box-sizing="content-box" direction="ltr" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="14" height="54">
+      <node x="2" y="2" width="10" height="50">
+        <node x="5" y="5" width="0" height="20"/>
+        <node x="5" y="25" width="0" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_inline_size_block_height_from_content__content_box_rtl.xml
+++ b/tests/xml/contain/contain_inline_size_block_height_from_content__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="contain_inline_size_block_height_from_content__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="max-content" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <div display="block" box-sizing="content-box" direction="rtl" contain="inline-size" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px">
+        <div display="block" box-sizing="content-box" direction="rtl" height="20px"/>
+        <div display="block" box-sizing="content-box" direction="rtl" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="14" height="54">
+      <node x="2" y="2" width="10" height="50">
+        <node x="5" y="5" width="0" height="20"/>
+        <node x="5" y="25" width="0" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_inline_size_leaf__border_box_ltr.xml
+++ b/tests/xml/contain/contain_inline_size_leaf__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="contain_inline_size_leaf__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="max-content" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <text direction="ltr" contain="inline-size" padding-top="4px" padding-left="4px" padding-bottom="4px" padding-right="4px">
+        XXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="12" height="22">
+      <node x="2" y="2" width="8" height="18"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_inline_size_leaf__border_box_rtl.xml
+++ b/tests/xml/contain/contain_inline_size_leaf__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="contain_inline_size_leaf__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="max-content" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <text direction="rtl" contain="inline-size" padding-top="4px" padding-left="4px" padding-bottom="4px" padding-right="4px">
+        XXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="12" height="22">
+      <node x="2" y="2" width="8" height="18"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_inline_size_leaf__content_box_ltr.xml
+++ b/tests/xml/contain/contain_inline_size_leaf__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="contain_inline_size_leaf__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="max-content" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <text box-sizing="content-box" direction="ltr" contain="inline-size" padding-top="4px" padding-left="4px" padding-bottom="4px" padding-right="4px">
+        XXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="12" height="22">
+      <node x="2" y="2" width="8" height="18"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_inline_size_leaf__content_box_rtl.xml
+++ b/tests/xml/contain/contain_inline_size_leaf__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="contain_inline_size_leaf__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="max-content" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <text box-sizing="content-box" direction="rtl" contain="inline-size" padding-top="4px" padding-left="4px" padding-bottom="4px" padding-right="4px">
+        XXX
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="12" height="22">
+      <node x="2" y="2" width="8" height="18"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_block_avoids_float__border_box_ltr.xml
+++ b/tests/xml/contain/contain_layout_block_avoids_float__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="contain_layout_block_avoids_float__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px">
+      <div display="block" direction="ltr" float="left" width="30px" height="30px"/>
+      <div display="block" direction="ltr" contain="layout" height="50px">
+        <div display="block" direction="ltr" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="50">
+      <node x="0" y="0" width="30" height="30"/>
+      <node x="30" y="0" width="70" height="50">
+        <node x="0" y="0" width="70" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_block_avoids_float__border_box_rtl.xml
+++ b/tests/xml/contain/contain_layout_block_avoids_float__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="contain_layout_block_avoids_float__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px">
+      <div display="block" direction="rtl" float="left" width="30px" height="30px"/>
+      <div display="block" direction="rtl" contain="layout" height="50px">
+        <div display="block" direction="rtl" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="50">
+      <node x="0" y="0" width="30" height="30"/>
+      <node x="30" y="0" width="70" height="50">
+        <node x="0" y="0" width="70" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_block_avoids_float__content_box_ltr.xml
+++ b/tests/xml/contain/contain_layout_block_avoids_float__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="contain_layout_block_avoids_float__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" float="left" width="30px" height="30px"/>
+      <div display="block" box-sizing="content-box" direction="ltr" contain="layout" height="50px">
+        <div display="block" box-sizing="content-box" direction="ltr" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="50">
+      <node x="0" y="0" width="30" height="30"/>
+      <node x="30" y="0" width="70" height="50">
+        <node x="0" y="0" width="70" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_block_avoids_float__content_box_rtl.xml
+++ b/tests/xml/contain/contain_layout_block_avoids_float__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="contain_layout_block_avoids_float__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" float="left" width="30px" height="30px"/>
+      <div display="block" box-sizing="content-box" direction="rtl" contain="layout" height="50px">
+        <div display="block" box-sizing="content-box" direction="rtl" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="50">
+      <node x="0" y="0" width="30" height="30"/>
+      <node x="30" y="0" width="70" height="50">
+        <node x="0" y="0" width="70" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_block_contains_floats__border_box_ltr.xml
+++ b/tests/xml/contain/contain_layout_block_contains_floats__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="contain_layout_block_contains_floats__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px">
+      <div display="block" direction="ltr" contain="layout">
+        <div display="block" direction="ltr" float="left" width="30px" height="30px"/>
+      </div>
+      <div display="block" direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="40">
+      <node x="0" y="0" width="100" height="30">
+        <node x="0" y="0" width="30" height="30"/>
+      </node>
+      <node x="0" y="30" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_block_contains_floats__border_box_rtl.xml
+++ b/tests/xml/contain/contain_layout_block_contains_floats__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="contain_layout_block_contains_floats__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px">
+      <div display="block" direction="rtl" contain="layout">
+        <div display="block" direction="rtl" float="left" width="30px" height="30px"/>
+      </div>
+      <div display="block" direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="40">
+      <node x="0" y="0" width="100" height="30">
+        <node x="0" y="0" width="30" height="30"/>
+      </node>
+      <node x="0" y="30" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_block_contains_floats__content_box_ltr.xml
+++ b/tests/xml/contain/contain_layout_block_contains_floats__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="contain_layout_block_contains_floats__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" contain="layout">
+        <div display="block" box-sizing="content-box" direction="ltr" float="left" width="30px" height="30px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="40">
+      <node x="0" y="0" width="100" height="30">
+        <node x="0" y="0" width="30" height="30"/>
+      </node>
+      <node x="0" y="30" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_block_contains_floats__content_box_rtl.xml
+++ b/tests/xml/contain/contain_layout_block_contains_floats__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="contain_layout_block_contains_floats__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" contain="layout">
+        <div display="block" box-sizing="content-box" direction="rtl" float="left" width="30px" height="30px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="40">
+      <node x="0" y="0" width="100" height="30">
+        <node x="0" y="0" width="30" height="30"/>
+      </node>
+      <node x="0" y="30" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_block_margin_collapse__border_box_ltr.xml
+++ b/tests/xml/contain/contain_layout_block_margin_collapse__border_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="contain_layout_block_margin_collapse__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <div display="block" direction="ltr" height="10px" margin-bottom="10px"/>
+      <div display="block" direction="ltr" contain="layout">
+        <div display="block" direction="ltr" height="10px" margin-top="20px" margin-bottom="20px"/>
+      </div>
+      <div display="block" direction="ltr" height="10px" margin-top="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="94">
+      <node x="2" y="2" width="96" height="10"/>
+      <node x="2" y="22" width="96" height="50">
+        <node x="0" y="20" width="96" height="10"/>
+      </node>
+      <node x="2" y="82" width="96" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_block_margin_collapse__border_box_rtl.xml
+++ b/tests/xml/contain/contain_layout_block_margin_collapse__border_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="contain_layout_block_margin_collapse__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <div display="block" direction="rtl" height="10px" margin-bottom="10px"/>
+      <div display="block" direction="rtl" contain="layout">
+        <div display="block" direction="rtl" height="10px" margin-top="20px" margin-bottom="20px"/>
+      </div>
+      <div display="block" direction="rtl" height="10px" margin-top="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="94">
+      <node x="2" y="2" width="96" height="10"/>
+      <node x="2" y="22" width="96" height="50">
+        <node x="0" y="20" width="96" height="10"/>
+      </node>
+      <node x="2" y="82" width="96" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_block_margin_collapse__content_box_ltr.xml
+++ b/tests/xml/contain/contain_layout_block_margin_collapse__content_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="contain_layout_block_margin_collapse__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <div display="block" box-sizing="content-box" direction="ltr" height="10px" margin-bottom="10px"/>
+      <div display="block" box-sizing="content-box" direction="ltr" contain="layout">
+        <div display="block" box-sizing="content-box" direction="ltr" height="10px" margin-top="20px" margin-bottom="20px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="ltr" height="10px" margin-top="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="104" height="94">
+      <node x="2" y="2" width="100" height="10"/>
+      <node x="2" y="22" width="100" height="50">
+        <node x="0" y="20" width="100" height="10"/>
+      </node>
+      <node x="2" y="82" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_block_margin_collapse__content_box_rtl.xml
+++ b/tests/xml/contain/contain_layout_block_margin_collapse__content_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="contain_layout_block_margin_collapse__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <div display="block" box-sizing="content-box" direction="rtl" height="10px" margin-bottom="10px"/>
+      <div display="block" box-sizing="content-box" direction="rtl" contain="layout">
+        <div display="block" box-sizing="content-box" direction="rtl" height="10px" margin-top="20px" margin-bottom="20px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="rtl" height="10px" margin-top="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="104" height="94">
+      <node x="2" y="2" width="100" height="10"/>
+      <node x="2" y="22" width="100" height="50">
+        <node x="0" y="20" width="100" height="10"/>
+      </node>
+      <node x="2" y="82" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_block_overflow_not_propagated__border_box_ltr.xml
+++ b/tests/xml/contain/contain_layout_block_overflow_not_propagated__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="contain_layout_block_overflow_not_propagated__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" overflow-x="scroll" overflow-y="scroll" scrollbar-width="15" width="100px" height="100px">
+      <div display="block" direction="ltr" contain="layout" width="50px" height="50px">
+        <div display="block" direction="ltr" width="200px" height="200px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100" scroll_width="0" scroll_height="0">
+      <node x="0" y="0" width="50" height="50">
+        <node x="0" y="0" width="200" height="200"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_block_overflow_not_propagated__border_box_rtl.xml
+++ b/tests/xml/contain/contain_layout_block_overflow_not_propagated__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="contain_layout_block_overflow_not_propagated__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" overflow-x="scroll" overflow-y="scroll" scrollbar-width="15" width="100px" height="100px">
+      <div display="block" direction="rtl" contain="layout" width="50px" height="50px">
+        <div display="block" direction="rtl" width="200px" height="200px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100" scroll_width="0" scroll_height="0">
+      <node x="50" y="0" width="50" height="50">
+        <node x="-150" y="0" width="200" height="200"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_block_overflow_not_propagated__content_box_ltr.xml
+++ b/tests/xml/contain/contain_layout_block_overflow_not_propagated__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="contain_layout_block_overflow_not_propagated__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" overflow-x="scroll" overflow-y="scroll" scrollbar-width="15" width="100px" height="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" contain="layout" width="50px" height="50px">
+        <div display="block" box-sizing="content-box" direction="ltr" width="200px" height="200px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100" scroll_width="0" scroll_height="0">
+      <node x="0" y="0" width="50" height="50">
+        <node x="0" y="0" width="200" height="200"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_block_overflow_not_propagated__content_box_rtl.xml
+++ b/tests/xml/contain/contain_layout_block_overflow_not_propagated__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="contain_layout_block_overflow_not_propagated__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" overflow-x="scroll" overflow-y="scroll" scrollbar-width="15" width="100px" height="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" contain="layout" width="50px" height="50px">
+        <div display="block" box-sizing="content-box" direction="rtl" width="200px" height="200px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100" scroll_width="0" scroll_height="0">
+      <node x="50" y="0" width="50" height="50">
+        <node x="-150" y="0" width="200" height="200"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_flex_baseline__border_box_ltr.xml
+++ b/tests/xml/contain/contain_layout_flex_baseline__border_box_ltr.xml
@@ -1,0 +1,23 @@
+<test name="contain_layout_flex_baseline__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" align-items="baseline" width="200px">
+      <div direction="ltr" width="50px" height="60px">
+        <div direction="ltr" width="50px" height="30px"/>
+      </div>
+      <div direction="ltr" contain="layout" width="50px" height="20px">
+        <div direction="ltr" width="50px" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="60">
+      <node x="0" y="0" width="50" height="60">
+        <node x="0" y="0" width="50" height="30"/>
+      </node>
+      <node x="50" y="10" width="50" height="20">
+        <node x="0" y="0" width="50" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_flex_baseline__border_box_rtl.xml
+++ b/tests/xml/contain/contain_layout_flex_baseline__border_box_rtl.xml
@@ -1,0 +1,23 @@
+<test name="contain_layout_flex_baseline__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" align-items="baseline" width="200px">
+      <div direction="rtl" width="50px" height="60px">
+        <div direction="rtl" width="50px" height="30px"/>
+      </div>
+      <div direction="rtl" contain="layout" width="50px" height="20px">
+        <div direction="rtl" width="50px" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="60">
+      <node x="150" y="0" width="50" height="60">
+        <node x="0" y="0" width="50" height="30"/>
+      </node>
+      <node x="100" y="10" width="50" height="20">
+        <node x="0" y="0" width="50" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_flex_baseline__content_box_ltr.xml
+++ b/tests/xml/contain/contain_layout_flex_baseline__content_box_ltr.xml
@@ -1,0 +1,23 @@
+<test name="contain_layout_flex_baseline__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" align-items="baseline" width="200px">
+      <div box-sizing="content-box" direction="ltr" width="50px" height="60px">
+        <div box-sizing="content-box" direction="ltr" width="50px" height="30px"/>
+      </div>
+      <div box-sizing="content-box" direction="ltr" contain="layout" width="50px" height="20px">
+        <div box-sizing="content-box" direction="ltr" width="50px" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="60">
+      <node x="0" y="0" width="50" height="60">
+        <node x="0" y="0" width="50" height="30"/>
+      </node>
+      <node x="50" y="10" width="50" height="20">
+        <node x="0" y="0" width="50" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_flex_baseline__content_box_rtl.xml
+++ b/tests/xml/contain/contain_layout_flex_baseline__content_box_rtl.xml
@@ -1,0 +1,23 @@
+<test name="contain_layout_flex_baseline__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" align-items="baseline" width="200px">
+      <div box-sizing="content-box" direction="rtl" width="50px" height="60px">
+        <div box-sizing="content-box" direction="rtl" width="50px" height="30px"/>
+      </div>
+      <div box-sizing="content-box" direction="rtl" contain="layout" width="50px" height="20px">
+        <div box-sizing="content-box" direction="rtl" width="50px" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="60">
+      <node x="150" y="0" width="50" height="60">
+        <node x="0" y="0" width="50" height="30"/>
+      </node>
+      <node x="100" y="10" width="50" height="20">
+        <node x="0" y="0" width="50" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_flex_overflow_not_propagated__border_box_ltr.xml
+++ b/tests/xml/contain/contain_layout_flex_overflow_not_propagated__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="contain_layout_flex_overflow_not_propagated__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" overflow-x="scroll" overflow-y="scroll" scrollbar-width="15" width="100px" height="100px">
+      <div display="block" direction="ltr" contain="layout" flex-shrink="0" width="50px" height="50px">
+        <div display="block" direction="ltr" width="200px" height="200px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100" scroll_width="0" scroll_height="0">
+      <node x="0" y="0" width="50" height="50">
+        <node x="0" y="0" width="200" height="200"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_flex_overflow_not_propagated__border_box_rtl.xml
+++ b/tests/xml/contain/contain_layout_flex_overflow_not_propagated__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="contain_layout_flex_overflow_not_propagated__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" overflow-x="scroll" overflow-y="scroll" scrollbar-width="15" width="100px" height="100px">
+      <div display="block" direction="rtl" contain="layout" flex-shrink="0" width="50px" height="50px">
+        <div display="block" direction="rtl" width="200px" height="200px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100" scroll_width="0" scroll_height="0">
+      <node x="50" y="0" width="50" height="50">
+        <node x="-150" y="0" width="200" height="200"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_flex_overflow_not_propagated__content_box_ltr.xml
+++ b/tests/xml/contain/contain_layout_flex_overflow_not_propagated__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="contain_layout_flex_overflow_not_propagated__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" overflow-x="scroll" overflow-y="scroll" scrollbar-width="15" width="100px" height="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" contain="layout" flex-shrink="0" width="50px" height="50px">
+        <div display="block" box-sizing="content-box" direction="ltr" width="200px" height="200px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100" scroll_width="0" scroll_height="0">
+      <node x="0" y="0" width="50" height="50">
+        <node x="0" y="0" width="200" height="200"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_flex_overflow_not_propagated__content_box_rtl.xml
+++ b/tests/xml/contain/contain_layout_flex_overflow_not_propagated__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="contain_layout_flex_overflow_not_propagated__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" overflow-x="scroll" overflow-y="scroll" scrollbar-width="15" width="100px" height="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" contain="layout" flex-shrink="0" width="50px" height="50px">
+        <div display="block" box-sizing="content-box" direction="rtl" width="200px" height="200px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100" scroll_width="0" scroll_height="0">
+      <node x="50" y="0" width="50" height="50">
+        <node x="-150" y="0" width="200" height="200"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_grid_overflow_not_propagated__border_box_ltr.xml
+++ b/tests/xml/contain/contain_layout_grid_overflow_not_propagated__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="contain_layout_grid_overflow_not_propagated__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" overflow-x="scroll" overflow-y="scroll" scrollbar-width="15" width="100px" height="100px" grid-template-rows="50px" grid-template-columns="50px">
+      <div display="block" direction="ltr" contain="layout">
+        <div display="block" direction="ltr" width="200px" height="200px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100" scroll_width="0" scroll_height="0">
+      <node x="0" y="0" width="50" height="50">
+        <node x="0" y="0" width="200" height="200"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_grid_overflow_not_propagated__border_box_rtl.xml
+++ b/tests/xml/contain/contain_layout_grid_overflow_not_propagated__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="contain_layout_grid_overflow_not_propagated__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" overflow-x="scroll" overflow-y="scroll" scrollbar-width="15" width="100px" height="100px" grid-template-rows="50px" grid-template-columns="50px">
+      <div display="block" direction="rtl" contain="layout">
+        <div display="block" direction="rtl" width="200px" height="200px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100" scroll_width="0" scroll_height="0">
+      <node x="50" y="0" width="50" height="50">
+        <node x="-150" y="0" width="200" height="200"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_grid_overflow_not_propagated__content_box_ltr.xml
+++ b/tests/xml/contain/contain_layout_grid_overflow_not_propagated__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="contain_layout_grid_overflow_not_propagated__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" overflow-x="scroll" overflow-y="scroll" scrollbar-width="15" width="100px" height="100px" grid-template-rows="50px" grid-template-columns="50px">
+      <div display="block" box-sizing="content-box" direction="ltr" contain="layout">
+        <div display="block" box-sizing="content-box" direction="ltr" width="200px" height="200px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100" scroll_width="0" scroll_height="0">
+      <node x="0" y="0" width="50" height="50">
+        <node x="0" y="0" width="200" height="200"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_grid_overflow_not_propagated__content_box_rtl.xml
+++ b/tests/xml/contain/contain_layout_grid_overflow_not_propagated__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="contain_layout_grid_overflow_not_propagated__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" overflow-x="scroll" overflow-y="scroll" scrollbar-width="15" width="100px" height="100px" grid-template-rows="50px" grid-template-columns="50px">
+      <div display="block" box-sizing="content-box" direction="rtl" contain="layout">
+        <div display="block" box-sizing="content-box" direction="rtl" width="200px" height="200px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100" scroll_width="0" scroll_height="0">
+      <node x="50" y="0" width="50" height="50">
+        <node x="-150" y="0" width="200" height="200"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_paint_block_contains_floats__border_box_ltr.xml
+++ b/tests/xml/contain/contain_paint_block_contains_floats__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="contain_paint_block_contains_floats__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px">
+      <div display="block" direction="ltr" contain="paint">
+        <div display="block" direction="ltr" float="left" width="30px" height="30px"/>
+      </div>
+      <div display="block" direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="40">
+      <node x="0" y="0" width="100" height="30">
+        <node x="0" y="0" width="30" height="30"/>
+      </node>
+      <node x="0" y="30" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_paint_block_contains_floats__border_box_rtl.xml
+++ b/tests/xml/contain/contain_paint_block_contains_floats__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="contain_paint_block_contains_floats__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px">
+      <div display="block" direction="rtl" contain="paint">
+        <div display="block" direction="rtl" float="left" width="30px" height="30px"/>
+      </div>
+      <div display="block" direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="40">
+      <node x="0" y="0" width="100" height="30">
+        <node x="0" y="0" width="30" height="30"/>
+      </node>
+      <node x="0" y="30" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_paint_block_contains_floats__content_box_ltr.xml
+++ b/tests/xml/contain/contain_paint_block_contains_floats__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="contain_paint_block_contains_floats__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" contain="paint">
+        <div display="block" box-sizing="content-box" direction="ltr" float="left" width="30px" height="30px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="40">
+      <node x="0" y="0" width="100" height="30">
+        <node x="0" y="0" width="30" height="30"/>
+      </node>
+      <node x="0" y="30" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_paint_block_contains_floats__content_box_rtl.xml
+++ b/tests/xml/contain/contain_paint_block_contains_floats__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="contain_paint_block_contains_floats__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" contain="paint">
+        <div display="block" box-sizing="content-box" direction="rtl" float="left" width="30px" height="30px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="40">
+      <node x="0" y="0" width="100" height="30">
+        <node x="0" y="0" width="30" height="30"/>
+      </node>
+      <node x="0" y="30" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_paint_block_margin_collapse__border_box_ltr.xml
+++ b/tests/xml/contain/contain_paint_block_margin_collapse__border_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="contain_paint_block_margin_collapse__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <div display="block" direction="ltr" height="10px" margin-bottom="10px"/>
+      <div display="block" direction="ltr" contain="paint">
+        <div display="block" direction="ltr" height="10px" margin-top="20px" margin-bottom="20px"/>
+      </div>
+      <div display="block" direction="ltr" height="10px" margin-top="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="94">
+      <node x="2" y="2" width="96" height="10"/>
+      <node x="2" y="22" width="96" height="50">
+        <node x="0" y="20" width="96" height="10"/>
+      </node>
+      <node x="2" y="82" width="96" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_paint_block_margin_collapse__border_box_rtl.xml
+++ b/tests/xml/contain/contain_paint_block_margin_collapse__border_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="contain_paint_block_margin_collapse__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <div display="block" direction="rtl" height="10px" margin-bottom="10px"/>
+      <div display="block" direction="rtl" contain="paint">
+        <div display="block" direction="rtl" height="10px" margin-top="20px" margin-bottom="20px"/>
+      </div>
+      <div display="block" direction="rtl" height="10px" margin-top="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="94">
+      <node x="2" y="2" width="96" height="10"/>
+      <node x="2" y="22" width="96" height="50">
+        <node x="0" y="20" width="96" height="10"/>
+      </node>
+      <node x="2" y="82" width="96" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_paint_block_margin_collapse__content_box_ltr.xml
+++ b/tests/xml/contain/contain_paint_block_margin_collapse__content_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="contain_paint_block_margin_collapse__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <div display="block" box-sizing="content-box" direction="ltr" height="10px" margin-bottom="10px"/>
+      <div display="block" box-sizing="content-box" direction="ltr" contain="paint">
+        <div display="block" box-sizing="content-box" direction="ltr" height="10px" margin-top="20px" margin-bottom="20px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="ltr" height="10px" margin-top="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="104" height="94">
+      <node x="2" y="2" width="100" height="10"/>
+      <node x="2" y="22" width="100" height="50">
+        <node x="0" y="20" width="100" height="10"/>
+      </node>
+      <node x="2" y="82" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_paint_block_margin_collapse__content_box_rtl.xml
+++ b/tests/xml/contain/contain_paint_block_margin_collapse__content_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="contain_paint_block_margin_collapse__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <div display="block" box-sizing="content-box" direction="rtl" height="10px" margin-bottom="10px"/>
+      <div display="block" box-sizing="content-box" direction="rtl" contain="paint">
+        <div display="block" box-sizing="content-box" direction="rtl" height="10px" margin-top="20px" margin-bottom="20px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="rtl" height="10px" margin-top="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="104" height="94">
+      <node x="2" y="2" width="100" height="10"/>
+      <node x="2" y="22" width="100" height="50">
+        <node x="0" y="20" width="100" height="10"/>
+      </node>
+      <node x="2" y="82" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_paint_block_overflow_not_propagated__border_box_ltr.xml
+++ b/tests/xml/contain/contain_paint_block_overflow_not_propagated__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="contain_paint_block_overflow_not_propagated__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" overflow-x="scroll" overflow-y="scroll" scrollbar-width="15" width="100px" height="100px">
+      <div display="block" direction="ltr" contain="paint" width="50px" height="50px">
+        <div display="block" direction="ltr" width="200px" height="200px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100" scroll_width="0" scroll_height="0">
+      <node x="0" y="0" width="50" height="50">
+        <node x="0" y="0" width="200" height="200"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_paint_block_overflow_not_propagated__border_box_rtl.xml
+++ b/tests/xml/contain/contain_paint_block_overflow_not_propagated__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="contain_paint_block_overflow_not_propagated__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" overflow-x="scroll" overflow-y="scroll" scrollbar-width="15" width="100px" height="100px">
+      <div display="block" direction="rtl" contain="paint" width="50px" height="50px">
+        <div display="block" direction="rtl" width="200px" height="200px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100" scroll_width="0" scroll_height="0">
+      <node x="50" y="0" width="50" height="50">
+        <node x="-150" y="0" width="200" height="200"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_paint_block_overflow_not_propagated__content_box_ltr.xml
+++ b/tests/xml/contain/contain_paint_block_overflow_not_propagated__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="contain_paint_block_overflow_not_propagated__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" overflow-x="scroll" overflow-y="scroll" scrollbar-width="15" width="100px" height="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" contain="paint" width="50px" height="50px">
+        <div display="block" box-sizing="content-box" direction="ltr" width="200px" height="200px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100" scroll_width="0" scroll_height="0">
+      <node x="0" y="0" width="50" height="50">
+        <node x="0" y="0" width="200" height="200"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_paint_block_overflow_not_propagated__content_box_rtl.xml
+++ b/tests/xml/contain/contain_paint_block_overflow_not_propagated__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="contain_paint_block_overflow_not_propagated__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" overflow-x="scroll" overflow-y="scroll" scrollbar-width="15" width="100px" height="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" contain="paint" width="50px" height="50px">
+        <div display="block" box-sizing="content-box" direction="rtl" width="200px" height="200px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100" scroll_width="0" scroll_height="0">
+      <node x="50" y="0" width="50" height="50">
+        <node x="-150" y="0" width="200" height="200"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_paint_flex_baseline__border_box_ltr.xml
+++ b/tests/xml/contain/contain_paint_flex_baseline__border_box_ltr.xml
@@ -1,0 +1,23 @@
+<test name="contain_paint_flex_baseline__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" align-items="baseline" width="200px">
+      <div direction="ltr" width="50px" height="60px">
+        <div direction="ltr" width="50px" height="30px"/>
+      </div>
+      <div direction="ltr" contain="paint" width="50px" height="20px">
+        <div direction="ltr" width="50px" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="60">
+      <node x="0" y="0" width="50" height="60">
+        <node x="0" y="0" width="50" height="30"/>
+      </node>
+      <node x="50" y="20" width="50" height="20">
+        <node x="0" y="0" width="50" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_paint_flex_baseline__border_box_rtl.xml
+++ b/tests/xml/contain/contain_paint_flex_baseline__border_box_rtl.xml
@@ -1,0 +1,23 @@
+<test name="contain_paint_flex_baseline__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" align-items="baseline" width="200px">
+      <div direction="rtl" width="50px" height="60px">
+        <div direction="rtl" width="50px" height="30px"/>
+      </div>
+      <div direction="rtl" contain="paint" width="50px" height="20px">
+        <div direction="rtl" width="50px" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="60">
+      <node x="150" y="0" width="50" height="60">
+        <node x="0" y="0" width="50" height="30"/>
+      </node>
+      <node x="100" y="20" width="50" height="20">
+        <node x="0" y="0" width="50" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_paint_flex_baseline__content_box_ltr.xml
+++ b/tests/xml/contain/contain_paint_flex_baseline__content_box_ltr.xml
@@ -1,0 +1,23 @@
+<test name="contain_paint_flex_baseline__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" align-items="baseline" width="200px">
+      <div box-sizing="content-box" direction="ltr" width="50px" height="60px">
+        <div box-sizing="content-box" direction="ltr" width="50px" height="30px"/>
+      </div>
+      <div box-sizing="content-box" direction="ltr" contain="paint" width="50px" height="20px">
+        <div box-sizing="content-box" direction="ltr" width="50px" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="60">
+      <node x="0" y="0" width="50" height="60">
+        <node x="0" y="0" width="50" height="30"/>
+      </node>
+      <node x="50" y="20" width="50" height="20">
+        <node x="0" y="0" width="50" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_paint_flex_baseline__content_box_rtl.xml
+++ b/tests/xml/contain/contain_paint_flex_baseline__content_box_rtl.xml
@@ -1,0 +1,23 @@
+<test name="contain_paint_flex_baseline__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" align-items="baseline" width="200px">
+      <div box-sizing="content-box" direction="rtl" width="50px" height="60px">
+        <div box-sizing="content-box" direction="rtl" width="50px" height="30px"/>
+      </div>
+      <div box-sizing="content-box" direction="rtl" contain="paint" width="50px" height="20px">
+        <div box-sizing="content-box" direction="rtl" width="50px" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="60">
+      <node x="150" y="0" width="50" height="60">
+        <node x="0" y="0" width="50" height="30"/>
+      </node>
+      <node x="100" y="20" width="50" height="20">
+        <node x="0" y="0" width="50" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_aspect_ratio_percent_child__border_box_ltr.xml
+++ b/tests/xml/contain/contain_size_aspect_ratio_percent_child__border_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="contain_size_aspect_ratio_percent_child__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px">
+      <div display="block" direction="ltr" contain="size" aspect-ratio="1">
+        <div display="block" direction="ltr" height="50%">
+          <div display="block" direction="ltr" height="20px"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="100" height="100">
+        <node x="0" y="0" width="100" height="50">
+          <node x="0" y="0" width="100" height="20"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_aspect_ratio_percent_child__border_box_rtl.xml
+++ b/tests/xml/contain/contain_size_aspect_ratio_percent_child__border_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="contain_size_aspect_ratio_percent_child__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px">
+      <div display="block" direction="rtl" contain="size" aspect-ratio="1">
+        <div display="block" direction="rtl" height="50%">
+          <div display="block" direction="rtl" height="20px"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="100" height="100">
+        <node x="0" y="0" width="100" height="50">
+          <node x="0" y="0" width="100" height="20"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_aspect_ratio_percent_child__content_box_ltr.xml
+++ b/tests/xml/contain/contain_size_aspect_ratio_percent_child__content_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="contain_size_aspect_ratio_percent_child__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" contain="size" aspect-ratio="1">
+        <div display="block" box-sizing="content-box" direction="ltr" height="50%">
+          <div display="block" box-sizing="content-box" direction="ltr" height="20px"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="100" height="100">
+        <node x="0" y="0" width="100" height="50">
+          <node x="0" y="0" width="100" height="20"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_aspect_ratio_percent_child__content_box_rtl.xml
+++ b/tests/xml/contain/contain_size_aspect_ratio_percent_child__content_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="contain_size_aspect_ratio_percent_child__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" contain="size" aspect-ratio="1">
+        <div display="block" box-sizing="content-box" direction="rtl" height="50%">
+          <div display="block" box-sizing="content-box" direction="rtl" height="20px"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="100" height="100">
+        <node x="0" y="0" width="100" height="50">
+          <node x="0" y="0" width="100" height="20"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_block__border_box_ltr.xml
+++ b/tests/xml/contain/contain_size_block__border_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="contain_size_block__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px">
+      <div display="block" direction="ltr" contain="size">
+        <div display="block" direction="ltr" height="20px"/>
+        <div display="block" direction="ltr" height="20px"/>
+      </div>
+      <div display="block" direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="10">
+      <node x="0" y="0" width="100" height="0">
+        <node x="0" y="0" width="100" height="20"/>
+        <node x="0" y="20" width="100" height="20"/>
+      </node>
+      <node x="0" y="0" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_block__border_box_rtl.xml
+++ b/tests/xml/contain/contain_size_block__border_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="contain_size_block__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px">
+      <div display="block" direction="rtl" contain="size">
+        <div display="block" direction="rtl" height="20px"/>
+        <div display="block" direction="rtl" height="20px"/>
+      </div>
+      <div display="block" direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="10">
+      <node x="0" y="0" width="100" height="0">
+        <node x="0" y="0" width="100" height="20"/>
+        <node x="0" y="20" width="100" height="20"/>
+      </node>
+      <node x="0" y="0" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_block__content_box_ltr.xml
+++ b/tests/xml/contain/contain_size_block__content_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="contain_size_block__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" contain="size">
+        <div display="block" box-sizing="content-box" direction="ltr" height="20px"/>
+        <div display="block" box-sizing="content-box" direction="ltr" height="20px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="10">
+      <node x="0" y="0" width="100" height="0">
+        <node x="0" y="0" width="100" height="20"/>
+        <node x="0" y="20" width="100" height="20"/>
+      </node>
+      <node x="0" y="0" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_block__content_box_rtl.xml
+++ b/tests/xml/contain/contain_size_block__content_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="contain_size_block__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" contain="size">
+        <div display="block" box-sizing="content-box" direction="rtl" height="20px"/>
+        <div display="block" box-sizing="content-box" direction="rtl" height="20px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="10">
+      <node x="0" y="0" width="100" height="0">
+        <node x="0" y="0" width="100" height="20"/>
+        <node x="0" y="20" width="100" height="20"/>
+      </node>
+      <node x="0" y="0" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_block_aspect_ratio__border_box_ltr.xml
+++ b/tests/xml/contain/contain_size_block_aspect_ratio__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="contain_size_block_aspect_ratio__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px">
+      <div display="block" direction="ltr" contain="size" width="50px" aspect-ratio="2">
+        <div display="block" direction="ltr" height="60px"/>
+      </div>
+      <div display="block" direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="35">
+      <node x="0" y="0" width="50" height="25">
+        <node x="0" y="0" width="50" height="60"/>
+      </node>
+      <node x="0" y="25" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_block_aspect_ratio__border_box_rtl.xml
+++ b/tests/xml/contain/contain_size_block_aspect_ratio__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="contain_size_block_aspect_ratio__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px">
+      <div display="block" direction="rtl" contain="size" width="50px" aspect-ratio="2">
+        <div display="block" direction="rtl" height="60px"/>
+      </div>
+      <div display="block" direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="35">
+      <node x="50" y="0" width="50" height="25">
+        <node x="0" y="0" width="50" height="60"/>
+      </node>
+      <node x="0" y="25" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_block_aspect_ratio__content_box_ltr.xml
+++ b/tests/xml/contain/contain_size_block_aspect_ratio__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="contain_size_block_aspect_ratio__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" contain="size" width="50px" aspect-ratio="2">
+        <div display="block" box-sizing="content-box" direction="ltr" height="60px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="35">
+      <node x="0" y="0" width="50" height="25">
+        <node x="0" y="0" width="50" height="60"/>
+      </node>
+      <node x="0" y="25" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_block_aspect_ratio__content_box_rtl.xml
+++ b/tests/xml/contain/contain_size_block_aspect_ratio__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="contain_size_block_aspect_ratio__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" contain="size" width="50px" aspect-ratio="2">
+        <div display="block" box-sizing="content-box" direction="rtl" height="60px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="35">
+      <node x="50" y="0" width="50" height="25">
+        <node x="0" y="0" width="50" height="60"/>
+      </node>
+      <node x="0" y="25" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_block_fixed_size__border_box_ltr.xml
+++ b/tests/xml/contain/contain_size_block_fixed_size__border_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="contain_size_block_fixed_size__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px">
+      <div display="block" direction="ltr" contain="size" width="60px" height="40px">
+        <div display="block" direction="ltr" height="20px"/>
+        <div display="block" direction="ltr" height="20px"/>
+        <div display="block" direction="ltr" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="40">
+      <node x="0" y="0" width="60" height="40">
+        <node x="0" y="0" width="60" height="20"/>
+        <node x="0" y="20" width="60" height="20"/>
+        <node x="0" y="40" width="60" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_block_fixed_size__border_box_rtl.xml
+++ b/tests/xml/contain/contain_size_block_fixed_size__border_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="contain_size_block_fixed_size__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px">
+      <div display="block" direction="rtl" contain="size" width="60px" height="40px">
+        <div display="block" direction="rtl" height="20px"/>
+        <div display="block" direction="rtl" height="20px"/>
+        <div display="block" direction="rtl" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="40">
+      <node x="40" y="0" width="60" height="40">
+        <node x="0" y="0" width="60" height="20"/>
+        <node x="0" y="20" width="60" height="20"/>
+        <node x="0" y="40" width="60" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_block_fixed_size__content_box_ltr.xml
+++ b/tests/xml/contain/contain_size_block_fixed_size__content_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="contain_size_block_fixed_size__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" contain="size" width="60px" height="40px">
+        <div display="block" box-sizing="content-box" direction="ltr" height="20px"/>
+        <div display="block" box-sizing="content-box" direction="ltr" height="20px"/>
+        <div display="block" box-sizing="content-box" direction="ltr" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="40">
+      <node x="0" y="0" width="60" height="40">
+        <node x="0" y="0" width="60" height="20"/>
+        <node x="0" y="20" width="60" height="20"/>
+        <node x="0" y="40" width="60" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_block_fixed_size__content_box_rtl.xml
+++ b/tests/xml/contain/contain_size_block_fixed_size__content_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="contain_size_block_fixed_size__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" contain="size" width="60px" height="40px">
+        <div display="block" box-sizing="content-box" direction="rtl" height="20px"/>
+        <div display="block" box-sizing="content-box" direction="rtl" height="20px"/>
+        <div display="block" box-sizing="content-box" direction="rtl" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="40">
+      <node x="40" y="0" width="60" height="40">
+        <node x="0" y="0" width="60" height="20"/>
+        <node x="0" y="20" width="60" height="20"/>
+        <node x="0" y="40" width="60" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_block_float_inside__border_box_ltr.xml
+++ b/tests/xml/contain/contain_size_block_float_inside__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="contain_size_block_float_inside__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px">
+      <div display="block" direction="ltr" contain="size">
+        <div display="block" direction="ltr" float="left" width="30px" height="30px"/>
+      </div>
+      <div display="block" direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="30">
+      <node x="0" y="0" width="100" height="0">
+        <node x="0" y="0" width="30" height="30"/>
+      </node>
+      <node x="0" y="0" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_block_float_inside__border_box_rtl.xml
+++ b/tests/xml/contain/contain_size_block_float_inside__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="contain_size_block_float_inside__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px">
+      <div display="block" direction="rtl" contain="size">
+        <div display="block" direction="rtl" float="left" width="30px" height="30px"/>
+      </div>
+      <div display="block" direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="30">
+      <node x="0" y="0" width="100" height="0">
+        <node x="0" y="0" width="30" height="30"/>
+      </node>
+      <node x="0" y="0" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_block_float_inside__content_box_ltr.xml
+++ b/tests/xml/contain/contain_size_block_float_inside__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="contain_size_block_float_inside__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" contain="size">
+        <div display="block" box-sizing="content-box" direction="ltr" float="left" width="30px" height="30px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="30">
+      <node x="0" y="0" width="100" height="0">
+        <node x="0" y="0" width="30" height="30"/>
+      </node>
+      <node x="0" y="0" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_block_float_inside__content_box_rtl.xml
+++ b/tests/xml/contain/contain_size_block_float_inside__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="contain_size_block_float_inside__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" contain="size">
+        <div display="block" box-sizing="content-box" direction="rtl" float="left" width="30px" height="30px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="30">
+      <node x="0" y="0" width="100" height="0">
+        <node x="0" y="0" width="30" height="30"/>
+      </node>
+      <node x="0" y="0" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_block_intrinsic_width__border_box_ltr.xml
+++ b/tests/xml/contain/contain_size_block_intrinsic_width__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="contain_size_block_intrinsic_width__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="max-content" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <text display="block" direction="ltr" contain="size">
+        XXX​XX​X
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="4" height="4">
+      <node x="2" y="2" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_block_intrinsic_width__border_box_rtl.xml
+++ b/tests/xml/contain/contain_size_block_intrinsic_width__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="contain_size_block_intrinsic_width__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="max-content" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <text display="block" direction="rtl" contain="size">
+        XXX​XX​X
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="4" height="4">
+      <node x="2" y="2" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_block_intrinsic_width__content_box_ltr.xml
+++ b/tests/xml/contain/contain_size_block_intrinsic_width__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="contain_size_block_intrinsic_width__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="max-content" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <text display="block" box-sizing="content-box" direction="ltr" contain="size">
+        XXX​XX​X
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="4" height="4">
+      <node x="2" y="2" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_block_intrinsic_width__content_box_rtl.xml
+++ b/tests/xml/contain/contain_size_block_intrinsic_width__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="contain_size_block_intrinsic_width__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="max-content" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <text display="block" box-sizing="content-box" direction="rtl" contain="size">
+        XXX​XX​X
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="4" height="4">
+      <node x="2" y="2" width="0" height="0"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_block_min_size__border_box_ltr.xml
+++ b/tests/xml/contain/contain_size_block_min_size__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="contain_size_block_min_size__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px">
+      <div display="block" direction="ltr" contain="size" min-width="30px" min-height="25px">
+        <div display="block" direction="ltr" height="60px"/>
+      </div>
+      <div display="block" direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="35">
+      <node x="0" y="0" width="100" height="25">
+        <node x="0" y="0" width="100" height="60"/>
+      </node>
+      <node x="0" y="25" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_block_min_size__border_box_rtl.xml
+++ b/tests/xml/contain/contain_size_block_min_size__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="contain_size_block_min_size__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px">
+      <div display="block" direction="rtl" contain="size" min-width="30px" min-height="25px">
+        <div display="block" direction="rtl" height="60px"/>
+      </div>
+      <div display="block" direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="35">
+      <node x="0" y="0" width="100" height="25">
+        <node x="0" y="0" width="100" height="60"/>
+      </node>
+      <node x="0" y="25" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_block_min_size__content_box_ltr.xml
+++ b/tests/xml/contain/contain_size_block_min_size__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="contain_size_block_min_size__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" contain="size" min-width="30px" min-height="25px">
+        <div display="block" box-sizing="content-box" direction="ltr" height="60px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="35">
+      <node x="0" y="0" width="100" height="25">
+        <node x="0" y="0" width="100" height="60"/>
+      </node>
+      <node x="0" y="25" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_block_min_size__content_box_rtl.xml
+++ b/tests/xml/contain/contain_size_block_min_size__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="contain_size_block_min_size__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" contain="size" min-width="30px" min-height="25px">
+        <div display="block" box-sizing="content-box" direction="rtl" height="60px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="35">
+      <node x="0" y="0" width="100" height="25">
+        <node x="0" y="0" width="100" height="60"/>
+      </node>
+      <node x="0" y="25" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_block_padding_border__border_box_ltr.xml
+++ b/tests/xml/contain/contain_size_block_padding_border__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="contain_size_block_padding_border__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px">
+      <div display="block" direction="ltr" contain="size" padding-top="5px" padding-left="10px" padding-bottom="5px" padding-right="10px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px">
+        <div display="block" direction="ltr" height="20px"/>
+      </div>
+      <div display="block" direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="26">
+      <node x="0" y="0" width="100" height="16">
+        <node x="13" y="8" width="74" height="20"/>
+      </node>
+      <node x="0" y="16" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_block_padding_border__border_box_rtl.xml
+++ b/tests/xml/contain/contain_size_block_padding_border__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="contain_size_block_padding_border__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px">
+      <div display="block" direction="rtl" contain="size" padding-top="5px" padding-left="10px" padding-bottom="5px" padding-right="10px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px">
+        <div display="block" direction="rtl" height="20px"/>
+      </div>
+      <div display="block" direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="26">
+      <node x="0" y="0" width="100" height="16">
+        <node x="13" y="8" width="74" height="20"/>
+      </node>
+      <node x="0" y="16" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_block_padding_border__content_box_ltr.xml
+++ b/tests/xml/contain/contain_size_block_padding_border__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="contain_size_block_padding_border__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" contain="size" padding-top="5px" padding-left="10px" padding-bottom="5px" padding-right="10px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px">
+        <div display="block" box-sizing="content-box" direction="ltr" height="20px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="26">
+      <node x="0" y="0" width="100" height="16">
+        <node x="13" y="8" width="74" height="20"/>
+      </node>
+      <node x="0" y="16" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_block_padding_border__content_box_rtl.xml
+++ b/tests/xml/contain/contain_size_block_padding_border__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="contain_size_block_padding_border__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" contain="size" padding-top="5px" padding-left="10px" padding-bottom="5px" padding-right="10px" border-top="3px" border-left="3px" border-bottom="3px" border-right="3px">
+        <div display="block" box-sizing="content-box" direction="rtl" height="20px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="26">
+      <node x="0" y="0" width="100" height="16">
+        <node x="13" y="8" width="74" height="20"/>
+      </node>
+      <node x="0" y="16" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_flex_basis_content__border_box_ltr.xml
+++ b/tests/xml/contain/contain_size_flex_basis_content__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="contain_size_flex_basis_content__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" align-items="flex-start" width="200px">
+      <div direction="ltr" contain="size" flex-basis="content">
+        <div direction="ltr" width="40px" height="30px"/>
+      </div>
+      <div direction="ltr" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="20">
+      <node x="0" y="0" width="0" height="0">
+        <node x="0" y="0" width="0" height="30"/>
+      </node>
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_flex_basis_content__border_box_rtl.xml
+++ b/tests/xml/contain/contain_size_flex_basis_content__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="contain_size_flex_basis_content__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" align-items="flex-start" width="200px">
+      <div direction="rtl" contain="size" flex-basis="content">
+        <div direction="rtl" width="40px" height="30px"/>
+      </div>
+      <div direction="rtl" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="20">
+      <node x="200" y="0" width="0" height="0">
+        <node x="0" y="0" width="0" height="30"/>
+      </node>
+      <node x="180" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_flex_basis_content__content_box_ltr.xml
+++ b/tests/xml/contain/contain_size_flex_basis_content__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="contain_size_flex_basis_content__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" align-items="flex-start" width="200px">
+      <div box-sizing="content-box" direction="ltr" contain="size" flex-basis="content">
+        <div box-sizing="content-box" direction="ltr" width="40px" height="30px"/>
+      </div>
+      <div box-sizing="content-box" direction="ltr" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="20">
+      <node x="0" y="0" width="0" height="0">
+        <node x="0" y="0" width="0" height="30"/>
+      </node>
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_flex_basis_content__content_box_rtl.xml
+++ b/tests/xml/contain/contain_size_flex_basis_content__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="contain_size_flex_basis_content__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" align-items="flex-start" width="200px">
+      <div box-sizing="content-box" direction="rtl" contain="size" flex-basis="content">
+        <div box-sizing="content-box" direction="rtl" width="40px" height="30px"/>
+      </div>
+      <div box-sizing="content-box" direction="rtl" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="20">
+      <node x="200" y="0" width="0" height="0">
+        <node x="0" y="0" width="0" height="30"/>
+      </node>
+      <node x="180" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_flex_container__border_box_ltr.xml
+++ b/tests/xml/contain/contain_size_flex_container__border_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="contain_size_flex_container__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="200px">
+      <div display="flex" direction="ltr" contain="size" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px">
+        <div direction="ltr" width="40px" height="30px"/>
+        <div direction="ltr" width="40px" height="30px"/>
+      </div>
+      <div direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="20">
+      <node x="0" y="0" width="200" height="10">
+        <node x="5" y="5" width="40" height="30"/>
+        <node x="45" y="5" width="40" height="30"/>
+      </node>
+      <node x="0" y="10" width="200" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_flex_container__border_box_rtl.xml
+++ b/tests/xml/contain/contain_size_flex_container__border_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="contain_size_flex_container__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="200px">
+      <div display="flex" direction="rtl" contain="size" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px">
+        <div direction="rtl" width="40px" height="30px"/>
+        <div direction="rtl" width="40px" height="30px"/>
+      </div>
+      <div direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="20">
+      <node x="0" y="0" width="200" height="10">
+        <node x="155" y="5" width="40" height="30"/>
+        <node x="115" y="5" width="40" height="30"/>
+      </node>
+      <node x="0" y="10" width="200" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_flex_container__content_box_ltr.xml
+++ b/tests/xml/contain/contain_size_flex_container__content_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="contain_size_flex_container__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="200px">
+      <div display="flex" box-sizing="content-box" direction="ltr" contain="size" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px">
+        <div box-sizing="content-box" direction="ltr" width="40px" height="30px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="30px"/>
+      </div>
+      <div box-sizing="content-box" direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="20">
+      <node x="0" y="0" width="200" height="10">
+        <node x="5" y="5" width="40" height="30"/>
+        <node x="45" y="5" width="40" height="30"/>
+      </node>
+      <node x="0" y="10" width="200" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_flex_container__content_box_rtl.xml
+++ b/tests/xml/contain/contain_size_flex_container__content_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="contain_size_flex_container__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="200px">
+      <div display="flex" box-sizing="content-box" direction="rtl" contain="size" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px">
+        <div box-sizing="content-box" direction="rtl" width="40px" height="30px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="30px"/>
+      </div>
+      <div box-sizing="content-box" direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="20">
+      <node x="0" y="0" width="200" height="10">
+        <node x="155" y="5" width="40" height="30"/>
+        <node x="115" y="5" width="40" height="30"/>
+      </node>
+      <node x="0" y="10" width="200" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_flex_item__border_box_ltr.xml
+++ b/tests/xml/contain/contain_size_flex_item__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="contain_size_flex_item__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" align-items="flex-start" width="200px">
+      <div direction="ltr" contain="size">
+        <div direction="ltr" width="40px" height="30px"/>
+      </div>
+      <div direction="ltr" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="20">
+      <node x="0" y="0" width="0" height="0">
+        <node x="0" y="0" width="0" height="30"/>
+      </node>
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_flex_item__border_box_rtl.xml
+++ b/tests/xml/contain/contain_size_flex_item__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="contain_size_flex_item__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" align-items="flex-start" width="200px">
+      <div direction="rtl" contain="size">
+        <div direction="rtl" width="40px" height="30px"/>
+      </div>
+      <div direction="rtl" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="20">
+      <node x="200" y="0" width="0" height="0">
+        <node x="0" y="0" width="0" height="30"/>
+      </node>
+      <node x="180" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_flex_item__content_box_ltr.xml
+++ b/tests/xml/contain/contain_size_flex_item__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="contain_size_flex_item__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" align-items="flex-start" width="200px">
+      <div box-sizing="content-box" direction="ltr" contain="size">
+        <div box-sizing="content-box" direction="ltr" width="40px" height="30px"/>
+      </div>
+      <div box-sizing="content-box" direction="ltr" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="20">
+      <node x="0" y="0" width="0" height="0">
+        <node x="0" y="0" width="0" height="30"/>
+      </node>
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_flex_item__content_box_rtl.xml
+++ b/tests/xml/contain/contain_size_flex_item__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="contain_size_flex_item__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" align-items="flex-start" width="200px">
+      <div box-sizing="content-box" direction="rtl" contain="size">
+        <div box-sizing="content-box" direction="rtl" width="40px" height="30px"/>
+      </div>
+      <div box-sizing="content-box" direction="rtl" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="20">
+      <node x="200" y="0" width="0" height="0">
+        <node x="0" y="0" width="0" height="30"/>
+      </node>
+      <node x="180" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_flex_percent_child_auto_height__border_box_ltr.xml
+++ b/tests/xml/contain/contain_size_flex_percent_child_auto_height__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="contain_size_flex_percent_child_auto_height__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" contain="size" width="100px">
+      <div direction="ltr" width="30px" height="50%">
+        <div display="block" direction="ltr" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="0">
+      <node x="0" y="0" width="30" height="20">
+        <node x="0" y="0" width="0" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_flex_percent_child_auto_height__border_box_rtl.xml
+++ b/tests/xml/contain/contain_size_flex_percent_child_auto_height__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="contain_size_flex_percent_child_auto_height__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" contain="size" width="100px">
+      <div direction="rtl" width="30px" height="50%">
+        <div display="block" direction="rtl" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="0">
+      <node x="70" y="0" width="30" height="20">
+        <node x="30" y="0" width="0" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_flex_percent_child_auto_height__content_box_ltr.xml
+++ b/tests/xml/contain/contain_size_flex_percent_child_auto_height__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="contain_size_flex_percent_child_auto_height__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" contain="size" width="100px">
+      <div box-sizing="content-box" direction="ltr" width="30px" height="50%">
+        <div display="block" box-sizing="content-box" direction="ltr" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="0">
+      <node x="0" y="0" width="30" height="20">
+        <node x="0" y="0" width="0" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_flex_percent_child_auto_height__content_box_rtl.xml
+++ b/tests/xml/contain/contain_size_flex_percent_child_auto_height__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="contain_size_flex_percent_child_auto_height__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" contain="size" width="100px">
+      <div box-sizing="content-box" direction="rtl" width="30px" height="50%">
+        <div display="block" box-sizing="content-box" direction="rtl" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="0">
+      <node x="70" y="0" width="30" height="20">
+        <node x="30" y="0" width="0" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_grid_container__border_box_ltr.xml
+++ b/tests/xml/contain/contain_size_grid_container__border_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="contain_size_grid_container__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="200px">
+      <div display="grid" direction="ltr" contain="size" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px" grid-template-columns="auto auto">
+        <div direction="ltr" width="40px" height="30px"/>
+        <div direction="ltr" width="40px" height="30px"/>
+      </div>
+      <div direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="20">
+      <node x="0" y="0" width="200" height="10">
+        <node x="5" y="5" width="40" height="30"/>
+        <node x="100" y="5" width="40" height="30"/>
+      </node>
+      <node x="0" y="10" width="200" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_grid_container__border_box_rtl.xml
+++ b/tests/xml/contain/contain_size_grid_container__border_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="contain_size_grid_container__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="200px">
+      <div display="grid" direction="rtl" contain="size" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px" grid-template-columns="auto auto">
+        <div direction="rtl" width="40px" height="30px"/>
+        <div direction="rtl" width="40px" height="30px"/>
+      </div>
+      <div direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="20">
+      <node x="0" y="0" width="200" height="10">
+        <node x="155" y="5" width="40" height="30"/>
+        <node x="60" y="5" width="40" height="30"/>
+      </node>
+      <node x="0" y="10" width="200" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_grid_container__content_box_ltr.xml
+++ b/tests/xml/contain/contain_size_grid_container__content_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="contain_size_grid_container__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="200px">
+      <div display="grid" box-sizing="content-box" direction="ltr" contain="size" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px" grid-template-columns="auto auto">
+        <div box-sizing="content-box" direction="ltr" width="40px" height="30px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="30px"/>
+      </div>
+      <div box-sizing="content-box" direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="20">
+      <node x="0" y="0" width="200" height="10">
+        <node x="5" y="5" width="40" height="30"/>
+        <node x="100" y="5" width="40" height="30"/>
+      </node>
+      <node x="0" y="10" width="200" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_grid_container__content_box_rtl.xml
+++ b/tests/xml/contain/contain_size_grid_container__content_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="contain_size_grid_container__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="200px">
+      <div display="grid" box-sizing="content-box" direction="rtl" contain="size" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px" grid-template-columns="auto auto">
+        <div box-sizing="content-box" direction="rtl" width="40px" height="30px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="30px"/>
+      </div>
+      <div box-sizing="content-box" direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="20">
+      <node x="0" y="0" width="200" height="10">
+        <node x="155" y="5" width="40" height="30"/>
+        <node x="60" y="5" width="40" height="30"/>
+      </node>
+      <node x="0" y="10" width="200" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_grid_explicit_tracks__border_box_ltr.xml
+++ b/tests/xml/contain/contain_size_grid_explicit_tracks__border_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="contain_size_grid_explicit_tracks__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="200px">
+      <div display="grid" direction="ltr" contain="size" grid-template-rows="20px" grid-template-columns="30px 30px">
+        <div direction="ltr"/>
+        <div direction="ltr"/>
+      </div>
+      <div direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="30">
+      <node x="0" y="0" width="200" height="20">
+        <node x="0" y="0" width="30" height="20"/>
+        <node x="30" y="0" width="30" height="20"/>
+      </node>
+      <node x="0" y="20" width="200" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_grid_explicit_tracks__border_box_rtl.xml
+++ b/tests/xml/contain/contain_size_grid_explicit_tracks__border_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="contain_size_grid_explicit_tracks__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="200px">
+      <div display="grid" direction="rtl" contain="size" grid-template-rows="20px" grid-template-columns="30px 30px">
+        <div direction="rtl"/>
+        <div direction="rtl"/>
+      </div>
+      <div direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="30">
+      <node x="0" y="0" width="200" height="20">
+        <node x="170" y="0" width="30" height="20"/>
+        <node x="140" y="0" width="30" height="20"/>
+      </node>
+      <node x="0" y="20" width="200" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_grid_explicit_tracks__content_box_ltr.xml
+++ b/tests/xml/contain/contain_size_grid_explicit_tracks__content_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="contain_size_grid_explicit_tracks__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="200px">
+      <div display="grid" box-sizing="content-box" direction="ltr" contain="size" grid-template-rows="20px" grid-template-columns="30px 30px">
+        <div box-sizing="content-box" direction="ltr"/>
+        <div box-sizing="content-box" direction="ltr"/>
+      </div>
+      <div box-sizing="content-box" direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="30">
+      <node x="0" y="0" width="200" height="20">
+        <node x="0" y="0" width="30" height="20"/>
+        <node x="30" y="0" width="30" height="20"/>
+      </node>
+      <node x="0" y="20" width="200" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_grid_explicit_tracks__content_box_rtl.xml
+++ b/tests/xml/contain/contain_size_grid_explicit_tracks__content_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="contain_size_grid_explicit_tracks__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="200px">
+      <div display="grid" box-sizing="content-box" direction="rtl" contain="size" grid-template-rows="20px" grid-template-columns="30px 30px">
+        <div box-sizing="content-box" direction="rtl"/>
+        <div box-sizing="content-box" direction="rtl"/>
+      </div>
+      <div box-sizing="content-box" direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="30">
+      <node x="0" y="0" width="200" height="20">
+        <node x="170" y="0" width="30" height="20"/>
+        <node x="140" y="0" width="30" height="20"/>
+      </node>
+      <node x="0" y="20" width="200" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_grid_item__border_box_ltr.xml
+++ b/tests/xml/contain/contain_size_grid_item__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="contain_size_grid_item__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="max-content" grid-template-rows="auto" grid-template-columns="auto auto">
+      <div direction="ltr" contain="size">
+        <div direction="ltr" width="40px" height="30px"/>
+      </div>
+      <div direction="ltr" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="20">
+      <node x="0" y="0" width="0" height="20">
+        <node x="0" y="0" width="0" height="30"/>
+      </node>
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_grid_item__border_box_rtl.xml
+++ b/tests/xml/contain/contain_size_grid_item__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="contain_size_grid_item__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="max-content" grid-template-rows="auto" grid-template-columns="auto auto">
+      <div direction="rtl" contain="size">
+        <div direction="rtl" width="40px" height="30px"/>
+      </div>
+      <div direction="rtl" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="20">
+      <node x="20" y="0" width="0" height="20">
+        <node x="0" y="0" width="0" height="30"/>
+      </node>
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_grid_item__content_box_ltr.xml
+++ b/tests/xml/contain/contain_size_grid_item__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="contain_size_grid_item__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="max-content" grid-template-rows="auto" grid-template-columns="auto auto">
+      <div box-sizing="content-box" direction="ltr" contain="size">
+        <div box-sizing="content-box" direction="ltr" width="40px" height="30px"/>
+      </div>
+      <div box-sizing="content-box" direction="ltr" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="20">
+      <node x="0" y="0" width="0" height="20">
+        <node x="0" y="0" width="0" height="30"/>
+      </node>
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_grid_item__content_box_rtl.xml
+++ b/tests/xml/contain/contain_size_grid_item__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="contain_size_grid_item__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="max-content" grid-template-rows="auto" grid-template-columns="auto auto">
+      <div box-sizing="content-box" direction="rtl" contain="size">
+        <div box-sizing="content-box" direction="rtl" width="40px" height="30px"/>
+      </div>
+      <div box-sizing="content-box" direction="rtl" width="20px" height="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="20" height="20">
+      <node x="20" y="0" width="0" height="20">
+        <node x="0" y="0" width="0" height="30"/>
+      </node>
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_grid_percent_child_auto_height__border_box_ltr.xml
+++ b/tests/xml/contain/contain_size_grid_percent_child_auto_height__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="contain_size_grid_percent_child_auto_height__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" contain="size" width="100px">
+      <div display="block" direction="ltr" height="50%">
+        <div display="block" direction="ltr" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="0">
+      <node x="0" y="0" width="100" height="10">
+        <node x="0" y="0" width="100" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_grid_percent_child_auto_height__border_box_rtl.xml
+++ b/tests/xml/contain/contain_size_grid_percent_child_auto_height__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="contain_size_grid_percent_child_auto_height__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" contain="size" width="100px">
+      <div display="block" direction="rtl" height="50%">
+        <div display="block" direction="rtl" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="0">
+      <node x="0" y="0" width="100" height="10">
+        <node x="0" y="0" width="100" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_grid_percent_child_auto_height__content_box_ltr.xml
+++ b/tests/xml/contain/contain_size_grid_percent_child_auto_height__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="contain_size_grid_percent_child_auto_height__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" contain="size" width="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" height="50%">
+        <div display="block" box-sizing="content-box" direction="ltr" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="0">
+      <node x="0" y="0" width="100" height="10">
+        <node x="0" y="0" width="100" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_grid_percent_child_auto_height__content_box_rtl.xml
+++ b/tests/xml/contain/contain_size_grid_percent_child_auto_height__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="contain_size_grid_percent_child_auto_height__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" contain="size" width="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" height="50%">
+        <div display="block" box-sizing="content-box" direction="rtl" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="0">
+      <node x="0" y="0" width="100" height="10">
+        <node x="0" y="0" width="100" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_leaf__border_box_ltr.xml
+++ b/tests/xml/contain/contain_size_leaf__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="contain_size_leaf__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px">
+      <text direction="ltr" contain="size">
+        XXX
+      </text>
+      <div direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="10">
+      <node x="0" y="0" width="100" height="0"/>
+      <node x="0" y="0" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_leaf__border_box_rtl.xml
+++ b/tests/xml/contain/contain_size_leaf__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="contain_size_leaf__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px">
+      <text direction="rtl" contain="size">
+        XXX
+      </text>
+      <div direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="10">
+      <node x="0" y="0" width="100" height="0"/>
+      <node x="0" y="0" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_leaf__content_box_ltr.xml
+++ b/tests/xml/contain/contain_size_leaf__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="contain_size_leaf__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px">
+      <text box-sizing="content-box" direction="ltr" contain="size">
+        XXX
+      </text>
+      <div box-sizing="content-box" direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="10">
+      <node x="0" y="0" width="100" height="0"/>
+      <node x="0" y="0" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_leaf__content_box_rtl.xml
+++ b/tests/xml/contain/contain_size_leaf__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="contain_size_leaf__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px">
+      <text box-sizing="content-box" direction="rtl" contain="size">
+        XXX
+      </text>
+      <div box-sizing="content-box" direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="10">
+      <node x="0" y="0" width="100" height="0"/>
+      <node x="0" y="0" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_percent_child_auto_height__border_box_ltr.xml
+++ b/tests/xml/contain/contain_size_percent_child_auto_height__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="contain_size_percent_child_auto_height__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" contain="size" width="100px">
+      <div display="block" direction="ltr" height="50%">
+        <div display="block" direction="ltr" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="0">
+      <node x="0" y="0" width="100" height="20">
+        <node x="0" y="0" width="100" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_percent_child_auto_height__border_box_rtl.xml
+++ b/tests/xml/contain/contain_size_percent_child_auto_height__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="contain_size_percent_child_auto_height__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" contain="size" width="100px">
+      <div display="block" direction="rtl" height="50%">
+        <div display="block" direction="rtl" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="0">
+      <node x="0" y="0" width="100" height="20">
+        <node x="0" y="0" width="100" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_percent_child_auto_height__content_box_ltr.xml
+++ b/tests/xml/contain/contain_size_percent_child_auto_height__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="contain_size_percent_child_auto_height__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" contain="size" width="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" height="50%">
+        <div display="block" box-sizing="content-box" direction="ltr" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="0">
+      <node x="0" y="0" width="100" height="20">
+        <node x="0" y="0" width="100" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_percent_child_auto_height__content_box_rtl.xml
+++ b/tests/xml/contain/contain_size_percent_child_auto_height__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="contain_size_percent_child_auto_height__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" contain="size" width="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" height="50%">
+        <div display="block" box-sizing="content-box" direction="rtl" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="0">
+      <node x="0" y="0" width="100" height="20">
+        <node x="0" y="0" width="100" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_percent_child_definite_height__border_box_ltr.xml
+++ b/tests/xml/contain/contain_size_percent_child_definite_height__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="contain_size_percent_child_definite_height__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" contain="size" width="100px" height="40px">
+      <div display="block" direction="ltr" height="50%">
+        <div display="block" direction="ltr" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="40">
+      <node x="0" y="0" width="100" height="20">
+        <node x="0" y="0" width="100" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_percent_child_definite_height__border_box_rtl.xml
+++ b/tests/xml/contain/contain_size_percent_child_definite_height__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="contain_size_percent_child_definite_height__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" contain="size" width="100px" height="40px">
+      <div display="block" direction="rtl" height="50%">
+        <div display="block" direction="rtl" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="40">
+      <node x="0" y="0" width="100" height="20">
+        <node x="0" y="0" width="100" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_percent_child_definite_height__content_box_ltr.xml
+++ b/tests/xml/contain/contain_size_percent_child_definite_height__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="contain_size_percent_child_definite_height__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" contain="size" width="100px" height="40px">
+      <div display="block" box-sizing="content-box" direction="ltr" height="50%">
+        <div display="block" box-sizing="content-box" direction="ltr" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="40">
+      <node x="0" y="0" width="100" height="20">
+        <node x="0" y="0" width="100" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_percent_child_definite_height__content_box_rtl.xml
+++ b/tests/xml/contain/contain_size_percent_child_definite_height__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="contain_size_percent_child_definite_height__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" contain="size" width="100px" height="40px">
+      <div display="block" box-sizing="content-box" direction="rtl" height="50%">
+        <div display="block" box-sizing="content-box" direction="rtl" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="40">
+      <node x="0" y="0" width="100" height="20">
+        <node x="0" y="0" width="100" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_width_fit_content__border_box_ltr.xml
+++ b/tests/xml/contain/contain_size_width_fit_content__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="contain_size_width_fit_content__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px">
+      <div display="block" direction="ltr" contain="size" width="fit-content" height="10px">
+        <div display="block" direction="ltr" width="80px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="10">
+      <node x="0" y="0" width="0" height="10">
+        <node x="0" y="0" width="80" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_width_fit_content__border_box_rtl.xml
+++ b/tests/xml/contain/contain_size_width_fit_content__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="contain_size_width_fit_content__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px">
+      <div display="block" direction="rtl" contain="size" width="fit-content" height="10px">
+        <div display="block" direction="rtl" width="80px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="10">
+      <node x="100" y="0" width="0" height="10">
+        <node x="-80" y="0" width="80" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_width_fit_content__content_box_ltr.xml
+++ b/tests/xml/contain/contain_size_width_fit_content__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="contain_size_width_fit_content__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" contain="size" width="fit-content" height="10px">
+        <div display="block" box-sizing="content-box" direction="ltr" width="80px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="10">
+      <node x="0" y="0" width="0" height="10">
+        <node x="0" y="0" width="80" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_width_fit_content__content_box_rtl.xml
+++ b/tests/xml/contain/contain_size_width_fit_content__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="contain_size_width_fit_content__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" contain="size" width="fit-content" height="10px">
+        <div display="block" box-sizing="content-box" direction="rtl" width="80px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="10">
+      <node x="100" y="0" width="0" height="10">
+        <node x="-80" y="0" width="80" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_width_max_content__border_box_ltr.xml
+++ b/tests/xml/contain/contain_size_width_max_content__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="contain_size_width_max_content__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px">
+      <text direction="ltr" contain="size" width="max-content" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+        XXX​XX
+      </text>
+      <div direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="14">
+      <node x="0" y="0" width="4" height="4"/>
+      <node x="0" y="4" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_width_max_content__border_box_rtl.xml
+++ b/tests/xml/contain/contain_size_width_max_content__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="contain_size_width_max_content__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px">
+      <text direction="rtl" contain="size" width="max-content" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+        XXX​XX
+      </text>
+      <div direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="14">
+      <node x="96" y="0" width="4" height="4"/>
+      <node x="0" y="4" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_width_max_content__content_box_ltr.xml
+++ b/tests/xml/contain/contain_size_width_max_content__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="contain_size_width_max_content__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px">
+      <text box-sizing="content-box" direction="ltr" contain="size" width="max-content" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+        XXX​XX
+      </text>
+      <div box-sizing="content-box" direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="14">
+      <node x="0" y="0" width="4" height="4"/>
+      <node x="0" y="4" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_width_max_content__content_box_rtl.xml
+++ b/tests/xml/contain/contain_size_width_max_content__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="contain_size_width_max_content__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px">
+      <text box-sizing="content-box" direction="rtl" contain="size" width="max-content" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+        XXX​XX
+      </text>
+      <div box-sizing="content-box" direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="14">
+      <node x="96" y="0" width="4" height="4"/>
+      <node x="0" y="4" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_width_min_content__border_box_ltr.xml
+++ b/tests/xml/contain/contain_size_width_min_content__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="contain_size_width_min_content__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px">
+      <div display="block" direction="ltr" contain="size" width="min-content" height="10px">
+        <div display="block" direction="ltr" width="80px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="10">
+      <node x="0" y="0" width="0" height="10">
+        <node x="0" y="0" width="80" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_width_min_content__border_box_rtl.xml
+++ b/tests/xml/contain/contain_size_width_min_content__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="contain_size_width_min_content__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px">
+      <div display="block" direction="rtl" contain="size" width="min-content" height="10px">
+        <div display="block" direction="rtl" width="80px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="10">
+      <node x="100" y="0" width="0" height="10">
+        <node x="-80" y="0" width="80" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_width_min_content__content_box_ltr.xml
+++ b/tests/xml/contain/contain_size_width_min_content__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="contain_size_width_min_content__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" contain="size" width="min-content" height="10px">
+        <div display="block" box-sizing="content-box" direction="ltr" width="80px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="10">
+      <node x="0" y="0" width="0" height="10">
+        <node x="0" y="0" width="80" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_size_width_min_content__content_box_rtl.xml
+++ b/tests/xml/contain/contain_size_width_min_content__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="contain_size_width_min_content__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" contain="size" width="min-content" height="10px">
+        <div display="block" box-sizing="content-box" direction="rtl" width="80px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="10">
+      <node x="100" y="0" width="0" height="10">
+        <node x="-80" y="0" width="80" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_strict_block__border_box_ltr.xml
+++ b/tests/xml/contain/contain_strict_block__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="contain_strict_block__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px">
+      <div display="block" direction="ltr" contain="strict" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px">
+        <div display="block" direction="ltr" height="20px"/>
+      </div>
+      <div display="block" direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="20">
+      <node x="0" y="0" width="100" height="10">
+        <node x="5" y="5" width="90" height="20"/>
+      </node>
+      <node x="0" y="10" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_strict_block__border_box_rtl.xml
+++ b/tests/xml/contain/contain_strict_block__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="contain_strict_block__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px">
+      <div display="block" direction="rtl" contain="strict" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px">
+        <div display="block" direction="rtl" height="20px"/>
+      </div>
+      <div display="block" direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="20">
+      <node x="0" y="0" width="100" height="10">
+        <node x="5" y="5" width="90" height="20"/>
+      </node>
+      <node x="0" y="10" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_strict_block__content_box_ltr.xml
+++ b/tests/xml/contain/contain_strict_block__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="contain_strict_block__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" contain="strict" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px">
+        <div display="block" box-sizing="content-box" direction="ltr" height="20px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="20">
+      <node x="0" y="0" width="100" height="10">
+        <node x="5" y="5" width="90" height="20"/>
+      </node>
+      <node x="0" y="10" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_strict_block__content_box_rtl.xml
+++ b/tests/xml/contain/contain_strict_block__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="contain_strict_block__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" contain="strict" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px">
+        <div display="block" box-sizing="content-box" direction="rtl" height="20px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="20">
+      <node x="0" y="0" width="100" height="10">
+        <node x="5" y="5" width="90" height="20"/>
+      </node>
+      <node x="0" y="10" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -4542,6 +4542,26 @@ mod block {
     }
 
     #[test]
+    fn block_overflowing_content_in_fixed_height_child__border_box_ltr() {
+        crate::run_xml_test("block", "block_overflowing_content_in_fixed_height_child__border_box_ltr");
+    }
+
+    #[test]
+    fn block_overflowing_content_in_fixed_height_child__content_box_ltr() {
+        crate::run_xml_test("block", "block_overflowing_content_in_fixed_height_child__content_box_ltr");
+    }
+
+    #[test]
+    fn block_overflowing_content_in_fixed_height_child__border_box_rtl() {
+        crate::run_xml_test("block", "block_overflowing_content_in_fixed_height_child__border_box_rtl");
+    }
+
+    #[test]
+    fn block_overflowing_content_in_fixed_height_child__content_box_rtl() {
+        crate::run_xml_test("block", "block_overflowing_content_in_fixed_height_child__content_box_rtl");
+    }
+
+    #[test]
     fn block_padding_border_fixed_size__border_box_ltr() {
         crate::run_xml_test("block", "block_padding_border_fixed_size__border_box_ltr");
     }
@@ -5283,6 +5303,528 @@ mod blockgrid {
     #[test]
     fn blockgrid_margin_y_last_child_collapse_blocked_by_grid__content_box_rtl() {
         crate::run_xml_test("blockgrid", "blockgrid_margin_y_last_child_collapse_blocked_by_grid__content_box_rtl");
+    }
+}
+
+mod contain {
+    #[test]
+    fn contain_content_block__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_content_block__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_content_block__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_content_block__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_content_block__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_content_block__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_content_block__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_content_block__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_inline_size_block__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_inline_size_block__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_inline_size_block__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_inline_size_block__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_inline_size_block__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_inline_size_block__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_inline_size_block__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_inline_size_block__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_inline_size_block_height_from_content__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_inline_size_block_height_from_content__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_inline_size_block_height_from_content__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_inline_size_block_height_from_content__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_inline_size_block_height_from_content__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_inline_size_block_height_from_content__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_inline_size_block_height_from_content__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_inline_size_block_height_from_content__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_inline_size_leaf__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_inline_size_leaf__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_inline_size_leaf__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_inline_size_leaf__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_inline_size_leaf__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_inline_size_leaf__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_inline_size_leaf__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_inline_size_leaf__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_layout_block_avoids_float__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_layout_block_avoids_float__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_layout_block_avoids_float__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_layout_block_avoids_float__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_layout_block_avoids_float__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_layout_block_avoids_float__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_layout_block_avoids_float__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_layout_block_avoids_float__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_layout_block_contains_floats__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_layout_block_contains_floats__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_layout_block_contains_floats__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_layout_block_contains_floats__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_layout_block_contains_floats__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_layout_block_contains_floats__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_layout_block_contains_floats__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_layout_block_contains_floats__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_layout_block_margin_collapse__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_layout_block_margin_collapse__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_layout_block_margin_collapse__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_layout_block_margin_collapse__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_layout_block_margin_collapse__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_layout_block_margin_collapse__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_layout_block_margin_collapse__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_layout_block_margin_collapse__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_layout_flex_baseline__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_layout_flex_baseline__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_layout_flex_baseline__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_layout_flex_baseline__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_layout_flex_baseline__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_layout_flex_baseline__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_layout_flex_baseline__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_layout_flex_baseline__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_block__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_block__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_block__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_block__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_block__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_block__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_block__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_block__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_block_aspect_ratio__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_block_aspect_ratio__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_block_aspect_ratio__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_block_aspect_ratio__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_block_aspect_ratio__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_block_aspect_ratio__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_block_aspect_ratio__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_block_aspect_ratio__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_block_fixed_size__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_block_fixed_size__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_block_fixed_size__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_block_fixed_size__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_block_fixed_size__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_block_fixed_size__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_block_fixed_size__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_block_fixed_size__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_block_float_inside__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_block_float_inside__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_block_float_inside__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_block_float_inside__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_block_float_inside__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_block_float_inside__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_block_float_inside__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_block_float_inside__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_block_intrinsic_width__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_block_intrinsic_width__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_block_intrinsic_width__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_block_intrinsic_width__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_block_intrinsic_width__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_block_intrinsic_width__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_block_intrinsic_width__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_block_intrinsic_width__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_block_min_size__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_block_min_size__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_block_min_size__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_block_min_size__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_block_min_size__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_block_min_size__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_block_min_size__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_block_min_size__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_block_padding_border__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_block_padding_border__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_block_padding_border__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_block_padding_border__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_block_padding_border__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_block_padding_border__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_block_padding_border__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_block_padding_border__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_flex_basis_content__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_flex_basis_content__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_flex_basis_content__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_flex_basis_content__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_flex_basis_content__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_flex_basis_content__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_flex_basis_content__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_flex_basis_content__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_flex_container__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_flex_container__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_flex_container__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_flex_container__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_flex_container__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_flex_container__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_flex_container__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_flex_container__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_flex_item__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_flex_item__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_flex_item__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_flex_item__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_flex_item__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_flex_item__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_flex_item__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_flex_item__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_grid_container__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_grid_container__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_grid_container__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_grid_container__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_grid_container__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_grid_container__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_grid_container__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_grid_container__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_grid_explicit_tracks__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_grid_explicit_tracks__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_grid_explicit_tracks__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_grid_explicit_tracks__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_grid_explicit_tracks__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_grid_explicit_tracks__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_grid_explicit_tracks__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_grid_explicit_tracks__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_grid_item__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_grid_item__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_grid_item__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_grid_item__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_grid_item__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_grid_item__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_grid_item__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_grid_item__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_leaf__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_leaf__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_leaf__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_leaf__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_leaf__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_leaf__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_leaf__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_leaf__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_width_fit_content__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_width_fit_content__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_width_fit_content__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_width_fit_content__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_width_fit_content__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_width_fit_content__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_width_fit_content__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_width_fit_content__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_width_max_content__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_width_max_content__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_width_max_content__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_width_max_content__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_width_max_content__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_width_max_content__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_width_max_content__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_width_max_content__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_width_min_content__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_width_min_content__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_width_min_content__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_width_min_content__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_width_min_content__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_width_min_content__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_width_min_content__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_width_min_content__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_strict_block__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_strict_block__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_strict_block__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_strict_block__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_strict_block__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_strict_block__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_strict_block__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_strict_block__content_box_rtl");
     }
 }
 

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -5668,6 +5668,26 @@ mod contain {
     }
 
     #[test]
+    fn contain_size_flex_percent_child_auto_height__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_flex_percent_child_auto_height__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_flex_percent_child_auto_height__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_flex_percent_child_auto_height__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_flex_percent_child_auto_height__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_flex_percent_child_auto_height__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_flex_percent_child_auto_height__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_flex_percent_child_auto_height__content_box_rtl");
+    }
+
+    #[test]
     fn contain_size_grid_container__border_box_ltr() {
         crate::run_xml_test("contain", "contain_size_grid_container__border_box_ltr");
     }
@@ -5728,6 +5748,26 @@ mod contain {
     }
 
     #[test]
+    fn contain_size_grid_percent_child_auto_height__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_grid_percent_child_auto_height__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_grid_percent_child_auto_height__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_grid_percent_child_auto_height__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_grid_percent_child_auto_height__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_grid_percent_child_auto_height__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_grid_percent_child_auto_height__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_grid_percent_child_auto_height__content_box_rtl");
+    }
+
+    #[test]
     fn contain_size_leaf__border_box_ltr() {
         crate::run_xml_test("contain", "contain_size_leaf__border_box_ltr");
     }
@@ -5745,6 +5785,46 @@ mod contain {
     #[test]
     fn contain_size_leaf__content_box_rtl() {
         crate::run_xml_test("contain", "contain_size_leaf__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_percent_child_auto_height__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_percent_child_auto_height__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_percent_child_auto_height__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_percent_child_auto_height__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_percent_child_auto_height__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_percent_child_auto_height__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_percent_child_auto_height__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_percent_child_auto_height__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_percent_child_definite_height__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_percent_child_definite_height__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_percent_child_definite_height__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_percent_child_definite_height__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_percent_child_definite_height__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_percent_child_definite_height__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_percent_child_definite_height__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_percent_child_definite_height__content_box_rtl");
     }
 
     #[test]

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -5608,6 +5608,26 @@ mod contain {
     }
 
     #[test]
+    fn contain_size_aspect_ratio_percent_child__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_aspect_ratio_percent_child__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_aspect_ratio_percent_child__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_size_aspect_ratio_percent_child__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_size_aspect_ratio_percent_child__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_aspect_ratio_percent_child__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_size_aspect_ratio_percent_child__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_size_aspect_ratio_percent_child__content_box_rtl");
+    }
+
+    #[test]
     fn contain_size_block__border_box_ltr() {
         crate::run_xml_test("contain", "contain_size_block__border_box_ltr");
     }

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -5468,6 +5468,66 @@ mod contain {
     }
 
     #[test]
+    fn contain_paint_block_contains_floats__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_paint_block_contains_floats__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_paint_block_contains_floats__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_paint_block_contains_floats__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_paint_block_contains_floats__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_paint_block_contains_floats__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_paint_block_contains_floats__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_paint_block_contains_floats__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_paint_block_margin_collapse__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_paint_block_margin_collapse__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_paint_block_margin_collapse__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_paint_block_margin_collapse__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_paint_block_margin_collapse__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_paint_block_margin_collapse__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_paint_block_margin_collapse__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_paint_block_margin_collapse__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_paint_flex_baseline__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_paint_flex_baseline__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_paint_flex_baseline__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_paint_flex_baseline__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_paint_flex_baseline__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_paint_flex_baseline__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_paint_flex_baseline__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_paint_flex_baseline__content_box_rtl");
+    }
+
+    #[test]
     fn contain_size_block__border_box_ltr() {
         crate::run_xml_test("contain", "contain_size_block__border_box_ltr");
     }

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -5448,6 +5448,26 @@ mod contain {
     }
 
     #[test]
+    fn contain_layout_block_overflow_not_propagated__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_layout_block_overflow_not_propagated__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_layout_block_overflow_not_propagated__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_layout_block_overflow_not_propagated__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_layout_block_overflow_not_propagated__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_layout_block_overflow_not_propagated__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_layout_block_overflow_not_propagated__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_layout_block_overflow_not_propagated__content_box_rtl");
+    }
+
+    #[test]
     fn contain_layout_flex_baseline__border_box_ltr() {
         crate::run_xml_test("contain", "contain_layout_flex_baseline__border_box_ltr");
     }
@@ -5465,6 +5485,46 @@ mod contain {
     #[test]
     fn contain_layout_flex_baseline__content_box_rtl() {
         crate::run_xml_test("contain", "contain_layout_flex_baseline__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_layout_flex_overflow_not_propagated__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_layout_flex_overflow_not_propagated__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_layout_flex_overflow_not_propagated__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_layout_flex_overflow_not_propagated__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_layout_flex_overflow_not_propagated__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_layout_flex_overflow_not_propagated__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_layout_flex_overflow_not_propagated__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_layout_flex_overflow_not_propagated__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_layout_grid_overflow_not_propagated__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_layout_grid_overflow_not_propagated__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_layout_grid_overflow_not_propagated__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_layout_grid_overflow_not_propagated__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_layout_grid_overflow_not_propagated__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_layout_grid_overflow_not_propagated__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_layout_grid_overflow_not_propagated__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_layout_grid_overflow_not_propagated__content_box_rtl");
     }
 
     #[test]
@@ -5505,6 +5565,26 @@ mod contain {
     #[test]
     fn contain_paint_block_margin_collapse__content_box_rtl() {
         crate::run_xml_test("contain", "contain_paint_block_margin_collapse__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_paint_block_overflow_not_propagated__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_paint_block_overflow_not_propagated__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_paint_block_overflow_not_propagated__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_paint_block_overflow_not_propagated__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_paint_block_overflow_not_propagated__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_paint_block_overflow_not_propagated__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_paint_block_overflow_not_propagated__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_paint_block_overflow_not_propagated__content_box_rtl");
     }
 
     #[test]


### PR DESCRIPTION
# Objective

Implement the layout-affecting parts of the CSS `contain` property (size, inline-size, layout and paint containment), as the layout prerequisite for container queries / `content-visibility` support in Blitz (stylo's `effective_containment` folds `container-type` and `content-visibility` into these bits).

## Style API

- New `Contain` bitflags-style type with `SIZE`, `INLINE_SIZE`, `LAYOUT` and `PAINT` flags (plus `NONE`/`STRICT`/`CONTENT` consts, `contains`/`intersects`/`union`, `BitOr`/`BitOrAssign`). `style` containment doesn't affect layout and has no flag.
- Derived-effect helpers so callers query effects rather than raw flags: `establishes_independent_formatting_context()` (true for `LAYOUT | PAINT`), `suppresses_baseline()` (true for `LAYOUT` only) and `contains_scrollable_overflow()` (true for `LAYOUT | PAINT`).
- New `Style::contain` field and a new **defaulted** `CoreStyle::contain()` trait method (returns `Contain::NONE`), so external `CoreStyle` impls remain source-compatible.
- CSS parsing (`parse` feature) for `contain: none | strict | content | [ size || inline-size || layout || style || paint ]`; `strict` → `SIZE | LAYOUT | PAINT`, `content` → `LAYOUT | PAINT`, `style` accepted but ignored.

## Implementation

**Size containment** (`compute/common/containment.rs`, shared by block/flex/grid) works in two phases:

1. *Size as if empty*: run the node's normal layout algorithm in `ComputeSize` mode with child enumeration suppressed (a new `hide_children: bool` threaded into `compute_{block,flexbox,grid}_layout_inner`). Running the real algorithm rather than special-casing means padding/border, aspect-ratio, min/max clamping, `box-sizing`, sizing keywords (`min-content`/`fit-content(...)`/etc.) and empty grid tracks all behave correctly for free.
2. *Layout in place*: re-run the algorithm normally with the resulting size passed as fixed `known_dimensions`, so children are laid out (and can overflow) inside the fixed-size box.

The fixed used size passed into phase 2 is distinguished from whether that size is *definite* for percentage resolution: per [CSSWG issue #7206](https://github.com/w3c/csswg-drafts/issues/7206), a used size computed for an `auto` axis by the as-if-empty pass does not make that axis definite. The `known_dimensions_are_definite` flags passed into phase 2 are derived from the node's original sizing constraints (`contained_size_is_definite`): a parent-imposed known dimension keeps the parent's definiteness, otherwise the axis is definite only if the node's own style resolves to a definite size (or degenerate `max <= min` constraint). So in

```html
<div style="contain:size; width:100px; height:auto">
  <div style="height:50%">
    <div style="height:20px"></div>
  </div>
</div>
```

the contained box's height is `0` but the `50%` child still resolves as `auto` (height `20`), matching Chrome. Flexbox needed two additional changes to honor an indefinite known *cross* size (previously impossible, so unhandled): item percentage sizes don't resolve against it, and the flex line cross size falls back to content-based sizing instead of the container's inner cross size.

Phase 1 is skipped for axes that are already known; phase 2 is skipped in `ComputeSize` mode. For block containers the as-if-empty pass runs in a fresh BFC (an empty box contributes nothing to the inherited one), while phase 2 inherits the surrounding BFC normally — so floats still escape a `contain: size` box that doesn't also have layout/paint containment (matches browsers).

**Inline-size containment** is the width-only variant of the above: width sized as-if-empty, height still content-based (taffy only supports horizontal-tb, so inline = horizontal).

**Layout and paint containment** (block layout): both establish an independent formatting context — `establishes_new_bfc` now also includes `contain().establishes_independent_formatting_context()` (same mechanism as scroll containers / non-normal `align-content`), such children are excluded from the parent's same-BFC classification, and collapse-through is prevented. Layout containment *additionally* suppresses `first_baselines` on the box's output for all three algorithms; paint containment does not (matching browsers, where a `contain: paint` flex item still baseline-aligns from its content while a `contain: layout` item synthesizes a baseline from its border box).

**Overflow propagation** (`content_size` feature): a layout- or paint-contained box's overflowing content no longer contributes to its ancestors' `content_size`/scrollable overflow region — layout containment turns visible overflow into ink overflow at the boundary, and paint containment clips it. `compute_content_size_contribution` now takes the child's `Contain` and treats overflow as non-visible when `contains_scrollable_overflow()`, applied at every call site (block in-flow/absolute, flex in-flow/absolute, grid). The contained box's *own* `content_size` still includes its overflowing content, so a `contain: layout` scroll container can still scroll to it. E.g. a `100×100` scroll container containing a `50×50` `contain: layout` child with a `200×200` descendant keeps a `100×100` scroll region (matching Chrome), where previously the `200×200` propagated out.

**Leaf/measure nodes**: `compute_leaf_layout` sizes as-if-empty under `SIZE` (still calling the measure function for `content_size` during `PerformLayout`), and zeroes the measured width contribution under `INLINE_SIZE`.

## Bug fix

The new fixtures surfaced a preexisting bug: `BlockContext::float_content_contribution` was initialized to `0.0` and updated with `.max(...)`, which let the overflowing in-flow content of a nested fixed-height block inflate the height of its BFC root as if it were floated content. The sentinel is now `f32::NEG_INFINITY`. Regression fixture: `block_overflowing_content_in_fixed_height_child`.

## Testing

- 40 new gentest fixtures under `test_fixtures/contain/` covering block/flex/grid/leaf size containment, padding/border/aspect-ratio/min-size/box-sizing interactions, sizing keywords, `flex-basis: content`, explicit grid tracks, intrinsic width queries, inline-size containment, layout containment (margin collapse, float containment/avoidance, baseline suppression), paint containment (margin collapse, float containment, baseline *not* suppressed), `strict` and `content`, percentage children of contained `auto`-height vs definite-height boxes (block/flex/grid), and overflow non-propagation out of layout/paint-contained boxes inside block/flex/grid scroll containers. Generated expectations match Chrome.
- Unit tests for the `contain` parser (combinations, duplicates, case-insensitivity, invalid inputs).
- `cargo test` passes for all CI feature combinations; CHANGELOG.md updated.

## Context

Implements the plan discussed previously: bitflags type, always-on (no cargo feature), stylo `BLOCK_SIZE` bit skipped, `contain-intrinsic-size` left as a follow-up. A follow-up Blitz PR maps stylo containment to `Contain` in `stylo_taffy`.

## Feedback wanted

- Leaf handling lives in `compute_leaf_layout`; custom measure functions that bypass it (post-#953) are responsible for their own containment handling.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/acd2d6680ec141b5ae16b24d5f958d3e
Requested by: @nicoburns