### PR TITLE
Clamp grid scroll-container item baselines to their border box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
 
 - `Dimension` also supports the `content` keyword (`Dimension::content()`, CSS `content`), which indicates an automatic size based on the box's content. This keyword is only valid for `flex-basis`, where it sizes the item based on its content (ignoring its main size property) when computing its flex base size. In any other context (e.g. `width`/`height`) it behaves as `auto`
 
+### Fixed
+
+- Grid: the first baselines of grid items which are scroll containers are now clamped to the item's border box (matching the existing flexbox behaviour, per the [CSSWG resolution](https://github.com/w3c/csswg-drafts/issues/7660))
+
 ### Changed
 
 - `LayoutOutput`'s `first_baselines: Point<Option<f32>>` field has been replaced with `baselines: Baselines`, where the new `Baselines` struct has `first: Option<f32>` and `last: Option<f32>` fields (both horizontal baselines, measured from the top edge of the node). The never-read vertical (x) baseline slot has been dropped in favour of a last-baseline slot. Last baselines are not yet computed by any of the built-in layout algorithms (this is purely a representational change), but custom tree implementations and measure functions can now report them

--- a/src/compute/grid/track_sizing.rs
+++ b/src/compute/grid/track_sizing.rs
@@ -512,9 +512,17 @@ fn resolve_item_baselines(
             let baseline = measured_size_and_baselines.baselines.first;
             let height = measured_size_and_baselines.size.height;
 
-            item.baseline = Some(
+            // Scroll containers' baselines are determined from their content as if scrolled to the
+            // initial position, but are additionally clamped to their border box.
+            // See https://github.com/w3c/csswg-drafts/issues/7660
+            let baseline = if item.overflow.y.is_scroll_container() {
+                baseline.unwrap_or(height).min(height).max(0.0)
+            } else {
                 baseline.unwrap_or(height)
-                    + item.margin.top.resolve_or_zero(inner_node_size.width, |val, basis| tree.calc(val, basis)),
+            };
+
+            item.baseline = Some(
+                baseline + item.margin.top.resolve_or_zero(inner_node_size.width, |val, basis| tree.calc(val, basis)),
             );
         }
 

--- a/test_fixtures/grid/grid_align_items_baseline_overflow_scroll.html
+++ b/test_fixtures/grid/grid_align_items_baseline_overflow_scroll.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-columns: 60px 60px; width: 120px; height: 100px; align-items: baseline;">
+  <div style="display: grid; overflow: scroll; width: 60px; height: 20px;">
+    <div style="display: grid; width: 10px; height: 40px;"></div>
+  </div>
+  <div style="display: grid; width: 60px; height: 60px;">
+    <div style="display: grid; width: 60px; height: 30px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/grid/grid_align_items_baseline_overflow_scroll__border_box_ltr.xml
+++ b/tests/xml/grid/grid_align_items_baseline_overflow_scroll__border_box_ltr.xml
@@ -1,0 +1,23 @@
+<test name="grid_align_items_baseline_overflow_scroll__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" align-items="baseline" width="120px" height="100px" grid-template-columns="60px 60px">
+      <div display="grid" direction="ltr" overflow-x="scroll" overflow-y="scroll" scrollbar-width="15" width="60px" height="20px">
+        <div display="grid" direction="ltr" width="10px" height="40px"/>
+      </div>
+      <div display="grid" direction="ltr" width="60px" height="60px">
+        <div display="grid" direction="ltr" width="60px" height="30px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="100">
+      <node x="0" y="10" width="60" height="20" scroll_width="0" scroll_height="35">
+        <node x="0" y="0" width="10" height="40"/>
+      </node>
+      <node x="60" y="0" width="60" height="60">
+        <node x="0" y="0" width="60" height="30"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_items_baseline_overflow_scroll__border_box_rtl.xml
+++ b/tests/xml/grid/grid_align_items_baseline_overflow_scroll__border_box_rtl.xml
@@ -1,0 +1,23 @@
+<test name="grid_align_items_baseline_overflow_scroll__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" align-items="baseline" width="120px" height="100px" grid-template-columns="60px 60px">
+      <div display="grid" direction="rtl" overflow-x="scroll" overflow-y="scroll" scrollbar-width="15" width="60px" height="20px">
+        <div display="grid" direction="rtl" width="10px" height="40px"/>
+      </div>
+      <div display="grid" direction="rtl" width="60px" height="60px">
+        <div display="grid" direction="rtl" width="60px" height="30px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="100">
+      <node x="60" y="10" width="60" height="20" scroll_width="0" scroll_height="35">
+        <node x="50" y="0" width="10" height="40"/>
+      </node>
+      <node x="0" y="0" width="60" height="60">
+        <node x="0" y="0" width="60" height="30"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_items_baseline_overflow_scroll__content_box_ltr.xml
+++ b/tests/xml/grid/grid_align_items_baseline_overflow_scroll__content_box_ltr.xml
@@ -1,0 +1,23 @@
+<test name="grid_align_items_baseline_overflow_scroll__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" align-items="baseline" width="120px" height="100px" grid-template-columns="60px 60px">
+      <div display="grid" box-sizing="content-box" direction="ltr" overflow-x="scroll" overflow-y="scroll" scrollbar-width="15" width="60px" height="20px">
+        <div display="grid" box-sizing="content-box" direction="ltr" width="10px" height="40px"/>
+      </div>
+      <div display="grid" box-sizing="content-box" direction="ltr" width="60px" height="60px">
+        <div display="grid" box-sizing="content-box" direction="ltr" width="60px" height="30px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="100">
+      <node x="0" y="10" width="60" height="20" scroll_width="0" scroll_height="35">
+        <node x="0" y="0" width="10" height="40"/>
+      </node>
+      <node x="60" y="0" width="60" height="60">
+        <node x="0" y="0" width="60" height="30"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_items_baseline_overflow_scroll__content_box_rtl.xml
+++ b/tests/xml/grid/grid_align_items_baseline_overflow_scroll__content_box_rtl.xml
@@ -1,0 +1,23 @@
+<test name="grid_align_items_baseline_overflow_scroll__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" align-items="baseline" width="120px" height="100px" grid-template-columns="60px 60px">
+      <div display="grid" box-sizing="content-box" direction="rtl" overflow-x="scroll" overflow-y="scroll" scrollbar-width="15" width="60px" height="20px">
+        <div display="grid" box-sizing="content-box" direction="rtl" width="10px" height="40px"/>
+      </div>
+      <div display="grid" box-sizing="content-box" direction="rtl" width="60px" height="60px">
+        <div display="grid" box-sizing="content-box" direction="rtl" width="60px" height="30px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="120" height="100">
+      <node x="60" y="10" width="60" height="20" scroll_width="0" scroll_height="35">
+        <node x="50" y="0" width="10" height="40"/>
+      </node>
+      <node x="0" y="0" width="60" height="60">
+        <node x="0" y="0" width="60" height="30"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -20699,6 +20699,30 @@ mod grid {
 
     #[cfg(feature = "grid")]
     #[test]
+    fn grid_align_items_baseline_overflow_scroll__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_align_items_baseline_overflow_scroll__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_items_baseline_overflow_scroll__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_align_items_baseline_overflow_scroll__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_items_baseline_overflow_scroll__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_align_items_baseline_overflow_scroll__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_items_baseline_overflow_scroll__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_align_items_baseline_overflow_scroll__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
     fn grid_align_items_sized_center__border_box_ltr() {
         crate::run_xml_test("grid", "grid_align_items_sized_center__border_box_ltr");
     }


### PR DESCRIPTION
# Objective

Grid was missing the scroll-container baseline clamp that flexbox already applies: per the [CSSWG resolution (csswg-drafts#7660)](https://github.com/w3c/csswg-drafts/issues/7660), a scroll container's baseline is determined from its content as if scrolled to the initial position, but additionally clamped to its border box.

`resolve_item_baselines` in grid track sizing now applies the same clamp as flexbox's `calculate_children_base_lines`:

```rust
let baseline = if item.overflow.y.is_scroll_container() {
    baseline.unwrap_or(height).min(height).max(0.0)
} else {
    baseline.unwrap_or(height)
};
```

## Context

- Based on #1107 (the `Baselines { first, last }` type change); intended to merge independently of the other baseline PRs in this series.
- Adds a gentest fixture `grid_align_items_baseline_overflow_scroll` where a baseline-aligned grid item is a scroll container whose content baseline (40px) exceeds its border-box height (20px). The generated tests fail without the fix and pass with it, matching Chrome.
- Changelog entry added under `### Fixed`.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/c0a80d9344d54e918b37cacfb71a2128
Requested by: @nicoburns