### PR TITLE
Fix grid percentage/calc gap resolution against indefinite sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 
 - Flexbox: items with `align-self: baseline` and an `auto` cross-axis margin no longer participate in baseline alignment, per [CSS Flexbox §8.3](https://www.w3.org/TR/css-flexbox-1/#baseline-participation). Previously such items were still counted when deciding whether a line performs baseline alignment, had their baselines measured, and could affect the container's own first baseline
 
+- Grid: percentage (and `calc()`) gaps now resolve against an indefinite container size correctly, matching Chrome. During intrinsic sizing a percentage gap with an indefinite basis contributes zero (so `calc()` gaps resolve their percentage part against zero); once the container's content-box size in that axis is resolved, gaps re-resolve against it and track positions account for the resolved gap. Previously such gaps remained zero (or their percentage part remained zero) in the final layout
+
 ### Changed
 
 - `LayoutOutput`'s `first_baselines: Point<Option<f32>>` field has been replaced with `baselines: Baselines`, where the new `Baselines` struct has `first: Option<f32>` and `last: Option<f32>` fields (both horizontal baselines, measured from the top edge of the node). The never-read vertical (x) baseline slot has been dropped in favour of a last-baseline slot. Last baselines are not yet computed by any of the built-in layout algorithms (this is purely a representational change), but custom tree implementations and measure functions can now report them

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -302,6 +302,12 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
     // Determine if the grid has any baseline aligned items
     let has_baseline_aligned_item = items.iter().any(|item| item.align_self == AlignSelf::BASELINE);
 
+    // Record whether the node's own size is definite in each axis before `inner_node_size` is
+    // overwritten with content-based sizes below. Percentage track sizing functions and gaps
+    // resolve against these sizes and must be re-resolved later if they were indefinite here.
+    let inner_node_width_indefinite = inner_node_size.width.is_none();
+    let inner_node_height_indefinite = inner_node_size.height.is_none();
+
     // Run track sizing algorithm for Inline axis
     track_sizing_algorithm(
         tree,
@@ -376,7 +382,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
     // 7. Resolve percentage track base sizes
     // In the case of an indefinitely sized container these resolve to zero during the "Initialise Tracks" step
     // and therefore need to be re-resolved here based on the content-sized content box of the container
-    if !available_grid_space.width.is_definite() {
+    if inner_node_width_indefinite {
         for column in &mut columns {
             let min: Option<f32> = column
                 .min_track_sizing_function
@@ -387,7 +393,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
             column.base_size = column.base_size.maybe_clamp(min, max);
         }
     }
-    if !available_grid_space.height.is_definite() {
+    if inner_node_height_indefinite {
         for row in &mut rows {
             let min: Option<f32> = row
                 .min_track_sizing_function
@@ -408,8 +414,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
 
     let has_percentage_column = columns.iter().any(|track| track.uses_percentage());
     let has_percentage_row = rows.iter().any(|track| track.uses_percentage());
-    let parent_width_indefinite = !available_space.width.is_definite();
-    rerun_column_sizing = parent_width_indefinite && has_percentage_column;
+    rerun_column_sizing = inner_node_width_indefinite && has_percentage_column;
 
     if !rerun_column_sizing {
         intrinsic_column_contribution_changed =
@@ -472,8 +477,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
         // TODO: Only rerun sizing for tracks that actually require it rather than for all tracks if any need it.
         let mut rerun_row_sizing;
 
-        let parent_height_indefinite = !available_space.height.is_definite();
-        rerun_row_sizing = parent_height_indefinite && has_percentage_row;
+        rerun_row_sizing = inner_node_height_indefinite && has_percentage_row;
 
         if !rerun_row_sizing {
             intrinsic_row_contribution_changed =

--- a/src/compute/grid/track_sizing.rs
+++ b/src/compute/grid/track_sizing.rs
@@ -1,6 +1,6 @@
 //! Implements the track sizing algorithm
 //! <https://www.w3.org/TR/css-grid-1/#layout-algorithm>
-use super::types::{GridItem, GridTrack, TrackCounts};
+use super::types::{GridItem, GridTrack, GridTrackKind, TrackCounts};
 use crate::geometry::{AbstractAxis, Line, Size};
 use crate::style::{AlignContent, AlignContentKeyword, AlignSelf, AvailableSpace};
 use crate::style_helpers::TaffyMinContent;
@@ -424,6 +424,14 @@ fn initialize_track_sizes(
     axis_inner_node_size: Option<f32>,
 ) {
     for track in axis_tracks.iter_mut() {
+        // Percentage gaps resolving against an indefinite size are treated as zero for the purposes
+        // of intrinsic sizing (so calc() gaps resolve against a percentage basis of zero). They are
+        // re-resolved against the container's resolved content-box size in `compute_grid_layout`.
+        let percentage_basis = match track.kind {
+            GridTrackKind::Gutter => axis_inner_node_size.or(Some(0.0)),
+            GridTrackKind::Track => axis_inner_node_size,
+        };
+
         // For each track, if the track’s min track sizing function is:
         // - A fixed sizing function
         //     Resolve to an absolute length and use that size as the track’s initial base size.
@@ -432,7 +440,7 @@ fn initialize_track_sizes(
         //     Use an initial base size of zero.
         track.base_size = track
             .min_track_sizing_function
-            .definite_value(axis_inner_node_size, |val, basis| tree.calc(val, basis))
+            .definite_value(percentage_basis, |val, basis| tree.calc(val, basis))
             .unwrap_or(0.0);
 
         // For each track, if the track’s max track sizing function is:
@@ -444,7 +452,7 @@ fn initialize_track_sizes(
         //     Use an initial growth limit of infinity.
         track.growth_limit = track
             .max_track_sizing_function
-            .definite_value(axis_inner_node_size, |val, basis| tree.calc(val, basis))
+            .definite_value(percentage_basis, |val, basis| tree.calc(val, basis))
             .unwrap_or(f32::INFINITY);
 
         // In all cases, if the growth limit is less than the base size, increase the growth limit to match the base size.

--- a/test_fixtures/blockgrid/blockgrid_grid_percent_gap_definite_width_indefinite_height.html
+++ b/test_fixtures/blockgrid/blockgrid_grid_percent_gap_definite_width_indefinite_height.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 250px;">
+  <div style="display: grid; width: 200px; gap: 10%; grid-template-columns: 90px 90px; grid-template-rows: 90px 90px;">
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/blockgrid/blockgrid_grid_percent_gap_fit_content_width.html
+++ b/test_fixtures/blockgrid/blockgrid_grid_percent_gap_fit_content_width.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 250px;">
+  <div style="display: grid; width: fit-content; padding: 5px; gap: 15% 10%; grid-template-columns: auto auto; grid-template-rows: auto auto;">
+    <div style="margin: 5px 10px; width: 70px; height: 30px;"></div>
+    <div style="margin: 5px 10px; width: 70px; height: 30px;"></div>
+    <div style="margin: 5px 10px; width: 70px; height: 30px;"></div>
+    <div style="margin: 5px 10px; width: 70px; height: 30px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_percent_gap_definite_width_indefinite_height.html
+++ b/test_fixtures/grid/grid_percent_gap_definite_width_indefinite_height.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 200px; gap: 10%; grid-template-columns: 90px 90px; grid-template-rows: 90px 90px;">
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_percent_gap_indefinite_both_axes.html
+++ b/test_fixtures/grid/grid_percent_gap_indefinite_both_axes.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; padding: 10px; grid-template-columns: 40px 40px; grid-template-rows: 40px 40px; gap: 20%;">
+  <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
+</div>
+
+</body>
+</html>

--- a/tests/hand_written.rs
+++ b/tests/hand_written.rs
@@ -4,6 +4,8 @@ mod hand_written {
     mod block_replaced;
     mod border_and_padding;
     mod caching;
+    #[cfg(feature = "calc")]
+    mod calc_gap;
     #[cfg(feature = "flexbox_balance")]
     mod flex_line_count;
     mod floats;

--- a/tests/hand_written/calc_gap.rs
+++ b/tests/hand_written/calc_gap.rs
@@ -1,0 +1,257 @@
+//! Tests for `calc()` gaps on grid containers, including re-resolution against
+//! the container's resolved content-box size when the percentage basis is
+//! initially indefinite.
+//!
+//! These use a custom tree because `TaffyTree`'s calc resolver always returns zero.
+use taffy::{
+    compute_cached_layout, compute_grid_layout, compute_leaf_layout, compute_root_layout, prelude::*, round_layout,
+    Cache, CacheTree, Point,
+};
+
+/// A calc value of the form `calc(<length>px + <percent>%)`
+struct CalcValue {
+    length: f32,
+    /// Percentage as a fraction (e.g. 0.05 for 5%)
+    percent: f32,
+}
+
+fn calc_length_percentage(length: f32, percent: f32) -> LengthPercentage {
+    let ptr: &'static CalcValue = Box::leak(Box::new(CalcValue { length, percent }));
+    LengthPercentage::calc(ptr as *const CalcValue as *const ())
+}
+
+struct Node {
+    style: Style,
+    is_grid: bool,
+    cache: Cache,
+    unrounded_layout: Layout,
+    final_layout: Layout,
+    children: Vec<usize>,
+}
+
+impl Node {
+    fn new_grid(style: Style) -> Node {
+        Node {
+            style: Style { display: Display::Grid, ..style },
+            is_grid: true,
+            cache: Cache::new(),
+            unrounded_layout: Layout::with_order(0),
+            final_layout: Layout::with_order(0),
+            children: Vec::new(),
+        }
+    }
+
+    fn new_leaf(style: Style) -> Node {
+        Node {
+            style,
+            is_grid: false,
+            cache: Cache::new(),
+            unrounded_layout: Layout::with_order(0),
+            final_layout: Layout::with_order(0),
+            children: Vec::new(),
+        }
+    }
+}
+
+struct Tree {
+    nodes: Vec<Node>,
+}
+
+impl Tree {
+    fn new() -> Tree {
+        Tree { nodes: Vec::new() }
+    }
+
+    fn add_node(&mut self, node: Node) -> usize {
+        self.nodes.push(node);
+        self.nodes.len() - 1
+    }
+
+    fn append_child(&mut self, parent: usize, child: usize) {
+        self.nodes[parent].children.push(child);
+    }
+
+    fn compute_layout(&mut self, root: usize, available_space: Size<AvailableSpace>) {
+        compute_root_layout(self, NodeId::from(root), available_space);
+        round_layout(self, NodeId::from(root));
+    }
+
+    fn layout(&self, node: usize) -> &Layout {
+        &self.nodes[node].final_layout
+    }
+}
+
+struct ChildIter<'a>(std::slice::Iter<'a, usize>);
+impl Iterator for ChildIter<'_> {
+    type Item = NodeId;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().copied().map(NodeId::from)
+    }
+}
+
+impl taffy::TraversePartialTree for Tree {
+    type ChildIter<'a> = ChildIter<'a>;
+
+    fn child_ids(&self, node_id: NodeId) -> Self::ChildIter<'_> {
+        ChildIter(self.nodes[usize::from(node_id)].children.iter())
+    }
+
+    fn child_count(&self, node_id: NodeId) -> usize {
+        self.nodes[usize::from(node_id)].children.len()
+    }
+
+    fn get_child_id(&self, node_id: NodeId, index: usize) -> NodeId {
+        NodeId::from(self.nodes[usize::from(node_id)].children[index])
+    }
+}
+
+impl taffy::TraverseTree for Tree {}
+
+impl taffy::LayoutPartialTree for Tree {
+    type CustomIdent = String;
+
+    type CoreContainerStyle<'a>
+        = &'a Style
+    where
+        Self: 'a;
+
+    fn get_core_container_style(&self, node_id: NodeId) -> Self::CoreContainerStyle<'_> {
+        &self.nodes[usize::from(node_id)].style
+    }
+
+    fn set_unrounded_layout(&mut self, node_id: NodeId, layout: &Layout) {
+        self.nodes[usize::from(node_id)].unrounded_layout = *layout;
+    }
+
+    #[allow(unsafe_code)]
+    fn resolve_calc_value(&self, val: *const (), basis: f32) -> f32 {
+        let calc = unsafe { &*(val as *const CalcValue) };
+        calc.length + calc.percent * basis
+    }
+
+    fn compute_child_layout(&mut self, node_id: NodeId, inputs: taffy::tree::LayoutInput) -> taffy::tree::LayoutOutput {
+        compute_cached_layout(self, node_id, inputs, |tree, node_id, inputs| {
+            let node = &tree.nodes[usize::from(node_id)];
+            if node.is_grid {
+                compute_grid_layout(tree, node_id, inputs)
+            } else {
+                compute_leaf_layout(
+                    inputs,
+                    &node.style,
+                    |_val, _basis| 0.0,
+                    |_known_dimensions, _available_space| Size::ZERO,
+                )
+            }
+        })
+    }
+}
+
+impl CacheTree for Tree {
+    fn cache_get(&self, node_id: NodeId, inputs: &taffy::LayoutInput) -> Option<taffy::LayoutOutput> {
+        self.nodes[usize::from(node_id)].cache.get(inputs)
+    }
+
+    fn cache_store(&mut self, node_id: NodeId, inputs: &taffy::LayoutInput, layout_output: taffy::LayoutOutput) {
+        self.nodes[usize::from(node_id)].cache.store(inputs, layout_output)
+    }
+
+    fn cache_clear(&mut self, node_id: NodeId) {
+        self.nodes[usize::from(node_id)].cache.clear();
+    }
+}
+
+impl taffy::LayoutGridContainer for Tree {
+    type GridContainerStyle<'a>
+        = &'a Style
+    where
+        Self: 'a;
+
+    type GridItemStyle<'a>
+        = &'a Style
+    where
+        Self: 'a;
+
+    fn get_grid_container_style(&self, node_id: NodeId) -> Self::GridContainerStyle<'_> {
+        &self.nodes[usize::from(node_id)].style
+    }
+
+    fn get_grid_child_style(&self, child_node_id: NodeId) -> Self::GridItemStyle<'_> {
+        &self.nodes[usize::from(child_node_id)].style
+    }
+}
+
+impl taffy::RoundTree for Tree {
+    fn get_unrounded_layout(&self, node_id: NodeId) -> Layout {
+        self.nodes[usize::from(node_id)].unrounded_layout
+    }
+
+    fn set_final_layout(&mut self, node_id: NodeId, layout: &Layout) {
+        self.nodes[usize::from(node_id)].final_layout = *layout;
+    }
+}
+
+fn build_grid(gap: LengthPercentage, width: Dimension) -> (Tree, usize, [usize; 4]) {
+    let mut tree = Tree::new();
+    let grid = tree.add_node(Node::new_grid(Style {
+        size: Size { width, height: Dimension::auto() },
+        gap: Size { width: gap, height: gap },
+        grid_template_columns: vec![length(90.0), length(90.0)],
+        grid_template_rows: vec![length(90.0), length(90.0)],
+        ..Style::default()
+    }));
+    let mut children = [0; 4];
+    for child in &mut children {
+        *child = tree.add_node(Node::new_leaf(Style::default()));
+        tree.append_child(grid, *child);
+    }
+    (tree, grid, children)
+}
+
+/// Mirrors the second grid of WPT css/css-grid/alignment/grid-gutters-009.html and
+/// grid-gutters-010.html: `display: inline-grid; width: auto; gap: calc(20px + 5%)`
+/// with 90px tracks in both axes.
+///
+/// During intrinsic sizing the percentage part of the gap resolves to zero, so
+/// the container sizes to 90 + 20 + 90 = 200 in both axes. The gaps then
+/// re-resolve against that content-box size to calc(20px + 5% * 200) = 30px,
+/// which offsets track positions without resizing the container.
+#[test]
+fn calc_gap_indefinite_both_axes() {
+    let (mut tree, grid, children) = build_grid(calc_length_percentage(20.0, 0.05), Dimension::auto());
+    tree.compute_layout(grid, Size::MAX_CONTENT);
+
+    assert_eq!(tree.layout(grid).size, Size { width: 200.0, height: 200.0 });
+    let expected_locations = [
+        Point { x: 0.0, y: 0.0 },
+        Point { x: 120.0, y: 0.0 },
+        Point { x: 0.0, y: 120.0 },
+        Point { x: 120.0, y: 120.0 },
+    ];
+    for (child, expected_location) in children.iter().zip(expected_locations) {
+        assert_eq!(tree.layout(*child).size, Size { width: 90.0, height: 90.0 });
+        assert_eq!(tree.layout(*child).location, expected_location);
+    }
+}
+
+/// Like the first grid of WPT grid-gutters-009/010 but with a calc() gap:
+/// `width: 200px; gap: calc(20px + 5%)`. The column gap resolves against the
+/// definite width immediately, while the row gap initially resolves its
+/// percentage part against zero and then re-resolves against the resolved
+/// content-box height of 200px.
+#[test]
+fn calc_gap_definite_width_indefinite_height() {
+    let (mut tree, grid, children) = build_grid(calc_length_percentage(20.0, 0.05), length(200.0));
+    tree.compute_layout(grid, Size { width: AvailableSpace::Definite(800.0), height: AvailableSpace::Definite(600.0) });
+
+    assert_eq!(tree.layout(grid).size, Size { width: 200.0, height: 200.0 });
+    let expected_locations = [
+        Point { x: 0.0, y: 0.0 },
+        Point { x: 120.0, y: 0.0 },
+        Point { x: 0.0, y: 120.0 },
+        Point { x: 120.0, y: 120.0 },
+    ];
+    for (child, expected_location) in children.iter().zip(expected_locations) {
+        assert_eq!(tree.layout(*child).size, Size { width: 90.0, height: 90.0 });
+        assert_eq!(tree.layout(*child).location, expected_location);
+    }
+}

--- a/tests/xml/blockgrid/blockgrid_grid_percent_gap_definite_width_indefinite_height__border_box_ltr.xml
+++ b/tests/xml/blockgrid/blockgrid_grid_percent_gap_definite_width_indefinite_height__border_box_ltr.xml
@@ -1,0 +1,23 @@
+<test name="blockgrid_grid_percent_gap_definite_width_indefinite_height__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="250px">
+      <div display="grid" direction="ltr" width="200px" row-gap="10%" column-gap="10%" grid-template-rows="90px 90px" grid-template-columns="90px 90px">
+        <div direction="ltr"/>
+        <div direction="ltr"/>
+        <div direction="ltr"/>
+        <div direction="ltr"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="250" height="180">
+      <node x="0" y="0" width="200" height="180">
+        <node x="0" y="0" width="90" height="90"/>
+        <node x="110" y="0" width="90" height="90"/>
+        <node x="0" y="108" width="90" height="90"/>
+        <node x="110" y="108" width="90" height="90"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/blockgrid/blockgrid_grid_percent_gap_definite_width_indefinite_height__border_box_rtl.xml
+++ b/tests/xml/blockgrid/blockgrid_grid_percent_gap_definite_width_indefinite_height__border_box_rtl.xml
@@ -1,0 +1,23 @@
+<test name="blockgrid_grid_percent_gap_definite_width_indefinite_height__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="250px">
+      <div display="grid" direction="rtl" width="200px" row-gap="10%" column-gap="10%" grid-template-rows="90px 90px" grid-template-columns="90px 90px">
+        <div direction="rtl"/>
+        <div direction="rtl"/>
+        <div direction="rtl"/>
+        <div direction="rtl"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="250" height="180">
+      <node x="50" y="0" width="200" height="180">
+        <node x="110" y="0" width="90" height="90"/>
+        <node x="0" y="0" width="90" height="90"/>
+        <node x="110" y="108" width="90" height="90"/>
+        <node x="0" y="108" width="90" height="90"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/blockgrid/blockgrid_grid_percent_gap_definite_width_indefinite_height__content_box_ltr.xml
+++ b/tests/xml/blockgrid/blockgrid_grid_percent_gap_definite_width_indefinite_height__content_box_ltr.xml
@@ -1,0 +1,23 @@
+<test name="blockgrid_grid_percent_gap_definite_width_indefinite_height__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="250px">
+      <div display="grid" box-sizing="content-box" direction="ltr" width="200px" row-gap="10%" column-gap="10%" grid-template-rows="90px 90px" grid-template-columns="90px 90px">
+        <div box-sizing="content-box" direction="ltr"/>
+        <div box-sizing="content-box" direction="ltr"/>
+        <div box-sizing="content-box" direction="ltr"/>
+        <div box-sizing="content-box" direction="ltr"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="250" height="180">
+      <node x="0" y="0" width="200" height="180">
+        <node x="0" y="0" width="90" height="90"/>
+        <node x="110" y="0" width="90" height="90"/>
+        <node x="0" y="108" width="90" height="90"/>
+        <node x="110" y="108" width="90" height="90"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/blockgrid/blockgrid_grid_percent_gap_definite_width_indefinite_height__content_box_rtl.xml
+++ b/tests/xml/blockgrid/blockgrid_grid_percent_gap_definite_width_indefinite_height__content_box_rtl.xml
@@ -1,0 +1,23 @@
+<test name="blockgrid_grid_percent_gap_definite_width_indefinite_height__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="250px">
+      <div display="grid" box-sizing="content-box" direction="rtl" width="200px" row-gap="10%" column-gap="10%" grid-template-rows="90px 90px" grid-template-columns="90px 90px">
+        <div box-sizing="content-box" direction="rtl"/>
+        <div box-sizing="content-box" direction="rtl"/>
+        <div box-sizing="content-box" direction="rtl"/>
+        <div box-sizing="content-box" direction="rtl"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="250" height="180">
+      <node x="50" y="0" width="200" height="180">
+        <node x="110" y="0" width="90" height="90"/>
+        <node x="0" y="0" width="90" height="90"/>
+        <node x="110" y="108" width="90" height="90"/>
+        <node x="0" y="108" width="90" height="90"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/blockgrid/blockgrid_grid_percent_gap_fit_content_width__border_box_ltr.xml
+++ b/tests/xml/blockgrid/blockgrid_grid_percent_gap_fit_content_width__border_box_ltr.xml
@@ -1,0 +1,23 @@
+<test name="blockgrid_grid_percent_gap_fit_content_width__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="250px">
+      <div display="grid" direction="ltr" width="fit-content" row-gap="15%" column-gap="10%" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px" grid-template-rows="auto auto" grid-template-columns="auto auto">
+        <div direction="ltr" width="70px" height="30px" margin-top="5px" margin-left="10px" margin-bottom="5px" margin-right="10px"/>
+        <div direction="ltr" width="70px" height="30px" margin-top="5px" margin-left="10px" margin-bottom="5px" margin-right="10px"/>
+        <div direction="ltr" width="70px" height="30px" margin-top="5px" margin-left="10px" margin-bottom="5px" margin-right="10px"/>
+        <div direction="ltr" width="70px" height="30px" margin-top="5px" margin-left="10px" margin-bottom="5px" margin-right="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="250" height="90">
+      <node x="0" y="0" width="190" height="90">
+        <node x="15" y="10" width="70" height="30"/>
+        <node x="123" y="10" width="70" height="30"/>
+        <node x="15" y="62" width="70" height="30"/>
+        <node x="123" y="62" width="70" height="30"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/blockgrid/blockgrid_grid_percent_gap_fit_content_width__border_box_rtl.xml
+++ b/tests/xml/blockgrid/blockgrid_grid_percent_gap_fit_content_width__border_box_rtl.xml
@@ -1,0 +1,23 @@
+<test name="blockgrid_grid_percent_gap_fit_content_width__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="250px">
+      <div display="grid" direction="rtl" width="fit-content" row-gap="15%" column-gap="10%" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px" grid-template-rows="auto auto" grid-template-columns="auto auto">
+        <div direction="rtl" width="70px" height="30px" margin-top="5px" margin-left="10px" margin-bottom="5px" margin-right="10px"/>
+        <div direction="rtl" width="70px" height="30px" margin-top="5px" margin-left="10px" margin-bottom="5px" margin-right="10px"/>
+        <div direction="rtl" width="70px" height="30px" margin-top="5px" margin-left="10px" margin-bottom="5px" margin-right="10px"/>
+        <div direction="rtl" width="70px" height="30px" margin-top="5px" margin-left="10px" margin-bottom="5px" margin-right="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="250" height="90">
+      <node x="60" y="0" width="190" height="90">
+        <node x="105" y="10" width="70" height="30"/>
+        <node x="-3" y="10" width="70" height="30"/>
+        <node x="105" y="62" width="70" height="30"/>
+        <node x="-3" y="62" width="70" height="30"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/blockgrid/blockgrid_grid_percent_gap_fit_content_width__content_box_ltr.xml
+++ b/tests/xml/blockgrid/blockgrid_grid_percent_gap_fit_content_width__content_box_ltr.xml
@@ -1,0 +1,23 @@
+<test name="blockgrid_grid_percent_gap_fit_content_width__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="250px">
+      <div display="grid" box-sizing="content-box" direction="ltr" width="fit-content" row-gap="15%" column-gap="10%" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px" grid-template-rows="auto auto" grid-template-columns="auto auto">
+        <div box-sizing="content-box" direction="ltr" width="70px" height="30px" margin-top="5px" margin-left="10px" margin-bottom="5px" margin-right="10px"/>
+        <div box-sizing="content-box" direction="ltr" width="70px" height="30px" margin-top="5px" margin-left="10px" margin-bottom="5px" margin-right="10px"/>
+        <div box-sizing="content-box" direction="ltr" width="70px" height="30px" margin-top="5px" margin-left="10px" margin-bottom="5px" margin-right="10px"/>
+        <div box-sizing="content-box" direction="ltr" width="70px" height="30px" margin-top="5px" margin-left="10px" margin-bottom="5px" margin-right="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="250" height="90">
+      <node x="0" y="0" width="190" height="90">
+        <node x="15" y="10" width="70" height="30"/>
+        <node x="123" y="10" width="70" height="30"/>
+        <node x="15" y="62" width="70" height="30"/>
+        <node x="123" y="62" width="70" height="30"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/blockgrid/blockgrid_grid_percent_gap_fit_content_width__content_box_rtl.xml
+++ b/tests/xml/blockgrid/blockgrid_grid_percent_gap_fit_content_width__content_box_rtl.xml
@@ -1,0 +1,23 @@
+<test name="blockgrid_grid_percent_gap_fit_content_width__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="250px">
+      <div display="grid" box-sizing="content-box" direction="rtl" width="fit-content" row-gap="15%" column-gap="10%" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px" grid-template-rows="auto auto" grid-template-columns="auto auto">
+        <div box-sizing="content-box" direction="rtl" width="70px" height="30px" margin-top="5px" margin-left="10px" margin-bottom="5px" margin-right="10px"/>
+        <div box-sizing="content-box" direction="rtl" width="70px" height="30px" margin-top="5px" margin-left="10px" margin-bottom="5px" margin-right="10px"/>
+        <div box-sizing="content-box" direction="rtl" width="70px" height="30px" margin-top="5px" margin-left="10px" margin-bottom="5px" margin-right="10px"/>
+        <div box-sizing="content-box" direction="rtl" width="70px" height="30px" margin-top="5px" margin-left="10px" margin-bottom="5px" margin-right="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="250" height="90">
+      <node x="60" y="0" width="190" height="90">
+        <node x="105" y="10" width="70" height="30"/>
+        <node x="-3" y="10" width="70" height="30"/>
+        <node x="105" y="62" width="70" height="30"/>
+        <node x="-3" y="62" width="70" height="30"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_percent_gap_definite_width_indefinite_height__border_box_ltr.xml
+++ b/tests/xml/grid/grid_percent_gap_definite_width_indefinite_height__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_percent_gap_definite_width_indefinite_height__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="200px" row-gap="10%" column-gap="10%" grid-template-rows="90px 90px" grid-template-columns="90px 90px">
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="180">
+      <node x="0" y="0" width="90" height="90"/>
+      <node x="110" y="0" width="90" height="90"/>
+      <node x="0" y="108" width="90" height="90"/>
+      <node x="110" y="108" width="90" height="90"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_percent_gap_definite_width_indefinite_height__border_box_rtl.xml
+++ b/tests/xml/grid/grid_percent_gap_definite_width_indefinite_height__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_percent_gap_definite_width_indefinite_height__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="200px" row-gap="10%" column-gap="10%" grid-template-rows="90px 90px" grid-template-columns="90px 90px">
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="180">
+      <node x="110" y="0" width="90" height="90"/>
+      <node x="0" y="0" width="90" height="90"/>
+      <node x="110" y="108" width="90" height="90"/>
+      <node x="0" y="108" width="90" height="90"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_percent_gap_definite_width_indefinite_height__content_box_ltr.xml
+++ b/tests/xml/grid/grid_percent_gap_definite_width_indefinite_height__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_percent_gap_definite_width_indefinite_height__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="200px" row-gap="10%" column-gap="10%" grid-template-rows="90px 90px" grid-template-columns="90px 90px">
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="180">
+      <node x="0" y="0" width="90" height="90"/>
+      <node x="110" y="0" width="90" height="90"/>
+      <node x="0" y="108" width="90" height="90"/>
+      <node x="110" y="108" width="90" height="90"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_percent_gap_definite_width_indefinite_height__content_box_rtl.xml
+++ b/tests/xml/grid/grid_percent_gap_definite_width_indefinite_height__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_percent_gap_definite_width_indefinite_height__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="200px" row-gap="10%" column-gap="10%" grid-template-rows="90px 90px" grid-template-columns="90px 90px">
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="180">
+      <node x="110" y="0" width="90" height="90"/>
+      <node x="0" y="0" width="90" height="90"/>
+      <node x="110" y="108" width="90" height="90"/>
+      <node x="0" y="108" width="90" height="90"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_percent_gap_indefinite_both_axes__border_box_ltr.xml
+++ b/tests/xml/grid/grid_percent_gap_indefinite_both_axes__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_percent_gap_indefinite_both_axes__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" row-gap="20%" column-gap="20%" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="40px 40px" grid-template-columns="40px 40px">
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+      <div direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="10" y="10" width="40" height="40"/>
+      <node x="66" y="10" width="40" height="40"/>
+      <node x="10" y="66" width="40" height="40"/>
+      <node x="66" y="66" width="40" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_percent_gap_indefinite_both_axes__border_box_rtl.xml
+++ b/tests/xml/grid/grid_percent_gap_indefinite_both_axes__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_percent_gap_indefinite_both_axes__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" row-gap="20%" column-gap="20%" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="40px 40px" grid-template-columns="40px 40px">
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+      <div direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="50" y="10" width="40" height="40"/>
+      <node x="-6" y="10" width="40" height="40"/>
+      <node x="50" y="66" width="40" height="40"/>
+      <node x="-6" y="66" width="40" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_percent_gap_indefinite_both_axes__content_box_ltr.xml
+++ b/tests/xml/grid/grid_percent_gap_indefinite_both_axes__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_percent_gap_indefinite_both_axes__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" row-gap="20%" column-gap="20%" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="40px 40px" grid-template-columns="40px 40px">
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+      <div box-sizing="content-box" direction="ltr"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="10" y="10" width="40" height="40"/>
+      <node x="66" y="10" width="40" height="40"/>
+      <node x="10" y="66" width="40" height="40"/>
+      <node x="66" y="66" width="40" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_percent_gap_indefinite_both_axes__content_box_rtl.xml
+++ b/tests/xml/grid/grid_percent_gap_indefinite_both_axes__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_percent_gap_indefinite_both_axes__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" row-gap="20%" column-gap="20%" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="40px 40px" grid-template-columns="40px 40px">
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+      <div box-sizing="content-box" direction="rtl"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="50" y="10" width="40" height="40"/>
+      <node x="-6" y="10" width="40" height="40"/>
+      <node x="50" y="66" width="40" height="40"/>
+      <node x="-6" y="66" width="40" height="40"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -5226,6 +5226,52 @@ mod blockgrid {
     }
 
     #[test]
+    fn blockgrid_grid_percent_gap_definite_width_indefinite_height__border_box_ltr() {
+        crate::run_xml_test("blockgrid", "blockgrid_grid_percent_gap_definite_width_indefinite_height__border_box_ltr");
+    }
+
+    #[test]
+    fn blockgrid_grid_percent_gap_definite_width_indefinite_height__content_box_ltr() {
+        crate::run_xml_test(
+            "blockgrid",
+            "blockgrid_grid_percent_gap_definite_width_indefinite_height__content_box_ltr",
+        );
+    }
+
+    #[test]
+    fn blockgrid_grid_percent_gap_definite_width_indefinite_height__border_box_rtl() {
+        crate::run_xml_test("blockgrid", "blockgrid_grid_percent_gap_definite_width_indefinite_height__border_box_rtl");
+    }
+
+    #[test]
+    fn blockgrid_grid_percent_gap_definite_width_indefinite_height__content_box_rtl() {
+        crate::run_xml_test(
+            "blockgrid",
+            "blockgrid_grid_percent_gap_definite_width_indefinite_height__content_box_rtl",
+        );
+    }
+
+    #[test]
+    fn blockgrid_grid_percent_gap_fit_content_width__border_box_ltr() {
+        crate::run_xml_test("blockgrid", "blockgrid_grid_percent_gap_fit_content_width__border_box_ltr");
+    }
+
+    #[test]
+    fn blockgrid_grid_percent_gap_fit_content_width__content_box_ltr() {
+        crate::run_xml_test("blockgrid", "blockgrid_grid_percent_gap_fit_content_width__content_box_ltr");
+    }
+
+    #[test]
+    fn blockgrid_grid_percent_gap_fit_content_width__border_box_rtl() {
+        crate::run_xml_test("blockgrid", "blockgrid_grid_percent_gap_fit_content_width__border_box_rtl");
+    }
+
+    #[test]
+    fn blockgrid_grid_percent_gap_fit_content_width__content_box_rtl() {
+        crate::run_xml_test("blockgrid", "blockgrid_grid_percent_gap_fit_content_width__content_box_rtl");
+    }
+
+    #[test]
     fn blockgrid_margin_y_collapse_through_blocked_by_grid__border_box_ltr() {
         crate::run_xml_test("blockgrid", "blockgrid_margin_y_collapse_through_blocked_by_grid__border_box_ltr");
     }
@@ -30947,6 +30993,54 @@ mod grid {
     #[test]
     fn grid_padding_border_overrides_size__content_box_rtl() {
         crate::run_xml_test("grid", "grid_padding_border_overrides_size__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_percent_gap_definite_width_indefinite_height__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_percent_gap_definite_width_indefinite_height__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_percent_gap_definite_width_indefinite_height__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_percent_gap_definite_width_indefinite_height__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_percent_gap_definite_width_indefinite_height__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_percent_gap_definite_width_indefinite_height__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_percent_gap_definite_width_indefinite_height__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_percent_gap_definite_width_indefinite_height__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_percent_gap_indefinite_both_axes__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_percent_gap_indefinite_both_axes__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_percent_gap_indefinite_both_axes__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_percent_gap_indefinite_both_axes__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_percent_gap_indefinite_both_axes__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_percent_gap_indefinite_both_axes__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_percent_gap_indefinite_both_axes__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_percent_gap_indefinite_both_axes__content_box_rtl");
     }
 
     #[cfg(feature = "grid")]


### PR DESCRIPTION
# Objective

Fix CSS Grid percentage / `calc()` gap resolution when the percentage basis is initially indefinite, matching Chrome. Fixes the following Blitz WPT failures (all horizontal-tb):

- `css/css-grid/alignment/grid-gutters-009.html`
- `css/css-grid/alignment/grid-gutters-010.html`
- `css/css-grid/alignment/grid-gutters-014.html`
- `css/css-grid/alignment/grid-gutters-015.html`

Behavior implemented: during intrinsic (min/max-content) sizing, a percentage gap against an indefinite basis contributes zero (so `calc()` gaps resolve their percentage part against a basis of zero); once the container's content-box size in an axis is resolved, gaps re-resolve against that final size and track positions account for them.

## Context

Two changes:

1. `track_sizing.rs` / `initialize_track_sizes`: gutter tracks now use a percentage basis of `axis_inner_node_size.or(Some(0.0))` instead of the raw (possibly `None`) inner node size, so a percentage gap initializes to `0` rather than staying unresolved, and a `calc(20px + 5%)` gap initializes to `20px`.

2. `mod.rs` / `compute_grid_layout`: the "re-resolve percentages against resolved content-box size and rerun track sizing" pass (which already existed for percentage *tracks*) is now keyed off whether the node's own inner size was indefinite *before* it gets overwritten with content-based sizes (`inner_node_width_indefinite` / `inner_node_height_indefinite`), rather than off `available_space`/`available_grid_space` definiteness. This makes the rerun trigger correctly for e.g. a grid with `width: 200px` inside a definite available space but with an indefinite height (the row-gap case), and gutters participate since `GridTrack::uses_percentage()` covers percent and calc values.

Test fixtures (generated via gentest with Chrome as oracle) and their corresponding WPT tests:

| Fixture | WPT test |
| --- | --- |
| `test_fixtures/grid/grid_percent_gap_definite_width_indefinite_height.html` | grid-gutters-009 / 010 (first grid: `width: 200px; gap: 10%`) |
| `test_fixtures/blockgrid/blockgrid_grid_percent_gap_definite_width_indefinite_height.html` | grid-gutters-009 / 010 (same, inside a block container) |
| `test_fixtures/grid/grid_percent_gap_indefinite_both_axes.html` | grid-gutters-015 (`inline-grid; padding: 10px; 40px tracks; gap: 20%`) |
| `test_fixtures/blockgrid/blockgrid_grid_percent_gap_fit_content_width.html` | grid-gutters-014 (fit-content/float sizing with `gap: 15% 10%`) |

The `calc()` gap cases (second grids of grid-gutters-009/010, `inline-grid; width: auto; gap: calc(20px + 5%)`) are covered by hand-written tests in `tests/hand_written/calc_gap.rs` rather than gentest fixtures, because the gentest/XML-test pipeline has no representation for `calc()` values and `TaffyTree`'s calc resolver always returns zero — the tests use a small custom tree that implements `resolve_calc_value`. Expected geometry matches the WPT reference (`grid-percentage-gap-ref.html`): container 200×200 with items offset by 120px.

`cargo test --workspace`, `cargo fmt` and `cargo clippy --workspace` are green; regenerating all gentests produced no changes to existing expectations.

## Feedback wanted

Whether keying the percentage re-resolution/rerun passes off the node's original inner-size definiteness (instead of `available_space` definiteness) is the preferred condition — it seems strictly more correct (a `width: 200px` grid in a definite available space previously skipped row re-resolution), and no existing generated expectations changed.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/b0b31a9d2f65480aa49c36622f025885
Requested by: @nicoburns