### PR TITLE
Replace `x`/`y` baselines with `first`/`last` baselines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
 
 ### Changed
 
+- `LayoutOutput`'s `first_baselines: Point<Option<f32>>` field has been replaced with `baselines: Baselines`, where the new `Baselines` struct has `first: Option<f32>` and `last: Option<f32>` fields (both horizontal baselines, measured from the top edge of the node). The never-read vertical (x) baseline slot has been dropped in favour of a last-baseline slot. Last baselines are not yet computed by any of the built-in layout algorithms (this is purely a representational change), but custom tree implementations and measure functions can now report them
+
+  Migration: replace `first_baselines: Point { x: None, y: baseline }` with `baselines: Baselines::from_first(baseline)`, and reads of `first_baselines.y` with `baselines.first`
+
 - `Style::min_size` and `Style::max_size` (and the corresponding `CoreStyle::min_size`/`CoreStyle::max_size` trait methods) are now `Size<LengthPercentageAuto>` rather than `Size<Dimension>`, as the min/max sizing properties do not support the new sizing keywords that `Dimension` now supports
 
 - `TaffyTree::compute_layout_with_measure`'s measure function now takes the full `LayoutInput` (plus `NodeId`, `Option<&mut NodeContext>` and `&Style`) and returns a `LayoutOutput` directly instead of a `Size<f32>`, allowing measure functions to set baselines (and other `LayoutOutput` fields) on leaf nodes. `compute_leaf_layout` is no longer called implicitly (#953)

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -2,7 +2,7 @@
 use crate::geometry::{Line, Point, Rect, Size};
 use crate::style::{AvailableSpace, CoreStyle, LengthPercentageAuto, Overflow, Position};
 use crate::style_helpers::TaffyMaxContent;
-use crate::tree::{CollapsibleMarginSet, Layout, LayoutInput, LayoutOutput, RunMode, SizingMode};
+use crate::tree::{Baselines, CollapsibleMarginSet, Layout, LayoutInput, LayoutOutput, RunMode, SizingMode};
 use crate::tree::{LayoutPartialTree, LayoutPartialTreeExt, NodeId};
 use crate::util::debug::debug_log;
 use crate::util::sys::f32_max;
@@ -689,7 +689,7 @@ fn compute_inner(
         size: final_outer_size,
         #[cfg(feature = "content_size")]
         content_size: Size::ZERO,
-        first_baselines: Point { x: None, y: first_baseline },
+        baselines: Baselines::from_first(first_baseline),
         top_margin: if own_margins_collapse_with_children.start {
             first_child_top_margin_set
         } else {
@@ -1456,7 +1456,7 @@ fn perform_final_layout_on_in_flow_children(
             // A block container's first baseline is the first baseline of its first in-flow child
             // that has one.
             if first_baseline.is_none() {
-                first_baseline = item_layout.first_baselines.y.map(|baseline| location.y + baseline);
+                first_baseline = item_layout.baselines.first.map(|baseline| location.y + baseline);
             }
 
             // Defer `set_unrounded_layout` to the post-loop pass in `compute_inner` so that

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -7,7 +7,7 @@ use crate::style::{
 };
 use crate::style::{CoreStyle, FlexDirection, FlexboxContainerStyle, FlexboxItemStyle};
 use crate::style_helpers::{TaffyMaxContent, TaffyMinContent};
-use crate::tree::{Layout, LayoutInput, LayoutOutput, RunMode, SizingMode};
+use crate::tree::{Baselines, Layout, LayoutInput, LayoutOutput, RunMode, SizingMode};
 use crate::tree::{LayoutFlexboxContainer, LayoutPartialTreeExt, NodeId};
 use crate::util::debug::debug_log;
 use crate::util::sys::{f32_max, f32_min, new_vec_with_capacity, Vec};
@@ -490,7 +490,7 @@ fn compute_preliminary(tree: &mut impl LayoutFlexboxContainer, node: NodeId, inp
     LayoutOutput::from_sizes_and_baselines(
         constants.container_size,
         inflow_content_size.f32_max(absolute_content_size),
-        Point { x: None, y: first_vertical_baseline },
+        Baselines::from_first(first_vertical_baseline),
     )
 }
 
@@ -1813,7 +1813,7 @@ fn calculate_children_base_lines(
                 },
             );
 
-            let baseline = measured_size_and_baselines.first_baselines.y;
+            let baseline = measured_size_and_baselines.baselines.first;
             let height = measured_size_and_baselines.size.height;
 
             // Scroll containers' baselines are determined from their content as if scrolled to the
@@ -2347,7 +2347,7 @@ fn calculate_flex_item(
         // position, but are additionally clamped to their border box.
         // See https://github.com/w3c/csswg-drafts/issues/7660
         let inner_baseline = {
-            let baseline = layout_output.first_baselines.y.unwrap_or(size.height);
+            let baseline = layout_output.baselines.first.unwrap_or(size.height);
             if item.overflow.y.is_scroll_container() {
                 baseline.min(size.height).max(0.0)
             } else {
@@ -2357,7 +2357,7 @@ fn calculate_flex_item(
         item.baseline = baseline_offset_cross + inner_baseline;
     } else {
         let baseline_offset_main = *total_offset_main + item.offset_main + item.margin.main_start(direction);
-        let inner_baseline = layout_output.first_baselines.y.unwrap_or(size.height);
+        let inner_baseline = layout_output.baselines.first.unwrap_or(size.height);
         item.baseline = baseline_offset_main + inner_baseline;
     }
 

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -1,9 +1,9 @@
 //! This module is a partial implementation of the CSS Grid Level 1 specification
 //! <https://www.w3.org/TR/css-grid-1>
 use crate::geometry::{AbsoluteAxis, AbstractAxis, InBothAbsAxis};
-use crate::geometry::{Line, Point, Rect, Size};
+use crate::geometry::{Line, Rect, Size};
 use crate::style::{AlignItems, AlignSelf, AvailableSpace, Overflow, Position};
-use crate::tree::{Layout, LayoutInput, LayoutOutput, LayoutPartialTreeExt, NodeId, RunMode, SizingMode};
+use crate::tree::{Baselines, Layout, LayoutInput, LayoutOutput, LayoutPartialTreeExt, NodeId, RunMode, SizingMode};
 use crate::util::debug::debug_log;
 use crate::util::sys::{f32_max, f32_min, GridTrackVec, Vec};
 use crate::util::MaybeMath;
@@ -802,7 +802,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
     LayoutOutput::from_sizes_and_baselines(
         container_border_box,
         content_size,
-        Point { x: None, y: Some(grid_container_baseline) },
+        Baselines::from_first(Some(grid_container_baseline)),
     )
 }
 

--- a/src/compute/grid/track_sizing.rs
+++ b/src/compute/grid/track_sizing.rs
@@ -509,7 +509,7 @@ fn resolve_item_baselines(
                 Line::FALSE,
             );
 
-            let baseline = measured_size_and_baselines.first_baselines.y;
+            let baseline = measured_size_and_baselines.baselines.first;
             let height = measured_size_and_baselines.size.height;
 
             item.baseline = Some(

--- a/src/compute/leaf.rs
+++ b/src/compute/leaf.rs
@@ -1,8 +1,8 @@
 //! Computes size using styles and measure functions
 
-use crate::geometry::{Point, Size};
+use crate::geometry::Size;
 use crate::style::{AvailableSpace, Overflow, Position};
-use crate::tree::{CollapsibleMarginSet, RunMode};
+use crate::tree::{Baselines, CollapsibleMarginSet, RunMode};
 use crate::tree::{LayoutInput, LayoutOutput, SizingMode};
 use crate::util::debug::debug_log;
 use crate::util::sys::f32_max;
@@ -99,7 +99,7 @@ where
                 size,
                 #[cfg(feature = "content_size")]
                 content_size: Size::ZERO,
-                first_baselines: Point::NONE,
+                baselines: Baselines::NONE,
                 top_margin: CollapsibleMarginSet::ZERO,
                 bottom_margin: CollapsibleMarginSet::ZERO,
                 margins_can_collapse_through: false,
@@ -154,7 +154,7 @@ where
         size,
         #[cfg(feature = "content_size")]
         content_size: measured_size + padding.sum_axes(),
-        first_baselines: Point::NONE,
+        baselines: Baselines::NONE,
         top_margin: CollapsibleMarginSet::ZERO,
         bottom_margin: CollapsibleMarginSet::ZERO,
         margins_can_collapse_through: !has_styles_preventing_being_collapsed_through

--- a/src/tree/layout.rs
+++ b/src/tree/layout.rs
@@ -162,12 +162,36 @@ impl LayoutInput {
     };
 }
 
+/// The first and last baselines of a node in the horizontal axis (i.e. baselines for horizontal text,
+/// measured as an offset from the top edge of the node's border box).
+///
+/// A baseline is the line on which text sits. See <https://www.w3.org/TR/css-writing-modes-3/#intro-baselines>
+/// for details.
+#[derive(Debug, Copy, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+pub struct Baselines {
+    /// The first baseline of the node, if any
+    pub first: Option<f32>,
+    /// The last baseline of the node, if any
+    pub last: Option<f32>,
+}
+
+impl Baselines {
+    /// A `Baselines` with neither a first nor a last baseline
+    pub const NONE: Self = Self { first: None, last: None };
+
+    /// Create a `Baselines` from just a first baseline
+    pub const fn from_first(first: Option<f32>) -> Self {
+        Self { first, last: None }
+    }
+}
+
 /// A struct containing the result of laying a single node, which is returned up to the parent node
 ///
 /// A baseline is the line on which text sits. Your node likely has a baseline if it is a text node, or contains
 /// children that may be text nodes. See <https://www.w3.org/TR/css-writing-modes-3/#intro-baselines> for details.
-/// If your node does not have a baseline (or you are unsure how to compute it), then simply return `Point::NONE`
-/// for the first_baselines field
+/// If your node does not have a baseline (or you are unsure how to compute it), then simply return `Baselines::NONE`
+/// for the baselines field
 #[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct LayoutOutput {
@@ -176,8 +200,8 @@ pub struct LayoutOutput {
     #[cfg(feature = "content_size")]
     /// The size of the content within the node
     pub content_size: Size<f32>,
-    /// The first baseline of the node in each dimension, if any
-    pub first_baselines: Point<Option<f32>>,
+    /// The first and last baselines of the node in the horizontal axis, if any
+    pub baselines: Baselines,
     /// Top margin that can be collapsed with. This is used for CSS block layout and can be set to
     /// `CollapsibleMarginSet::ZERO` for other layout modes that don't support margin collapsing
     pub top_margin: CollapsibleMarginSet,
@@ -195,7 +219,7 @@ impl LayoutOutput {
         size: Size::ZERO,
         #[cfg(feature = "content_size")]
         content_size: Size::ZERO,
-        first_baselines: Point::NONE,
+        baselines: Baselines::NONE,
         top_margin: CollapsibleMarginSet::ZERO,
         bottom_margin: CollapsibleMarginSet::ZERO,
         margins_can_collapse_through: false,
@@ -208,13 +232,13 @@ impl LayoutOutput {
     pub fn from_sizes_and_baselines(
         size: Size<f32>,
         #[cfg_attr(not(feature = "content_size"), allow(unused_variables))] content_size: Size<f32>,
-        first_baselines: Point<Option<f32>>,
+        baselines: Baselines,
     ) -> Self {
         Self {
             size,
             #[cfg(feature = "content_size")]
             content_size,
-            first_baselines,
+            baselines,
             top_margin: CollapsibleMarginSet::ZERO,
             bottom_margin: CollapsibleMarginSet::ZERO,
             margins_can_collapse_through: false,
@@ -223,7 +247,7 @@ impl LayoutOutput {
 
     /// Construct a `LayoutOutput` from just the container and content sizes
     pub fn from_sizes(size: Size<f32>, content_size: Size<f32>) -> Self {
-        Self::from_sizes_and_baselines(size, content_size, Point::NONE)
+        Self::from_sizes_and_baselines(size, content_size, Baselines::NONE)
     }
 
     /// Construct a `LayoutOutput` from just the container's size.

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -10,7 +10,9 @@ mod node;
 pub mod traits;
 
 pub use cache::{Cache, ClearState};
-pub use layout::{CollapsibleMarginSet, Layout, LayoutInput, LayoutOutput, RequestedAxis, RunMode, SizingMode};
+pub use layout::{
+    Baselines, CollapsibleMarginSet, Layout, LayoutInput, LayoutOutput, RequestedAxis, RunMode, SizingMode,
+};
 pub use node::NodeId;
 pub(crate) use traits::LayoutPartialTreeExt;
 pub use traits::{LayoutPartialTree, PrintTree, RoundTree, TraversePartialTree, TraverseTree};

--- a/tests/hand_written/baseline.rs
+++ b/tests/hand_written/baseline.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod baseline {
     use taffy::prelude::*;
-    use taffy::{LayoutInput, LayoutOutput, Point};
+    use taffy::{Baselines, LayoutInput, LayoutOutput};
 
     /// A node context that pairs an intrinsic size with a first-baseline offset
     /// (measured from the node's top edge in the block axis).
@@ -18,7 +18,11 @@ mod baseline {
         _style: &Style,
     ) -> LayoutOutput {
         let Some(context) = context else { return LayoutOutput::DEFAULT };
-        LayoutOutput::from_sizes_and_baselines(context.size, Size::ZERO, Point { x: None, y: Some(context.baseline_y) })
+        LayoutOutput::from_sizes_and_baselines(
+            context.size,
+            Size::ZERO,
+            Baselines::from_first(Some(context.baseline_y)),
+        )
     }
 
     /// Two flex items with different intrinsic baselines are aligned along their baselines


### PR DESCRIPTION
# Objective

Groundwork for last-baseline support. This is a purely representational change with no behaviour change: no layout algorithm computes a last baseline yet (follow-up PRs will add last-baseline output and `align-items: last baseline` alignment on top of this).

```rust
// Before
pub struct LayoutOutput {
    pub first_baselines: Point<Option<f32>>,
    ...
}

// After
pub struct Baselines {
    pub first: Option<f32>,
    pub last: Option<f32>,
}
pub struct LayoutOutput {
    pub baselines: Baselines,
    ...
}
```

## Context

The `first_baselines.x` (vertical/inline-axis baseline) slot was never read anywhere in the codebase — vertical writing modes are unsupported — so it is dropped in favour of a `last` horizontal-baseline slot. The struct stays the same size (2 × `Option<f32>`), so `LayoutOutput` and cache entries do not grow.

All internal reads/writes are mechanically updated (`first_baselines.y` → `baselines.first`; construction sites use `Baselines::from_first(...)` / `Baselines::NONE`), and `LayoutOutput::from_sizes_and_baselines` now takes `Baselines`. Custom tree implementations and measure functions can already report a last baseline through the new field, even though nothing consumes it yet.

CHANGELOG.md updated with a migration note.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/c0a80d9344d54e918b37cacfb71a2128
Requested by: @nicoburns