### PR TITLE
Output last baselines from all built-in layout algorithms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
   In contexts where a keyword cannot be resolved it behaves as `auto`
 
+- All built-in layout algorithms (flexbox, grid and block) now compute and output the *last baseline* of a container (`LayoutOutput::baselines.last`) in addition to its first baseline. A flex container's last baseline is generated from the last item of its cross-end-most line, a grid container's from the last row containing items, and a block container's from its last in-flow child with a baseline. Last baselines reported by children (e.g. by measure functions) are propagated up the tree, with scroll containers' baselines clamped to their border box. Note that last-baseline *alignment* (`align-items: last baseline`) is not yet supported
+
 - `Dimension` also supports the `content` keyword (`Dimension::content()`, CSS `content`), which indicates an automatic size based on the box's content. This keyword is only valid for `flex-basis`, where it sizes the item based on its content (ignoring its main size property) when computing its flex base size. In any other context (e.g. `width`/`height`) it behaves as `auto`
 
 - Support for the layout-affecting parts of the `layout` and `paint` values of the CSS `contain` property via a new `Contain` bitflags style type, a new `Style::contain` field and a new (defaulted) `CoreStyle::contain` trait method:

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -600,7 +600,7 @@ fn compute_inner(
         mut intrinsic_outer_height,
         first_child_top_margin_set,
         last_child_bottom_margin_set,
-        mut first_baseline,
+        mut baselines,
     ) = perform_final_layout_on_in_flow_children(
         tree,
         run_mode,
@@ -655,7 +655,8 @@ fn compute_inner(
         if any_in_flow {
             let keyword = apply_alignment_fallback(free_space, 1, align_content);
             let group_offset = compute_alignment_offset(free_space, 1, 0.0, keyword, false, true);
-            first_baseline = first_baseline.map(|baseline| baseline + group_offset);
+            baselines.first = baselines.first.map(|baseline| baseline + group_offset);
+            baselines.last = baselines.last.map(|baseline| baseline + group_offset);
             for item in items.iter_mut() {
                 if let Some(layout) = item.final_layout.as_mut() {
                     layout.location.y += group_offset;
@@ -709,7 +710,7 @@ fn compute_inner(
         size: final_outer_size,
         #[cfg(feature = "content_size")]
         scrollable_overflow_rect: Rect::ZERO,
-        baselines: Baselines::from_first(first_baseline),
+        baselines,
         top_margin: if own_margins_collapse_with_children.start {
             first_child_top_margin_set
         } else {
@@ -971,7 +972,7 @@ fn perform_final_layout_on_in_flow_children(
     own_margins_collapse_with_children: Line<bool>,
     #[cfg(feature = "content_size")] is_scroll_container: bool,
     block_ctx: &mut BlockContext<'_>,
-) -> (Rect<f32>, f32, CollapsibleMarginSet, CollapsibleMarginSet, Option<f32>) {
+) -> (Rect<f32>, f32, CollapsibleMarginSet, CollapsibleMarginSet, Baselines) {
     // Resolve container_inner_width for sizing child nodes using initial content_box_inset
     let container_inner_width = container_outer_width - resolved_content_box_inset.horizontal_axis_sum();
     let container_percentage_resolution_height =
@@ -1009,7 +1010,7 @@ fn perform_final_layout_on_in_flow_children(
     let mut first_child_top_margin_set = CollapsibleMarginSet::ZERO;
     let mut active_collapsible_margin_set = CollapsibleMarginSet::ZERO;
     let mut is_collapsing_with_first_margin_set = true;
-    let mut first_baseline: Option<f32> = None;
+    let mut baselines = Baselines::NONE;
     // Whether the active margin set contains the margins of a self-collapsing element with
     // clearance. Such margins collapse with the margins of following siblings but the resulting
     // margin does not collapse with the bottom margin of the parent block.
@@ -1491,26 +1492,30 @@ fn perform_final_layout_on_in_flow_children(
             }
 
             // A block container's first baseline is the first baseline of its first in-flow child
+            // that has one, and its last baseline is the last baseline of its last in-flow child
             // that has one.
             //
             // Scroll containers' baselines are determined from their content as if scrolled to the
             // initial position, but are additionally clamped to their border box. A scroll container
             // with no baseline synthesizes one from its border-box bottom edge.
             // See https://github.com/w3c/csswg-drafts/issues/7660
-            if first_baseline.is_none() {
-                let child_baseline = if item.overflow.y.is_scroll_container() {
-                    Some(
-                        item_layout
-                            .baselines
-                            .first
-                            .unwrap_or(item_layout.size.height)
-                            .min(item_layout.size.height)
-                            .max(0.0),
-                    )
+            let is_scroll_container = item.overflow.y.is_scroll_container();
+            let clamp_to_border_box = |baseline: f32| baseline.min(item_layout.size.height).max(0.0);
+            if baselines.first.is_none() {
+                let child_baseline = if is_scroll_container {
+                    Some(clamp_to_border_box(item_layout.baselines.first.unwrap_or(item_layout.size.height)))
                 } else {
                     item_layout.baselines.first
                 };
-                first_baseline = child_baseline.map(|baseline| location.y + baseline);
+                baselines.first = child_baseline.map(|baseline| location.y + baseline);
+            }
+            let child_last_baseline = if is_scroll_container {
+                Some(clamp_to_border_box(item_layout.baselines.last.unwrap_or(item_layout.size.height)))
+            } else {
+                item_layout.baselines.last
+            };
+            if let Some(last) = child_last_baseline {
+                baselines.last = Some(location.y + last);
             }
 
             // Defer `set_unrounded_layout` to the post-loop pass in `compute_inner` so that
@@ -1615,7 +1620,7 @@ fn perform_final_layout_on_in_flow_children(
 
     committed_y_offset += resolved_content_box_inset.bottom + bottom_y_margin_offset;
     let content_height = f32_max(0.0, committed_y_offset);
-    (inflow_overflow_rect, content_height, first_child_top_margin_set, last_child_bottom_margin_set, first_baseline)
+    (inflow_overflow_rect, content_height, first_child_top_margin_set, last_child_bottom_margin_set, baselines)
 }
 
 /// Perform absolute layout on all absolutely positioned children.

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -96,6 +96,8 @@ struct FlexItem {
 
     /// The position of the bottom edge of this item
     baseline: f32,
+    /// The position of this item's last baseline (relative to the container's border box)
+    last_baseline: f32,
 
     /// A temporary value for the main offset
     ///
@@ -523,10 +525,16 @@ fn compute_preliminary(tree: &mut impl LayoutFlexboxContainer, node: NodeId, inp
         }
     });
 
+    // The container's last baseline is generated from the cross-end-most line (the first line for
+    // wrap-reverse containers). As no items ever participate in last-baseline alignment (which is not
+    // yet supported), it is always generated from the line's last flex item.
+    let last_line = if constants.is_wrap_reverse { flex_lines.first() } else { flex_lines.last() };
+    let last_vertical_baseline = last_line.and_then(|line| line.items.last().map(|child| child.last_baseline));
+
     LayoutOutput::from_sizes_and_baselines(
         constants.container_size,
         inflow_overflow_rect.union(absolute_overflow_rect),
-        Baselines::from_first(first_vertical_baseline),
+        Baselines { first: first_vertical_baseline, last: last_vertical_baseline },
     )
 }
 
@@ -730,6 +738,7 @@ fn generate_anonymous_flex_items(
                 content_flex_fraction: 0.0,
 
                 baseline: 0.0,
+                last_baseline: 0.0,
 
                 offset_main: 0.0,
                 offset_cross: 0.0,
@@ -2410,19 +2419,23 @@ fn calculate_flex_item(
         // Scroll containers' baselines are determined from their content as if scrolled to the initial
         // position, but are additionally clamped to their border box.
         // See https://github.com/w3c/csswg-drafts/issues/7660
-        let inner_baseline = {
-            let baseline = layout_output.baselines.first.unwrap_or(size.height);
+        let clamp_to_border_box = |baseline: f32| {
             if item.overflow.y.is_scroll_container() {
                 baseline.min(size.height).max(0.0)
             } else {
                 baseline
             }
         };
+        let inner_baseline = clamp_to_border_box(layout_output.baselines.first.unwrap_or(size.height));
+        let inner_last_baseline = clamp_to_border_box(layout_output.baselines.last.unwrap_or(size.height));
         item.baseline = baseline_offset_cross + inner_baseline;
+        item.last_baseline = baseline_offset_cross + inner_last_baseline;
     } else {
         let baseline_offset_main = *total_offset_main + item.offset_main + item.margin.main_start(direction);
         let inner_baseline = layout_output.baselines.first.unwrap_or(size.height);
+        let inner_last_baseline = layout_output.baselines.last.unwrap_or(size.height);
         item.baseline = baseline_offset_main + inner_baseline;
+        item.last_baseline = baseline_offset_main + inner_last_baseline;
     }
 
     let location = if direction.is_row() {

--- a/src/compute/grid/alignment.rs
+++ b/src/compute/grid/alignment.rs
@@ -8,7 +8,7 @@ use crate::style::{
     AlignContent, AlignItems, AlignItemsKeyword, AlignSelf, AvailableSpace, CoreStyle, GridItemStyle, Overflow,
     Position,
 };
-use crate::tree::{Layout, LayoutPartialTreeExt, NodeId, SizingMode};
+use crate::tree::{Baselines, Layout, LayoutPartialTreeExt, NodeId, SizingMode};
 use crate::util::sys::f32_max;
 use crate::util::{MaybeMath, MaybeResolve, ResolveOrZero};
 
@@ -95,7 +95,7 @@ pub(super) fn align_and_position_item(
     container_border_box_width: f32,
     container_border: Rect<f32>,
     #[cfg(feature = "content_size")] container_is_scroll_container: bool,
-) -> (Rect<f32>, f32, f32) {
+) -> (Rect<f32>, f32, f32, Baselines) {
     let grid_area_size = Size { width: grid_area.right - grid_area.left, height: grid_area.bottom - grid_area.top };
 
     let style = tree.get_grid_child_style(node);
@@ -416,7 +416,17 @@ pub(super) fn align_and_position_item(
     #[cfg(not(feature = "content_size"))]
     let contribution = Rect::ZERO;
 
-    (contribution, y, height)
+    // Scroll containers' baselines are determined from their content as if scrolled to the
+    // initial position, but are additionally clamped to their border box.
+    // See https://github.com/w3c/csswg-drafts/issues/7660
+    let baselines = if overflow.y.is_scroll_container() {
+        let clamp = |baseline: Option<f32>| baseline.map(|baseline| baseline.min(height).max(0.0));
+        Baselines { first: clamp(layout_output.baselines.first), last: clamp(layout_output.baselines.last) }
+    } else {
+        layout_output.baselines
+    };
+
+    (contribution, y, height, baselines)
 }
 
 /// Align and size a grid item along a single axis

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -623,7 +623,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
             },
         };
         #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
-        let (overflow_contribution, y_position, height) = align_and_position_item(
+        let (overflow_contribution, y_position, height, baselines) = align_and_position_item(
             tree,
             item.node,
             index as u32,
@@ -638,6 +638,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
         );
         item.y_position = y_position;
         item.height = height;
+        item.last_baseline = baselines.last;
 
         #[cfg(feature = "content_size")]
         {
@@ -769,7 +770,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
 
             // TODO: Baseline alignment support for absolutely positioned items (should check if is actually specified)
             #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
-            let (overflow_contribution, _, _) = align_and_position_item(
+            let (overflow_contribution, _, _, _) = align_and_position_item(
                 tree,
                 child,
                 order,
@@ -829,7 +830,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
         return LayoutOutput::from_outer_size(container_border_box);
     }
 
-    // Determine the grid container baseline(s) (currently we only compute the first baseline)
+    // Determine the grid container's first baseline, generated from the first row containing items.
     // Layout containment suppresses the box's baseline for baseline-alignment purposes
     let grid_container_baseline: Option<f32> = if contain.suppresses_baseline() {
         None
@@ -853,6 +854,25 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
         Some(item.y_position + item.baseline.unwrap_or(item.height))
     };
 
+    // Determine the grid container's last baseline, generated from the last row containing items.
+    // As no items ever participate in last-baseline alignment (which is not yet supported), it is
+    // always generated from the row's first item.
+    let grid_container_last_baseline: Option<f32> = if contain.suppresses_baseline() {
+        None
+    } else {
+        // Sort items by row start position so that we can iterate items in groups which are in the same row
+        items.sort_by_key(|item| item.row_indexes.start);
+
+        // Get the row index of the last row containing items
+        let last_row = items[items.len() - 1].row_indexes.start;
+
+        // Create a slice of all of the items that start in this row (taking advantage of the fact that the array is sorted)
+        let last_row_items = &items[0..].rsplit(|item| item.row_indexes.start != last_row).next().unwrap();
+
+        let item = &last_row_items[0];
+        Some(item.y_position + item.last_baseline.unwrap_or(item.height))
+    };
+
     // A scroll container's own padding at the end of the content is part of its scrollable
     // overflow region, so it is included in the in-flow overflow rect. Boxes that are not
     // scroll containers do not extend their overflow region by their own padding.
@@ -871,7 +891,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
     LayoutOutput::from_sizes_and_baselines(
         container_border_box,
         scrollable_overflow_rect,
-        Baselines::from_first(grid_container_baseline),
+        Baselines { first: grid_container_baseline, last: grid_container_last_baseline },
     )
 }
 

--- a/src/compute/grid/types/grid_item.rs
+++ b/src/compute/grid/types/grid_item.rs
@@ -56,6 +56,9 @@ pub(in super::super) struct GridItem {
     pub justify_self: AlignSelf,
     /// The items first baseline (horizontal)
     pub baseline: Option<f32>,
+    /// The item's last baseline (horizontal), measured from the top of its border box.
+    /// Set from the item's final layout. Used to compute the container's last baseline.
+    pub last_baseline: Option<f32>,
     /// Shim for baseline alignment that acts like an extra top margin
     /// TODO: Support last baseline and vertical text baselines
     pub baseline_shim: f32,
@@ -121,6 +124,7 @@ impl GridItem {
             align_self: style.align_self().unwrap_or(parent_align_items),
             justify_self: style.justify_self().unwrap_or(parent_justify_items),
             baseline: None,
+            last_baseline: None,
             baseline_shim: 0.0,
             row_indexes: Line { start: 0, end: 0 }, // Properly initialised later
             column_indexes: Line { start: 0, end: 0 }, // Properly initialised later

--- a/tests/hand_written.rs
+++ b/tests/hand_written.rs
@@ -8,6 +8,8 @@ mod hand_written {
     #[cfg(feature = "flexbox_balance")]
     mod flex_line_count;
     mod floats;
+    #[cfg(all(feature = "flexbox", feature = "grid", feature = "block_layout"))]
+    mod last_baseline;
     mod measure;
     mod min_max_overrides;
     mod relayout;

--- a/tests/hand_written/last_baseline.rs
+++ b/tests/hand_written/last_baseline.rs
@@ -131,7 +131,7 @@ mod last_baseline {
                         let style_size =
                             node.style.size.map(|dim| dim.into_option().unwrap_or(0.0)).map(Some).unwrap_or(Size::ZERO);
                         let size = inputs.known_dimensions.unwrap_or(style_size);
-                        LayoutOutput::from_sizes_and_baselines(size, Size::ZERO, baselines)
+                        LayoutOutput::from_sizes_and_baselines(size, taffy::Rect::ZERO, baselines)
                     }
                 }
             })

--- a/tests/hand_written/last_baseline.rs
+++ b/tests/hand_written/last_baseline.rs
@@ -1,0 +1,360 @@
+//! Tests that layout algorithms output correct first/last baselines in `LayoutOutput`.
+//!
+//! These use a minimal custom tree (rather than `TaffyTree`) so that the `LayoutOutput`
+//! returned for the root container can be inspected directly.
+#[cfg(test)]
+mod last_baseline {
+    use taffy::prelude::*;
+    use taffy::{
+        compute_block_layout, compute_cached_layout, compute_flexbox_layout, compute_grid_layout, Baselines, Cache,
+        CacheTree, LayoutInput, LayoutOutput, LayoutPartialTree, RunMode, SizingMode,
+    };
+
+    #[derive(Debug, Copy, Clone)]
+    enum NodeKind {
+        Flexbox,
+        Grid,
+        Block,
+        /// A leaf with a fixed size that reports the given baselines (offsets from its top edge)
+        Leaf(Baselines),
+    }
+
+    struct Node {
+        kind: NodeKind,
+        style: Style,
+        cache: Cache,
+        unrounded_layout: Layout,
+        children: Vec<usize>,
+    }
+
+    struct Tree {
+        nodes: Vec<Node>,
+    }
+
+    impl Tree {
+        fn new() -> Tree {
+            Tree { nodes: Vec::new() }
+        }
+
+        fn add_node(&mut self, kind: NodeKind, style: Style, children: &[usize]) -> usize {
+            self.nodes.push(Node {
+                kind,
+                style,
+                cache: Cache::new(),
+                unrounded_layout: Layout::with_order(0),
+                children: children.to_vec(),
+            });
+            self.nodes.len() - 1
+        }
+
+        fn add_leaf(&mut self, width: f32, height: f32, first: f32, last: f32) -> usize {
+            self.add_node(
+                NodeKind::Leaf(Baselines { first: Some(first), last: Some(last) }),
+                Style { size: Size { width: length(width), height: length(height) }, ..Default::default() },
+                &[],
+            )
+        }
+
+        /// Perform layout on the given root node and return its `LayoutOutput`
+        fn layout_root(&mut self, root: usize) -> LayoutOutput {
+            self.compute_child_layout(
+                NodeId::from(root),
+                LayoutInput {
+                    known_dimensions: Size::NONE,
+                    known_dimensions_are_definite: taffy::geometry::Size { width: false, height: false },
+                    parent_size: Size::NONE,
+                    available_space: Size::MAX_CONTENT,
+                    sizing_mode: SizingMode::InherentSize,
+                    run_mode: RunMode::PerformLayout,
+                    axis: taffy::RequestedAxis::Both,
+                    vertical_margins_are_collapsible: taffy::geometry::Line::FALSE,
+                },
+            )
+        }
+    }
+
+    struct ChildIter<'a>(std::slice::Iter<'a, usize>);
+    impl Iterator for ChildIter<'_> {
+        type Item = NodeId;
+        fn next(&mut self) -> Option<Self::Item> {
+            self.0.next().copied().map(NodeId::from)
+        }
+    }
+
+    impl taffy::TraversePartialTree for Tree {
+        type ChildIter<'a> = ChildIter<'a>;
+
+        fn child_ids(&self, node_id: NodeId) -> Self::ChildIter<'_> {
+            ChildIter(self.nodes[usize::from(node_id)].children.iter())
+        }
+
+        fn child_count(&self, node_id: NodeId) -> usize {
+            self.nodes[usize::from(node_id)].children.len()
+        }
+
+        fn get_child_id(&self, node_id: NodeId, index: usize) -> NodeId {
+            NodeId::from(self.nodes[usize::from(node_id)].children[index])
+        }
+    }
+
+    impl taffy::TraverseTree for Tree {}
+
+    impl LayoutPartialTree for Tree {
+        type CustomIdent = String;
+
+        type CoreContainerStyle<'a>
+            = &'a Style
+        where
+            Self: 'a;
+
+        fn get_core_container_style(&self, node_id: NodeId) -> Self::CoreContainerStyle<'_> {
+            &self.nodes[usize::from(node_id)].style
+        }
+
+        fn set_unrounded_layout(&mut self, node_id: NodeId, layout: &Layout) {
+            self.nodes[usize::from(node_id)].unrounded_layout = *layout;
+        }
+
+        fn resolve_calc_value(&self, _val: *const (), _basis: f32) -> f32 {
+            0.0
+        }
+
+        fn compute_child_layout(&mut self, node_id: NodeId, inputs: LayoutInput) -> LayoutOutput {
+            compute_cached_layout(self, node_id, inputs, |tree, node_id, inputs| {
+                let node = &tree.nodes[usize::from(node_id)];
+
+                match node.kind {
+                    NodeKind::Flexbox => compute_flexbox_layout(tree, node_id, inputs),
+                    NodeKind::Grid => compute_grid_layout(tree, node_id, inputs),
+                    NodeKind::Block => compute_block_layout(tree, node_id, inputs, None),
+                    NodeKind::Leaf(baselines) => {
+                        let style_size =
+                            node.style.size.map(|dim| dim.into_option().unwrap_or(0.0)).map(Some).unwrap_or(Size::ZERO);
+                        let size = inputs.known_dimensions.unwrap_or(style_size);
+                        LayoutOutput::from_sizes_and_baselines(size, Size::ZERO, baselines)
+                    }
+                }
+            })
+        }
+    }
+
+    impl CacheTree for Tree {
+        fn cache_get(&self, node_id: NodeId, inputs: &LayoutInput) -> Option<LayoutOutput> {
+            self.nodes[usize::from(node_id)].cache.get(inputs)
+        }
+
+        fn cache_store(&mut self, node_id: NodeId, inputs: &LayoutInput, layout_output: LayoutOutput) {
+            self.nodes[usize::from(node_id)].cache.store(inputs, layout_output)
+        }
+
+        fn cache_clear(&mut self, node_id: NodeId) {
+            self.nodes[usize::from(node_id)].cache.clear();
+        }
+    }
+
+    impl taffy::LayoutFlexboxContainer for Tree {
+        type FlexboxContainerStyle<'a>
+            = &'a Style
+        where
+            Self: 'a;
+
+        type FlexboxItemStyle<'a>
+            = &'a Style
+        where
+            Self: 'a;
+
+        fn get_flexbox_container_style(&self, node_id: NodeId) -> Self::FlexboxContainerStyle<'_> {
+            &self.nodes[usize::from(node_id)].style
+        }
+
+        fn get_flexbox_child_style(&self, child_node_id: NodeId) -> Self::FlexboxItemStyle<'_> {
+            &self.nodes[usize::from(child_node_id)].style
+        }
+    }
+
+    impl taffy::LayoutGridContainer for Tree {
+        type GridContainerStyle<'a>
+            = &'a Style
+        where
+            Self: 'a;
+
+        type GridItemStyle<'a>
+            = &'a Style
+        where
+            Self: 'a;
+
+        fn get_grid_container_style(&self, node_id: NodeId) -> Self::GridContainerStyle<'_> {
+            &self.nodes[usize::from(node_id)].style
+        }
+
+        fn get_grid_child_style(&self, child_node_id: NodeId) -> Self::GridItemStyle<'_> {
+            &self.nodes[usize::from(child_node_id)].style
+        }
+    }
+
+    impl taffy::LayoutBlockContainer for Tree {
+        type BlockContainerStyle<'a>
+            = &'a Style
+        where
+            Self: 'a;
+
+        type BlockItemStyle<'a>
+            = &'a Style
+        where
+            Self: 'a;
+
+        fn get_block_container_style(&self, node_id: NodeId) -> Self::BlockContainerStyle<'_> {
+            &self.nodes[usize::from(node_id)].style
+        }
+
+        fn get_block_child_style(&self, child_node_id: NodeId) -> Self::BlockItemStyle<'_> {
+            &self.nodes[usize::from(child_node_id)].style
+        }
+    }
+
+    /// A flex row's first baseline comes from its first item and its last baseline from its
+    /// last item, each measured relative to the container.
+    #[test]
+    fn flex_row_baselines() {
+        let mut tree = Tree::new();
+        let child_a = tree.add_leaf(50.0, 50.0, 30.0, 40.0);
+        let child_b = tree.add_leaf(60.0, 60.0, 20.0, 55.0);
+        let root = tree.add_node(
+            NodeKind::Flexbox,
+            Style {
+                display: Display::Flex,
+                flex_direction: FlexDirection::Row,
+                size: Size { width: length(200.0), height: length(100.0) },
+                ..Default::default()
+            },
+            &[child_a, child_b],
+        );
+
+        let output = tree.layout_root(root);
+        assert_eq!(output.baselines, Baselines { first: Some(30.0), last: Some(55.0) });
+    }
+
+    /// A flex column's first baseline comes from its first item and its last baseline from its
+    /// last item, offset by the items' main-axis positions.
+    #[test]
+    fn flex_column_baselines() {
+        let mut tree = Tree::new();
+        let child_a = tree.add_leaf(50.0, 50.0, 30.0, 40.0);
+        let child_b = tree.add_leaf(60.0, 60.0, 20.0, 55.0);
+        let root = tree.add_node(
+            NodeKind::Flexbox,
+            Style {
+                display: Display::Flex,
+                flex_direction: FlexDirection::Column,
+                size: Size { width: length(200.0), height: length(200.0) },
+                ..Default::default()
+            },
+            &[child_a, child_b],
+        );
+
+        let output = tree.layout_root(root);
+        // Child B is positioned at y=50 (below child A)
+        assert_eq!(output.baselines, Baselines { first: Some(30.0), last: Some(50.0 + 55.0) });
+    }
+
+    /// A multi-line flex row's first baseline comes from the first line and its last baseline
+    /// from the last line.
+    #[test]
+    fn flex_wrap_baselines() {
+        let mut tree = Tree::new();
+        let child_a = tree.add_leaf(60.0, 50.0, 30.0, 40.0);
+        let child_b = tree.add_leaf(60.0, 50.0, 20.0, 45.0);
+        let child_c = tree.add_leaf(60.0, 60.0, 25.0, 55.0);
+        let root = tree.add_node(
+            NodeKind::Flexbox,
+            Style {
+                display: Display::Flex,
+                flex_direction: FlexDirection::Row,
+                flex_wrap: FlexWrap::Wrap,
+                align_content: Some(AlignContent::FLEX_START),
+                size: Size { width: length(130.0), height: length(200.0) },
+                ..Default::default()
+            },
+            &[child_a, child_b, child_c],
+        );
+
+        let output = tree.layout_root(root);
+        // Line 1 contains children A and B (height 50), line 2 contains child C at y=50
+        assert_eq!(output.baselines, Baselines { first: Some(30.0), last: Some(50.0 + 55.0) });
+    }
+
+    /// For wrap-reverse containers the lines are in reverse order: the first baseline is
+    /// generated from the cross-start-most line (the last line) and the last baseline from
+    /// the cross-end-most line (the first line).
+    #[test]
+    fn flex_wrap_reverse_baselines() {
+        let mut tree = Tree::new();
+        let child_a = tree.add_leaf(60.0, 50.0, 30.0, 40.0);
+        let child_b = tree.add_leaf(60.0, 50.0, 20.0, 45.0);
+        let child_c = tree.add_leaf(60.0, 60.0, 25.0, 55.0);
+        let root = tree.add_node(
+            NodeKind::Flexbox,
+            Style {
+                display: Display::Flex,
+                flex_direction: FlexDirection::Row,
+                flex_wrap: FlexWrap::WrapReverse,
+                align_content: Some(AlignContent::FLEX_START),
+                size: Size { width: length(130.0), height: length(200.0) },
+                ..Default::default()
+            },
+            &[child_a, child_b, child_c],
+        );
+
+        let output = tree.layout_root(root);
+        // Wrap-reverse flips the cross axis, so `flex-start` packs lines at the bottom: line 1
+        // (children A and B, height 50) occupies y=150..200 and line 2 (child C, height 60)
+        // occupies y=90..150. The first baseline is generated from the cross-start-most line
+        // (child C's line) and the last baseline from the cross-end-most line (child B's line).
+        assert_eq!(output.baselines, Baselines { first: Some(90.0 + 25.0), last: Some(150.0 + 45.0) });
+    }
+
+    /// A grid container's first baseline is generated from the first row and its last baseline
+    /// from the last row.
+    #[test]
+    fn grid_baselines() {
+        let mut tree = Tree::new();
+        let child_a = tree.add_leaf(50.0, 50.0, 30.0, 40.0);
+        let child_b = tree.add_leaf(60.0, 60.0, 20.0, 55.0);
+        let root = tree.add_node(
+            NodeKind::Grid,
+            Style {
+                display: Display::Grid,
+                grid_template_columns: vec![length(100.0)],
+                grid_template_rows: vec![length(50.0), length(60.0)],
+                ..Default::default()
+            },
+            &[child_a, child_b],
+        );
+
+        let output = tree.layout_root(root);
+        // First baseline: no baseline-aligned items, so synthesized from the first item's
+        // border box (y=0 + height=50). Last baseline: the last row's item's last baseline (y=50 + 55).
+        assert_eq!(output.baselines, Baselines { first: Some(50.0), last: Some(50.0 + 55.0) });
+    }
+
+    /// A block container's first baseline comes from its first in-flow child with a baseline,
+    /// and its last baseline from its last in-flow child with one.
+    #[test]
+    fn block_baselines() {
+        let mut tree = Tree::new();
+        let child_a = tree.add_leaf(50.0, 50.0, 30.0, 40.0);
+        let child_b = tree.add_leaf(60.0, 60.0, 20.0, 55.0);
+        let root = tree.add_node(
+            NodeKind::Block,
+            Style {
+                display: Display::Block,
+                size: Size { width: length(200.0), height: auto() },
+                ..Default::default()
+            },
+            &[child_a, child_b],
+        );
+
+        let output = tree.layout_root(root);
+        assert_eq!(output.baselines, Baselines { first: Some(30.0), last: Some(50.0 + 55.0) });
+    }
+}


### PR DESCRIPTION
# Objective

Compute and output the *last baseline* of a container (`LayoutOutput::baselines.last`) from all built-in layout algorithms (flexbox, grid and block), building on the `Baselines { first, last }` representation introduced in #1107. Last-baseline *alignment* (`align-items: last baseline`) is not part of this PR and will follow separately.

## Context

Last baselines ride along with the existing layout passes — no additional layout computation is performed. Selection rules (per [css-align §9.1 "baseline export"](https://www.w3.org/TR/css-align-3/#baseline-export) / [css-flexbox §8.5](https://www.w3.org/TR/css-flexbox-1/#flex-baselines)):

- **Flexbox**: the last baseline is generated from the cross-end-most line (the *first* line for wrap-reverse containers), from that line's last flex item. Each item's last baseline is captured during the final layout pass, mirroring the existing first-baseline handling:
  ```rust
  item.baseline      = baseline_offset + baselines.first.unwrap_or(size.height)  // existing
  item.last_baseline = baseline_offset + baselines.last.unwrap_or(size.height)   // new
  ```
  with both clamped to the item's border box for scroll containers (csswg#7660).
- **Grid**: the last baseline is generated from the last row containing items, using the row's first item's last baseline (synthesized from its border box when it has none). `align_and_position_item` now returns the child's `Baselines` (clamped for scroll containers), stored on `GridItem` as `last_baseline`.
- **Block**: the container's last baseline is the last baseline of its last in-flow child that has one (the first baseline is unchanged: the first baseline of the first in-flow child with one). Both are shifted together when `align-content` offsets the in-flow group.

Since no built-in leaf produces baselines and nothing consumes `baselines.last` yet, this is only observable via custom trees / measure functions, so coverage is a new hand-written test suite (`tests/hand_written/last_baseline.rs`) with a minimal custom tree whose leaves report fixed first/last baselines, asserting the root `LayoutOutput.baselines` for flex row/column/wrap/wrap-reverse, grid multi-row, and block containers.

`cargo fmt` / `clippy` / `cargo test --workspace` all pass.

## Feedback wanted

- Grid's *first* baseline currently uses the alignment baseline (`item.baseline`, only set for baseline-aligned items) with a border-box fallback, whereas the new last baseline uses the child's actual reported last baseline. This asymmetry preserves existing first-baseline behaviour; happy to align the first-baseline path with the "actual baseline" approach in a follow-up if desired.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/c0a80d9344d54e918b37cacfb71a2128
Requested by: @nicoburns