### PR TITLE
Flexbox: exclude items with auto cross-axis margins from baseline alignment participation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 
 - Grid: the first baselines of grid items which are scroll containers are now clamped to the item's border box (matching the existing flexbox behaviour, per the [CSSWG resolution](https://github.com/w3c/csswg-drafts/issues/7660))
 
+- Flexbox: items with `align-self: baseline` and an `auto` cross-axis margin no longer participate in baseline alignment, per [CSS Flexbox §8.3](https://www.w3.org/TR/css-flexbox-1/#baseline-participation). Previously such items were still counted when deciding whether a line performs baseline alignment, had their baselines measured, and could affect the container's own first baseline
+
 ### Changed
 
 - `LayoutOutput`'s `first_baselines: Point<Option<f32>>` field has been replaced with `baselines: Baselines`, where the new `Baselines` struct has `first: Option<f32>` and `last: Option<f32>` fields (both horizontal baselines, measured from the top edge of the node). The never-read vertical (x) baseline slot has been dropped in favour of a last-baseline slot. Last baselines are not yet computed by any of the built-in layout algorithms (this is purely a representational change), but custom tree implementations and measure functions can now report them

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -112,6 +112,15 @@ impl FlexItem {
     fn is_scroll_container(&self) -> bool {
         self.overflow.x.is_scroll_container() | self.overflow.y.is_scroll_container()
     }
+
+    /// Returns true if the item participates in baseline alignment: it has `align-self: baseline`
+    /// and neither of its cross-axis margins are `auto`.
+    /// See <https://www.w3.org/TR/css-flexbox-1/#baseline-participation>
+    fn participates_in_baseline_alignment(&self, dir: FlexDirection) -> bool {
+        self.align_self == AlignSelf::BASELINE
+            && !self.margin_is_auto.cross_start(dir)
+            && !self.margin_is_auto.cross_end(dir)
+    }
 }
 
 /// A line of [`FlexItem`] used for intermediate computation
@@ -482,7 +491,7 @@ fn compute_preliminary(tree: &mut impl LayoutFlexboxContainer, node: NodeId, inp
     let first_vertical_baseline = first_line.and_then(|line| {
         line.items
             .iter()
-            .find(|item| constants.is_column || item.align_self == AlignSelf::BASELINE)
+            .find(|item| constants.is_column || item.participates_in_baseline_alignment(constants.dir))
             .or_else(|| line.items.iter().next())
             .map(|child| child.baseline)
     });
@@ -1766,14 +1775,14 @@ fn calculate_children_base_lines(
     for line in flex_lines {
         // If a flex line has one or zero items participating in baseline alignment then baseline alignment is a no-op so we skip
         let line_baseline_child_count =
-            line.items.iter().filter(|child| child.align_self == AlignSelf::BASELINE).count();
+            line.items.iter().filter(|child| child.participates_in_baseline_alignment(constants.dir)).count();
         if line_baseline_child_count <= 1 {
             continue;
         }
 
         for child in line.items.iter_mut() {
             // Only calculate baselines for children participating in baseline alignment
-            if child.align_self != AlignSelf::BASELINE {
+            if !child.participates_in_baseline_alignment(constants.dir) {
                 continue;
             }
 
@@ -1869,10 +1878,7 @@ fn calculate_cross_size(flex_lines: &mut [FlexLine], node_size: Size<Option<f32>
                 .items
                 .iter()
                 .map(|child| {
-                    if child.align_self == AlignSelf::BASELINE
-                        && !child.margin_is_auto.cross_start(constants.dir)
-                        && !child.margin_is_auto.cross_end(constants.dir)
-                    {
+                    if child.participates_in_baseline_alignment(constants.dir) {
                         max_baseline - child.baseline + child.hypothetical_outer_size.cross(constants.dir)
                     } else {
                         child.hypothetical_outer_size.cross(constants.dir)
@@ -2083,7 +2089,7 @@ fn resolve_cross_axis_auto_margins(flex_lines: &mut [FlexLine], constants: &Algo
         let max_baseline_to_bottom_distance: f32 = line
             .items
             .iter_mut()
-            .filter(|child| child.align_self == AlignSelf::BASELINE)
+            .filter(|child| child.participates_in_baseline_alignment(constants.dir))
             .map(|child| child.outer_target_size.cross(constants.dir) - child.baseline)
             .fold(0.0, |acc, x| acc.max(x));
 

--- a/test_fixtures/flex/align_baseline_child_auto_margin_cross_end.html
+++ b/test_fixtures/flex/align_baseline_child_auto_margin_cross_end.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 200px; height: 100px; flex-direction: row; align-items: baseline;">
+  <div style="flex-direction: column; width: 50px; height: 40px;">
+    <div style="width: 50px; height: 20px;"></div>
+  </div>
+  <div style="flex-direction: column; width: 50px; height: 60px;">
+    <div style="width: 50px; height: 30px;"></div>
+  </div>
+  <div style="flex-direction: column; width: 50px; height: 50px; margin-bottom: auto;">
+    <div style="width: 50px; height: 45px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/align_baseline_child_auto_margin_cross_start.html
+++ b/test_fixtures/flex/align_baseline_child_auto_margin_cross_start.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 200px; height: 100px; flex-direction: row; align-items: baseline;">
+  <div style="flex-direction: column; width: 50px; height: 40px;">
+    <div style="width: 50px; height: 20px;"></div>
+  </div>
+  <div style="flex-direction: column; width: 50px; height: 60px;">
+    <div style="width: 50px; height: 30px;"></div>
+  </div>
+  <div style="flex-direction: column; width: 50px; height: 50px; margin-top: auto;">
+    <div style="width: 50px; height: 45px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/flex/align_baseline_child_auto_margin_cross_end__border_box_ltr.xml
+++ b/tests/xml/flex/align_baseline_child_auto_margin_cross_end__border_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="align_baseline_child_auto_margin_cross_end__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" align-items="baseline" width="200px" height="100px">
+      <div direction="ltr" flex-direction="column" width="50px" height="40px">
+        <div direction="ltr" width="50px" height="20px"/>
+      </div>
+      <div direction="ltr" flex-direction="column" width="50px" height="60px">
+        <div direction="ltr" width="50px" height="30px"/>
+      </div>
+      <div direction="ltr" flex-direction="column" width="50px" height="50px" margin-bottom="auto">
+        <div direction="ltr" width="50px" height="45px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="0" y="10" width="50" height="40">
+        <node x="0" y="0" width="50" height="20"/>
+      </node>
+      <node x="50" y="0" width="50" height="60">
+        <node x="0" y="0" width="50" height="30"/>
+      </node>
+      <node x="100" y="0" width="50" height="50">
+        <node x="0" y="0" width="50" height="45"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_baseline_child_auto_margin_cross_end__border_box_rtl.xml
+++ b/tests/xml/flex/align_baseline_child_auto_margin_cross_end__border_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="align_baseline_child_auto_margin_cross_end__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" align-items="baseline" width="200px" height="100px">
+      <div direction="rtl" flex-direction="column" width="50px" height="40px">
+        <div direction="rtl" width="50px" height="20px"/>
+      </div>
+      <div direction="rtl" flex-direction="column" width="50px" height="60px">
+        <div direction="rtl" width="50px" height="30px"/>
+      </div>
+      <div direction="rtl" flex-direction="column" width="50px" height="50px" margin-bottom="auto">
+        <div direction="rtl" width="50px" height="45px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="150" y="10" width="50" height="40">
+        <node x="0" y="0" width="50" height="20"/>
+      </node>
+      <node x="100" y="0" width="50" height="60">
+        <node x="0" y="0" width="50" height="30"/>
+      </node>
+      <node x="50" y="0" width="50" height="50">
+        <node x="0" y="0" width="50" height="45"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_baseline_child_auto_margin_cross_end__content_box_ltr.xml
+++ b/tests/xml/flex/align_baseline_child_auto_margin_cross_end__content_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="align_baseline_child_auto_margin_cross_end__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" align-items="baseline" width="200px" height="100px">
+      <div box-sizing="content-box" direction="ltr" flex-direction="column" width="50px" height="40px">
+        <div box-sizing="content-box" direction="ltr" width="50px" height="20px"/>
+      </div>
+      <div box-sizing="content-box" direction="ltr" flex-direction="column" width="50px" height="60px">
+        <div box-sizing="content-box" direction="ltr" width="50px" height="30px"/>
+      </div>
+      <div box-sizing="content-box" direction="ltr" flex-direction="column" width="50px" height="50px" margin-bottom="auto">
+        <div box-sizing="content-box" direction="ltr" width="50px" height="45px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="0" y="10" width="50" height="40">
+        <node x="0" y="0" width="50" height="20"/>
+      </node>
+      <node x="50" y="0" width="50" height="60">
+        <node x="0" y="0" width="50" height="30"/>
+      </node>
+      <node x="100" y="0" width="50" height="50">
+        <node x="0" y="0" width="50" height="45"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_baseline_child_auto_margin_cross_end__content_box_rtl.xml
+++ b/tests/xml/flex/align_baseline_child_auto_margin_cross_end__content_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="align_baseline_child_auto_margin_cross_end__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" align-items="baseline" width="200px" height="100px">
+      <div box-sizing="content-box" direction="rtl" flex-direction="column" width="50px" height="40px">
+        <div box-sizing="content-box" direction="rtl" width="50px" height="20px"/>
+      </div>
+      <div box-sizing="content-box" direction="rtl" flex-direction="column" width="50px" height="60px">
+        <div box-sizing="content-box" direction="rtl" width="50px" height="30px"/>
+      </div>
+      <div box-sizing="content-box" direction="rtl" flex-direction="column" width="50px" height="50px" margin-bottom="auto">
+        <div box-sizing="content-box" direction="rtl" width="50px" height="45px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="150" y="10" width="50" height="40">
+        <node x="0" y="0" width="50" height="20"/>
+      </node>
+      <node x="100" y="0" width="50" height="60">
+        <node x="0" y="0" width="50" height="30"/>
+      </node>
+      <node x="50" y="0" width="50" height="50">
+        <node x="0" y="0" width="50" height="45"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_baseline_child_auto_margin_cross_start__border_box_ltr.xml
+++ b/tests/xml/flex/align_baseline_child_auto_margin_cross_start__border_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="align_baseline_child_auto_margin_cross_start__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" align-items="baseline" width="200px" height="100px">
+      <div direction="ltr" flex-direction="column" width="50px" height="40px">
+        <div direction="ltr" width="50px" height="20px"/>
+      </div>
+      <div direction="ltr" flex-direction="column" width="50px" height="60px">
+        <div direction="ltr" width="50px" height="30px"/>
+      </div>
+      <div direction="ltr" flex-direction="column" width="50px" height="50px" margin-top="auto">
+        <div direction="ltr" width="50px" height="45px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="0" y="10" width="50" height="40">
+        <node x="0" y="0" width="50" height="20"/>
+      </node>
+      <node x="50" y="0" width="50" height="60">
+        <node x="0" y="0" width="50" height="30"/>
+      </node>
+      <node x="100" y="50" width="50" height="50">
+        <node x="0" y="0" width="50" height="45"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_baseline_child_auto_margin_cross_start__border_box_rtl.xml
+++ b/tests/xml/flex/align_baseline_child_auto_margin_cross_start__border_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="align_baseline_child_auto_margin_cross_start__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" align-items="baseline" width="200px" height="100px">
+      <div direction="rtl" flex-direction="column" width="50px" height="40px">
+        <div direction="rtl" width="50px" height="20px"/>
+      </div>
+      <div direction="rtl" flex-direction="column" width="50px" height="60px">
+        <div direction="rtl" width="50px" height="30px"/>
+      </div>
+      <div direction="rtl" flex-direction="column" width="50px" height="50px" margin-top="auto">
+        <div direction="rtl" width="50px" height="45px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="150" y="10" width="50" height="40">
+        <node x="0" y="0" width="50" height="20"/>
+      </node>
+      <node x="100" y="0" width="50" height="60">
+        <node x="0" y="0" width="50" height="30"/>
+      </node>
+      <node x="50" y="50" width="50" height="50">
+        <node x="0" y="0" width="50" height="45"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_baseline_child_auto_margin_cross_start__content_box_ltr.xml
+++ b/tests/xml/flex/align_baseline_child_auto_margin_cross_start__content_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="align_baseline_child_auto_margin_cross_start__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" align-items="baseline" width="200px" height="100px">
+      <div box-sizing="content-box" direction="ltr" flex-direction="column" width="50px" height="40px">
+        <div box-sizing="content-box" direction="ltr" width="50px" height="20px"/>
+      </div>
+      <div box-sizing="content-box" direction="ltr" flex-direction="column" width="50px" height="60px">
+        <div box-sizing="content-box" direction="ltr" width="50px" height="30px"/>
+      </div>
+      <div box-sizing="content-box" direction="ltr" flex-direction="column" width="50px" height="50px" margin-top="auto">
+        <div box-sizing="content-box" direction="ltr" width="50px" height="45px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="0" y="10" width="50" height="40">
+        <node x="0" y="0" width="50" height="20"/>
+      </node>
+      <node x="50" y="0" width="50" height="60">
+        <node x="0" y="0" width="50" height="30"/>
+      </node>
+      <node x="100" y="50" width="50" height="50">
+        <node x="0" y="0" width="50" height="45"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_baseline_child_auto_margin_cross_start__content_box_rtl.xml
+++ b/tests/xml/flex/align_baseline_child_auto_margin_cross_start__content_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="align_baseline_child_auto_margin_cross_start__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" align-items="baseline" width="200px" height="100px">
+      <div box-sizing="content-box" direction="rtl" flex-direction="column" width="50px" height="40px">
+        <div box-sizing="content-box" direction="rtl" width="50px" height="20px"/>
+      </div>
+      <div box-sizing="content-box" direction="rtl" flex-direction="column" width="50px" height="60px">
+        <div box-sizing="content-box" direction="rtl" width="50px" height="30px"/>
+      </div>
+      <div box-sizing="content-box" direction="rtl" flex-direction="column" width="50px" height="50px" margin-top="auto">
+        <div box-sizing="content-box" direction="rtl" width="50px" height="45px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="150" y="10" width="50" height="40">
+        <node x="0" y="0" width="50" height="20"/>
+      </node>
+      <node x="100" y="0" width="50" height="60">
+        <node x="0" y="0" width="50" height="30"/>
+      </node>
+      <node x="50" y="50" width="50" height="50">
+        <node x="0" y="0" width="50" height="45"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -6708,6 +6708,46 @@ mod flex {
     }
 
     #[test]
+    fn align_baseline_child_auto_margin_cross_end__border_box_ltr() {
+        crate::run_xml_test("flex", "align_baseline_child_auto_margin_cross_end__border_box_ltr");
+    }
+
+    #[test]
+    fn align_baseline_child_auto_margin_cross_end__content_box_ltr() {
+        crate::run_xml_test("flex", "align_baseline_child_auto_margin_cross_end__content_box_ltr");
+    }
+
+    #[test]
+    fn align_baseline_child_auto_margin_cross_end__border_box_rtl() {
+        crate::run_xml_test("flex", "align_baseline_child_auto_margin_cross_end__border_box_rtl");
+    }
+
+    #[test]
+    fn align_baseline_child_auto_margin_cross_end__content_box_rtl() {
+        crate::run_xml_test("flex", "align_baseline_child_auto_margin_cross_end__content_box_rtl");
+    }
+
+    #[test]
+    fn align_baseline_child_auto_margin_cross_start__border_box_ltr() {
+        crate::run_xml_test("flex", "align_baseline_child_auto_margin_cross_start__border_box_ltr");
+    }
+
+    #[test]
+    fn align_baseline_child_auto_margin_cross_start__content_box_ltr() {
+        crate::run_xml_test("flex", "align_baseline_child_auto_margin_cross_start__content_box_ltr");
+    }
+
+    #[test]
+    fn align_baseline_child_auto_margin_cross_start__border_box_rtl() {
+        crate::run_xml_test("flex", "align_baseline_child_auto_margin_cross_start__border_box_rtl");
+    }
+
+    #[test]
+    fn align_baseline_child_auto_margin_cross_start__content_box_rtl() {
+        crate::run_xml_test("flex", "align_baseline_child_auto_margin_cross_start__content_box_rtl");
+    }
+
+    #[test]
     fn align_baseline_child_margin__border_box_ltr() {
         crate::run_xml_test("flex", "align_baseline_child_margin__border_box_ltr");
     }


### PR DESCRIPTION
# Objective

Per [CSS Flexbox §8.3](https://www.w3.org/TR/css-flexbox-1/#baseline-participation), a flex item only participates in baseline alignment if its `align-self` is `baseline` **and** neither of its cross-axis margins are `auto`. Taffy applied this margin exclusion in `calculate_cross_size` but not in:

- `calculate_children_base_lines`: the count deciding whether a line performs baseline alignment, and which items have their baselines measured
- the container's own first-baseline selection (which item's baseline becomes the flex container's first baseline)
- the `max_baseline_to_bottom_distance` fold in `resolve_cross_axis_auto_margins` (used for wrap-reverse baseline alignment)

This PR introduces `FlexItem::participates_in_baseline_alignment(dir)` and uses it at all of these sites (including refactoring the existing inline check in `calculate_cross_size`), so an item with `align-self: baseline` and an auto cross-axis margin no longer influences the line's shared baseline or the container's first baseline.

## Context

- Based on #1107 (the `Baselines { first, last }` type change); intended to merge independently of the other baseline PRs in this series.
- Adds gentest fixtures `align_baseline_child_auto_margin_cross_start` / `_cross_end` where a third item with `align-self: baseline` and `margin-top: auto` / `margin-bottom: auto` has the largest would-be baseline. The generated tests fail without the fix and pass with it, matching Chrome.
- Changelog entry added under `### Fixed`.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/c0a80d9344d54e918b37cacfb71a2128
Requested by: @nicoburns