### PR TITLE
Fix nested flex/grid baseline selection, synthesized baselines, and grid-order baseline selection

### DIFF
--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -543,7 +543,10 @@ fn compute_preliminary(tree: &mut impl LayoutFlexboxContainer, node: NodeId, inp
     let last_line = if constants.is_wrap_reverse { flex_lines.first() } else { flex_lines.last() };
     let last_vertical_baseline = last_line.and_then(|line| {
         if constants.is_column {
-            line.items.last().map(|child| child.last_baseline)
+            // For column containers the last baseline is generated from the endmost item in the
+            // line, which for reverse-direction containers is the first item in flex order.
+            let item = if constants.dir.is_reverse() { line.items.first() } else { line.items.last() };
+            item.map(|child| child.last_baseline)
         } else {
             // Prefer the first item in the line participating in last-baseline alignment, then the
             // first item participating in any baseline alignment, then the line's last item.

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -519,6 +519,8 @@ fn compute_preliminary(tree: &mut impl LayoutFlexboxContainer, node: NodeId, inp
     // line's visual position: for wrap-reverse containers the cross axis is flipped, so the
     // startmost line is the last line in flex-line order rather than the first.
     let first_line = if constants.is_wrap_reverse { flex_lines.last() } else { flex_lines.first() };
+    // Prefer the first item in the line participating in first-baseline alignment, then the first
+    // item participating in any baseline alignment, then the line's first item.
     let first_vertical_baseline = first_line.and_then(|line| {
         if constants.is_column {
             // For column containers the baseline is generated from the startmost item in the line,
@@ -529,7 +531,8 @@ fn compute_preliminary(tree: &mut impl LayoutFlexboxContainer, node: NodeId, inp
             line.items
                 .iter()
                 .find(|item| item.participates_in_baseline_alignment(constants.dir))
-                .or_else(|| line.items.iter().next())
+                .or_else(|| line.items.iter().find(|item| item.participates_in_last_baseline_alignment(constants.dir)))
+                .or_else(|| line.items.first())
                 .map(|child| child.baseline)
         }
     });
@@ -542,9 +545,12 @@ fn compute_preliminary(tree: &mut impl LayoutFlexboxContainer, node: NodeId, inp
         if constants.is_column {
             line.items.last().map(|child| child.last_baseline)
         } else {
+            // Prefer the first item in the line participating in last-baseline alignment, then the
+            // first item participating in any baseline alignment, then the line's last item.
             line.items
                 .iter()
                 .find(|item| item.participates_in_last_baseline_alignment(constants.dir))
+                .or_else(|| line.items.iter().find(|item| item.participates_in_baseline_alignment(constants.dir)))
                 .or_else(|| line.items.last())
                 .map(|child| child.last_baseline)
         }

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -834,9 +834,8 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
     // "Grid order" key: row-major order of the grid areas items occupy, with ties resolved by
     // document order (`items` is sorted by document order at this point, and `min_by_key` returns
     // the first of equally-minimum elements, so ties fall back to document order for free)
-    // (column indexes are visually reversed for RTL, so negate them to recover logical column order)
-    let column_dir_factor: i32 = if direction.is_rtl() { -1 } else { 1 };
-    let column_order_key = |item: &&GridItem| column_dir_factor * item.column_indexes.start as i32;
+    // (column indexes are stored in logical order, including for RTL)
+    let column_order_key = |item: &&GridItem| item.column_indexes.start;
 
     // Determine the grid container's first baseline, generated from the first row containing items.
     // Layout containment suppresses the box's baseline for baseline-alignment purposes

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -831,30 +831,31 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
         return LayoutOutput::from_outer_size(container_border_box);
     }
 
+    // "Grid order" key: row-major order of the grid areas items occupy, with ties resolved by
+    // document order (`items` is sorted by document order at this point, and `min_by_key` returns
+    // the first of equally-minimum elements, so ties fall back to document order for free)
+    // (column indexes are visually reversed for RTL, so negate them to recover logical column order)
+    let column_dir_factor: i32 = if direction.is_rtl() { -1 } else { 1 };
+    let column_order_key = |item: &&GridItem| column_dir_factor * item.column_indexes.start as i32;
+
     // Determine the grid container's first baseline, generated from the first row containing items.
     // Layout containment suppresses the box's baseline for baseline-alignment purposes
     let grid_container_baseline: Option<f32> = if contain.suppresses_baseline() {
         None
     } else {
-        // Sort items into "grid order" (row-major order of the grid areas they occupy, with ties
-        // resolved by document order, which the items are already sorted by at this point)
-        // (column indexes are visually reversed for RTL, so negate them to recover logical column order)
-        let column_dir_factor: i32 = if direction.is_rtl() { -1 } else { 1 };
-        items.sort_by_key(|item| (item.row_indexes.start, column_dir_factor * item.column_indexes.start as i32));
-
         // Get the row index of the first row containing items
-        let first_row = items[0].row_indexes.start;
+        let first_row = items.iter().map(|item| item.row_indexes.start).min().unwrap();
+        let first_row_items = items.iter().filter(|item| item.row_indexes.start == first_row);
 
-        // Create a slice of all of the items start in this row (taking advantage of the fact that we have just sorted the array)
-        let first_row_items = &items[0..].split(|item| item.row_indexes.start != first_row).next().unwrap();
-
-        // Prefer the first item in *this row* which participates in first-baseline alignment
-        // (items with an auto block-axis margin do not participate: https://www.w3.org/TR/css-align-3/#baseline-align-self),
-        // falling back to the row's first item
+        // Prefer the first item (in grid order) in *this row* which participates in
+        // first-baseline alignment (items with an auto block-axis margin do not participate:
+        // https://www.w3.org/TR/css-align-3/#baseline-align-self), falling back to the row's first item
         let item = first_row_items
-            .iter()
-            .find(|item| item.participates_in_baseline_group(AlignItemsKeyword::Baseline))
-            .unwrap_or(&first_row_items[0]);
+            .clone()
+            .filter(|item| item.participates_in_baseline_group(AlignItemsKeyword::Baseline))
+            .min_by_key(column_order_key)
+            .or_else(|| first_row_items.min_by_key(column_order_key))
+            .unwrap();
 
         Some(item.y_position + item.baseline.unwrap_or(item.height))
     };
@@ -868,14 +869,17 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
     } else {
         // Get the row end index of the last row containing items
         let last_row_end = items.iter().map(|item| item.row_indexes.end).max().unwrap();
+        let last_row_items = items.iter().filter(|item| item.row_indexes.end == last_row_end);
 
         // Prefer the first item (in grid order) ending in this row which participates in
         // last-baseline alignment, falling back to the first item ending in this row
-        let mut last_row_items = items.iter().filter(|item| item.row_indexes.end == last_row_end);
-        let first_item = last_row_items.clone().next().unwrap();
         let item = last_row_items
-            .find(|item| item.align_self.keyword == AlignItemsKeyword::LastBaseline)
-            .unwrap_or(first_item);
+            .clone()
+            .filter(|item| item.align_self.keyword == AlignItemsKeyword::LastBaseline)
+            .min_by_key(column_order_key)
+            .or_else(|| last_row_items.min_by_key(column_order_key))
+            .unwrap();
+
         Some(item.y_position + item.last_baseline.unwrap_or(item.height))
     };
 

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -19,14 +19,14 @@ use placement::place_grid_items;
 use track_sizing::{
     determine_if_item_crosses_flexible_or_intrinsic_tracks, resolve_item_track_indexes, track_sizing_algorithm,
 };
-use types::{CellOccupancyMatrix, GridTrack, NamedLineResolver};
+use types::{CellOccupancyMatrix, GridItem, GridTrack, NamedLineResolver};
 
 #[cfg(feature = "detailed_layout_info")]
 use crate::sys::{DefaultCheapStr, String};
 #[cfg(feature = "detailed_layout_info")]
 use crate::{CheapCloneStr, GridPlacement, OriginZeroGridPlacement};
 #[cfg(feature = "detailed_layout_info")]
-use types::{GridItem, GridTrackKind, TrackCounts};
+use types::{GridTrackKind, TrackCounts};
 
 pub(crate) use types::{GridCoordinate, GridLine, OriginZeroLine, MAX_GRID_TRACKS, MAX_OZ_LINE, MIN_OZ_LINE};
 

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -342,7 +342,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
         &mut columns,
         &mut items,
         |track: &GridTrack, _, _| Some(track.base_size),
-        false, // TODO: Support baseline alignment in the vertical axis
+        has_baseline_aligned_item,
     );
     let initial_row_sum = rows.iter().map(|track| track.base_size).sum::<f32>();
     inner_node_size.height = inner_node_size.height.or_else(|| initial_row_sum.into());
@@ -528,7 +528,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
                 &mut columns,
                 &mut items,
                 |track: &GridTrack, _, _| Some(track.base_size),
-                false, // TODO: Support baseline alignment in the vertical axis
+                has_baseline_aligned_item,
             );
         }
     }
@@ -638,6 +638,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
         );
         item.y_position = y_position;
         item.height = height;
+        item.baseline = baselines.first;
         item.last_baseline = baselines.last;
 
         #[cfg(feature = "content_size")]
@@ -835,8 +836,11 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
     let grid_container_baseline: Option<f32> = if contain.suppresses_baseline() {
         None
     } else {
-        // Sort items by row start position so that we can iterate items in groups which are in the same row
-        items.sort_by_key(|item| item.row_indexes.start);
+        // Sort items into "grid order" (row-major order of the grid areas they occupy, with ties
+        // resolved by document order, which the items are already sorted by at this point)
+        // (column indexes are visually reversed for RTL, so negate them to recover logical column order)
+        let column_dir_factor: i32 = if direction.is_rtl() { -1 } else { 1 };
+        items.sort_by_key(|item| (item.row_indexes.start, column_dir_factor * item.column_indexes.start as i32));
 
         // Get the row index of the first row containing items
         let first_row = items[0].row_indexes.start;
@@ -859,10 +863,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
     let grid_container_last_baseline: Option<f32> = if contain.suppresses_baseline() {
         None
     } else {
-        // Sort items by row start position so that we can iterate items in groups which are in the same row
-        items.sort_by_key(|item| item.row_indexes.start);
-
-        // Get the row index of the last row containing items
+        // Get the row index of the last row containing items (items are sorted by row start position above)
         let last_row = items[items.len() - 1].row_indexes.start;
 
         // Create a slice of all of the items that start in this row (taking advantage of the fact that the array is sorted)

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -875,7 +875,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
         // last-baseline alignment, falling back to the first item ending in this row
         let item = last_row_items
             .clone()
-            .filter(|item| item.align_self.keyword == AlignItemsKeyword::LastBaseline)
+            .filter(|item| item.participates_in_baseline_group(AlignItemsKeyword::LastBaseline))
             .min_by_key(column_order_key)
             .or_else(|| last_row_items.min_by_key(column_order_key))
             .unwrap();

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -859,22 +859,23 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
         Some(item.y_position + item.baseline.unwrap_or(item.height))
     };
 
-    // Determine the grid container's last baseline, generated from the last row containing items
+    // Determine the grid container's last baseline, generated from the last row containing items.
+    // Items participate in the last row's baseline-sharing group if their grid area *ends* in that
+    // row, so the last row is the one with the maximum row end index and membership is determined
+    // by row end rather than row start.
     let grid_container_last_baseline: Option<f32> = if contain.suppresses_baseline() {
         None
     } else {
-        // Get the row index of the last row containing items (items are sorted by row start position above)
-        let last_row = items[items.len() - 1].row_indexes.start;
+        // Get the row end index of the last row containing items
+        let last_row_end = items.iter().map(|item| item.row_indexes.end).max().unwrap();
 
-        // Create a slice of all of the items that start in this row (taking advantage of the fact that the array is sorted)
-        let last_row_items = &items[0..].rsplit(|item| item.row_indexes.start != last_row).next().unwrap();
-
-        // Prefer the first item in *this row* which participates in last-baseline alignment,
-        // falling back to the row's first item
+        // Prefer the first item (in grid order) ending in this row which participates in
+        // last-baseline alignment, falling back to the first item ending in this row
+        let mut last_row_items = items.iter().filter(|item| item.row_indexes.end == last_row_end);
+        let first_item = last_row_items.clone().next().unwrap();
         let item = last_row_items
-            .iter()
             .find(|item| item.align_self.keyword == AlignItemsKeyword::LastBaseline)
-            .unwrap_or(&last_row_items[0]);
+            .unwrap_or(first_item);
         Some(item.y_position + item.last_baseline.unwrap_or(item.height))
     };
 

--- a/src/compute/grid/track_sizing.rs
+++ b/src/compute/grid/track_sizing.rs
@@ -477,6 +477,12 @@ fn resolve_item_baselines_for_group(
     columns: &[GridTrack],
     group_keyword: AlignItemsKeyword,
 ) {
+    // If fewer than two items participate in this kind of baseline alignment then no row can
+    // contain a multi-item baseline-sharing group, so skip sorting and grouping entirely
+    if items.iter().filter(|item| item.align_self.keyword == group_keyword).count() <= 1 {
+        return;
+    }
+
     let is_first_baseline = group_keyword == AlignItemsKeyword::Baseline;
 
     // The grid row line at which an item participates in baseline alignment: the start of its

--- a/src/compute/grid/track_sizing.rs
+++ b/src/compute/grid/track_sizing.rs
@@ -462,25 +462,51 @@ fn resolve_item_baselines(
     inner_node_size: Size<Option<f32>>,
     columns: &[GridTrack],
 ) {
-    // Sort items by row start position so that we can iterate items in groups which are in the same row
-    let other_axis = AbstractAxis::Block;
-    items.sort_by_key(|item| item.placement(other_axis).start);
+    // First-baseline aligned items participate in the baseline-sharing group of their start-most
+    // row, while last-baseline aligned items participate in that of their end-most row.
+    // See https://www.w3.org/TR/css-align-3/#baseline-sharing-group
+    resolve_item_baselines_for_group(tree, items, inner_node_size, columns, AlignItemsKeyword::Baseline);
+    resolve_item_baselines_for_group(tree, items, inner_node_size, columns, AlignItemsKeyword::LastBaseline);
+}
+
+/// Resolve baselines and shims for either the first-baseline or last-baseline alignment group.
+fn resolve_item_baselines_for_group(
+    tree: &mut impl LayoutPartialTree,
+    items: &mut [GridItem],
+    inner_node_size: Size<Option<f32>>,
+    columns: &[GridTrack],
+    group_keyword: AlignItemsKeyword,
+) {
+    let is_first_baseline = group_keyword == AlignItemsKeyword::Baseline;
+
+    // The grid row line at which an item participates in baseline alignment: the start of its
+    // start-most row for first-baseline alignment, the end of its end-most row for last-baseline
+    let participation_line = |item: &GridItem| {
+        let placement = item.placement(AbstractAxis::Block);
+        if is_first_baseline {
+            placement.start
+        } else {
+            placement.end
+        }
+    };
+
+    // Sort items by their participation line so that we can iterate items in groups which share a row edge
+    items.sort_by_key(participation_line);
 
     // Iterate over grid rows
     let mut remaining_items = &mut items[0..];
     while !remaining_items.is_empty() {
-        // Get the row index of the current row
-        let current_row = remaining_items[0].placement(other_axis).start;
+        // Get the row line of the current group
+        let current_line = participation_line(&remaining_items[0]);
 
-        // Find the item index of the first item that is in a different row (or None if we've reached the end of the list)
-        let next_row_first_item =
-            remaining_items.iter().position(|item| item.placement(other_axis).start != current_row);
+        // Find the item index of the first item that is in a different group (or None if we've reached the end of the list)
+        let next_group_first_item = remaining_items.iter().position(|item| participation_line(item) != current_line);
 
         // Use this index to split the `remaining_items` slice in two slices:
-        //    - A `row_items` slice containing the items (that start) in the current row
+        //    - A `row_items` slice containing the items that participate at the current row line
         //    - A new `remaining_items` consisting of the remainder of the `remaining_items` slice
-        //      that hasn't been split off into `row_items
-        let row_items = if let Some(index) = next_row_first_item {
+        //      that hasn't been split off into `row_items`
+        let row_items = if let Some(index) = next_group_first_item {
             let (row_items, tail) = remaining_items.split_at_mut(index);
             remaining_items = tail;
             row_items
@@ -490,27 +516,19 @@ fn resolve_item_baselines(
             row_items
         };
 
-        // Count how many items in *this row* participate in each baseline alignment group
+        // Count how many items in *this row* participate in the baseline alignment group
         // (items with an auto block-axis margin do not participate).
-        // If a group has one or zero items then baseline alignment is a no-op for those items
-        // and we skip further computations for that group
-        let row_first_baseline_item_count =
-            row_items.iter().filter(|item| item.participates_in_baseline_group(AlignItemsKeyword::Baseline)).count();
-        let row_last_baseline_item_count = row_items
-            .iter()
-            .filter(|item| item.participates_in_baseline_group(AlignItemsKeyword::LastBaseline))
-            .count();
-        if row_first_baseline_item_count <= 1 && row_last_baseline_item_count <= 1 {
+        // If the group has one or zero items then baseline alignment is a no-op for those items
+        // and we skip further computations for the group
+        let baseline_item_count =
+            row_items.iter().filter(|item| item.participates_in_baseline_group(group_keyword)).count();
+        if baseline_item_count <= 1 {
             continue;
         }
 
-        // Compute the baselines of all items in the row participating in baseline alignment
+        // Compute the baselines of all items in the group
         for item in row_items.iter_mut() {
-            let is_first_baseline = item.participates_in_baseline_group(AlignItemsKeyword::Baseline);
-            let is_last_baseline = item.participates_in_baseline_group(AlignItemsKeyword::LastBaseline);
-            let should_measure = (is_first_baseline && row_first_baseline_item_count > 1)
-                || (is_last_baseline && row_last_baseline_item_count > 1);
-            if !should_measure {
+            if !item.participates_in_baseline_group(group_keyword) {
                 continue;
             }
 
@@ -560,8 +578,8 @@ fn resolve_item_baselines(
             }
         }
 
-        // Compute the max first-baseline ascent and shim each item in the first-baseline group
-        if row_first_baseline_item_count > 1 {
+        if is_first_baseline {
+            // Compute the max first-baseline ascent and shim each item in the first-baseline group
             let row_max_baseline = row_items
                 .iter()
                 .filter(|item| item.participates_in_baseline_group(AlignItemsKeyword::Baseline))
@@ -573,10 +591,8 @@ fn resolve_item_baselines(
             {
                 item.baseline_shims.start = row_max_baseline - item.baseline.unwrap_or(0.0);
             }
-        }
-
-        // Compute the max last-baseline descent and shim each item in the last-baseline group
-        if row_last_baseline_item_count > 1 {
+        } else {
+            // Compute the max last-baseline descent and shim each item in the last-baseline group
             let row_max_descent = row_items
                 .iter()
                 .filter(|item| item.participates_in_baseline_group(AlignItemsKeyword::LastBaseline))

--- a/src/compute/grid/track_sizing.rs
+++ b/src/compute/grid/track_sizing.rs
@@ -3,7 +3,6 @@
 use super::types::{GridItem, GridTrack, TrackCounts};
 use crate::geometry::{AbstractAxis, Line, Size};
 use crate::style::{AlignContent, AlignContentKeyword, AlignItemsKeyword, AvailableSpace};
-use crate::style_helpers::TaffyMinContent;
 use crate::tree::{LayoutPartialTree, LayoutPartialTreeExt, SizingMode};
 use crate::util::sys::{f32_max, f32_min, Vec};
 use crate::util::{MaybeMath, ResolveOrZero};
@@ -291,8 +290,10 @@ pub(super) fn track_sizing_algorithm<Tree: LayoutPartialTree>(
     initialize_track_sizes(tree, axis_tracks, percentage_basis);
 
     // 11.5.1 Shim item baselines
-    if has_baseline_aligned_item {
-        resolve_item_baselines(tree, axis, items, inner_node_size);
+    // Baseline shims apply in the block axis, and are resolved once the inline axis (column) tracks
+    // have been sized so that percentage-sized and aspect-ratio-dependent items measure correctly.
+    if has_baseline_aligned_item && axis == AbstractAxis::Block {
+        resolve_item_baselines(tree, items, inner_node_size, other_axis_tracks);
     }
 
     // If all tracks have a fixed min track sizing function and base_size = growth_limit,
@@ -457,13 +458,12 @@ fn initialize_track_sizes(
 /// 11.5.1 Shim baseline-aligned items so their intrinsic size contributions reflect their baseline alignment.
 fn resolve_item_baselines(
     tree: &mut impl LayoutPartialTree,
-    axis: AbstractAxis,
     items: &mut [GridItem],
     inner_node_size: Size<Option<f32>>,
+    columns: &[GridTrack],
 ) {
-    // Sort items by track in the other axis (row) start position so that we can iterate items in groups which
-    // are in the same track in the other axis (row)
-    let other_axis = axis.other();
+    // Sort items by row start position so that we can iterate items in groups which are in the same row
+    let other_axis = AbstractAxis::Block;
     items.sort_by_key(|item| item.placement(other_axis).start);
 
     // Iterate over grid rows
@@ -514,11 +514,18 @@ fn resolve_item_baselines(
                 continue;
             }
 
+            // Measure the item using its grid area width (including any spanned gutters) as the
+            // containing block width so that percentage sizes and aspect ratios resolve correctly
+            let grid_area_width: f32 =
+                item.track_range_excluding_lines(AbstractAxis::Inline).map(|index| columns[index].base_size).sum();
+            let grid_area_size = Size { width: Some(grid_area_width), height: None };
+            let known_dimensions = item.known_dimensions(tree, grid_area_size);
+
             let measured_size_and_baselines = tree.perform_child_layout(
                 item.node,
-                Size::NONE,
-                inner_node_size,
-                Size::MIN_CONTENT,
+                known_dimensions,
+                grid_area_size,
+                Size { width: AvailableSpace::Definite(grid_area_width), height: AvailableSpace::MinContent },
                 SizingMode::InherentSize,
                 Line::FALSE,
             );

--- a/src/compute/grid/types/grid_item.rs
+++ b/src/compute/grid/types/grid_item.rs
@@ -274,7 +274,7 @@ impl GridItem {
     /// Compute the known_dimensions to be passed to the child sizing functions
     /// The key thing that is being done here is applying stretch alignment, which is necessary to
     /// allow percentage sizes further down the tree to resolve properly in some cases
-    fn known_dimensions(
+    pub(in crate::compute::grid) fn known_dimensions(
         &self,
         tree: &mut impl LayoutPartialTree,
         grid_area_size: Size<Option<f32>>,

--- a/test_fixtures/flex/align_baseline_nested_flex_wrap_first_baseline_items.html
+++ b/test_fixtures/flex/align_baseline_nested_flex_wrap_first_baseline_items.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="align-items: baseline; width: 200px;">
+  <div style="width: 20px; height: 45px;"></div>
+  <div style="flex-wrap: wrap; width: 140px; gap: 10px;">
+    <div style="width: 40px; height: 10px;"></div>
+    <div style="width: 40px; height: 30px; margin: 10px 0; align-self: baseline;"></div>
+    <div style="width: 40px; height: 50px;"></div>
+    <div style="width: 40px; height: 60px;"></div>
+    <div style="width: 40px; height: 40px; margin: 10px 0; align-self: baseline;"></div>
+    <div style="width: 40px; height: 20px;"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/test_fixtures/flex/align_baseline_nested_flex_wrap_last_baseline_items.html
+++ b/test_fixtures/flex/align_baseline_nested_flex_wrap_last_baseline_items.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="align-items: baseline; width: 200px;">
+  <div style="width: 20px; height: 45px;"></div>
+  <div style="flex-wrap: wrap; width: 140px; gap: 10px;">
+    <div style="width: 40px; height: 10px;"></div>
+    <div style="width: 40px; height: 30px; margin: 10px 0; align-self: last baseline;"></div>
+    <div style="width: 40px; height: 50px;"></div>
+    <div style="width: 40px; height: 60px;"></div>
+    <div style="width: 40px; height: 40px; margin: 10px 0; align-self: last baseline;"></div>
+    <div style="width: 40px; height: 20px;"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/test_fixtures/flex/align_baseline_nested_flex_wrap_mixed_baseline_items.html
+++ b/test_fixtures/flex/align_baseline_nested_flex_wrap_mixed_baseline_items.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="align-items: baseline; width: 200px;">
+  <div style="width: 20px; height: 45px;"></div>
+  <div style="flex-wrap: wrap; width: 140px; gap: 10px;">
+    <div style="width: 40px; height: 30px; margin: 5px 0; align-self: last baseline;"></div>
+    <div style="width: 40px; height: 20px; margin: 10px 0; align-self: baseline;"></div>
+    <div style="width: 40px; height: 50px;"></div>
+    <div style="width: 40px; height: 60px;"></div>
+    <div style="width: 40px; height: 40px;"></div>
+    <div style="width: 40px; height: 20px;"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/test_fixtures/flex/align_baseline_nested_flex_wrap_reverse_first_baseline_items.html
+++ b/test_fixtures/flex/align_baseline_nested_flex_wrap_reverse_first_baseline_items.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="align-items: baseline; width: 200px;">
+  <div style="width: 20px; height: 45px;"></div>
+  <div style="flex-wrap: wrap-reverse; width: 140px; gap: 10px;">
+    <div style="width: 40px; height: 10px;"></div>
+    <div style="width: 40px; height: 30px; margin: 10px 0; align-self: baseline;"></div>
+    <div style="width: 40px; height: 50px;"></div>
+    <div style="width: 40px; height: 60px;"></div>
+    <div style="width: 40px; height: 40px; margin: 10px 0; align-self: baseline;"></div>
+    <div style="width: 40px; height: 20px;"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/test_fixtures/flex/align_baseline_nested_flex_wrap_reverse_last_baseline_items.html
+++ b/test_fixtures/flex/align_baseline_nested_flex_wrap_reverse_last_baseline_items.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="align-items: baseline; width: 200px;">
+  <div style="width: 20px; height: 45px;"></div>
+  <div style="flex-wrap: wrap-reverse; width: 140px; gap: 10px;">
+    <div style="width: 40px; height: 10px;"></div>
+    <div style="width: 40px; height: 30px; margin: 10px 0; align-self: last baseline;"></div>
+    <div style="width: 40px; height: 50px;"></div>
+    <div style="width: 40px; height: 60px;"></div>
+    <div style="width: 40px; height: 40px; margin: 10px 0; align-self: last baseline;"></div>
+    <div style="width: 40px; height: 20px;"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/test_fixtures/flex/align_last_baseline_nested_flex_wrap_first_baseline_items.html
+++ b/test_fixtures/flex/align_last_baseline_nested_flex_wrap_first_baseline_items.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="align-items: last baseline; width: 200px;">
+  <div style="width: 20px; height: 45px;"></div>
+  <div style="flex-wrap: wrap; width: 140px; gap: 10px;">
+    <div style="width: 40px; height: 10px;"></div>
+    <div style="width: 40px; height: 30px; margin: 10px 0; align-self: baseline;"></div>
+    <div style="width: 40px; height: 50px;"></div>
+    <div style="width: 40px; height: 60px;"></div>
+    <div style="width: 40px; height: 40px; margin: 10px 0; align-self: baseline;"></div>
+    <div style="width: 40px; height: 20px;"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/test_fixtures/flex/align_last_baseline_nested_flex_wrap_last_baseline_items.html
+++ b/test_fixtures/flex/align_last_baseline_nested_flex_wrap_last_baseline_items.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="align-items: last baseline; width: 200px;">
+  <div style="width: 20px; height: 45px;"></div>
+  <div style="flex-wrap: wrap; width: 140px; gap: 10px;">
+    <div style="width: 40px; height: 10px;"></div>
+    <div style="width: 40px; height: 30px; margin: 10px 0; align-self: last baseline;"></div>
+    <div style="width: 40px; height: 50px;"></div>
+    <div style="width: 40px; height: 60px;"></div>
+    <div style="width: 40px; height: 40px; margin: 10px 0; align-self: last baseline;"></div>
+    <div style="width: 40px; height: 20px;"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/test_fixtures/flex/align_last_baseline_nested_flex_wrap_mixed_baseline_items.html
+++ b/test_fixtures/flex/align_last_baseline_nested_flex_wrap_mixed_baseline_items.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="align-items: last baseline; width: 200px;">
+  <div style="width: 20px; height: 45px;"></div>
+  <div style="flex-wrap: wrap; width: 140px; gap: 10px;">
+    <div style="width: 40px; height: 30px;"></div>
+    <div style="width: 40px; height: 20px;"></div>
+    <div style="width: 40px; height: 50px;"></div>
+    <div style="width: 40px; height: 60px; margin: 5px 0; align-self: baseline;"></div>
+    <div style="width: 40px; height: 40px; margin: 10px 0; align-self: last baseline;"></div>
+    <div style="width: 40px; height: 20px;"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/test_fixtures/flex/align_last_baseline_nested_flex_wrap_reverse_first_baseline_items.html
+++ b/test_fixtures/flex/align_last_baseline_nested_flex_wrap_reverse_first_baseline_items.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="align-items: last baseline; width: 200px;">
+  <div style="width: 20px; height: 45px;"></div>
+  <div style="flex-wrap: wrap-reverse; width: 140px; gap: 10px;">
+    <div style="width: 40px; height: 10px;"></div>
+    <div style="width: 40px; height: 30px; margin: 10px 0; align-self: baseline;"></div>
+    <div style="width: 40px; height: 50px;"></div>
+    <div style="width: 40px; height: 60px;"></div>
+    <div style="width: 40px; height: 40px; margin: 10px 0; align-self: baseline;"></div>
+    <div style="width: 40px; height: 20px;"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/test_fixtures/flex/align_last_baseline_nested_flex_wrap_reverse_last_baseline_items.html
+++ b/test_fixtures/flex/align_last_baseline_nested_flex_wrap_reverse_last_baseline_items.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="align-items: last baseline; width: 200px;">
+  <div style="width: 20px; height: 45px;"></div>
+  <div style="flex-wrap: wrap-reverse; width: 140px; gap: 10px;">
+    <div style="width: 40px; height: 10px;"></div>
+    <div style="width: 40px; height: 30px; margin: 10px 0; align-self: last baseline;"></div>
+    <div style="width: 40px; height: 50px;"></div>
+    <div style="width: 40px; height: 60px;"></div>
+    <div style="width: 40px; height: 40px; margin: 10px 0; align-self: last baseline;"></div>
+    <div style="width: 40px; height: 20px;"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/test_fixtures/grid/grid_align_baseline_double_nested_grid.html
+++ b/test_fixtures/grid/grid_align_baseline_double_nested_grid.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-columns: 60px 100px; align-items: baseline; width: 200px;">
+  <div style="height: 45px;"></div>
+  <div style="display: grid; align-items: baseline; border-top: 10px solid red; border-bottom: 40px solid red; padding-bottom: 20px;">
+    <div style="display: grid; align-items: baseline;">
+      <div style="width: 40px; height: 10px;"></div>
+      <div style="grid-row: 2; width: 40px; height: 25px;"></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/test_fixtures/grid/grid_align_baseline_spanned_nested_grid.html
+++ b/test_fixtures/grid/grid_align_baseline_spanned_nested_grid.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-rows: 20px auto auto auto 30px; grid-template-columns: 30px auto; align-items: baseline; width: 200px;">
+  <div style="grid-row: 2; grid-column: 1; width: 30px; height: 60px;"></div>
+  <div style="grid-row: 2 / span 2; grid-column: 2; display: grid; align-items: baseline; border-top: 10px solid red; border-bottom: 40px solid red; padding-bottom: 20px;">
+    <div style="width: 40px; height: 35px;"></div>
+    <div style="grid-row: 2; width: 40px; height: 10px;"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/test_fixtures/grid/grid_align_baseline_spanned_nested_grid_spanned_item.html
+++ b/test_fixtures/grid/grid_align_baseline_spanned_nested_grid_spanned_item.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-rows: 20px auto auto auto 30px; grid-template-columns: 30px auto; align-items: baseline; width: 200px;">
+  <div style="grid-row: 2; grid-column: 1; width: 30px; height: 60px;"></div>
+  <div style="grid-row: 2 / span 2; grid-column: 2; display: grid; align-items: baseline; border-top: 10px solid red; border-bottom: 40px solid red; padding-bottom: 20px;">
+    <div style="grid-row: 1 / span 3; width: 40px; height: 35px;"></div>
+    <div style="grid-row: 4; width: 40px; height: 10px;"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/test_fixtures/grid/grid_align_items_baseline_synthesized_and_natural.html
+++ b/test_fixtures/grid/grid_align_items_baseline_synthesized_and_natural.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-columns: 60px 60px 60px; align-items: baseline; width: 200px;">
+  <div style="height: 40px;">
+    <div style="width: 20px; height: 10px;"></div>
+  </div>
+  <div style="height: 40px;"></div>
+  <div style="height: 25px;"></div>
+</div>
+</body>
+</html>

--- a/test_fixtures/grid/grid_align_items_baseline_synthesized_margins.html
+++ b/test_fixtures/grid/grid_align_items_baseline_synthesized_margins.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-columns: 50px 50px 50px; align-items: baseline; width: 200px;">
+  <div style="height: 20px; margin: 40px 0;"></div>
+  <div style="height: 20px; margin: 0;"></div>
+  <div style="height: 20px; margin: 20px 0;"></div>
+</div>
+</body>
+</html>

--- a/test_fixtures/grid/grid_align_last_baseline_double_nested_grid.html
+++ b/test_fixtures/grid/grid_align_last_baseline_double_nested_grid.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-columns: 60px 100px; align-items: last baseline; width: 200px;">
+  <div style="height: 45px;"></div>
+  <div style="display: grid; align-items: last baseline; border-top: 10px solid red; border-bottom: 40px solid red; padding-bottom: 20px;">
+    <div style="display: grid; align-items: last baseline;">
+      <div style="width: 40px; height: 10px;"></div>
+      <div style="grid-row: 2; width: 40px; height: 25px;"></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/test_fixtures/grid/grid_align_last_baseline_spanned_nested_grid.html
+++ b/test_fixtures/grid/grid_align_last_baseline_spanned_nested_grid.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-rows: 20px auto auto auto 30px; grid-template-columns: 30px auto; align-items: last baseline; width: 200px;">
+  <div style="grid-row: 3; grid-column: 1; width: 30px; height: 60px;"></div>
+  <div style="grid-row: 2 / span 2; grid-column: 2; display: grid; align-items: last baseline; border-top: 10px solid red; border-bottom: 40px solid red; padding-bottom: 20px;">
+    <div style="width: 40px; height: 10px;"></div>
+    <div style="grid-row: 2; width: 40px; height: 35px;"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/test_fixtures/grid/grid_align_last_baseline_spanned_nested_grid_spanned_item.html
+++ b/test_fixtures/grid/grid_align_last_baseline_spanned_nested_grid_spanned_item.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-rows: 20px auto auto auto 30px; grid-template-columns: 30px auto; align-items: last baseline; width: 200px;">
+  <div style="grid-row: 3; grid-column: 1; width: 30px; height: 60px;"></div>
+  <div style="grid-row: 2 / span 2; grid-column: 2; display: grid; align-items: last baseline; border-top: 10px solid red; border-bottom: 40px solid red; padding-bottom: 20px;">
+    <div style="width: 40px; height: 10px;"></div>
+    <div style="grid-row: 2 / span 3; width: 40px; height: 35px;"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/test_fixtures/grid/grid_align_self_baseline_aspect_ratio_percent_tracks.html
+++ b/test_fixtures/grid/grid_align_self_baseline_aspect_ratio_percent_tracks.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-columns: 25% 25% 25% 25%; width: 400px;">
+  <div style="aspect-ratio: 2 / 1; width: 100%; align-self: baseline;"></div>
+  <div style="aspect-ratio: 1 / 1; width: 100%; align-self: baseline;"></div>
+  <div style="aspect-ratio: 4 / 1; width: 100%; align-self: baseline;"></div>
+  <div style="height: 120px;"></div>
+</div>
+</body>
+</html>

--- a/test_fixtures/grid/grid_align_self_baseline_synthesized_margins.html
+++ b/test_fixtures/grid/grid_align_self_baseline_synthesized_margins.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-columns: 50px 50px 50px 50px; width: 250px;">
+  <div style="height: 20px; align-self: baseline;"></div>
+  <div style="height: 10px; margin: 30px 0 10px; align-self: baseline;"></div>
+  <div style="height: 10px; margin: 20px 0 0; align-self: baseline;"></div>
+  <div style="height: 100px;"></div>
+</div>
+</body>
+</html>

--- a/test_fixtures/grid/grid_align_self_last_baseline_synthesized_margins.html
+++ b/test_fixtures/grid/grid_align_self_last_baseline_synthesized_margins.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-columns: 50px 50px 50px 50px; width: 250px;">
+  <div style="height: 20px; align-self: last baseline;"></div>
+  <div style="height: 10px; margin: 30px 0 10px; align-self: last baseline;"></div>
+  <div style="height: 10px; margin: 20px 0 0; align-self: last baseline;"></div>
+  <div style="height: 100px;"></div>
+</div>
+</body>
+</html>

--- a/test_fixtures/gridflex/gridflex_align_baseline_nested_grid.html
+++ b/test_fixtures/gridflex/gridflex_align_baseline_nested_grid.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="align-items: baseline; width: 300px;">
+  <div style="width: 20px; height: 45px;"></div>
+  <div style="display: grid; grid-template-columns: 40px 40px; gap: 10px;">
+    <div style="height: 10px;"></div>
+    <div style="height: 30px; margin: 10px 0; align-self: baseline;"></div>
+    <div style="height: 50px;"></div>
+    <div style="height: 40px; margin: 10px 0; align-self: baseline;"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/test_fixtures/gridflex/gridflex_align_last_baseline_nested_grid.html
+++ b/test_fixtures/gridflex/gridflex_align_last_baseline_nested_grid.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="align-items: last baseline; width: 300px;">
+  <div style="width: 20px; height: 45px;"></div>
+  <div style="display: grid; grid-template-columns: 40px 40px; gap: 10px;">
+    <div style="height: 10px;"></div>
+    <div style="height: 30px; margin: 10px 0; align-self: last baseline;"></div>
+    <div style="height: 50px;"></div>
+    <div style="height: 40px; margin: 10px 0; align-self: last baseline;"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/test_fixtures/gridflex/gridflex_grid_align_baseline_nested_flex_wrap.html
+++ b/test_fixtures/gridflex/gridflex_grid_align_baseline_nested_flex_wrap.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-columns: 40px 160px; align-items: baseline; width: 200px;">
+  <div style="height: 45px;"></div>
+  <div style="flex-wrap: wrap; width: 140px; gap: 10px;">
+    <div style="width: 40px; height: 10px;"></div>
+    <div style="width: 40px; height: 30px; margin: 10px 0; align-self: baseline;"></div>
+    <div style="width: 40px; height: 50px;"></div>
+    <div style="width: 40px; height: 60px;"></div>
+    <div style="width: 40px; height: 40px; margin: 10px 0; align-self: baseline;"></div>
+    <div style="width: 40px; height: 20px;"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/test_fixtures/gridflex/gridflex_grid_align_baseline_nested_flex_wrap_reverse.html
+++ b/test_fixtures/gridflex/gridflex_grid_align_baseline_nested_flex_wrap_reverse.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-columns: 40px 160px; align-items: baseline; width: 200px;">
+  <div style="height: 45px;"></div>
+  <div style="flex-wrap: wrap-reverse; width: 140px; gap: 10px;">
+    <div style="width: 40px; height: 10px;"></div>
+    <div style="width: 40px; height: 30px; margin: 10px 0; align-self: baseline;"></div>
+    <div style="width: 40px; height: 50px;"></div>
+    <div style="width: 40px; height: 60px;"></div>
+    <div style="width: 40px; height: 40px; margin: 10px 0; align-self: baseline;"></div>
+    <div style="width: 40px; height: 20px;"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/test_fixtures/gridflex/gridflex_grid_baseline_empty_grid.html
+++ b/test_fixtures/gridflex/gridflex_grid_baseline_empty_grid.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="align-items: baseline; width: 300px;">
+  <div style="width: 20px; height: 45px;"></div>
+  <div style="display: grid; width: 50px; height: 30px; margin: 15px 0 30px; border-top: 5px solid red; border-bottom: 10px solid red; padding: 10px 0 20px;"></div>
+  <div style="display: grid; width: 50px; height: 60px;"></div>
+</div>
+</body>
+</html>

--- a/test_fixtures/gridflex/gridflex_grid_baseline_grid_order.html
+++ b/test_fixtures/gridflex/gridflex_grid_baseline_grid_order.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="align-items: baseline; width: 400px;">
+  <div style="width: 20px; height: 45px;"></div>
+  <div style="display: grid; grid-template-columns: 50px 50px; grid-template-rows: 50px 50px;">
+    <div style="grid-row: 2; grid-column: 2; height: 25px;"></div>
+    <div style="grid-row: 1; grid-column: 2; height: 25px; margin-top: 10px;"></div>
+    <div style="grid-row: 1; grid-column: 1; height: 25px; margin-top: 20px;"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/test_fixtures/gridflex/gridflex_grid_baseline_grid_order_columns.html
+++ b/test_fixtures/gridflex/gridflex_grid_baseline_grid_order_columns.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="align-items: baseline; width: 400px;">
+  <div style="width: 20px; height: 45px;"></div>
+  <div style="display: grid; grid-template-columns: 50px 50px 50px; grid-template-rows: 50px;">
+    <div style="grid-row: 1; grid-column: 3; height: 25px;"></div>
+    <div style="grid-row: 1; grid-column: 1; height: 25px; margin-top: 10px;"></div>
+    <div style="grid-row: 1; grid-column: 2; height: 25px; margin-top: 20px;"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/tests/hand_written/last_baseline.rs
+++ b/tests/hand_written/last_baseline.rs
@@ -332,9 +332,9 @@ mod last_baseline {
         );
 
         let output = tree.layout_root(root);
-        // First baseline: no baseline-aligned items, so synthesized from the first item's
-        // border box (y=0 + height=50). Last baseline: the last row's item's last baseline (y=50 + 55).
-        assert_eq!(output.baselines, Baselines { first: Some(50.0), last: Some(50.0 + 55.0) });
+        // First baseline: the first row's item's first baseline (y=0 + 30).
+        // Last baseline: the last row's item's last baseline (y=50 + 55).
+        assert_eq!(output.baselines, Baselines { first: Some(30.0), last: Some(50.0 + 55.0) });
     }
 
     /// A block container's first baseline comes from its first in-flow child with a baseline,

--- a/tests/xml/flex/align_baseline_nested_flex_wrap_first_baseline_items__border_box_ltr.xml
+++ b/tests/xml/flex/align_baseline_nested_flex_wrap_first_baseline_items__border_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="align_baseline_nested_flex_wrap_first_baseline_items__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" align-items="baseline" width="200px">
+      <div direction="ltr" width="20px" height="45px"/>
+      <div direction="ltr" flex-wrap="wrap" width="140px" row-gap="10px" column-gap="10px">
+        <div direction="ltr" width="40px" height="10px"/>
+        <div direction="ltr" align-self="baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="ltr" width="40px" height="50px"/>
+        <div direction="ltr" width="40px" height="60px"/>
+        <div direction="ltr" align-self="baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="ltr" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="125">
+      <node x="0" y="0" width="20" height="45"/>
+      <node x="20" y="5" width="140" height="120">
+        <node x="0" y="0" width="40" height="10"/>
+        <node x="50" y="10" width="40" height="30"/>
+        <node x="100" y="0" width="40" height="50"/>
+        <node x="0" y="60" width="40" height="60"/>
+        <node x="50" y="70" width="40" height="40"/>
+        <node x="100" y="60" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_baseline_nested_flex_wrap_first_baseline_items__border_box_rtl.xml
+++ b/tests/xml/flex/align_baseline_nested_flex_wrap_first_baseline_items__border_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="align_baseline_nested_flex_wrap_first_baseline_items__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" align-items="baseline" width="200px">
+      <div direction="rtl" width="20px" height="45px"/>
+      <div direction="rtl" flex-wrap="wrap" width="140px" row-gap="10px" column-gap="10px">
+        <div direction="rtl" width="40px" height="10px"/>
+        <div direction="rtl" align-self="baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="rtl" width="40px" height="50px"/>
+        <div direction="rtl" width="40px" height="60px"/>
+        <div direction="rtl" align-self="baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="rtl" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="125">
+      <node x="180" y="0" width="20" height="45"/>
+      <node x="40" y="5" width="140" height="120">
+        <node x="100" y="0" width="40" height="10"/>
+        <node x="50" y="10" width="40" height="30"/>
+        <node x="0" y="0" width="40" height="50"/>
+        <node x="100" y="60" width="40" height="60"/>
+        <node x="50" y="70" width="40" height="40"/>
+        <node x="0" y="60" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_baseline_nested_flex_wrap_first_baseline_items__content_box_ltr.xml
+++ b/tests/xml/flex/align_baseline_nested_flex_wrap_first_baseline_items__content_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="align_baseline_nested_flex_wrap_first_baseline_items__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" align-items="baseline" width="200px">
+      <div box-sizing="content-box" direction="ltr" width="20px" height="45px"/>
+      <div box-sizing="content-box" direction="ltr" flex-wrap="wrap" width="140px" row-gap="10px" column-gap="10px">
+        <div box-sizing="content-box" direction="ltr" width="40px" height="10px"/>
+        <div box-sizing="content-box" direction="ltr" align-self="baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="50px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="60px"/>
+        <div box-sizing="content-box" direction="ltr" align-self="baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="125">
+      <node x="0" y="0" width="20" height="45"/>
+      <node x="20" y="5" width="140" height="120">
+        <node x="0" y="0" width="40" height="10"/>
+        <node x="50" y="10" width="40" height="30"/>
+        <node x="100" y="0" width="40" height="50"/>
+        <node x="0" y="60" width="40" height="60"/>
+        <node x="50" y="70" width="40" height="40"/>
+        <node x="100" y="60" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_baseline_nested_flex_wrap_first_baseline_items__content_box_rtl.xml
+++ b/tests/xml/flex/align_baseline_nested_flex_wrap_first_baseline_items__content_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="align_baseline_nested_flex_wrap_first_baseline_items__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" align-items="baseline" width="200px">
+      <div box-sizing="content-box" direction="rtl" width="20px" height="45px"/>
+      <div box-sizing="content-box" direction="rtl" flex-wrap="wrap" width="140px" row-gap="10px" column-gap="10px">
+        <div box-sizing="content-box" direction="rtl" width="40px" height="10px"/>
+        <div box-sizing="content-box" direction="rtl" align-self="baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="50px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="60px"/>
+        <div box-sizing="content-box" direction="rtl" align-self="baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="125">
+      <node x="180" y="0" width="20" height="45"/>
+      <node x="40" y="5" width="140" height="120">
+        <node x="100" y="0" width="40" height="10"/>
+        <node x="50" y="10" width="40" height="30"/>
+        <node x="0" y="0" width="40" height="50"/>
+        <node x="100" y="60" width="40" height="60"/>
+        <node x="50" y="70" width="40" height="40"/>
+        <node x="0" y="60" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_baseline_nested_flex_wrap_last_baseline_items__border_box_ltr.xml
+++ b/tests/xml/flex/align_baseline_nested_flex_wrap_last_baseline_items__border_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="align_baseline_nested_flex_wrap_last_baseline_items__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" align-items="baseline" width="200px">
+      <div direction="ltr" width="20px" height="45px"/>
+      <div direction="ltr" flex-wrap="wrap" width="140px" row-gap="10px" column-gap="10px">
+        <div direction="ltr" width="40px" height="10px"/>
+        <div direction="ltr" align-self="last baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="ltr" width="40px" height="50px"/>
+        <div direction="ltr" width="40px" height="60px"/>
+        <div direction="ltr" align-self="last baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="ltr" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="125">
+      <node x="0" y="0" width="20" height="45"/>
+      <node x="20" y="5" width="140" height="120">
+        <node x="0" y="0" width="40" height="10"/>
+        <node x="50" y="10" width="40" height="30"/>
+        <node x="100" y="0" width="40" height="50"/>
+        <node x="0" y="60" width="40" height="60"/>
+        <node x="50" y="70" width="40" height="40"/>
+        <node x="100" y="60" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_baseline_nested_flex_wrap_last_baseline_items__border_box_rtl.xml
+++ b/tests/xml/flex/align_baseline_nested_flex_wrap_last_baseline_items__border_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="align_baseline_nested_flex_wrap_last_baseline_items__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" align-items="baseline" width="200px">
+      <div direction="rtl" width="20px" height="45px"/>
+      <div direction="rtl" flex-wrap="wrap" width="140px" row-gap="10px" column-gap="10px">
+        <div direction="rtl" width="40px" height="10px"/>
+        <div direction="rtl" align-self="last baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="rtl" width="40px" height="50px"/>
+        <div direction="rtl" width="40px" height="60px"/>
+        <div direction="rtl" align-self="last baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="rtl" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="125">
+      <node x="180" y="0" width="20" height="45"/>
+      <node x="40" y="5" width="140" height="120">
+        <node x="100" y="0" width="40" height="10"/>
+        <node x="50" y="10" width="40" height="30"/>
+        <node x="0" y="0" width="40" height="50"/>
+        <node x="100" y="60" width="40" height="60"/>
+        <node x="50" y="70" width="40" height="40"/>
+        <node x="0" y="60" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_baseline_nested_flex_wrap_last_baseline_items__content_box_ltr.xml
+++ b/tests/xml/flex/align_baseline_nested_flex_wrap_last_baseline_items__content_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="align_baseline_nested_flex_wrap_last_baseline_items__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" align-items="baseline" width="200px">
+      <div box-sizing="content-box" direction="ltr" width="20px" height="45px"/>
+      <div box-sizing="content-box" direction="ltr" flex-wrap="wrap" width="140px" row-gap="10px" column-gap="10px">
+        <div box-sizing="content-box" direction="ltr" width="40px" height="10px"/>
+        <div box-sizing="content-box" direction="ltr" align-self="last baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="50px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="60px"/>
+        <div box-sizing="content-box" direction="ltr" align-self="last baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="125">
+      <node x="0" y="0" width="20" height="45"/>
+      <node x="20" y="5" width="140" height="120">
+        <node x="0" y="0" width="40" height="10"/>
+        <node x="50" y="10" width="40" height="30"/>
+        <node x="100" y="0" width="40" height="50"/>
+        <node x="0" y="60" width="40" height="60"/>
+        <node x="50" y="70" width="40" height="40"/>
+        <node x="100" y="60" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_baseline_nested_flex_wrap_last_baseline_items__content_box_rtl.xml
+++ b/tests/xml/flex/align_baseline_nested_flex_wrap_last_baseline_items__content_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="align_baseline_nested_flex_wrap_last_baseline_items__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" align-items="baseline" width="200px">
+      <div box-sizing="content-box" direction="rtl" width="20px" height="45px"/>
+      <div box-sizing="content-box" direction="rtl" flex-wrap="wrap" width="140px" row-gap="10px" column-gap="10px">
+        <div box-sizing="content-box" direction="rtl" width="40px" height="10px"/>
+        <div box-sizing="content-box" direction="rtl" align-self="last baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="50px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="60px"/>
+        <div box-sizing="content-box" direction="rtl" align-self="last baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="125">
+      <node x="180" y="0" width="20" height="45"/>
+      <node x="40" y="5" width="140" height="120">
+        <node x="100" y="0" width="40" height="10"/>
+        <node x="50" y="10" width="40" height="30"/>
+        <node x="0" y="0" width="40" height="50"/>
+        <node x="100" y="60" width="40" height="60"/>
+        <node x="50" y="70" width="40" height="40"/>
+        <node x="0" y="60" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_baseline_nested_flex_wrap_mixed_baseline_items__border_box_ltr.xml
+++ b/tests/xml/flex/align_baseline_nested_flex_wrap_mixed_baseline_items__border_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="align_baseline_nested_flex_wrap_mixed_baseline_items__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" align-items="baseline" width="200px">
+      <div direction="ltr" width="20px" height="45px"/>
+      <div direction="ltr" flex-wrap="wrap" width="140px" row-gap="10px" column-gap="10px">
+        <div direction="ltr" align-self="last baseline" width="40px" height="30px" margin-top="5px" margin-left="0px" margin-bottom="5px" margin-right="0px"/>
+        <div direction="ltr" align-self="baseline" width="40px" height="20px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="ltr" width="40px" height="50px"/>
+        <div direction="ltr" width="40px" height="60px"/>
+        <div direction="ltr" width="40px" height="40px"/>
+        <div direction="ltr" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="135">
+      <node x="0" y="0" width="20" height="45"/>
+      <node x="20" y="15" width="140" height="120">
+        <node x="0" y="15" width="40" height="30"/>
+        <node x="50" y="10" width="40" height="20"/>
+        <node x="100" y="0" width="40" height="50"/>
+        <node x="0" y="60" width="40" height="60"/>
+        <node x="50" y="60" width="40" height="40"/>
+        <node x="100" y="60" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_baseline_nested_flex_wrap_mixed_baseline_items__border_box_rtl.xml
+++ b/tests/xml/flex/align_baseline_nested_flex_wrap_mixed_baseline_items__border_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="align_baseline_nested_flex_wrap_mixed_baseline_items__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" align-items="baseline" width="200px">
+      <div direction="rtl" width="20px" height="45px"/>
+      <div direction="rtl" flex-wrap="wrap" width="140px" row-gap="10px" column-gap="10px">
+        <div direction="rtl" align-self="last baseline" width="40px" height="30px" margin-top="5px" margin-left="0px" margin-bottom="5px" margin-right="0px"/>
+        <div direction="rtl" align-self="baseline" width="40px" height="20px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="rtl" width="40px" height="50px"/>
+        <div direction="rtl" width="40px" height="60px"/>
+        <div direction="rtl" width="40px" height="40px"/>
+        <div direction="rtl" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="135">
+      <node x="180" y="0" width="20" height="45"/>
+      <node x="40" y="15" width="140" height="120">
+        <node x="100" y="15" width="40" height="30"/>
+        <node x="50" y="10" width="40" height="20"/>
+        <node x="0" y="0" width="40" height="50"/>
+        <node x="100" y="60" width="40" height="60"/>
+        <node x="50" y="60" width="40" height="40"/>
+        <node x="0" y="60" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_baseline_nested_flex_wrap_mixed_baseline_items__content_box_ltr.xml
+++ b/tests/xml/flex/align_baseline_nested_flex_wrap_mixed_baseline_items__content_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="align_baseline_nested_flex_wrap_mixed_baseline_items__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" align-items="baseline" width="200px">
+      <div box-sizing="content-box" direction="ltr" width="20px" height="45px"/>
+      <div box-sizing="content-box" direction="ltr" flex-wrap="wrap" width="140px" row-gap="10px" column-gap="10px">
+        <div box-sizing="content-box" direction="ltr" align-self="last baseline" width="40px" height="30px" margin-top="5px" margin-left="0px" margin-bottom="5px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="ltr" align-self="baseline" width="40px" height="20px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="50px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="60px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="40px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="135">
+      <node x="0" y="0" width="20" height="45"/>
+      <node x="20" y="15" width="140" height="120">
+        <node x="0" y="15" width="40" height="30"/>
+        <node x="50" y="10" width="40" height="20"/>
+        <node x="100" y="0" width="40" height="50"/>
+        <node x="0" y="60" width="40" height="60"/>
+        <node x="50" y="60" width="40" height="40"/>
+        <node x="100" y="60" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_baseline_nested_flex_wrap_mixed_baseline_items__content_box_rtl.xml
+++ b/tests/xml/flex/align_baseline_nested_flex_wrap_mixed_baseline_items__content_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="align_baseline_nested_flex_wrap_mixed_baseline_items__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" align-items="baseline" width="200px">
+      <div box-sizing="content-box" direction="rtl" width="20px" height="45px"/>
+      <div box-sizing="content-box" direction="rtl" flex-wrap="wrap" width="140px" row-gap="10px" column-gap="10px">
+        <div box-sizing="content-box" direction="rtl" align-self="last baseline" width="40px" height="30px" margin-top="5px" margin-left="0px" margin-bottom="5px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="rtl" align-self="baseline" width="40px" height="20px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="50px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="60px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="40px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="135">
+      <node x="180" y="0" width="20" height="45"/>
+      <node x="40" y="15" width="140" height="120">
+        <node x="100" y="15" width="40" height="30"/>
+        <node x="50" y="10" width="40" height="20"/>
+        <node x="0" y="0" width="40" height="50"/>
+        <node x="100" y="60" width="40" height="60"/>
+        <node x="50" y="60" width="40" height="40"/>
+        <node x="0" y="60" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_baseline_nested_flex_wrap_reverse_first_baseline_items__border_box_ltr.xml
+++ b/tests/xml/flex/align_baseline_nested_flex_wrap_reverse_first_baseline_items__border_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="align_baseline_nested_flex_wrap_reverse_first_baseline_items__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" align-items="baseline" width="200px">
+      <div direction="ltr" width="20px" height="45px"/>
+      <div direction="ltr" flex-wrap="wrap-reverse" width="140px" row-gap="10px" column-gap="10px">
+        <div direction="ltr" width="40px" height="10px"/>
+        <div direction="ltr" align-self="baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="ltr" width="40px" height="50px"/>
+        <div direction="ltr" width="40px" height="60px"/>
+        <div direction="ltr" align-self="baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="ltr" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="120">
+      <node x="0" y="5" width="20" height="45"/>
+      <node x="20" y="0" width="140" height="120">
+        <node x="0" y="110" width="40" height="10"/>
+        <node x="50" y="80" width="40" height="30"/>
+        <node x="100" y="70" width="40" height="50"/>
+        <node x="0" y="0" width="40" height="60"/>
+        <node x="50" y="10" width="40" height="40"/>
+        <node x="100" y="40" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_baseline_nested_flex_wrap_reverse_first_baseline_items__border_box_rtl.xml
+++ b/tests/xml/flex/align_baseline_nested_flex_wrap_reverse_first_baseline_items__border_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="align_baseline_nested_flex_wrap_reverse_first_baseline_items__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" align-items="baseline" width="200px">
+      <div direction="rtl" width="20px" height="45px"/>
+      <div direction="rtl" flex-wrap="wrap-reverse" width="140px" row-gap="10px" column-gap="10px">
+        <div direction="rtl" width="40px" height="10px"/>
+        <div direction="rtl" align-self="baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="rtl" width="40px" height="50px"/>
+        <div direction="rtl" width="40px" height="60px"/>
+        <div direction="rtl" align-self="baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="rtl" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="120">
+      <node x="180" y="5" width="20" height="45"/>
+      <node x="40" y="0" width="140" height="120">
+        <node x="100" y="110" width="40" height="10"/>
+        <node x="50" y="80" width="40" height="30"/>
+        <node x="0" y="70" width="40" height="50"/>
+        <node x="100" y="0" width="40" height="60"/>
+        <node x="50" y="10" width="40" height="40"/>
+        <node x="0" y="40" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_baseline_nested_flex_wrap_reverse_first_baseline_items__content_box_ltr.xml
+++ b/tests/xml/flex/align_baseline_nested_flex_wrap_reverse_first_baseline_items__content_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="align_baseline_nested_flex_wrap_reverse_first_baseline_items__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" align-items="baseline" width="200px">
+      <div box-sizing="content-box" direction="ltr" width="20px" height="45px"/>
+      <div box-sizing="content-box" direction="ltr" flex-wrap="wrap-reverse" width="140px" row-gap="10px" column-gap="10px">
+        <div box-sizing="content-box" direction="ltr" width="40px" height="10px"/>
+        <div box-sizing="content-box" direction="ltr" align-self="baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="50px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="60px"/>
+        <div box-sizing="content-box" direction="ltr" align-self="baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="120">
+      <node x="0" y="5" width="20" height="45"/>
+      <node x="20" y="0" width="140" height="120">
+        <node x="0" y="110" width="40" height="10"/>
+        <node x="50" y="80" width="40" height="30"/>
+        <node x="100" y="70" width="40" height="50"/>
+        <node x="0" y="0" width="40" height="60"/>
+        <node x="50" y="10" width="40" height="40"/>
+        <node x="100" y="40" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_baseline_nested_flex_wrap_reverse_first_baseline_items__content_box_rtl.xml
+++ b/tests/xml/flex/align_baseline_nested_flex_wrap_reverse_first_baseline_items__content_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="align_baseline_nested_flex_wrap_reverse_first_baseline_items__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" align-items="baseline" width="200px">
+      <div box-sizing="content-box" direction="rtl" width="20px" height="45px"/>
+      <div box-sizing="content-box" direction="rtl" flex-wrap="wrap-reverse" width="140px" row-gap="10px" column-gap="10px">
+        <div box-sizing="content-box" direction="rtl" width="40px" height="10px"/>
+        <div box-sizing="content-box" direction="rtl" align-self="baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="50px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="60px"/>
+        <div box-sizing="content-box" direction="rtl" align-self="baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="120">
+      <node x="180" y="5" width="20" height="45"/>
+      <node x="40" y="0" width="140" height="120">
+        <node x="100" y="110" width="40" height="10"/>
+        <node x="50" y="80" width="40" height="30"/>
+        <node x="0" y="70" width="40" height="50"/>
+        <node x="100" y="0" width="40" height="60"/>
+        <node x="50" y="10" width="40" height="40"/>
+        <node x="0" y="40" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_baseline_nested_flex_wrap_reverse_last_baseline_items__border_box_ltr.xml
+++ b/tests/xml/flex/align_baseline_nested_flex_wrap_reverse_last_baseline_items__border_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="align_baseline_nested_flex_wrap_reverse_last_baseline_items__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" align-items="baseline" width="200px">
+      <div direction="ltr" width="20px" height="45px"/>
+      <div direction="ltr" flex-wrap="wrap-reverse" width="140px" row-gap="10px" column-gap="10px">
+        <div direction="ltr" width="40px" height="10px"/>
+        <div direction="ltr" align-self="last baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="ltr" width="40px" height="50px"/>
+        <div direction="ltr" width="40px" height="60px"/>
+        <div direction="ltr" align-self="last baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="ltr" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="120">
+      <node x="0" y="5" width="20" height="45"/>
+      <node x="20" y="0" width="140" height="120">
+        <node x="0" y="110" width="40" height="10"/>
+        <node x="50" y="80" width="40" height="30"/>
+        <node x="100" y="70" width="40" height="50"/>
+        <node x="0" y="0" width="40" height="60"/>
+        <node x="50" y="10" width="40" height="40"/>
+        <node x="100" y="40" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_baseline_nested_flex_wrap_reverse_last_baseline_items__border_box_rtl.xml
+++ b/tests/xml/flex/align_baseline_nested_flex_wrap_reverse_last_baseline_items__border_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="align_baseline_nested_flex_wrap_reverse_last_baseline_items__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" align-items="baseline" width="200px">
+      <div direction="rtl" width="20px" height="45px"/>
+      <div direction="rtl" flex-wrap="wrap-reverse" width="140px" row-gap="10px" column-gap="10px">
+        <div direction="rtl" width="40px" height="10px"/>
+        <div direction="rtl" align-self="last baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="rtl" width="40px" height="50px"/>
+        <div direction="rtl" width="40px" height="60px"/>
+        <div direction="rtl" align-self="last baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="rtl" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="120">
+      <node x="180" y="5" width="20" height="45"/>
+      <node x="40" y="0" width="140" height="120">
+        <node x="100" y="110" width="40" height="10"/>
+        <node x="50" y="80" width="40" height="30"/>
+        <node x="0" y="70" width="40" height="50"/>
+        <node x="100" y="0" width="40" height="60"/>
+        <node x="50" y="10" width="40" height="40"/>
+        <node x="0" y="40" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_baseline_nested_flex_wrap_reverse_last_baseline_items__content_box_ltr.xml
+++ b/tests/xml/flex/align_baseline_nested_flex_wrap_reverse_last_baseline_items__content_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="align_baseline_nested_flex_wrap_reverse_last_baseline_items__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" align-items="baseline" width="200px">
+      <div box-sizing="content-box" direction="ltr" width="20px" height="45px"/>
+      <div box-sizing="content-box" direction="ltr" flex-wrap="wrap-reverse" width="140px" row-gap="10px" column-gap="10px">
+        <div box-sizing="content-box" direction="ltr" width="40px" height="10px"/>
+        <div box-sizing="content-box" direction="ltr" align-self="last baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="50px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="60px"/>
+        <div box-sizing="content-box" direction="ltr" align-self="last baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="120">
+      <node x="0" y="5" width="20" height="45"/>
+      <node x="20" y="0" width="140" height="120">
+        <node x="0" y="110" width="40" height="10"/>
+        <node x="50" y="80" width="40" height="30"/>
+        <node x="100" y="70" width="40" height="50"/>
+        <node x="0" y="0" width="40" height="60"/>
+        <node x="50" y="10" width="40" height="40"/>
+        <node x="100" y="40" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_baseline_nested_flex_wrap_reverse_last_baseline_items__content_box_rtl.xml
+++ b/tests/xml/flex/align_baseline_nested_flex_wrap_reverse_last_baseline_items__content_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="align_baseline_nested_flex_wrap_reverse_last_baseline_items__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" align-items="baseline" width="200px">
+      <div box-sizing="content-box" direction="rtl" width="20px" height="45px"/>
+      <div box-sizing="content-box" direction="rtl" flex-wrap="wrap-reverse" width="140px" row-gap="10px" column-gap="10px">
+        <div box-sizing="content-box" direction="rtl" width="40px" height="10px"/>
+        <div box-sizing="content-box" direction="rtl" align-self="last baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="50px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="60px"/>
+        <div box-sizing="content-box" direction="rtl" align-self="last baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="120">
+      <node x="180" y="5" width="20" height="45"/>
+      <node x="40" y="0" width="140" height="120">
+        <node x="100" y="110" width="40" height="10"/>
+        <node x="50" y="80" width="40" height="30"/>
+        <node x="0" y="70" width="40" height="50"/>
+        <node x="100" y="0" width="40" height="60"/>
+        <node x="50" y="10" width="40" height="40"/>
+        <node x="0" y="40" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_last_baseline_nested_flex_wrap_first_baseline_items__border_box_ltr.xml
+++ b/tests/xml/flex/align_last_baseline_nested_flex_wrap_first_baseline_items__border_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="align_last_baseline_nested_flex_wrap_first_baseline_items__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" align-items="last baseline" width="200px">
+      <div direction="ltr" width="20px" height="45px"/>
+      <div direction="ltr" flex-wrap="wrap" width="140px" row-gap="10px" column-gap="10px">
+        <div direction="ltr" width="40px" height="10px"/>
+        <div direction="ltr" align-self="baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="ltr" width="40px" height="50px"/>
+        <div direction="ltr" width="40px" height="60px"/>
+        <div direction="ltr" align-self="baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="ltr" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="120">
+      <node x="0" y="65" width="20" height="45"/>
+      <node x="20" y="0" width="140" height="120">
+        <node x="0" y="0" width="40" height="10"/>
+        <node x="50" y="10" width="40" height="30"/>
+        <node x="100" y="0" width="40" height="50"/>
+        <node x="0" y="60" width="40" height="60"/>
+        <node x="50" y="70" width="40" height="40"/>
+        <node x="100" y="60" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_last_baseline_nested_flex_wrap_first_baseline_items__border_box_rtl.xml
+++ b/tests/xml/flex/align_last_baseline_nested_flex_wrap_first_baseline_items__border_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="align_last_baseline_nested_flex_wrap_first_baseline_items__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" align-items="last baseline" width="200px">
+      <div direction="rtl" width="20px" height="45px"/>
+      <div direction="rtl" flex-wrap="wrap" width="140px" row-gap="10px" column-gap="10px">
+        <div direction="rtl" width="40px" height="10px"/>
+        <div direction="rtl" align-self="baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="rtl" width="40px" height="50px"/>
+        <div direction="rtl" width="40px" height="60px"/>
+        <div direction="rtl" align-self="baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="rtl" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="120">
+      <node x="180" y="65" width="20" height="45"/>
+      <node x="40" y="0" width="140" height="120">
+        <node x="100" y="0" width="40" height="10"/>
+        <node x="50" y="10" width="40" height="30"/>
+        <node x="0" y="0" width="40" height="50"/>
+        <node x="100" y="60" width="40" height="60"/>
+        <node x="50" y="70" width="40" height="40"/>
+        <node x="0" y="60" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_last_baseline_nested_flex_wrap_first_baseline_items__content_box_ltr.xml
+++ b/tests/xml/flex/align_last_baseline_nested_flex_wrap_first_baseline_items__content_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="align_last_baseline_nested_flex_wrap_first_baseline_items__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" align-items="last baseline" width="200px">
+      <div box-sizing="content-box" direction="ltr" width="20px" height="45px"/>
+      <div box-sizing="content-box" direction="ltr" flex-wrap="wrap" width="140px" row-gap="10px" column-gap="10px">
+        <div box-sizing="content-box" direction="ltr" width="40px" height="10px"/>
+        <div box-sizing="content-box" direction="ltr" align-self="baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="50px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="60px"/>
+        <div box-sizing="content-box" direction="ltr" align-self="baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="120">
+      <node x="0" y="65" width="20" height="45"/>
+      <node x="20" y="0" width="140" height="120">
+        <node x="0" y="0" width="40" height="10"/>
+        <node x="50" y="10" width="40" height="30"/>
+        <node x="100" y="0" width="40" height="50"/>
+        <node x="0" y="60" width="40" height="60"/>
+        <node x="50" y="70" width="40" height="40"/>
+        <node x="100" y="60" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_last_baseline_nested_flex_wrap_first_baseline_items__content_box_rtl.xml
+++ b/tests/xml/flex/align_last_baseline_nested_flex_wrap_first_baseline_items__content_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="align_last_baseline_nested_flex_wrap_first_baseline_items__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" align-items="last baseline" width="200px">
+      <div box-sizing="content-box" direction="rtl" width="20px" height="45px"/>
+      <div box-sizing="content-box" direction="rtl" flex-wrap="wrap" width="140px" row-gap="10px" column-gap="10px">
+        <div box-sizing="content-box" direction="rtl" width="40px" height="10px"/>
+        <div box-sizing="content-box" direction="rtl" align-self="baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="50px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="60px"/>
+        <div box-sizing="content-box" direction="rtl" align-self="baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="120">
+      <node x="180" y="65" width="20" height="45"/>
+      <node x="40" y="0" width="140" height="120">
+        <node x="100" y="0" width="40" height="10"/>
+        <node x="50" y="10" width="40" height="30"/>
+        <node x="0" y="0" width="40" height="50"/>
+        <node x="100" y="60" width="40" height="60"/>
+        <node x="50" y="70" width="40" height="40"/>
+        <node x="0" y="60" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_last_baseline_nested_flex_wrap_last_baseline_items__border_box_ltr.xml
+++ b/tests/xml/flex/align_last_baseline_nested_flex_wrap_last_baseline_items__border_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="align_last_baseline_nested_flex_wrap_last_baseline_items__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" align-items="last baseline" width="200px">
+      <div direction="ltr" width="20px" height="45px"/>
+      <div direction="ltr" flex-wrap="wrap" width="140px" row-gap="10px" column-gap="10px">
+        <div direction="ltr" width="40px" height="10px"/>
+        <div direction="ltr" align-self="last baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="ltr" width="40px" height="50px"/>
+        <div direction="ltr" width="40px" height="60px"/>
+        <div direction="ltr" align-self="last baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="ltr" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="120">
+      <node x="0" y="65" width="20" height="45"/>
+      <node x="20" y="0" width="140" height="120">
+        <node x="0" y="0" width="40" height="10"/>
+        <node x="50" y="10" width="40" height="30"/>
+        <node x="100" y="0" width="40" height="50"/>
+        <node x="0" y="60" width="40" height="60"/>
+        <node x="50" y="70" width="40" height="40"/>
+        <node x="100" y="60" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_last_baseline_nested_flex_wrap_last_baseline_items__border_box_rtl.xml
+++ b/tests/xml/flex/align_last_baseline_nested_flex_wrap_last_baseline_items__border_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="align_last_baseline_nested_flex_wrap_last_baseline_items__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" align-items="last baseline" width="200px">
+      <div direction="rtl" width="20px" height="45px"/>
+      <div direction="rtl" flex-wrap="wrap" width="140px" row-gap="10px" column-gap="10px">
+        <div direction="rtl" width="40px" height="10px"/>
+        <div direction="rtl" align-self="last baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="rtl" width="40px" height="50px"/>
+        <div direction="rtl" width="40px" height="60px"/>
+        <div direction="rtl" align-self="last baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="rtl" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="120">
+      <node x="180" y="65" width="20" height="45"/>
+      <node x="40" y="0" width="140" height="120">
+        <node x="100" y="0" width="40" height="10"/>
+        <node x="50" y="10" width="40" height="30"/>
+        <node x="0" y="0" width="40" height="50"/>
+        <node x="100" y="60" width="40" height="60"/>
+        <node x="50" y="70" width="40" height="40"/>
+        <node x="0" y="60" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_last_baseline_nested_flex_wrap_last_baseline_items__content_box_ltr.xml
+++ b/tests/xml/flex/align_last_baseline_nested_flex_wrap_last_baseline_items__content_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="align_last_baseline_nested_flex_wrap_last_baseline_items__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" align-items="last baseline" width="200px">
+      <div box-sizing="content-box" direction="ltr" width="20px" height="45px"/>
+      <div box-sizing="content-box" direction="ltr" flex-wrap="wrap" width="140px" row-gap="10px" column-gap="10px">
+        <div box-sizing="content-box" direction="ltr" width="40px" height="10px"/>
+        <div box-sizing="content-box" direction="ltr" align-self="last baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="50px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="60px"/>
+        <div box-sizing="content-box" direction="ltr" align-self="last baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="120">
+      <node x="0" y="65" width="20" height="45"/>
+      <node x="20" y="0" width="140" height="120">
+        <node x="0" y="0" width="40" height="10"/>
+        <node x="50" y="10" width="40" height="30"/>
+        <node x="100" y="0" width="40" height="50"/>
+        <node x="0" y="60" width="40" height="60"/>
+        <node x="50" y="70" width="40" height="40"/>
+        <node x="100" y="60" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_last_baseline_nested_flex_wrap_last_baseline_items__content_box_rtl.xml
+++ b/tests/xml/flex/align_last_baseline_nested_flex_wrap_last_baseline_items__content_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="align_last_baseline_nested_flex_wrap_last_baseline_items__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" align-items="last baseline" width="200px">
+      <div box-sizing="content-box" direction="rtl" width="20px" height="45px"/>
+      <div box-sizing="content-box" direction="rtl" flex-wrap="wrap" width="140px" row-gap="10px" column-gap="10px">
+        <div box-sizing="content-box" direction="rtl" width="40px" height="10px"/>
+        <div box-sizing="content-box" direction="rtl" align-self="last baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="50px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="60px"/>
+        <div box-sizing="content-box" direction="rtl" align-self="last baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="120">
+      <node x="180" y="65" width="20" height="45"/>
+      <node x="40" y="0" width="140" height="120">
+        <node x="100" y="0" width="40" height="10"/>
+        <node x="50" y="10" width="40" height="30"/>
+        <node x="0" y="0" width="40" height="50"/>
+        <node x="100" y="60" width="40" height="60"/>
+        <node x="50" y="70" width="40" height="40"/>
+        <node x="0" y="60" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_last_baseline_nested_flex_wrap_mixed_baseline_items__border_box_ltr.xml
+++ b/tests/xml/flex/align_last_baseline_nested_flex_wrap_mixed_baseline_items__border_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="align_last_baseline_nested_flex_wrap_mixed_baseline_items__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" align-items="last baseline" width="200px">
+      <div direction="ltr" width="20px" height="45px"/>
+      <div direction="ltr" flex-wrap="wrap" width="140px" row-gap="10px" column-gap="10px">
+        <div direction="ltr" width="40px" height="30px"/>
+        <div direction="ltr" width="40px" height="20px"/>
+        <div direction="ltr" width="40px" height="50px"/>
+        <div direction="ltr" align-self="baseline" width="40px" height="60px" margin-top="5px" margin-left="0px" margin-bottom="5px" margin-right="0px"/>
+        <div direction="ltr" align-self="last baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="ltr" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="130">
+      <node x="0" y="75" width="20" height="45"/>
+      <node x="20" y="0" width="140" height="130">
+        <node x="0" y="0" width="40" height="30"/>
+        <node x="50" y="0" width="40" height="20"/>
+        <node x="100" y="0" width="40" height="50"/>
+        <node x="0" y="65" width="40" height="60"/>
+        <node x="50" y="80" width="40" height="40"/>
+        <node x="100" y="60" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_last_baseline_nested_flex_wrap_mixed_baseline_items__border_box_rtl.xml
+++ b/tests/xml/flex/align_last_baseline_nested_flex_wrap_mixed_baseline_items__border_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="align_last_baseline_nested_flex_wrap_mixed_baseline_items__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" align-items="last baseline" width="200px">
+      <div direction="rtl" width="20px" height="45px"/>
+      <div direction="rtl" flex-wrap="wrap" width="140px" row-gap="10px" column-gap="10px">
+        <div direction="rtl" width="40px" height="30px"/>
+        <div direction="rtl" width="40px" height="20px"/>
+        <div direction="rtl" width="40px" height="50px"/>
+        <div direction="rtl" align-self="baseline" width="40px" height="60px" margin-top="5px" margin-left="0px" margin-bottom="5px" margin-right="0px"/>
+        <div direction="rtl" align-self="last baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="rtl" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="130">
+      <node x="180" y="75" width="20" height="45"/>
+      <node x="40" y="0" width="140" height="130">
+        <node x="100" y="0" width="40" height="30"/>
+        <node x="50" y="0" width="40" height="20"/>
+        <node x="0" y="0" width="40" height="50"/>
+        <node x="100" y="65" width="40" height="60"/>
+        <node x="50" y="80" width="40" height="40"/>
+        <node x="0" y="60" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_last_baseline_nested_flex_wrap_mixed_baseline_items__content_box_ltr.xml
+++ b/tests/xml/flex/align_last_baseline_nested_flex_wrap_mixed_baseline_items__content_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="align_last_baseline_nested_flex_wrap_mixed_baseline_items__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" align-items="last baseline" width="200px">
+      <div box-sizing="content-box" direction="ltr" width="20px" height="45px"/>
+      <div box-sizing="content-box" direction="ltr" flex-wrap="wrap" width="140px" row-gap="10px" column-gap="10px">
+        <div box-sizing="content-box" direction="ltr" width="40px" height="30px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="20px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="50px"/>
+        <div box-sizing="content-box" direction="ltr" align-self="baseline" width="40px" height="60px" margin-top="5px" margin-left="0px" margin-bottom="5px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="ltr" align-self="last baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="130">
+      <node x="0" y="75" width="20" height="45"/>
+      <node x="20" y="0" width="140" height="130">
+        <node x="0" y="0" width="40" height="30"/>
+        <node x="50" y="0" width="40" height="20"/>
+        <node x="100" y="0" width="40" height="50"/>
+        <node x="0" y="65" width="40" height="60"/>
+        <node x="50" y="80" width="40" height="40"/>
+        <node x="100" y="60" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_last_baseline_nested_flex_wrap_mixed_baseline_items__content_box_rtl.xml
+++ b/tests/xml/flex/align_last_baseline_nested_flex_wrap_mixed_baseline_items__content_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="align_last_baseline_nested_flex_wrap_mixed_baseline_items__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" align-items="last baseline" width="200px">
+      <div box-sizing="content-box" direction="rtl" width="20px" height="45px"/>
+      <div box-sizing="content-box" direction="rtl" flex-wrap="wrap" width="140px" row-gap="10px" column-gap="10px">
+        <div box-sizing="content-box" direction="rtl" width="40px" height="30px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="20px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="50px"/>
+        <div box-sizing="content-box" direction="rtl" align-self="baseline" width="40px" height="60px" margin-top="5px" margin-left="0px" margin-bottom="5px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="rtl" align-self="last baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="130">
+      <node x="180" y="75" width="20" height="45"/>
+      <node x="40" y="0" width="140" height="130">
+        <node x="100" y="0" width="40" height="30"/>
+        <node x="50" y="0" width="40" height="20"/>
+        <node x="0" y="0" width="40" height="50"/>
+        <node x="100" y="65" width="40" height="60"/>
+        <node x="50" y="80" width="40" height="40"/>
+        <node x="0" y="60" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_last_baseline_nested_flex_wrap_reverse_first_baseline_items__border_box_ltr.xml
+++ b/tests/xml/flex/align_last_baseline_nested_flex_wrap_reverse_first_baseline_items__border_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="align_last_baseline_nested_flex_wrap_reverse_first_baseline_items__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" align-items="last baseline" width="200px">
+      <div direction="ltr" width="20px" height="45px"/>
+      <div direction="ltr" flex-wrap="wrap-reverse" width="140px" row-gap="10px" column-gap="10px">
+        <div direction="ltr" width="40px" height="10px"/>
+        <div direction="ltr" align-self="baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="ltr" width="40px" height="50px"/>
+        <div direction="ltr" width="40px" height="60px"/>
+        <div direction="ltr" align-self="baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="ltr" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="120">
+      <node x="0" y="65" width="20" height="45"/>
+      <node x="20" y="0" width="140" height="120">
+        <node x="0" y="110" width="40" height="10"/>
+        <node x="50" y="80" width="40" height="30"/>
+        <node x="100" y="70" width="40" height="50"/>
+        <node x="0" y="0" width="40" height="60"/>
+        <node x="50" y="10" width="40" height="40"/>
+        <node x="100" y="40" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_last_baseline_nested_flex_wrap_reverse_first_baseline_items__border_box_rtl.xml
+++ b/tests/xml/flex/align_last_baseline_nested_flex_wrap_reverse_first_baseline_items__border_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="align_last_baseline_nested_flex_wrap_reverse_first_baseline_items__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" align-items="last baseline" width="200px">
+      <div direction="rtl" width="20px" height="45px"/>
+      <div direction="rtl" flex-wrap="wrap-reverse" width="140px" row-gap="10px" column-gap="10px">
+        <div direction="rtl" width="40px" height="10px"/>
+        <div direction="rtl" align-self="baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="rtl" width="40px" height="50px"/>
+        <div direction="rtl" width="40px" height="60px"/>
+        <div direction="rtl" align-self="baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="rtl" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="120">
+      <node x="180" y="65" width="20" height="45"/>
+      <node x="40" y="0" width="140" height="120">
+        <node x="100" y="110" width="40" height="10"/>
+        <node x="50" y="80" width="40" height="30"/>
+        <node x="0" y="70" width="40" height="50"/>
+        <node x="100" y="0" width="40" height="60"/>
+        <node x="50" y="10" width="40" height="40"/>
+        <node x="0" y="40" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_last_baseline_nested_flex_wrap_reverse_first_baseline_items__content_box_ltr.xml
+++ b/tests/xml/flex/align_last_baseline_nested_flex_wrap_reverse_first_baseline_items__content_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="align_last_baseline_nested_flex_wrap_reverse_first_baseline_items__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" align-items="last baseline" width="200px">
+      <div box-sizing="content-box" direction="ltr" width="20px" height="45px"/>
+      <div box-sizing="content-box" direction="ltr" flex-wrap="wrap-reverse" width="140px" row-gap="10px" column-gap="10px">
+        <div box-sizing="content-box" direction="ltr" width="40px" height="10px"/>
+        <div box-sizing="content-box" direction="ltr" align-self="baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="50px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="60px"/>
+        <div box-sizing="content-box" direction="ltr" align-self="baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="120">
+      <node x="0" y="65" width="20" height="45"/>
+      <node x="20" y="0" width="140" height="120">
+        <node x="0" y="110" width="40" height="10"/>
+        <node x="50" y="80" width="40" height="30"/>
+        <node x="100" y="70" width="40" height="50"/>
+        <node x="0" y="0" width="40" height="60"/>
+        <node x="50" y="10" width="40" height="40"/>
+        <node x="100" y="40" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_last_baseline_nested_flex_wrap_reverse_first_baseline_items__content_box_rtl.xml
+++ b/tests/xml/flex/align_last_baseline_nested_flex_wrap_reverse_first_baseline_items__content_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="align_last_baseline_nested_flex_wrap_reverse_first_baseline_items__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" align-items="last baseline" width="200px">
+      <div box-sizing="content-box" direction="rtl" width="20px" height="45px"/>
+      <div box-sizing="content-box" direction="rtl" flex-wrap="wrap-reverse" width="140px" row-gap="10px" column-gap="10px">
+        <div box-sizing="content-box" direction="rtl" width="40px" height="10px"/>
+        <div box-sizing="content-box" direction="rtl" align-self="baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="50px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="60px"/>
+        <div box-sizing="content-box" direction="rtl" align-self="baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="120">
+      <node x="180" y="65" width="20" height="45"/>
+      <node x="40" y="0" width="140" height="120">
+        <node x="100" y="110" width="40" height="10"/>
+        <node x="50" y="80" width="40" height="30"/>
+        <node x="0" y="70" width="40" height="50"/>
+        <node x="100" y="0" width="40" height="60"/>
+        <node x="50" y="10" width="40" height="40"/>
+        <node x="0" y="40" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_last_baseline_nested_flex_wrap_reverse_last_baseline_items__border_box_ltr.xml
+++ b/tests/xml/flex/align_last_baseline_nested_flex_wrap_reverse_last_baseline_items__border_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="align_last_baseline_nested_flex_wrap_reverse_last_baseline_items__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" align-items="last baseline" width="200px">
+      <div direction="ltr" width="20px" height="45px"/>
+      <div direction="ltr" flex-wrap="wrap-reverse" width="140px" row-gap="10px" column-gap="10px">
+        <div direction="ltr" width="40px" height="10px"/>
+        <div direction="ltr" align-self="last baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="ltr" width="40px" height="50px"/>
+        <div direction="ltr" width="40px" height="60px"/>
+        <div direction="ltr" align-self="last baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="ltr" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="120">
+      <node x="0" y="65" width="20" height="45"/>
+      <node x="20" y="0" width="140" height="120">
+        <node x="0" y="110" width="40" height="10"/>
+        <node x="50" y="80" width="40" height="30"/>
+        <node x="100" y="70" width="40" height="50"/>
+        <node x="0" y="0" width="40" height="60"/>
+        <node x="50" y="10" width="40" height="40"/>
+        <node x="100" y="40" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_last_baseline_nested_flex_wrap_reverse_last_baseline_items__border_box_rtl.xml
+++ b/tests/xml/flex/align_last_baseline_nested_flex_wrap_reverse_last_baseline_items__border_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="align_last_baseline_nested_flex_wrap_reverse_last_baseline_items__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" align-items="last baseline" width="200px">
+      <div direction="rtl" width="20px" height="45px"/>
+      <div direction="rtl" flex-wrap="wrap-reverse" width="140px" row-gap="10px" column-gap="10px">
+        <div direction="rtl" width="40px" height="10px"/>
+        <div direction="rtl" align-self="last baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="rtl" width="40px" height="50px"/>
+        <div direction="rtl" width="40px" height="60px"/>
+        <div direction="rtl" align-self="last baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="rtl" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="120">
+      <node x="180" y="65" width="20" height="45"/>
+      <node x="40" y="0" width="140" height="120">
+        <node x="100" y="110" width="40" height="10"/>
+        <node x="50" y="80" width="40" height="30"/>
+        <node x="0" y="70" width="40" height="50"/>
+        <node x="100" y="0" width="40" height="60"/>
+        <node x="50" y="10" width="40" height="40"/>
+        <node x="0" y="40" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_last_baseline_nested_flex_wrap_reverse_last_baseline_items__content_box_ltr.xml
+++ b/tests/xml/flex/align_last_baseline_nested_flex_wrap_reverse_last_baseline_items__content_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="align_last_baseline_nested_flex_wrap_reverse_last_baseline_items__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" align-items="last baseline" width="200px">
+      <div box-sizing="content-box" direction="ltr" width="20px" height="45px"/>
+      <div box-sizing="content-box" direction="ltr" flex-wrap="wrap-reverse" width="140px" row-gap="10px" column-gap="10px">
+        <div box-sizing="content-box" direction="ltr" width="40px" height="10px"/>
+        <div box-sizing="content-box" direction="ltr" align-self="last baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="50px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="60px"/>
+        <div box-sizing="content-box" direction="ltr" align-self="last baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="120">
+      <node x="0" y="65" width="20" height="45"/>
+      <node x="20" y="0" width="140" height="120">
+        <node x="0" y="110" width="40" height="10"/>
+        <node x="50" y="80" width="40" height="30"/>
+        <node x="100" y="70" width="40" height="50"/>
+        <node x="0" y="0" width="40" height="60"/>
+        <node x="50" y="10" width="40" height="40"/>
+        <node x="100" y="40" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/align_last_baseline_nested_flex_wrap_reverse_last_baseline_items__content_box_rtl.xml
+++ b/tests/xml/flex/align_last_baseline_nested_flex_wrap_reverse_last_baseline_items__content_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="align_last_baseline_nested_flex_wrap_reverse_last_baseline_items__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" align-items="last baseline" width="200px">
+      <div box-sizing="content-box" direction="rtl" width="20px" height="45px"/>
+      <div box-sizing="content-box" direction="rtl" flex-wrap="wrap-reverse" width="140px" row-gap="10px" column-gap="10px">
+        <div box-sizing="content-box" direction="rtl" width="40px" height="10px"/>
+        <div box-sizing="content-box" direction="rtl" align-self="last baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="50px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="60px"/>
+        <div box-sizing="content-box" direction="rtl" align-self="last baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="120">
+      <node x="180" y="65" width="20" height="45"/>
+      <node x="40" y="0" width="140" height="120">
+        <node x="100" y="110" width="40" height="10"/>
+        <node x="50" y="80" width="40" height="30"/>
+        <node x="0" y="70" width="40" height="50"/>
+        <node x="100" y="0" width="40" height="60"/>
+        <node x="50" y="10" width="40" height="40"/>
+        <node x="0" y="40" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_baseline_double_nested_grid__border_box_ltr.xml
+++ b/tests/xml/grid/grid_align_baseline_double_nested_grid__border_box_ltr.xml
@@ -1,0 +1,25 @@
+<test name="grid_align_baseline_double_nested_grid__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" align-items="baseline" width="200px" grid-template-columns="60px 100px">
+      <div direction="ltr" height="45px"/>
+      <div display="grid" direction="ltr" align-items="baseline" padding-bottom="20px" border-top="10px" border-bottom="40px">
+        <div display="grid" direction="ltr" align-items="baseline">
+          <div direction="ltr" width="40px" height="10px"/>
+          <div direction="ltr" width="40px" height="25px" grid-row-start="2"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="130">
+      <node x="0" y="0" width="60" height="45"/>
+      <node x="60" y="25" width="100" height="105">
+        <node x="0" y="10" width="100" height="35">
+          <node x="0" y="0" width="40" height="10"/>
+          <node x="0" y="10" width="40" height="25"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_baseline_double_nested_grid__border_box_rtl.xml
+++ b/tests/xml/grid/grid_align_baseline_double_nested_grid__border_box_rtl.xml
@@ -1,0 +1,25 @@
+<test name="grid_align_baseline_double_nested_grid__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" align-items="baseline" width="200px" grid-template-columns="60px 100px">
+      <div direction="rtl" height="45px"/>
+      <div display="grid" direction="rtl" align-items="baseline" padding-bottom="20px" border-top="10px" border-bottom="40px">
+        <div display="grid" direction="rtl" align-items="baseline">
+          <div direction="rtl" width="40px" height="10px"/>
+          <div direction="rtl" width="40px" height="25px" grid-row-start="2"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="130">
+      <node x="140" y="0" width="60" height="45"/>
+      <node x="40" y="25" width="100" height="105">
+        <node x="0" y="10" width="100" height="35">
+          <node x="60" y="0" width="40" height="10"/>
+          <node x="60" y="10" width="40" height="25"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_baseline_double_nested_grid__content_box_ltr.xml
+++ b/tests/xml/grid/grid_align_baseline_double_nested_grid__content_box_ltr.xml
@@ -1,0 +1,25 @@
+<test name="grid_align_baseline_double_nested_grid__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" align-items="baseline" width="200px" grid-template-columns="60px 100px">
+      <div box-sizing="content-box" direction="ltr" height="45px"/>
+      <div display="grid" box-sizing="content-box" direction="ltr" align-items="baseline" padding-bottom="20px" border-top="10px" border-bottom="40px">
+        <div display="grid" box-sizing="content-box" direction="ltr" align-items="baseline">
+          <div box-sizing="content-box" direction="ltr" width="40px" height="10px"/>
+          <div box-sizing="content-box" direction="ltr" width="40px" height="25px" grid-row-start="2"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="130">
+      <node x="0" y="0" width="60" height="45"/>
+      <node x="60" y="25" width="100" height="105">
+        <node x="0" y="10" width="100" height="35">
+          <node x="0" y="0" width="40" height="10"/>
+          <node x="0" y="10" width="40" height="25"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_baseline_double_nested_grid__content_box_rtl.xml
+++ b/tests/xml/grid/grid_align_baseline_double_nested_grid__content_box_rtl.xml
@@ -1,0 +1,25 @@
+<test name="grid_align_baseline_double_nested_grid__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" align-items="baseline" width="200px" grid-template-columns="60px 100px">
+      <div box-sizing="content-box" direction="rtl" height="45px"/>
+      <div display="grid" box-sizing="content-box" direction="rtl" align-items="baseline" padding-bottom="20px" border-top="10px" border-bottom="40px">
+        <div display="grid" box-sizing="content-box" direction="rtl" align-items="baseline">
+          <div box-sizing="content-box" direction="rtl" width="40px" height="10px"/>
+          <div box-sizing="content-box" direction="rtl" width="40px" height="25px" grid-row-start="2"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="130">
+      <node x="140" y="0" width="60" height="45"/>
+      <node x="40" y="25" width="100" height="105">
+        <node x="0" y="10" width="100" height="35">
+          <node x="60" y="0" width="40" height="10"/>
+          <node x="60" y="10" width="40" height="25"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_baseline_spanned_nested_grid__border_box_ltr.xml
+++ b/tests/xml/grid/grid_align_baseline_spanned_nested_grid__border_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="grid_align_baseline_spanned_nested_grid__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" align-items="baseline" width="200px" grid-template-rows="20px auto auto auto 30px" grid-template-columns="30px auto">
+      <div direction="ltr" width="30px" height="60px" grid-row-start="2" grid-column-start="1"/>
+      <div display="grid" direction="ltr" align-items="baseline" padding-bottom="20px" border-top="10px" border-bottom="40px" grid-row-start="2" grid-row-end="span 2" grid-column-start="2">
+        <div direction="ltr" width="40px" height="35px"/>
+        <div direction="ltr" width="40px" height="10px" grid-row-start="2"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="180">
+      <node x="0" y="20" width="30" height="60"/>
+      <node x="30" y="35" width="170" height="115">
+        <node x="0" y="10" width="40" height="35"/>
+        <node x="0" y="45" width="40" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_baseline_spanned_nested_grid__border_box_rtl.xml
+++ b/tests/xml/grid/grid_align_baseline_spanned_nested_grid__border_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="grid_align_baseline_spanned_nested_grid__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" align-items="baseline" width="200px" grid-template-rows="20px auto auto auto 30px" grid-template-columns="30px auto">
+      <div direction="rtl" width="30px" height="60px" grid-row-start="2" grid-column-start="1"/>
+      <div display="grid" direction="rtl" align-items="baseline" padding-bottom="20px" border-top="10px" border-bottom="40px" grid-row-start="2" grid-row-end="span 2" grid-column-start="2">
+        <div direction="rtl" width="40px" height="35px"/>
+        <div direction="rtl" width="40px" height="10px" grid-row-start="2"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="180">
+      <node x="170" y="20" width="30" height="60"/>
+      <node x="0" y="35" width="170" height="115">
+        <node x="130" y="10" width="40" height="35"/>
+        <node x="130" y="45" width="40" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_baseline_spanned_nested_grid__content_box_ltr.xml
+++ b/tests/xml/grid/grid_align_baseline_spanned_nested_grid__content_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="grid_align_baseline_spanned_nested_grid__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" align-items="baseline" width="200px" grid-template-rows="20px auto auto auto 30px" grid-template-columns="30px auto">
+      <div box-sizing="content-box" direction="ltr" width="30px" height="60px" grid-row-start="2" grid-column-start="1"/>
+      <div display="grid" box-sizing="content-box" direction="ltr" align-items="baseline" padding-bottom="20px" border-top="10px" border-bottom="40px" grid-row-start="2" grid-row-end="span 2" grid-column-start="2">
+        <div box-sizing="content-box" direction="ltr" width="40px" height="35px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="10px" grid-row-start="2"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="180">
+      <node x="0" y="20" width="30" height="60"/>
+      <node x="30" y="35" width="170" height="115">
+        <node x="0" y="10" width="40" height="35"/>
+        <node x="0" y="45" width="40" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_baseline_spanned_nested_grid__content_box_rtl.xml
+++ b/tests/xml/grid/grid_align_baseline_spanned_nested_grid__content_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="grid_align_baseline_spanned_nested_grid__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" align-items="baseline" width="200px" grid-template-rows="20px auto auto auto 30px" grid-template-columns="30px auto">
+      <div box-sizing="content-box" direction="rtl" width="30px" height="60px" grid-row-start="2" grid-column-start="1"/>
+      <div display="grid" box-sizing="content-box" direction="rtl" align-items="baseline" padding-bottom="20px" border-top="10px" border-bottom="40px" grid-row-start="2" grid-row-end="span 2" grid-column-start="2">
+        <div box-sizing="content-box" direction="rtl" width="40px" height="35px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="10px" grid-row-start="2"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="180">
+      <node x="170" y="20" width="30" height="60"/>
+      <node x="0" y="35" width="170" height="115">
+        <node x="130" y="10" width="40" height="35"/>
+        <node x="130" y="45" width="40" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_baseline_spanned_nested_grid_spanned_item__border_box_ltr.xml
+++ b/tests/xml/grid/grid_align_baseline_spanned_nested_grid_spanned_item__border_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="grid_align_baseline_spanned_nested_grid_spanned_item__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" align-items="baseline" width="200px" grid-template-rows="20px auto auto auto 30px" grid-template-columns="30px auto">
+      <div direction="ltr" width="30px" height="60px" grid-row-start="2" grid-column-start="1"/>
+      <div display="grid" direction="ltr" align-items="baseline" padding-bottom="20px" border-top="10px" border-bottom="40px" grid-row-start="2" grid-row-end="span 2" grid-column-start="2">
+        <div direction="ltr" width="40px" height="35px" grid-row-start="1" grid-row-end="span 3"/>
+        <div direction="ltr" width="40px" height="10px" grid-row-start="4"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="180">
+      <node x="0" y="20" width="30" height="60"/>
+      <node x="30" y="35" width="170" height="115">
+        <node x="0" y="10" width="40" height="35"/>
+        <node x="0" y="45" width="40" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_baseline_spanned_nested_grid_spanned_item__border_box_rtl.xml
+++ b/tests/xml/grid/grid_align_baseline_spanned_nested_grid_spanned_item__border_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="grid_align_baseline_spanned_nested_grid_spanned_item__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" align-items="baseline" width="200px" grid-template-rows="20px auto auto auto 30px" grid-template-columns="30px auto">
+      <div direction="rtl" width="30px" height="60px" grid-row-start="2" grid-column-start="1"/>
+      <div display="grid" direction="rtl" align-items="baseline" padding-bottom="20px" border-top="10px" border-bottom="40px" grid-row-start="2" grid-row-end="span 2" grid-column-start="2">
+        <div direction="rtl" width="40px" height="35px" grid-row-start="1" grid-row-end="span 3"/>
+        <div direction="rtl" width="40px" height="10px" grid-row-start="4"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="180">
+      <node x="170" y="20" width="30" height="60"/>
+      <node x="0" y="35" width="170" height="115">
+        <node x="130" y="10" width="40" height="35"/>
+        <node x="130" y="45" width="40" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_baseline_spanned_nested_grid_spanned_item__content_box_ltr.xml
+++ b/tests/xml/grid/grid_align_baseline_spanned_nested_grid_spanned_item__content_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="grid_align_baseline_spanned_nested_grid_spanned_item__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" align-items="baseline" width="200px" grid-template-rows="20px auto auto auto 30px" grid-template-columns="30px auto">
+      <div box-sizing="content-box" direction="ltr" width="30px" height="60px" grid-row-start="2" grid-column-start="1"/>
+      <div display="grid" box-sizing="content-box" direction="ltr" align-items="baseline" padding-bottom="20px" border-top="10px" border-bottom="40px" grid-row-start="2" grid-row-end="span 2" grid-column-start="2">
+        <div box-sizing="content-box" direction="ltr" width="40px" height="35px" grid-row-start="1" grid-row-end="span 3"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="10px" grid-row-start="4"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="180">
+      <node x="0" y="20" width="30" height="60"/>
+      <node x="30" y="35" width="170" height="115">
+        <node x="0" y="10" width="40" height="35"/>
+        <node x="0" y="45" width="40" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_baseline_spanned_nested_grid_spanned_item__content_box_rtl.xml
+++ b/tests/xml/grid/grid_align_baseline_spanned_nested_grid_spanned_item__content_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="grid_align_baseline_spanned_nested_grid_spanned_item__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" align-items="baseline" width="200px" grid-template-rows="20px auto auto auto 30px" grid-template-columns="30px auto">
+      <div box-sizing="content-box" direction="rtl" width="30px" height="60px" grid-row-start="2" grid-column-start="1"/>
+      <div display="grid" box-sizing="content-box" direction="rtl" align-items="baseline" padding-bottom="20px" border-top="10px" border-bottom="40px" grid-row-start="2" grid-row-end="span 2" grid-column-start="2">
+        <div box-sizing="content-box" direction="rtl" width="40px" height="35px" grid-row-start="1" grid-row-end="span 3"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="10px" grid-row-start="4"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="180">
+      <node x="170" y="20" width="30" height="60"/>
+      <node x="0" y="35" width="170" height="115">
+        <node x="130" y="10" width="40" height="35"/>
+        <node x="130" y="45" width="40" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_items_baseline_synthesized_and_natural__border_box_ltr.xml
+++ b/tests/xml/grid/grid_align_items_baseline_synthesized_and_natural__border_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="grid_align_items_baseline_synthesized_and_natural__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" align-items="baseline" width="200px" grid-template-columns="60px 60px 60px">
+      <div direction="ltr" height="40px">
+        <div direction="ltr" width="20px" height="10px"/>
+      </div>
+      <div direction="ltr" height="40px"/>
+      <div direction="ltr" height="25px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="70">
+      <node x="0" y="30" width="60" height="40">
+        <node x="0" y="0" width="20" height="10"/>
+      </node>
+      <node x="60" y="0" width="60" height="40"/>
+      <node x="120" y="15" width="60" height="25"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_items_baseline_synthesized_and_natural__border_box_rtl.xml
+++ b/tests/xml/grid/grid_align_items_baseline_synthesized_and_natural__border_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="grid_align_items_baseline_synthesized_and_natural__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" align-items="baseline" width="200px" grid-template-columns="60px 60px 60px">
+      <div direction="rtl" height="40px">
+        <div direction="rtl" width="20px" height="10px"/>
+      </div>
+      <div direction="rtl" height="40px"/>
+      <div direction="rtl" height="25px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="70">
+      <node x="140" y="30" width="60" height="40">
+        <node x="40" y="0" width="20" height="10"/>
+      </node>
+      <node x="80" y="0" width="60" height="40"/>
+      <node x="20" y="15" width="60" height="25"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_items_baseline_synthesized_and_natural__content_box_ltr.xml
+++ b/tests/xml/grid/grid_align_items_baseline_synthesized_and_natural__content_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="grid_align_items_baseline_synthesized_and_natural__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" align-items="baseline" width="200px" grid-template-columns="60px 60px 60px">
+      <div box-sizing="content-box" direction="ltr" height="40px">
+        <div box-sizing="content-box" direction="ltr" width="20px" height="10px"/>
+      </div>
+      <div box-sizing="content-box" direction="ltr" height="40px"/>
+      <div box-sizing="content-box" direction="ltr" height="25px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="70">
+      <node x="0" y="30" width="60" height="40">
+        <node x="0" y="0" width="20" height="10"/>
+      </node>
+      <node x="60" y="0" width="60" height="40"/>
+      <node x="120" y="15" width="60" height="25"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_items_baseline_synthesized_and_natural__content_box_rtl.xml
+++ b/tests/xml/grid/grid_align_items_baseline_synthesized_and_natural__content_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="grid_align_items_baseline_synthesized_and_natural__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" align-items="baseline" width="200px" grid-template-columns="60px 60px 60px">
+      <div box-sizing="content-box" direction="rtl" height="40px">
+        <div box-sizing="content-box" direction="rtl" width="20px" height="10px"/>
+      </div>
+      <div box-sizing="content-box" direction="rtl" height="40px"/>
+      <div box-sizing="content-box" direction="rtl" height="25px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="70">
+      <node x="140" y="30" width="60" height="40">
+        <node x="40" y="0" width="20" height="10"/>
+      </node>
+      <node x="80" y="0" width="60" height="40"/>
+      <node x="20" y="15" width="60" height="25"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_items_baseline_synthesized_margins__border_box_ltr.xml
+++ b/tests/xml/grid/grid_align_items_baseline_synthesized_margins__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_align_items_baseline_synthesized_margins__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" align-items="baseline" width="200px" grid-template-columns="50px 50px 50px">
+      <div direction="ltr" height="20px" margin-top="40px" margin-left="0px" margin-bottom="40px" margin-right="0px"/>
+      <div direction="ltr" height="20px" margin-top="0px" margin-left="0px" margin-bottom="0px" margin-right="0px"/>
+      <div direction="ltr" height="20px" margin-top="20px" margin-left="0px" margin-bottom="20px" margin-right="0px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="0" y="40" width="50" height="20"/>
+      <node x="50" y="40" width="50" height="20"/>
+      <node x="100" y="40" width="50" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_items_baseline_synthesized_margins__border_box_rtl.xml
+++ b/tests/xml/grid/grid_align_items_baseline_synthesized_margins__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_align_items_baseline_synthesized_margins__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" align-items="baseline" width="200px" grid-template-columns="50px 50px 50px">
+      <div direction="rtl" height="20px" margin-top="40px" margin-left="0px" margin-bottom="40px" margin-right="0px"/>
+      <div direction="rtl" height="20px" margin-top="0px" margin-left="0px" margin-bottom="0px" margin-right="0px"/>
+      <div direction="rtl" height="20px" margin-top="20px" margin-left="0px" margin-bottom="20px" margin-right="0px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="150" y="40" width="50" height="20"/>
+      <node x="100" y="40" width="50" height="20"/>
+      <node x="50" y="40" width="50" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_items_baseline_synthesized_margins__content_box_ltr.xml
+++ b/tests/xml/grid/grid_align_items_baseline_synthesized_margins__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_align_items_baseline_synthesized_margins__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" align-items="baseline" width="200px" grid-template-columns="50px 50px 50px">
+      <div box-sizing="content-box" direction="ltr" height="20px" margin-top="40px" margin-left="0px" margin-bottom="40px" margin-right="0px"/>
+      <div box-sizing="content-box" direction="ltr" height="20px" margin-top="0px" margin-left="0px" margin-bottom="0px" margin-right="0px"/>
+      <div box-sizing="content-box" direction="ltr" height="20px" margin-top="20px" margin-left="0px" margin-bottom="20px" margin-right="0px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="0" y="40" width="50" height="20"/>
+      <node x="50" y="40" width="50" height="20"/>
+      <node x="100" y="40" width="50" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_items_baseline_synthesized_margins__content_box_rtl.xml
+++ b/tests/xml/grid/grid_align_items_baseline_synthesized_margins__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_align_items_baseline_synthesized_margins__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" align-items="baseline" width="200px" grid-template-columns="50px 50px 50px">
+      <div box-sizing="content-box" direction="rtl" height="20px" margin-top="40px" margin-left="0px" margin-bottom="40px" margin-right="0px"/>
+      <div box-sizing="content-box" direction="rtl" height="20px" margin-top="0px" margin-left="0px" margin-bottom="0px" margin-right="0px"/>
+      <div box-sizing="content-box" direction="rtl" height="20px" margin-top="20px" margin-left="0px" margin-bottom="20px" margin-right="0px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="150" y="40" width="50" height="20"/>
+      <node x="100" y="40" width="50" height="20"/>
+      <node x="50" y="40" width="50" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_last_baseline_double_nested_grid__border_box_ltr.xml
+++ b/tests/xml/grid/grid_align_last_baseline_double_nested_grid__border_box_ltr.xml
@@ -1,0 +1,25 @@
+<test name="grid_align_last_baseline_double_nested_grid__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" align-items="last baseline" width="200px" grid-template-columns="60px 100px">
+      <div direction="ltr" height="45px"/>
+      <div display="grid" direction="ltr" align-items="last baseline" padding-bottom="20px" border-top="10px" border-bottom="40px">
+        <div display="grid" direction="ltr" align-items="last baseline">
+          <div direction="ltr" width="40px" height="10px"/>
+          <div direction="ltr" width="40px" height="25px" grid-row-start="2"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="105">
+      <node x="0" y="0" width="60" height="45"/>
+      <node x="60" y="0" width="100" height="105">
+        <node x="0" y="10" width="100" height="35">
+          <node x="0" y="0" width="40" height="10"/>
+          <node x="0" y="10" width="40" height="25"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_last_baseline_double_nested_grid__border_box_rtl.xml
+++ b/tests/xml/grid/grid_align_last_baseline_double_nested_grid__border_box_rtl.xml
@@ -1,0 +1,25 @@
+<test name="grid_align_last_baseline_double_nested_grid__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" align-items="last baseline" width="200px" grid-template-columns="60px 100px">
+      <div direction="rtl" height="45px"/>
+      <div display="grid" direction="rtl" align-items="last baseline" padding-bottom="20px" border-top="10px" border-bottom="40px">
+        <div display="grid" direction="rtl" align-items="last baseline">
+          <div direction="rtl" width="40px" height="10px"/>
+          <div direction="rtl" width="40px" height="25px" grid-row-start="2"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="105">
+      <node x="140" y="0" width="60" height="45"/>
+      <node x="40" y="0" width="100" height="105">
+        <node x="0" y="10" width="100" height="35">
+          <node x="60" y="0" width="40" height="10"/>
+          <node x="60" y="10" width="40" height="25"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_last_baseline_double_nested_grid__content_box_ltr.xml
+++ b/tests/xml/grid/grid_align_last_baseline_double_nested_grid__content_box_ltr.xml
@@ -1,0 +1,25 @@
+<test name="grid_align_last_baseline_double_nested_grid__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" align-items="last baseline" width="200px" grid-template-columns="60px 100px">
+      <div box-sizing="content-box" direction="ltr" height="45px"/>
+      <div display="grid" box-sizing="content-box" direction="ltr" align-items="last baseline" padding-bottom="20px" border-top="10px" border-bottom="40px">
+        <div display="grid" box-sizing="content-box" direction="ltr" align-items="last baseline">
+          <div box-sizing="content-box" direction="ltr" width="40px" height="10px"/>
+          <div box-sizing="content-box" direction="ltr" width="40px" height="25px" grid-row-start="2"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="105">
+      <node x="0" y="0" width="60" height="45"/>
+      <node x="60" y="0" width="100" height="105">
+        <node x="0" y="10" width="100" height="35">
+          <node x="0" y="0" width="40" height="10"/>
+          <node x="0" y="10" width="40" height="25"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_last_baseline_double_nested_grid__content_box_rtl.xml
+++ b/tests/xml/grid/grid_align_last_baseline_double_nested_grid__content_box_rtl.xml
@@ -1,0 +1,25 @@
+<test name="grid_align_last_baseline_double_nested_grid__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" align-items="last baseline" width="200px" grid-template-columns="60px 100px">
+      <div box-sizing="content-box" direction="rtl" height="45px"/>
+      <div display="grid" box-sizing="content-box" direction="rtl" align-items="last baseline" padding-bottom="20px" border-top="10px" border-bottom="40px">
+        <div display="grid" box-sizing="content-box" direction="rtl" align-items="last baseline">
+          <div box-sizing="content-box" direction="rtl" width="40px" height="10px"/>
+          <div box-sizing="content-box" direction="rtl" width="40px" height="25px" grid-row-start="2"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="105">
+      <node x="140" y="0" width="60" height="45"/>
+      <node x="40" y="0" width="100" height="105">
+        <node x="0" y="10" width="100" height="35">
+          <node x="60" y="0" width="40" height="10"/>
+          <node x="60" y="10" width="40" height="25"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_last_baseline_spanned_nested_grid__border_box_ltr.xml
+++ b/tests/xml/grid/grid_align_last_baseline_spanned_nested_grid__border_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="grid_align_last_baseline_spanned_nested_grid__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" align-items="last baseline" width="200px" grid-template-rows="20px auto auto auto 30px" grid-template-columns="30px auto">
+      <div direction="ltr" width="30px" height="60px" grid-row-start="3" grid-column-start="1"/>
+      <div display="grid" direction="ltr" align-items="last baseline" padding-bottom="20px" border-top="10px" border-bottom="40px" grid-row-start="2" grid-row-end="span 2" grid-column-start="2">
+        <div direction="ltr" width="40px" height="10px"/>
+        <div direction="ltr" width="40px" height="35px" grid-row-start="2"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="170">
+      <node x="0" y="20" width="30" height="60"/>
+      <node x="30" y="25" width="170" height="115">
+        <node x="0" y="10" width="40" height="10"/>
+        <node x="0" y="20" width="40" height="35"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_last_baseline_spanned_nested_grid__border_box_rtl.xml
+++ b/tests/xml/grid/grid_align_last_baseline_spanned_nested_grid__border_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="grid_align_last_baseline_spanned_nested_grid__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" align-items="last baseline" width="200px" grid-template-rows="20px auto auto auto 30px" grid-template-columns="30px auto">
+      <div direction="rtl" width="30px" height="60px" grid-row-start="3" grid-column-start="1"/>
+      <div display="grid" direction="rtl" align-items="last baseline" padding-bottom="20px" border-top="10px" border-bottom="40px" grid-row-start="2" grid-row-end="span 2" grid-column-start="2">
+        <div direction="rtl" width="40px" height="10px"/>
+        <div direction="rtl" width="40px" height="35px" grid-row-start="2"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="170">
+      <node x="170" y="20" width="30" height="60"/>
+      <node x="0" y="25" width="170" height="115">
+        <node x="130" y="10" width="40" height="10"/>
+        <node x="130" y="20" width="40" height="35"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_last_baseline_spanned_nested_grid__content_box_ltr.xml
+++ b/tests/xml/grid/grid_align_last_baseline_spanned_nested_grid__content_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="grid_align_last_baseline_spanned_nested_grid__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" align-items="last baseline" width="200px" grid-template-rows="20px auto auto auto 30px" grid-template-columns="30px auto">
+      <div box-sizing="content-box" direction="ltr" width="30px" height="60px" grid-row-start="3" grid-column-start="1"/>
+      <div display="grid" box-sizing="content-box" direction="ltr" align-items="last baseline" padding-bottom="20px" border-top="10px" border-bottom="40px" grid-row-start="2" grid-row-end="span 2" grid-column-start="2">
+        <div box-sizing="content-box" direction="ltr" width="40px" height="10px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="35px" grid-row-start="2"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="170">
+      <node x="0" y="20" width="30" height="60"/>
+      <node x="30" y="25" width="170" height="115">
+        <node x="0" y="10" width="40" height="10"/>
+        <node x="0" y="20" width="40" height="35"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_last_baseline_spanned_nested_grid__content_box_rtl.xml
+++ b/tests/xml/grid/grid_align_last_baseline_spanned_nested_grid__content_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="grid_align_last_baseline_spanned_nested_grid__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" align-items="last baseline" width="200px" grid-template-rows="20px auto auto auto 30px" grid-template-columns="30px auto">
+      <div box-sizing="content-box" direction="rtl" width="30px" height="60px" grid-row-start="3" grid-column-start="1"/>
+      <div display="grid" box-sizing="content-box" direction="rtl" align-items="last baseline" padding-bottom="20px" border-top="10px" border-bottom="40px" grid-row-start="2" grid-row-end="span 2" grid-column-start="2">
+        <div box-sizing="content-box" direction="rtl" width="40px" height="10px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="35px" grid-row-start="2"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="170">
+      <node x="170" y="20" width="30" height="60"/>
+      <node x="0" y="25" width="170" height="115">
+        <node x="130" y="10" width="40" height="10"/>
+        <node x="130" y="20" width="40" height="35"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_last_baseline_spanned_nested_grid_spanned_item__border_box_ltr.xml
+++ b/tests/xml/grid/grid_align_last_baseline_spanned_nested_grid_spanned_item__border_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="grid_align_last_baseline_spanned_nested_grid_spanned_item__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" align-items="last baseline" width="200px" grid-template-rows="20px auto auto auto 30px" grid-template-columns="30px auto">
+      <div direction="ltr" width="30px" height="60px" grid-row-start="3" grid-column-start="1"/>
+      <div display="grid" direction="ltr" align-items="last baseline" padding-bottom="20px" border-top="10px" border-bottom="40px" grid-row-start="2" grid-row-end="span 2" grid-column-start="2">
+        <div direction="ltr" width="40px" height="10px"/>
+        <div direction="ltr" width="40px" height="35px" grid-row-start="2" grid-row-end="span 3"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="170">
+      <node x="0" y="20" width="30" height="60"/>
+      <node x="30" y="25" width="170" height="115">
+        <node x="0" y="10" width="40" height="10"/>
+        <node x="0" y="20" width="40" height="35"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_last_baseline_spanned_nested_grid_spanned_item__border_box_rtl.xml
+++ b/tests/xml/grid/grid_align_last_baseline_spanned_nested_grid_spanned_item__border_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="grid_align_last_baseline_spanned_nested_grid_spanned_item__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" align-items="last baseline" width="200px" grid-template-rows="20px auto auto auto 30px" grid-template-columns="30px auto">
+      <div direction="rtl" width="30px" height="60px" grid-row-start="3" grid-column-start="1"/>
+      <div display="grid" direction="rtl" align-items="last baseline" padding-bottom="20px" border-top="10px" border-bottom="40px" grid-row-start="2" grid-row-end="span 2" grid-column-start="2">
+        <div direction="rtl" width="40px" height="10px"/>
+        <div direction="rtl" width="40px" height="35px" grid-row-start="2" grid-row-end="span 3"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="170">
+      <node x="170" y="20" width="30" height="60"/>
+      <node x="0" y="25" width="170" height="115">
+        <node x="130" y="10" width="40" height="10"/>
+        <node x="130" y="20" width="40" height="35"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_last_baseline_spanned_nested_grid_spanned_item__content_box_ltr.xml
+++ b/tests/xml/grid/grid_align_last_baseline_spanned_nested_grid_spanned_item__content_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="grid_align_last_baseline_spanned_nested_grid_spanned_item__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" align-items="last baseline" width="200px" grid-template-rows="20px auto auto auto 30px" grid-template-columns="30px auto">
+      <div box-sizing="content-box" direction="ltr" width="30px" height="60px" grid-row-start="3" grid-column-start="1"/>
+      <div display="grid" box-sizing="content-box" direction="ltr" align-items="last baseline" padding-bottom="20px" border-top="10px" border-bottom="40px" grid-row-start="2" grid-row-end="span 2" grid-column-start="2">
+        <div box-sizing="content-box" direction="ltr" width="40px" height="10px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="35px" grid-row-start="2" grid-row-end="span 3"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="170">
+      <node x="0" y="20" width="30" height="60"/>
+      <node x="30" y="25" width="170" height="115">
+        <node x="0" y="10" width="40" height="10"/>
+        <node x="0" y="20" width="40" height="35"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_last_baseline_spanned_nested_grid_spanned_item__content_box_rtl.xml
+++ b/tests/xml/grid/grid_align_last_baseline_spanned_nested_grid_spanned_item__content_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="grid_align_last_baseline_spanned_nested_grid_spanned_item__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" align-items="last baseline" width="200px" grid-template-rows="20px auto auto auto 30px" grid-template-columns="30px auto">
+      <div box-sizing="content-box" direction="rtl" width="30px" height="60px" grid-row-start="3" grid-column-start="1"/>
+      <div display="grid" box-sizing="content-box" direction="rtl" align-items="last baseline" padding-bottom="20px" border-top="10px" border-bottom="40px" grid-row-start="2" grid-row-end="span 2" grid-column-start="2">
+        <div box-sizing="content-box" direction="rtl" width="40px" height="10px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="35px" grid-row-start="2" grid-row-end="span 3"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="170">
+      <node x="170" y="20" width="30" height="60"/>
+      <node x="0" y="25" width="170" height="115">
+        <node x="130" y="10" width="40" height="10"/>
+        <node x="130" y="20" width="40" height="35"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_self_baseline_aspect_ratio_percent_tracks__border_box_ltr.xml
+++ b/tests/xml/grid/grid_align_self_baseline_aspect_ratio_percent_tracks__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_align_self_baseline_aspect_ratio_percent_tracks__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="400px" grid-template-columns="25% 25% 25% 25%">
+      <div direction="ltr" align-self="baseline" width="100%" aspect-ratio="2"/>
+      <div direction="ltr" align-self="baseline" width="100%" aspect-ratio="1"/>
+      <div direction="ltr" align-self="baseline" width="100%" aspect-ratio="4"/>
+      <div direction="ltr" height="120px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="120">
+      <node x="0" y="50" width="100" height="50"/>
+      <node x="100" y="0" width="100" height="100"/>
+      <node x="200" y="75" width="100" height="25"/>
+      <node x="300" y="0" width="100" height="120"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_self_baseline_aspect_ratio_percent_tracks__border_box_rtl.xml
+++ b/tests/xml/grid/grid_align_self_baseline_aspect_ratio_percent_tracks__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_align_self_baseline_aspect_ratio_percent_tracks__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="400px" grid-template-columns="25% 25% 25% 25%">
+      <div direction="rtl" align-self="baseline" width="100%" aspect-ratio="2"/>
+      <div direction="rtl" align-self="baseline" width="100%" aspect-ratio="1"/>
+      <div direction="rtl" align-self="baseline" width="100%" aspect-ratio="4"/>
+      <div direction="rtl" height="120px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="120">
+      <node x="300" y="50" width="100" height="50"/>
+      <node x="200" y="0" width="100" height="100"/>
+      <node x="100" y="75" width="100" height="25"/>
+      <node x="0" y="0" width="100" height="120"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_self_baseline_aspect_ratio_percent_tracks__content_box_ltr.xml
+++ b/tests/xml/grid/grid_align_self_baseline_aspect_ratio_percent_tracks__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_align_self_baseline_aspect_ratio_percent_tracks__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="400px" grid-template-columns="25% 25% 25% 25%">
+      <div box-sizing="content-box" direction="ltr" align-self="baseline" width="100%" aspect-ratio="2"/>
+      <div box-sizing="content-box" direction="ltr" align-self="baseline" width="100%" aspect-ratio="1"/>
+      <div box-sizing="content-box" direction="ltr" align-self="baseline" width="100%" aspect-ratio="4"/>
+      <div box-sizing="content-box" direction="ltr" height="120px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="120">
+      <node x="0" y="50" width="100" height="50"/>
+      <node x="100" y="0" width="100" height="100"/>
+      <node x="200" y="75" width="100" height="25"/>
+      <node x="300" y="0" width="100" height="120"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_self_baseline_aspect_ratio_percent_tracks__content_box_rtl.xml
+++ b/tests/xml/grid/grid_align_self_baseline_aspect_ratio_percent_tracks__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_align_self_baseline_aspect_ratio_percent_tracks__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="400px" grid-template-columns="25% 25% 25% 25%">
+      <div box-sizing="content-box" direction="rtl" align-self="baseline" width="100%" aspect-ratio="2"/>
+      <div box-sizing="content-box" direction="rtl" align-self="baseline" width="100%" aspect-ratio="1"/>
+      <div box-sizing="content-box" direction="rtl" align-self="baseline" width="100%" aspect-ratio="4"/>
+      <div box-sizing="content-box" direction="rtl" height="120px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="120">
+      <node x="300" y="50" width="100" height="50"/>
+      <node x="200" y="0" width="100" height="100"/>
+      <node x="100" y="75" width="100" height="25"/>
+      <node x="0" y="0" width="100" height="120"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_self_baseline_synthesized_margins__border_box_ltr.xml
+++ b/tests/xml/grid/grid_align_self_baseline_synthesized_margins__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_align_self_baseline_synthesized_margins__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="250px" grid-template-columns="50px 50px 50px 50px">
+      <div direction="ltr" align-self="baseline" height="20px"/>
+      <div direction="ltr" align-self="baseline" height="10px" margin-top="30px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+      <div direction="ltr" align-self="baseline" height="10px" margin-top="20px" margin-left="0px" margin-bottom="0px" margin-right="0px"/>
+      <div direction="ltr" height="100px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="250" height="100">
+      <node x="0" y="20" width="50" height="20"/>
+      <node x="50" y="30" width="50" height="10"/>
+      <node x="100" y="30" width="50" height="10"/>
+      <node x="150" y="0" width="50" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_self_baseline_synthesized_margins__border_box_rtl.xml
+++ b/tests/xml/grid/grid_align_self_baseline_synthesized_margins__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_align_self_baseline_synthesized_margins__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="250px" grid-template-columns="50px 50px 50px 50px">
+      <div direction="rtl" align-self="baseline" height="20px"/>
+      <div direction="rtl" align-self="baseline" height="10px" margin-top="30px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+      <div direction="rtl" align-self="baseline" height="10px" margin-top="20px" margin-left="0px" margin-bottom="0px" margin-right="0px"/>
+      <div direction="rtl" height="100px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="250" height="100">
+      <node x="200" y="20" width="50" height="20"/>
+      <node x="150" y="30" width="50" height="10"/>
+      <node x="100" y="30" width="50" height="10"/>
+      <node x="50" y="0" width="50" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_self_baseline_synthesized_margins__content_box_ltr.xml
+++ b/tests/xml/grid/grid_align_self_baseline_synthesized_margins__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_align_self_baseline_synthesized_margins__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="250px" grid-template-columns="50px 50px 50px 50px">
+      <div box-sizing="content-box" direction="ltr" align-self="baseline" height="20px"/>
+      <div box-sizing="content-box" direction="ltr" align-self="baseline" height="10px" margin-top="30px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+      <div box-sizing="content-box" direction="ltr" align-self="baseline" height="10px" margin-top="20px" margin-left="0px" margin-bottom="0px" margin-right="0px"/>
+      <div box-sizing="content-box" direction="ltr" height="100px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="250" height="100">
+      <node x="0" y="20" width="50" height="20"/>
+      <node x="50" y="30" width="50" height="10"/>
+      <node x="100" y="30" width="50" height="10"/>
+      <node x="150" y="0" width="50" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_self_baseline_synthesized_margins__content_box_rtl.xml
+++ b/tests/xml/grid/grid_align_self_baseline_synthesized_margins__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_align_self_baseline_synthesized_margins__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="250px" grid-template-columns="50px 50px 50px 50px">
+      <div box-sizing="content-box" direction="rtl" align-self="baseline" height="20px"/>
+      <div box-sizing="content-box" direction="rtl" align-self="baseline" height="10px" margin-top="30px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+      <div box-sizing="content-box" direction="rtl" align-self="baseline" height="10px" margin-top="20px" margin-left="0px" margin-bottom="0px" margin-right="0px"/>
+      <div box-sizing="content-box" direction="rtl" height="100px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="250" height="100">
+      <node x="200" y="20" width="50" height="20"/>
+      <node x="150" y="30" width="50" height="10"/>
+      <node x="100" y="30" width="50" height="10"/>
+      <node x="50" y="0" width="50" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_self_last_baseline_synthesized_margins__border_box_ltr.xml
+++ b/tests/xml/grid/grid_align_self_last_baseline_synthesized_margins__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_align_self_last_baseline_synthesized_margins__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="250px" grid-template-columns="50px 50px 50px 50px">
+      <div direction="ltr" align-self="last baseline" height="20px"/>
+      <div direction="ltr" align-self="last baseline" height="10px" margin-top="30px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+      <div direction="ltr" align-self="last baseline" height="10px" margin-top="20px" margin-left="0px" margin-bottom="0px" margin-right="0px"/>
+      <div direction="ltr" height="100px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="250" height="100">
+      <node x="0" y="70" width="50" height="20"/>
+      <node x="50" y="80" width="50" height="10"/>
+      <node x="100" y="80" width="50" height="10"/>
+      <node x="150" y="0" width="50" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_self_last_baseline_synthesized_margins__border_box_rtl.xml
+++ b/tests/xml/grid/grid_align_self_last_baseline_synthesized_margins__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_align_self_last_baseline_synthesized_margins__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="250px" grid-template-columns="50px 50px 50px 50px">
+      <div direction="rtl" align-self="last baseline" height="20px"/>
+      <div direction="rtl" align-self="last baseline" height="10px" margin-top="30px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+      <div direction="rtl" align-self="last baseline" height="10px" margin-top="20px" margin-left="0px" margin-bottom="0px" margin-right="0px"/>
+      <div direction="rtl" height="100px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="250" height="100">
+      <node x="200" y="70" width="50" height="20"/>
+      <node x="150" y="80" width="50" height="10"/>
+      <node x="100" y="80" width="50" height="10"/>
+      <node x="50" y="0" width="50" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_self_last_baseline_synthesized_margins__content_box_ltr.xml
+++ b/tests/xml/grid/grid_align_self_last_baseline_synthesized_margins__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_align_self_last_baseline_synthesized_margins__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="250px" grid-template-columns="50px 50px 50px 50px">
+      <div box-sizing="content-box" direction="ltr" align-self="last baseline" height="20px"/>
+      <div box-sizing="content-box" direction="ltr" align-self="last baseline" height="10px" margin-top="30px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+      <div box-sizing="content-box" direction="ltr" align-self="last baseline" height="10px" margin-top="20px" margin-left="0px" margin-bottom="0px" margin-right="0px"/>
+      <div box-sizing="content-box" direction="ltr" height="100px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="250" height="100">
+      <node x="0" y="70" width="50" height="20"/>
+      <node x="50" y="80" width="50" height="10"/>
+      <node x="100" y="80" width="50" height="10"/>
+      <node x="150" y="0" width="50" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_align_self_last_baseline_synthesized_margins__content_box_rtl.xml
+++ b/tests/xml/grid/grid_align_self_last_baseline_synthesized_margins__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_align_self_last_baseline_synthesized_margins__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="250px" grid-template-columns="50px 50px 50px 50px">
+      <div box-sizing="content-box" direction="rtl" align-self="last baseline" height="20px"/>
+      <div box-sizing="content-box" direction="rtl" align-self="last baseline" height="10px" margin-top="30px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+      <div box-sizing="content-box" direction="rtl" align-self="last baseline" height="10px" margin-top="20px" margin-left="0px" margin-bottom="0px" margin-right="0px"/>
+      <div box-sizing="content-box" direction="rtl" height="100px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="250" height="100">
+      <node x="200" y="70" width="50" height="20"/>
+      <node x="150" y="80" width="50" height="10"/>
+      <node x="100" y="80" width="50" height="10"/>
+      <node x="50" y="0" width="50" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/gridflex/gridflex_align_baseline_nested_grid__border_box_ltr.xml
+++ b/tests/xml/gridflex/gridflex_align_baseline_nested_grid__border_box_ltr.xml
@@ -1,0 +1,25 @@
+<test name="gridflex_align_baseline_nested_grid__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" align-items="baseline" width="300px">
+      <div direction="ltr" width="20px" height="45px"/>
+      <div display="grid" direction="ltr" row-gap="10px" column-gap="10px" grid-template-columns="40px 40px">
+        <div direction="ltr" height="10px"/>
+        <div direction="ltr" align-self="baseline" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="ltr" height="50px"/>
+        <div direction="ltr" align-self="baseline" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="125">
+      <node x="0" y="0" width="20" height="45"/>
+      <node x="20" y="5" width="90" height="120">
+        <node x="0" y="0" width="40" height="10"/>
+        <node x="50" y="10" width="40" height="30"/>
+        <node x="0" y="60" width="40" height="50"/>
+        <node x="50" y="70" width="40" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/gridflex/gridflex_align_baseline_nested_grid__border_box_rtl.xml
+++ b/tests/xml/gridflex/gridflex_align_baseline_nested_grid__border_box_rtl.xml
@@ -1,0 +1,25 @@
+<test name="gridflex_align_baseline_nested_grid__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" align-items="baseline" width="300px">
+      <div direction="rtl" width="20px" height="45px"/>
+      <div display="grid" direction="rtl" row-gap="10px" column-gap="10px" grid-template-columns="40px 40px">
+        <div direction="rtl" height="10px"/>
+        <div direction="rtl" align-self="baseline" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="rtl" height="50px"/>
+        <div direction="rtl" align-self="baseline" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="125">
+      <node x="280" y="0" width="20" height="45"/>
+      <node x="190" y="5" width="90" height="120">
+        <node x="50" y="0" width="40" height="10"/>
+        <node x="0" y="10" width="40" height="30"/>
+        <node x="50" y="60" width="40" height="50"/>
+        <node x="0" y="70" width="40" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/gridflex/gridflex_align_baseline_nested_grid__content_box_ltr.xml
+++ b/tests/xml/gridflex/gridflex_align_baseline_nested_grid__content_box_ltr.xml
@@ -1,0 +1,25 @@
+<test name="gridflex_align_baseline_nested_grid__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" align-items="baseline" width="300px">
+      <div box-sizing="content-box" direction="ltr" width="20px" height="45px"/>
+      <div display="grid" box-sizing="content-box" direction="ltr" row-gap="10px" column-gap="10px" grid-template-columns="40px 40px">
+        <div box-sizing="content-box" direction="ltr" height="10px"/>
+        <div box-sizing="content-box" direction="ltr" align-self="baseline" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="ltr" height="50px"/>
+        <div box-sizing="content-box" direction="ltr" align-self="baseline" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="125">
+      <node x="0" y="0" width="20" height="45"/>
+      <node x="20" y="5" width="90" height="120">
+        <node x="0" y="0" width="40" height="10"/>
+        <node x="50" y="10" width="40" height="30"/>
+        <node x="0" y="60" width="40" height="50"/>
+        <node x="50" y="70" width="40" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/gridflex/gridflex_align_baseline_nested_grid__content_box_rtl.xml
+++ b/tests/xml/gridflex/gridflex_align_baseline_nested_grid__content_box_rtl.xml
@@ -1,0 +1,25 @@
+<test name="gridflex_align_baseline_nested_grid__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" align-items="baseline" width="300px">
+      <div box-sizing="content-box" direction="rtl" width="20px" height="45px"/>
+      <div display="grid" box-sizing="content-box" direction="rtl" row-gap="10px" column-gap="10px" grid-template-columns="40px 40px">
+        <div box-sizing="content-box" direction="rtl" height="10px"/>
+        <div box-sizing="content-box" direction="rtl" align-self="baseline" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="rtl" height="50px"/>
+        <div box-sizing="content-box" direction="rtl" align-self="baseline" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="125">
+      <node x="280" y="0" width="20" height="45"/>
+      <node x="190" y="5" width="90" height="120">
+        <node x="50" y="0" width="40" height="10"/>
+        <node x="0" y="10" width="40" height="30"/>
+        <node x="50" y="60" width="40" height="50"/>
+        <node x="0" y="70" width="40" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/gridflex/gridflex_align_last_baseline_nested_grid__border_box_ltr.xml
+++ b/tests/xml/gridflex/gridflex_align_last_baseline_nested_grid__border_box_ltr.xml
@@ -1,0 +1,25 @@
+<test name="gridflex_align_last_baseline_nested_grid__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" align-items="last baseline" width="300px">
+      <div direction="ltr" width="20px" height="45px"/>
+      <div display="grid" direction="ltr" row-gap="10px" column-gap="10px" grid-template-columns="40px 40px">
+        <div direction="ltr" height="10px"/>
+        <div direction="ltr" align-self="last baseline" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="ltr" height="50px"/>
+        <div direction="ltr" align-self="last baseline" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="120">
+      <node x="0" y="65" width="20" height="45"/>
+      <node x="20" y="0" width="90" height="120">
+        <node x="0" y="0" width="40" height="10"/>
+        <node x="50" y="10" width="40" height="30"/>
+        <node x="0" y="60" width="40" height="50"/>
+        <node x="50" y="70" width="40" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/gridflex/gridflex_align_last_baseline_nested_grid__border_box_rtl.xml
+++ b/tests/xml/gridflex/gridflex_align_last_baseline_nested_grid__border_box_rtl.xml
@@ -1,0 +1,25 @@
+<test name="gridflex_align_last_baseline_nested_grid__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" align-items="last baseline" width="300px">
+      <div direction="rtl" width="20px" height="45px"/>
+      <div display="grid" direction="rtl" row-gap="10px" column-gap="10px" grid-template-columns="40px 40px">
+        <div direction="rtl" height="10px"/>
+        <div direction="rtl" align-self="last baseline" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="rtl" height="50px"/>
+        <div direction="rtl" align-self="last baseline" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="120">
+      <node x="280" y="65" width="20" height="45"/>
+      <node x="190" y="0" width="90" height="120">
+        <node x="50" y="0" width="40" height="10"/>
+        <node x="0" y="10" width="40" height="30"/>
+        <node x="50" y="60" width="40" height="50"/>
+        <node x="0" y="70" width="40" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/gridflex/gridflex_align_last_baseline_nested_grid__content_box_ltr.xml
+++ b/tests/xml/gridflex/gridflex_align_last_baseline_nested_grid__content_box_ltr.xml
@@ -1,0 +1,25 @@
+<test name="gridflex_align_last_baseline_nested_grid__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" align-items="last baseline" width="300px">
+      <div box-sizing="content-box" direction="ltr" width="20px" height="45px"/>
+      <div display="grid" box-sizing="content-box" direction="ltr" row-gap="10px" column-gap="10px" grid-template-columns="40px 40px">
+        <div box-sizing="content-box" direction="ltr" height="10px"/>
+        <div box-sizing="content-box" direction="ltr" align-self="last baseline" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="ltr" height="50px"/>
+        <div box-sizing="content-box" direction="ltr" align-self="last baseline" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="120">
+      <node x="0" y="65" width="20" height="45"/>
+      <node x="20" y="0" width="90" height="120">
+        <node x="0" y="0" width="40" height="10"/>
+        <node x="50" y="10" width="40" height="30"/>
+        <node x="0" y="60" width="40" height="50"/>
+        <node x="50" y="70" width="40" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/gridflex/gridflex_align_last_baseline_nested_grid__content_box_rtl.xml
+++ b/tests/xml/gridflex/gridflex_align_last_baseline_nested_grid__content_box_rtl.xml
@@ -1,0 +1,25 @@
+<test name="gridflex_align_last_baseline_nested_grid__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" align-items="last baseline" width="300px">
+      <div box-sizing="content-box" direction="rtl" width="20px" height="45px"/>
+      <div display="grid" box-sizing="content-box" direction="rtl" row-gap="10px" column-gap="10px" grid-template-columns="40px 40px">
+        <div box-sizing="content-box" direction="rtl" height="10px"/>
+        <div box-sizing="content-box" direction="rtl" align-self="last baseline" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="rtl" height="50px"/>
+        <div box-sizing="content-box" direction="rtl" align-self="last baseline" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="120">
+      <node x="280" y="65" width="20" height="45"/>
+      <node x="190" y="0" width="90" height="120">
+        <node x="50" y="0" width="40" height="10"/>
+        <node x="0" y="10" width="40" height="30"/>
+        <node x="50" y="60" width="40" height="50"/>
+        <node x="0" y="70" width="40" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/gridflex/gridflex_grid_align_baseline_nested_flex_wrap__border_box_ltr.xml
+++ b/tests/xml/gridflex/gridflex_grid_align_baseline_nested_flex_wrap__border_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="gridflex_grid_align_baseline_nested_flex_wrap__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" align-items="baseline" width="200px" grid-template-columns="40px 160px">
+      <div direction="ltr" height="45px"/>
+      <div direction="ltr" flex-wrap="wrap" width="140px" row-gap="10px" column-gap="10px">
+        <div direction="ltr" width="40px" height="10px"/>
+        <div direction="ltr" align-self="baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="ltr" width="40px" height="50px"/>
+        <div direction="ltr" width="40px" height="60px"/>
+        <div direction="ltr" align-self="baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="ltr" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="125">
+      <node x="0" y="0" width="40" height="45"/>
+      <node x="40" y="5" width="140" height="120">
+        <node x="0" y="0" width="40" height="10"/>
+        <node x="50" y="10" width="40" height="30"/>
+        <node x="100" y="0" width="40" height="50"/>
+        <node x="0" y="60" width="40" height="60"/>
+        <node x="50" y="70" width="40" height="40"/>
+        <node x="100" y="60" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/gridflex/gridflex_grid_align_baseline_nested_flex_wrap__border_box_rtl.xml
+++ b/tests/xml/gridflex/gridflex_grid_align_baseline_nested_flex_wrap__border_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="gridflex_grid_align_baseline_nested_flex_wrap__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" align-items="baseline" width="200px" grid-template-columns="40px 160px">
+      <div direction="rtl" height="45px"/>
+      <div direction="rtl" flex-wrap="wrap" width="140px" row-gap="10px" column-gap="10px">
+        <div direction="rtl" width="40px" height="10px"/>
+        <div direction="rtl" align-self="baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="rtl" width="40px" height="50px"/>
+        <div direction="rtl" width="40px" height="60px"/>
+        <div direction="rtl" align-self="baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="rtl" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="125">
+      <node x="160" y="0" width="40" height="45"/>
+      <node x="20" y="5" width="140" height="120">
+        <node x="100" y="0" width="40" height="10"/>
+        <node x="50" y="10" width="40" height="30"/>
+        <node x="0" y="0" width="40" height="50"/>
+        <node x="100" y="60" width="40" height="60"/>
+        <node x="50" y="70" width="40" height="40"/>
+        <node x="0" y="60" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/gridflex/gridflex_grid_align_baseline_nested_flex_wrap__content_box_ltr.xml
+++ b/tests/xml/gridflex/gridflex_grid_align_baseline_nested_flex_wrap__content_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="gridflex_grid_align_baseline_nested_flex_wrap__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" align-items="baseline" width="200px" grid-template-columns="40px 160px">
+      <div box-sizing="content-box" direction="ltr" height="45px"/>
+      <div box-sizing="content-box" direction="ltr" flex-wrap="wrap" width="140px" row-gap="10px" column-gap="10px">
+        <div box-sizing="content-box" direction="ltr" width="40px" height="10px"/>
+        <div box-sizing="content-box" direction="ltr" align-self="baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="50px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="60px"/>
+        <div box-sizing="content-box" direction="ltr" align-self="baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="125">
+      <node x="0" y="0" width="40" height="45"/>
+      <node x="40" y="5" width="140" height="120">
+        <node x="0" y="0" width="40" height="10"/>
+        <node x="50" y="10" width="40" height="30"/>
+        <node x="100" y="0" width="40" height="50"/>
+        <node x="0" y="60" width="40" height="60"/>
+        <node x="50" y="70" width="40" height="40"/>
+        <node x="100" y="60" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/gridflex/gridflex_grid_align_baseline_nested_flex_wrap__content_box_rtl.xml
+++ b/tests/xml/gridflex/gridflex_grid_align_baseline_nested_flex_wrap__content_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="gridflex_grid_align_baseline_nested_flex_wrap__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" align-items="baseline" width="200px" grid-template-columns="40px 160px">
+      <div box-sizing="content-box" direction="rtl" height="45px"/>
+      <div box-sizing="content-box" direction="rtl" flex-wrap="wrap" width="140px" row-gap="10px" column-gap="10px">
+        <div box-sizing="content-box" direction="rtl" width="40px" height="10px"/>
+        <div box-sizing="content-box" direction="rtl" align-self="baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="50px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="60px"/>
+        <div box-sizing="content-box" direction="rtl" align-self="baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="125">
+      <node x="160" y="0" width="40" height="45"/>
+      <node x="20" y="5" width="140" height="120">
+        <node x="100" y="0" width="40" height="10"/>
+        <node x="50" y="10" width="40" height="30"/>
+        <node x="0" y="0" width="40" height="50"/>
+        <node x="100" y="60" width="40" height="60"/>
+        <node x="50" y="70" width="40" height="40"/>
+        <node x="0" y="60" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/gridflex/gridflex_grid_align_baseline_nested_flex_wrap_reverse__border_box_ltr.xml
+++ b/tests/xml/gridflex/gridflex_grid_align_baseline_nested_flex_wrap_reverse__border_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="gridflex_grid_align_baseline_nested_flex_wrap_reverse__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" align-items="baseline" width="200px" grid-template-columns="40px 160px">
+      <div direction="ltr" height="45px"/>
+      <div direction="ltr" flex-wrap="wrap-reverse" width="140px" row-gap="10px" column-gap="10px">
+        <div direction="ltr" width="40px" height="10px"/>
+        <div direction="ltr" align-self="baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="ltr" width="40px" height="50px"/>
+        <div direction="ltr" width="40px" height="60px"/>
+        <div direction="ltr" align-self="baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="ltr" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="120">
+      <node x="0" y="5" width="40" height="45"/>
+      <node x="40" y="0" width="140" height="120">
+        <node x="0" y="110" width="40" height="10"/>
+        <node x="50" y="80" width="40" height="30"/>
+        <node x="100" y="70" width="40" height="50"/>
+        <node x="0" y="0" width="40" height="60"/>
+        <node x="50" y="10" width="40" height="40"/>
+        <node x="100" y="40" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/gridflex/gridflex_grid_align_baseline_nested_flex_wrap_reverse__border_box_rtl.xml
+++ b/tests/xml/gridflex/gridflex_grid_align_baseline_nested_flex_wrap_reverse__border_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="gridflex_grid_align_baseline_nested_flex_wrap_reverse__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" align-items="baseline" width="200px" grid-template-columns="40px 160px">
+      <div direction="rtl" height="45px"/>
+      <div direction="rtl" flex-wrap="wrap-reverse" width="140px" row-gap="10px" column-gap="10px">
+        <div direction="rtl" width="40px" height="10px"/>
+        <div direction="rtl" align-self="baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="rtl" width="40px" height="50px"/>
+        <div direction="rtl" width="40px" height="60px"/>
+        <div direction="rtl" align-self="baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div direction="rtl" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="120">
+      <node x="160" y="5" width="40" height="45"/>
+      <node x="20" y="0" width="140" height="120">
+        <node x="100" y="110" width="40" height="10"/>
+        <node x="50" y="80" width="40" height="30"/>
+        <node x="0" y="70" width="40" height="50"/>
+        <node x="100" y="0" width="40" height="60"/>
+        <node x="50" y="10" width="40" height="40"/>
+        <node x="0" y="40" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/gridflex/gridflex_grid_align_baseline_nested_flex_wrap_reverse__content_box_ltr.xml
+++ b/tests/xml/gridflex/gridflex_grid_align_baseline_nested_flex_wrap_reverse__content_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="gridflex_grid_align_baseline_nested_flex_wrap_reverse__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" align-items="baseline" width="200px" grid-template-columns="40px 160px">
+      <div box-sizing="content-box" direction="ltr" height="45px"/>
+      <div box-sizing="content-box" direction="ltr" flex-wrap="wrap-reverse" width="140px" row-gap="10px" column-gap="10px">
+        <div box-sizing="content-box" direction="ltr" width="40px" height="10px"/>
+        <div box-sizing="content-box" direction="ltr" align-self="baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="50px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="60px"/>
+        <div box-sizing="content-box" direction="ltr" align-self="baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="120">
+      <node x="0" y="5" width="40" height="45"/>
+      <node x="40" y="0" width="140" height="120">
+        <node x="0" y="110" width="40" height="10"/>
+        <node x="50" y="80" width="40" height="30"/>
+        <node x="100" y="70" width="40" height="50"/>
+        <node x="0" y="0" width="40" height="60"/>
+        <node x="50" y="10" width="40" height="40"/>
+        <node x="100" y="40" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/gridflex/gridflex_grid_align_baseline_nested_flex_wrap_reverse__content_box_rtl.xml
+++ b/tests/xml/gridflex/gridflex_grid_align_baseline_nested_flex_wrap_reverse__content_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="gridflex_grid_align_baseline_nested_flex_wrap_reverse__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" align-items="baseline" width="200px" grid-template-columns="40px 160px">
+      <div box-sizing="content-box" direction="rtl" height="45px"/>
+      <div box-sizing="content-box" direction="rtl" flex-wrap="wrap-reverse" width="140px" row-gap="10px" column-gap="10px">
+        <div box-sizing="content-box" direction="rtl" width="40px" height="10px"/>
+        <div box-sizing="content-box" direction="rtl" align-self="baseline" width="40px" height="30px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="50px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="60px"/>
+        <div box-sizing="content-box" direction="rtl" align-self="baseline" width="40px" height="40px" margin-top="10px" margin-left="0px" margin-bottom="10px" margin-right="0px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="120">
+      <node x="160" y="5" width="40" height="45"/>
+      <node x="20" y="0" width="140" height="120">
+        <node x="100" y="110" width="40" height="10"/>
+        <node x="50" y="80" width="40" height="30"/>
+        <node x="0" y="70" width="40" height="50"/>
+        <node x="100" y="0" width="40" height="60"/>
+        <node x="50" y="10" width="40" height="40"/>
+        <node x="0" y="40" width="40" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/gridflex/gridflex_grid_baseline_empty_grid__border_box_ltr.xml
+++ b/tests/xml/gridflex/gridflex_grid_baseline_empty_grid__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="gridflex_grid_baseline_empty_grid__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" align-items="baseline" width="300px">
+      <div direction="ltr" width="20px" height="45px"/>
+      <div display="grid" direction="ltr" width="50px" height="30px" margin-top="15px" margin-left="0px" margin-bottom="30px" margin-right="0px" padding-top="10px" padding-left="0px" padding-bottom="20px" padding-right="0px" border-top="5px" border-bottom="10px"/>
+      <div display="grid" direction="ltr" width="50px" height="60px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="90">
+      <node x="0" y="15" width="20" height="45"/>
+      <node x="20" y="15" width="50" height="45"/>
+      <node x="70" y="0" width="50" height="60"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/gridflex/gridflex_grid_baseline_empty_grid__border_box_rtl.xml
+++ b/tests/xml/gridflex/gridflex_grid_baseline_empty_grid__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="gridflex_grid_baseline_empty_grid__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" align-items="baseline" width="300px">
+      <div direction="rtl" width="20px" height="45px"/>
+      <div display="grid" direction="rtl" width="50px" height="30px" margin-top="15px" margin-left="0px" margin-bottom="30px" margin-right="0px" padding-top="10px" padding-left="0px" padding-bottom="20px" padding-right="0px" border-top="5px" border-bottom="10px"/>
+      <div display="grid" direction="rtl" width="50px" height="60px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="90">
+      <node x="280" y="15" width="20" height="45"/>
+      <node x="230" y="15" width="50" height="45"/>
+      <node x="180" y="0" width="50" height="60"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/gridflex/gridflex_grid_baseline_empty_grid__content_box_ltr.xml
+++ b/tests/xml/gridflex/gridflex_grid_baseline_empty_grid__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="gridflex_grid_baseline_empty_grid__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" align-items="baseline" width="300px">
+      <div box-sizing="content-box" direction="ltr" width="20px" height="45px"/>
+      <div display="grid" box-sizing="content-box" direction="ltr" width="50px" height="30px" margin-top="15px" margin-left="0px" margin-bottom="30px" margin-right="0px" padding-top="10px" padding-left="0px" padding-bottom="20px" padding-right="0px" border-top="5px" border-bottom="10px"/>
+      <div display="grid" box-sizing="content-box" direction="ltr" width="50px" height="60px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="120">
+      <node x="0" y="45" width="20" height="45"/>
+      <node x="20" y="15" width="50" height="75"/>
+      <node x="70" y="30" width="50" height="60"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/gridflex/gridflex_grid_baseline_empty_grid__content_box_rtl.xml
+++ b/tests/xml/gridflex/gridflex_grid_baseline_empty_grid__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="gridflex_grid_baseline_empty_grid__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" align-items="baseline" width="300px">
+      <div box-sizing="content-box" direction="rtl" width="20px" height="45px"/>
+      <div display="grid" box-sizing="content-box" direction="rtl" width="50px" height="30px" margin-top="15px" margin-left="0px" margin-bottom="30px" margin-right="0px" padding-top="10px" padding-left="0px" padding-bottom="20px" padding-right="0px" border-top="5px" border-bottom="10px"/>
+      <div display="grid" box-sizing="content-box" direction="rtl" width="50px" height="60px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="120">
+      <node x="280" y="45" width="20" height="45"/>
+      <node x="230" y="15" width="50" height="75"/>
+      <node x="180" y="30" width="50" height="60"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/gridflex/gridflex_grid_baseline_grid_order__border_box_ltr.xml
+++ b/tests/xml/gridflex/gridflex_grid_baseline_grid_order__border_box_ltr.xml
@@ -1,0 +1,23 @@
+<test name="gridflex_grid_baseline_grid_order__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" align-items="baseline" width="400px">
+      <div direction="ltr" width="20px" height="45px"/>
+      <div display="grid" direction="ltr" grid-template-rows="50px 50px" grid-template-columns="50px 50px">
+        <div direction="ltr" height="25px" grid-row-start="2" grid-column-start="2"/>
+        <div direction="ltr" height="25px" margin-top="10px" grid-row-start="1" grid-column-start="2"/>
+        <div direction="ltr" height="25px" margin-top="20px" grid-row-start="1" grid-column-start="1"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="100">
+      <node x="0" y="0" width="20" height="45"/>
+      <node x="20" y="0" width="100" height="100">
+        <node x="50" y="50" width="50" height="25"/>
+        <node x="50" y="10" width="50" height="25"/>
+        <node x="0" y="20" width="50" height="25"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/gridflex/gridflex_grid_baseline_grid_order__border_box_rtl.xml
+++ b/tests/xml/gridflex/gridflex_grid_baseline_grid_order__border_box_rtl.xml
@@ -1,0 +1,23 @@
+<test name="gridflex_grid_baseline_grid_order__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" align-items="baseline" width="400px">
+      <div direction="rtl" width="20px" height="45px"/>
+      <div display="grid" direction="rtl" grid-template-rows="50px 50px" grid-template-columns="50px 50px">
+        <div direction="rtl" height="25px" grid-row-start="2" grid-column-start="2"/>
+        <div direction="rtl" height="25px" margin-top="10px" grid-row-start="1" grid-column-start="2"/>
+        <div direction="rtl" height="25px" margin-top="20px" grid-row-start="1" grid-column-start="1"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="100">
+      <node x="380" y="0" width="20" height="45"/>
+      <node x="280" y="0" width="100" height="100">
+        <node x="0" y="50" width="50" height="25"/>
+        <node x="0" y="10" width="50" height="25"/>
+        <node x="50" y="20" width="50" height="25"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/gridflex/gridflex_grid_baseline_grid_order__content_box_ltr.xml
+++ b/tests/xml/gridflex/gridflex_grid_baseline_grid_order__content_box_ltr.xml
@@ -1,0 +1,23 @@
+<test name="gridflex_grid_baseline_grid_order__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" align-items="baseline" width="400px">
+      <div box-sizing="content-box" direction="ltr" width="20px" height="45px"/>
+      <div display="grid" box-sizing="content-box" direction="ltr" grid-template-rows="50px 50px" grid-template-columns="50px 50px">
+        <div box-sizing="content-box" direction="ltr" height="25px" grid-row-start="2" grid-column-start="2"/>
+        <div box-sizing="content-box" direction="ltr" height="25px" margin-top="10px" grid-row-start="1" grid-column-start="2"/>
+        <div box-sizing="content-box" direction="ltr" height="25px" margin-top="20px" grid-row-start="1" grid-column-start="1"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="100">
+      <node x="0" y="0" width="20" height="45"/>
+      <node x="20" y="0" width="100" height="100">
+        <node x="50" y="50" width="50" height="25"/>
+        <node x="50" y="10" width="50" height="25"/>
+        <node x="0" y="20" width="50" height="25"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/gridflex/gridflex_grid_baseline_grid_order__content_box_rtl.xml
+++ b/tests/xml/gridflex/gridflex_grid_baseline_grid_order__content_box_rtl.xml
@@ -1,0 +1,23 @@
+<test name="gridflex_grid_baseline_grid_order__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" align-items="baseline" width="400px">
+      <div box-sizing="content-box" direction="rtl" width="20px" height="45px"/>
+      <div display="grid" box-sizing="content-box" direction="rtl" grid-template-rows="50px 50px" grid-template-columns="50px 50px">
+        <div box-sizing="content-box" direction="rtl" height="25px" grid-row-start="2" grid-column-start="2"/>
+        <div box-sizing="content-box" direction="rtl" height="25px" margin-top="10px" grid-row-start="1" grid-column-start="2"/>
+        <div box-sizing="content-box" direction="rtl" height="25px" margin-top="20px" grid-row-start="1" grid-column-start="1"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="100">
+      <node x="380" y="0" width="20" height="45"/>
+      <node x="280" y="0" width="100" height="100">
+        <node x="0" y="50" width="50" height="25"/>
+        <node x="0" y="10" width="50" height="25"/>
+        <node x="50" y="20" width="50" height="25"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/gridflex/gridflex_grid_baseline_grid_order_columns__border_box_ltr.xml
+++ b/tests/xml/gridflex/gridflex_grid_baseline_grid_order_columns__border_box_ltr.xml
@@ -1,0 +1,23 @@
+<test name="gridflex_grid_baseline_grid_order_columns__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" align-items="baseline" width="400px">
+      <div direction="ltr" width="20px" height="45px"/>
+      <div display="grid" direction="ltr" grid-template-rows="50px" grid-template-columns="50px 50px 50px">
+        <div direction="ltr" height="25px" grid-row-start="1" grid-column-start="3"/>
+        <div direction="ltr" height="25px" margin-top="10px" grid-row-start="1" grid-column-start="1"/>
+        <div direction="ltr" height="25px" margin-top="20px" grid-row-start="1" grid-column-start="2"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="60">
+      <node x="0" y="0" width="20" height="45"/>
+      <node x="20" y="10" width="150" height="50">
+        <node x="100" y="0" width="50" height="25"/>
+        <node x="0" y="10" width="50" height="25"/>
+        <node x="50" y="20" width="50" height="25"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/gridflex/gridflex_grid_baseline_grid_order_columns__border_box_rtl.xml
+++ b/tests/xml/gridflex/gridflex_grid_baseline_grid_order_columns__border_box_rtl.xml
@@ -1,0 +1,23 @@
+<test name="gridflex_grid_baseline_grid_order_columns__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" align-items="baseline" width="400px">
+      <div direction="rtl" width="20px" height="45px"/>
+      <div display="grid" direction="rtl" grid-template-rows="50px" grid-template-columns="50px 50px 50px">
+        <div direction="rtl" height="25px" grid-row-start="1" grid-column-start="3"/>
+        <div direction="rtl" height="25px" margin-top="10px" grid-row-start="1" grid-column-start="1"/>
+        <div direction="rtl" height="25px" margin-top="20px" grid-row-start="1" grid-column-start="2"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="60">
+      <node x="380" y="0" width="20" height="45"/>
+      <node x="230" y="10" width="150" height="50">
+        <node x="0" y="0" width="50" height="25"/>
+        <node x="100" y="10" width="50" height="25"/>
+        <node x="50" y="20" width="50" height="25"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/gridflex/gridflex_grid_baseline_grid_order_columns__content_box_ltr.xml
+++ b/tests/xml/gridflex/gridflex_grid_baseline_grid_order_columns__content_box_ltr.xml
@@ -1,0 +1,23 @@
+<test name="gridflex_grid_baseline_grid_order_columns__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" align-items="baseline" width="400px">
+      <div box-sizing="content-box" direction="ltr" width="20px" height="45px"/>
+      <div display="grid" box-sizing="content-box" direction="ltr" grid-template-rows="50px" grid-template-columns="50px 50px 50px">
+        <div box-sizing="content-box" direction="ltr" height="25px" grid-row-start="1" grid-column-start="3"/>
+        <div box-sizing="content-box" direction="ltr" height="25px" margin-top="10px" grid-row-start="1" grid-column-start="1"/>
+        <div box-sizing="content-box" direction="ltr" height="25px" margin-top="20px" grid-row-start="1" grid-column-start="2"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="60">
+      <node x="0" y="0" width="20" height="45"/>
+      <node x="20" y="10" width="150" height="50">
+        <node x="100" y="0" width="50" height="25"/>
+        <node x="0" y="10" width="50" height="25"/>
+        <node x="50" y="20" width="50" height="25"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/gridflex/gridflex_grid_baseline_grid_order_columns__content_box_rtl.xml
+++ b/tests/xml/gridflex/gridflex_grid_baseline_grid_order_columns__content_box_rtl.xml
@@ -1,0 +1,23 @@
+<test name="gridflex_grid_baseline_grid_order_columns__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" align-items="baseline" width="400px">
+      <div box-sizing="content-box" direction="rtl" width="20px" height="45px"/>
+      <div display="grid" box-sizing="content-box" direction="rtl" grid-template-rows="50px" grid-template-columns="50px 50px 50px">
+        <div box-sizing="content-box" direction="rtl" height="25px" grid-row-start="1" grid-column-start="3"/>
+        <div box-sizing="content-box" direction="rtl" height="25px" margin-top="10px" grid-row-start="1" grid-column-start="1"/>
+        <div box-sizing="content-box" direction="rtl" height="25px" margin-top="20px" grid-row-start="1" grid-column-start="2"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="60">
+      <node x="380" y="0" width="20" height="45"/>
+      <node x="230" y="10" width="150" height="50">
+        <node x="0" y="0" width="50" height="25"/>
+        <node x="100" y="10" width="50" height="25"/>
+        <node x="50" y="20" width="50" height="25"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -7410,6 +7410,106 @@ mod flex {
     }
 
     #[test]
+    fn align_baseline_nested_flex_wrap_first_baseline_items__border_box_ltr() {
+        crate::run_xml_test("flex", "align_baseline_nested_flex_wrap_first_baseline_items__border_box_ltr");
+    }
+
+    #[test]
+    fn align_baseline_nested_flex_wrap_first_baseline_items__content_box_ltr() {
+        crate::run_xml_test("flex", "align_baseline_nested_flex_wrap_first_baseline_items__content_box_ltr");
+    }
+
+    #[test]
+    fn align_baseline_nested_flex_wrap_first_baseline_items__border_box_rtl() {
+        crate::run_xml_test("flex", "align_baseline_nested_flex_wrap_first_baseline_items__border_box_rtl");
+    }
+
+    #[test]
+    fn align_baseline_nested_flex_wrap_first_baseline_items__content_box_rtl() {
+        crate::run_xml_test("flex", "align_baseline_nested_flex_wrap_first_baseline_items__content_box_rtl");
+    }
+
+    #[test]
+    fn align_baseline_nested_flex_wrap_last_baseline_items__border_box_ltr() {
+        crate::run_xml_test("flex", "align_baseline_nested_flex_wrap_last_baseline_items__border_box_ltr");
+    }
+
+    #[test]
+    fn align_baseline_nested_flex_wrap_last_baseline_items__content_box_ltr() {
+        crate::run_xml_test("flex", "align_baseline_nested_flex_wrap_last_baseline_items__content_box_ltr");
+    }
+
+    #[test]
+    fn align_baseline_nested_flex_wrap_last_baseline_items__border_box_rtl() {
+        crate::run_xml_test("flex", "align_baseline_nested_flex_wrap_last_baseline_items__border_box_rtl");
+    }
+
+    #[test]
+    fn align_baseline_nested_flex_wrap_last_baseline_items__content_box_rtl() {
+        crate::run_xml_test("flex", "align_baseline_nested_flex_wrap_last_baseline_items__content_box_rtl");
+    }
+
+    #[test]
+    fn align_baseline_nested_flex_wrap_mixed_baseline_items__border_box_ltr() {
+        crate::run_xml_test("flex", "align_baseline_nested_flex_wrap_mixed_baseline_items__border_box_ltr");
+    }
+
+    #[test]
+    fn align_baseline_nested_flex_wrap_mixed_baseline_items__content_box_ltr() {
+        crate::run_xml_test("flex", "align_baseline_nested_flex_wrap_mixed_baseline_items__content_box_ltr");
+    }
+
+    #[test]
+    fn align_baseline_nested_flex_wrap_mixed_baseline_items__border_box_rtl() {
+        crate::run_xml_test("flex", "align_baseline_nested_flex_wrap_mixed_baseline_items__border_box_rtl");
+    }
+
+    #[test]
+    fn align_baseline_nested_flex_wrap_mixed_baseline_items__content_box_rtl() {
+        crate::run_xml_test("flex", "align_baseline_nested_flex_wrap_mixed_baseline_items__content_box_rtl");
+    }
+
+    #[test]
+    fn align_baseline_nested_flex_wrap_reverse_first_baseline_items__border_box_ltr() {
+        crate::run_xml_test("flex", "align_baseline_nested_flex_wrap_reverse_first_baseline_items__border_box_ltr");
+    }
+
+    #[test]
+    fn align_baseline_nested_flex_wrap_reverse_first_baseline_items__content_box_ltr() {
+        crate::run_xml_test("flex", "align_baseline_nested_flex_wrap_reverse_first_baseline_items__content_box_ltr");
+    }
+
+    #[test]
+    fn align_baseline_nested_flex_wrap_reverse_first_baseline_items__border_box_rtl() {
+        crate::run_xml_test("flex", "align_baseline_nested_flex_wrap_reverse_first_baseline_items__border_box_rtl");
+    }
+
+    #[test]
+    fn align_baseline_nested_flex_wrap_reverse_first_baseline_items__content_box_rtl() {
+        crate::run_xml_test("flex", "align_baseline_nested_flex_wrap_reverse_first_baseline_items__content_box_rtl");
+    }
+
+    #[test]
+    fn align_baseline_nested_flex_wrap_reverse_last_baseline_items__border_box_ltr() {
+        crate::run_xml_test("flex", "align_baseline_nested_flex_wrap_reverse_last_baseline_items__border_box_ltr");
+    }
+
+    #[test]
+    fn align_baseline_nested_flex_wrap_reverse_last_baseline_items__content_box_ltr() {
+        crate::run_xml_test("flex", "align_baseline_nested_flex_wrap_reverse_last_baseline_items__content_box_ltr");
+    }
+
+    #[test]
+    fn align_baseline_nested_flex_wrap_reverse_last_baseline_items__border_box_rtl() {
+        crate::run_xml_test("flex", "align_baseline_nested_flex_wrap_reverse_last_baseline_items__border_box_rtl");
+    }
+
+    #[test]
+    fn align_baseline_nested_flex_wrap_reverse_last_baseline_items__content_box_rtl() {
+        crate::run_xml_test("flex", "align_baseline_nested_flex_wrap_reverse_last_baseline_items__content_box_rtl");
+    }
+
+    #[test]
     fn align_baseline_wrap_reverse__border_box_ltr() {
         crate::run_xml_test("flex", "align_baseline_wrap_reverse__border_box_ltr");
     }
@@ -9235,6 +9335,124 @@ mod flex {
     #[test]
     fn align_last_baseline_nested_child__content_box_rtl() {
         crate::run_xml_test("flex", "align_last_baseline_nested_child__content_box_rtl");
+    }
+
+    #[test]
+    fn align_last_baseline_nested_flex_wrap_first_baseline_items__border_box_ltr() {
+        crate::run_xml_test("flex", "align_last_baseline_nested_flex_wrap_first_baseline_items__border_box_ltr");
+    }
+
+    #[test]
+    fn align_last_baseline_nested_flex_wrap_first_baseline_items__content_box_ltr() {
+        crate::run_xml_test("flex", "align_last_baseline_nested_flex_wrap_first_baseline_items__content_box_ltr");
+    }
+
+    #[test]
+    fn align_last_baseline_nested_flex_wrap_first_baseline_items__border_box_rtl() {
+        crate::run_xml_test("flex", "align_last_baseline_nested_flex_wrap_first_baseline_items__border_box_rtl");
+    }
+
+    #[test]
+    fn align_last_baseline_nested_flex_wrap_first_baseline_items__content_box_rtl() {
+        crate::run_xml_test("flex", "align_last_baseline_nested_flex_wrap_first_baseline_items__content_box_rtl");
+    }
+
+    #[test]
+    fn align_last_baseline_nested_flex_wrap_last_baseline_items__border_box_ltr() {
+        crate::run_xml_test("flex", "align_last_baseline_nested_flex_wrap_last_baseline_items__border_box_ltr");
+    }
+
+    #[test]
+    fn align_last_baseline_nested_flex_wrap_last_baseline_items__content_box_ltr() {
+        crate::run_xml_test("flex", "align_last_baseline_nested_flex_wrap_last_baseline_items__content_box_ltr");
+    }
+
+    #[test]
+    fn align_last_baseline_nested_flex_wrap_last_baseline_items__border_box_rtl() {
+        crate::run_xml_test("flex", "align_last_baseline_nested_flex_wrap_last_baseline_items__border_box_rtl");
+    }
+
+    #[test]
+    fn align_last_baseline_nested_flex_wrap_last_baseline_items__content_box_rtl() {
+        crate::run_xml_test("flex", "align_last_baseline_nested_flex_wrap_last_baseline_items__content_box_rtl");
+    }
+
+    #[test]
+    fn align_last_baseline_nested_flex_wrap_mixed_baseline_items__border_box_ltr() {
+        crate::run_xml_test("flex", "align_last_baseline_nested_flex_wrap_mixed_baseline_items__border_box_ltr");
+    }
+
+    #[test]
+    fn align_last_baseline_nested_flex_wrap_mixed_baseline_items__content_box_ltr() {
+        crate::run_xml_test("flex", "align_last_baseline_nested_flex_wrap_mixed_baseline_items__content_box_ltr");
+    }
+
+    #[test]
+    fn align_last_baseline_nested_flex_wrap_mixed_baseline_items__border_box_rtl() {
+        crate::run_xml_test("flex", "align_last_baseline_nested_flex_wrap_mixed_baseline_items__border_box_rtl");
+    }
+
+    #[test]
+    fn align_last_baseline_nested_flex_wrap_mixed_baseline_items__content_box_rtl() {
+        crate::run_xml_test("flex", "align_last_baseline_nested_flex_wrap_mixed_baseline_items__content_box_rtl");
+    }
+
+    #[test]
+    fn align_last_baseline_nested_flex_wrap_reverse_first_baseline_items__border_box_ltr() {
+        crate::run_xml_test(
+            "flex",
+            "align_last_baseline_nested_flex_wrap_reverse_first_baseline_items__border_box_ltr",
+        );
+    }
+
+    #[test]
+    fn align_last_baseline_nested_flex_wrap_reverse_first_baseline_items__content_box_ltr() {
+        crate::run_xml_test(
+            "flex",
+            "align_last_baseline_nested_flex_wrap_reverse_first_baseline_items__content_box_ltr",
+        );
+    }
+
+    #[test]
+    fn align_last_baseline_nested_flex_wrap_reverse_first_baseline_items__border_box_rtl() {
+        crate::run_xml_test(
+            "flex",
+            "align_last_baseline_nested_flex_wrap_reverse_first_baseline_items__border_box_rtl",
+        );
+    }
+
+    #[test]
+    fn align_last_baseline_nested_flex_wrap_reverse_first_baseline_items__content_box_rtl() {
+        crate::run_xml_test(
+            "flex",
+            "align_last_baseline_nested_flex_wrap_reverse_first_baseline_items__content_box_rtl",
+        );
+    }
+
+    #[test]
+    fn align_last_baseline_nested_flex_wrap_reverse_last_baseline_items__border_box_ltr() {
+        crate::run_xml_test("flex", "align_last_baseline_nested_flex_wrap_reverse_last_baseline_items__border_box_ltr");
+    }
+
+    #[test]
+    fn align_last_baseline_nested_flex_wrap_reverse_last_baseline_items__content_box_ltr() {
+        crate::run_xml_test(
+            "flex",
+            "align_last_baseline_nested_flex_wrap_reverse_last_baseline_items__content_box_ltr",
+        );
+    }
+
+    #[test]
+    fn align_last_baseline_nested_flex_wrap_reverse_last_baseline_items__border_box_rtl() {
+        crate::run_xml_test("flex", "align_last_baseline_nested_flex_wrap_reverse_last_baseline_items__border_box_rtl");
+    }
+
+    #[test]
+    fn align_last_baseline_nested_flex_wrap_reverse_last_baseline_items__content_box_rtl() {
+        crate::run_xml_test(
+            "flex",
+            "align_last_baseline_nested_flex_wrap_reverse_last_baseline_items__content_box_rtl",
+        );
     }
 
     #[test]
@@ -20597,6 +20815,30 @@ mod grid {
 
     #[cfg(feature = "grid")]
     #[test]
+    fn grid_align_baseline_double_nested_grid__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_align_baseline_double_nested_grid__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_baseline_double_nested_grid__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_align_baseline_double_nested_grid__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_baseline_double_nested_grid__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_align_baseline_double_nested_grid__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_baseline_double_nested_grid__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_align_baseline_double_nested_grid__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
     fn grid_align_content_center__border_box_ltr() {
         crate::run_xml_test("grid", "grid_align_content_center__border_box_ltr");
     }
@@ -21449,6 +21691,54 @@ mod grid {
 
     #[cfg(feature = "grid")]
     #[test]
+    fn grid_align_items_baseline_synthesized_and_natural__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_align_items_baseline_synthesized_and_natural__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_items_baseline_synthesized_and_natural__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_align_items_baseline_synthesized_and_natural__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_items_baseline_synthesized_and_natural__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_align_items_baseline_synthesized_and_natural__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_items_baseline_synthesized_and_natural__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_align_items_baseline_synthesized_and_natural__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_items_baseline_synthesized_margins__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_align_items_baseline_synthesized_margins__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_items_baseline_synthesized_margins__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_align_items_baseline_synthesized_margins__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_items_baseline_synthesized_margins__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_align_items_baseline_synthesized_margins__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_items_baseline_synthesized_margins__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_align_items_baseline_synthesized_margins__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
     fn grid_align_items_last_baseline__border_box_ltr() {
         crate::run_xml_test("grid", "grid_align_items_last_baseline__border_box_ltr");
     }
@@ -21613,6 +21903,102 @@ mod grid {
     #[test]
     fn grid_align_items_sized_stretch__content_box_rtl() {
         crate::run_xml_test("grid", "grid_align_items_sized_stretch__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_last_baseline_double_nested_grid__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_align_last_baseline_double_nested_grid__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_last_baseline_double_nested_grid__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_align_last_baseline_double_nested_grid__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_last_baseline_double_nested_grid__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_align_last_baseline_double_nested_grid__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_last_baseline_double_nested_grid__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_align_last_baseline_double_nested_grid__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_self_baseline_aspect_ratio_percent_tracks__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_align_self_baseline_aspect_ratio_percent_tracks__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_self_baseline_aspect_ratio_percent_tracks__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_align_self_baseline_aspect_ratio_percent_tracks__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_self_baseline_aspect_ratio_percent_tracks__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_align_self_baseline_aspect_ratio_percent_tracks__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_self_baseline_aspect_ratio_percent_tracks__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_align_self_baseline_aspect_ratio_percent_tracks__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_self_baseline_synthesized_margins__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_align_self_baseline_synthesized_margins__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_self_baseline_synthesized_margins__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_align_self_baseline_synthesized_margins__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_self_baseline_synthesized_margins__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_align_self_baseline_synthesized_margins__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_self_baseline_synthesized_margins__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_align_self_baseline_synthesized_margins__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_self_last_baseline_synthesized_margins__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_align_self_last_baseline_synthesized_margins__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_self_last_baseline_synthesized_margins__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_align_self_last_baseline_synthesized_margins__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_self_last_baseline_synthesized_margins__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_align_self_last_baseline_synthesized_margins__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_self_last_baseline_synthesized_margins__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_align_self_last_baseline_synthesized_margins__content_box_rtl");
     }
 
     #[cfg(feature = "grid")]
@@ -33187,6 +33573,54 @@ mod grid {
 mod gridflex {
     #[cfg(feature = "grid")]
     #[test]
+    fn gridflex_align_baseline_nested_grid__border_box_ltr() {
+        crate::run_xml_test("gridflex", "gridflex_align_baseline_nested_grid__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn gridflex_align_baseline_nested_grid__content_box_ltr() {
+        crate::run_xml_test("gridflex", "gridflex_align_baseline_nested_grid__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn gridflex_align_baseline_nested_grid__border_box_rtl() {
+        crate::run_xml_test("gridflex", "gridflex_align_baseline_nested_grid__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn gridflex_align_baseline_nested_grid__content_box_rtl() {
+        crate::run_xml_test("gridflex", "gridflex_align_baseline_nested_grid__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn gridflex_align_last_baseline_nested_grid__border_box_ltr() {
+        crate::run_xml_test("gridflex", "gridflex_align_last_baseline_nested_grid__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn gridflex_align_last_baseline_nested_grid__content_box_ltr() {
+        crate::run_xml_test("gridflex", "gridflex_align_last_baseline_nested_grid__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn gridflex_align_last_baseline_nested_grid__border_box_rtl() {
+        crate::run_xml_test("gridflex", "gridflex_align_last_baseline_nested_grid__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn gridflex_align_last_baseline_nested_grid__content_box_rtl() {
+        crate::run_xml_test("gridflex", "gridflex_align_last_baseline_nested_grid__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
     fn gridflex_column_integration__border_box_ltr() {
         crate::run_xml_test("gridflex", "gridflex_column_integration__border_box_ltr");
     }
@@ -33207,6 +33641,126 @@ mod gridflex {
     #[test]
     fn gridflex_column_integration__content_box_rtl() {
         crate::run_xml_test("gridflex", "gridflex_column_integration__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn gridflex_grid_align_baseline_nested_flex_wrap__border_box_ltr() {
+        crate::run_xml_test("gridflex", "gridflex_grid_align_baseline_nested_flex_wrap__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn gridflex_grid_align_baseline_nested_flex_wrap__content_box_ltr() {
+        crate::run_xml_test("gridflex", "gridflex_grid_align_baseline_nested_flex_wrap__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn gridflex_grid_align_baseline_nested_flex_wrap__border_box_rtl() {
+        crate::run_xml_test("gridflex", "gridflex_grid_align_baseline_nested_flex_wrap__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn gridflex_grid_align_baseline_nested_flex_wrap__content_box_rtl() {
+        crate::run_xml_test("gridflex", "gridflex_grid_align_baseline_nested_flex_wrap__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn gridflex_grid_align_baseline_nested_flex_wrap_reverse__border_box_ltr() {
+        crate::run_xml_test("gridflex", "gridflex_grid_align_baseline_nested_flex_wrap_reverse__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn gridflex_grid_align_baseline_nested_flex_wrap_reverse__content_box_ltr() {
+        crate::run_xml_test("gridflex", "gridflex_grid_align_baseline_nested_flex_wrap_reverse__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn gridflex_grid_align_baseline_nested_flex_wrap_reverse__border_box_rtl() {
+        crate::run_xml_test("gridflex", "gridflex_grid_align_baseline_nested_flex_wrap_reverse__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn gridflex_grid_align_baseline_nested_flex_wrap_reverse__content_box_rtl() {
+        crate::run_xml_test("gridflex", "gridflex_grid_align_baseline_nested_flex_wrap_reverse__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn gridflex_grid_baseline_empty_grid__border_box_ltr() {
+        crate::run_xml_test("gridflex", "gridflex_grid_baseline_empty_grid__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn gridflex_grid_baseline_empty_grid__content_box_ltr() {
+        crate::run_xml_test("gridflex", "gridflex_grid_baseline_empty_grid__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn gridflex_grid_baseline_empty_grid__border_box_rtl() {
+        crate::run_xml_test("gridflex", "gridflex_grid_baseline_empty_grid__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn gridflex_grid_baseline_empty_grid__content_box_rtl() {
+        crate::run_xml_test("gridflex", "gridflex_grid_baseline_empty_grid__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn gridflex_grid_baseline_grid_order__border_box_ltr() {
+        crate::run_xml_test("gridflex", "gridflex_grid_baseline_grid_order__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn gridflex_grid_baseline_grid_order__content_box_ltr() {
+        crate::run_xml_test("gridflex", "gridflex_grid_baseline_grid_order__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn gridflex_grid_baseline_grid_order__border_box_rtl() {
+        crate::run_xml_test("gridflex", "gridflex_grid_baseline_grid_order__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn gridflex_grid_baseline_grid_order__content_box_rtl() {
+        crate::run_xml_test("gridflex", "gridflex_grid_baseline_grid_order__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn gridflex_grid_baseline_grid_order_columns__border_box_ltr() {
+        crate::run_xml_test("gridflex", "gridflex_grid_baseline_grid_order_columns__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn gridflex_grid_baseline_grid_order_columns__content_box_ltr() {
+        crate::run_xml_test("gridflex", "gridflex_grid_baseline_grid_order_columns__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn gridflex_grid_baseline_grid_order_columns__border_box_rtl() {
+        crate::run_xml_test("gridflex", "gridflex_grid_baseline_grid_order_columns__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn gridflex_grid_baseline_grid_order_columns__content_box_rtl() {
+        crate::run_xml_test("gridflex", "gridflex_grid_baseline_grid_order_columns__content_box_rtl");
     }
 
     #[cfg(feature = "grid")]

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -20839,6 +20839,54 @@ mod grid {
 
     #[cfg(feature = "grid")]
     #[test]
+    fn grid_align_baseline_spanned_nested_grid__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_align_baseline_spanned_nested_grid__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_baseline_spanned_nested_grid__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_align_baseline_spanned_nested_grid__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_baseline_spanned_nested_grid__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_align_baseline_spanned_nested_grid__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_baseline_spanned_nested_grid__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_align_baseline_spanned_nested_grid__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_baseline_spanned_nested_grid_spanned_item__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_align_baseline_spanned_nested_grid_spanned_item__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_baseline_spanned_nested_grid_spanned_item__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_align_baseline_spanned_nested_grid_spanned_item__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_baseline_spanned_nested_grid_spanned_item__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_align_baseline_spanned_nested_grid_spanned_item__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_baseline_spanned_nested_grid_spanned_item__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_align_baseline_spanned_nested_grid_spanned_item__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
     fn grid_align_content_center__border_box_ltr() {
         crate::run_xml_test("grid", "grid_align_content_center__border_box_ltr");
     }
@@ -21927,6 +21975,54 @@ mod grid {
     #[test]
     fn grid_align_last_baseline_double_nested_grid__content_box_rtl() {
         crate::run_xml_test("grid", "grid_align_last_baseline_double_nested_grid__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_last_baseline_spanned_nested_grid__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_align_last_baseline_spanned_nested_grid__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_last_baseline_spanned_nested_grid__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_align_last_baseline_spanned_nested_grid__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_last_baseline_spanned_nested_grid__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_align_last_baseline_spanned_nested_grid__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_last_baseline_spanned_nested_grid__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_align_last_baseline_spanned_nested_grid__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_last_baseline_spanned_nested_grid_spanned_item__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_align_last_baseline_spanned_nested_grid_spanned_item__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_last_baseline_spanned_nested_grid_spanned_item__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_align_last_baseline_spanned_nested_grid_spanned_item__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_last_baseline_spanned_nested_grid_spanned_item__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_align_last_baseline_spanned_nested_grid_spanned_item__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_align_last_baseline_spanned_nested_grid_spanned_item__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_align_last_baseline_spanned_nested_grid_spanned_item__content_box_rtl");
     }
 
     #[cfg(feature = "grid")]


### PR DESCRIPTION
# Objective

Fix two groups of baseline-alignment bugs (stacked on #1111) that cause WPT failures in Blitz's css-flexbox/alignment and css-grid/alignment suites (horizontal-tb).

## Changes

### 1. Flex container baseline export: consider items in either baseline group (`src/compute/flexbox.rs`)

When a multi-line flex container exports its first/last baseline, the item used was previously only searched among items participating in the *same-kind* baseline group. Chrome (and css-align) consider items participating in *any* baseline alignment:

```text
first baseline item = first item in cross-start-most line participating in first-baseline alignment
                      else first item participating in last-baseline alignment
                      else the line's first item
last baseline item  = symmetric, from the cross-end-most line, falling back to the line's last item
```

Addresses: `flex-align-baseline-flex-001/003`, `grid-align-baseline-flex-001/003`, `flex-align-baseline-grid-001`, `grid-align-baseline-grid-001`.

### 2. Grid container baseline export (`src/compute/grid/mod.rs`)

- The item that generates the container's baseline is now selected in **grid-modified document order** (first by row, then by *logical* column — negated for RTL since taffy's column indexes are visually reversed — with document-order ties preserved). Previously only the row was considered, so an earlier-in-document item in a later column won incorrectly. This is done with linear scans (`min`/`max` + `min_by_key`, whose first-of-equal semantics preserve document-order ties) — no sorting.
- `item.baseline` is now stored from the item's final layout output (like `last_baseline` already was), so a nested grid/flex item's *natural* baseline propagates even when it isn't part of a multi-item baseline group. Synthesis from the border box (`unwrap_or(height)`) still applies when the item has no natural baseline. This fixes baseline propagation through two levels of nested grids, including inner borders/padding.

Addresses: `grid-align-baseline.html`, `grid-align-baseline-004/005`, `grid-baseline-004`, `grid-baseline-align-001`, `grid-self-alignment-baseline-with-grid-001..004`, `grid-self-baseline-horiz-001`.

### 3. Grid baseline shims resolved after column sizing (`src/compute/grid/track_sizing.rs`)

`resolve_item_baselines` previously ran during the *inline* track-sizing pass, measuring items with the container's inner width as the containing block — so items with `width: 100%` or aspect-ratio in percentage tracks measured wildly wrong baselines. Shims only affect the block axis, so baseline resolution now runs at the start of the *block* pass, once columns are sized, and measures each item against its grid-area width:

```rust
let grid_area_width = item.track_range_excluding_lines(Inline).map(|i| columns[i].base_size).sum();
let known_dimensions = item.known_dimensions(tree, grid_area_size); // applies stretch + % resolution
```

Addresses: `grid-self-baseline-008` (canvases with aspect-ratio + width:100% in 25% tracks), `grid-baseline-004`.

### 4. Row-spanning grid items: last-baseline participation uses the end-most row (`src/compute/grid/track_sizing.rs`, `src/compute/grid/mod.rs`)

Per [css-align baseline-sharing-group rules](https://www.w3.org/TR/css-align-3/#baseline-sharing-group), an item spanning multiple rows participates in first-baseline alignment in its *start-most* row but in last-baseline alignment in its *end-most* row. Previously both groups were keyed on `row start`, so:

- `resolve_item_baselines` now resolves the two groups in separate passes: first-baseline items grouped by row-start line (as before), last-baseline items grouped by row-*end* line, so a row-spanning item shims/aligns against the items it shares its end row with. Each pass returns early (before any sorting) unless at least two items participate in that kind of baseline alignment, and the whole function is still gated on the container having baseline-aligned items at all.
- The grid container's exported *last* baseline is now generated from items whose grid area **ends** in the last row (`row_indexes.end == max end`) rather than items that *start* in the row-start-sorted last row.

Addresses: `grid-self-alignment-baseline-with-grid-003/004` (verified passing in Blitz's WPT runner with last-baseline plumbing enabled, with no regressions across the css-flexbox/alignment and css-grid/alignment suites; `grid-align-baseline-004` also went 1/2 → 2/2).

## Performance notes

The per-layout container-baseline export path does no sorting (linear scans only). Sorting only happens in `resolve_item_baselines`, which is skipped entirely unless the container has baseline-aligned items, and each group pass is skipped unless ≥2 items participate in that group.

## Tests

27 new gentest fixtures (Chrome-for-Testing as oracle), all passing, covering: nested wrap/wrap-reverse flex baselines (first/last/mixed baseline groups), nested & double-nested grid baselines with borders/padding, row-spanning nested grids and row-spanning inner items (first + last baseline), synthesized baselines for empty items (with margins), empty-grid containers, grid-order/column-order baseline selection (LTR + RTL), and aspect-ratio items in percentage tracks.

One hand-written expectation (`grid_baselines` in `tests/hand_written/last_baseline.rs`) encoded the old behavior (synthesizing from the border box even when the item has a natural measure-function baseline) and was updated to expect the item's natural baseline.

`cargo test --workspace`, `cargo fmt`, and `cargo clippy --workspace` are all clean.

## Context

Stacked on #1111 (`devin/1786752736-last-baseline-alignment`). WPT sources under `css/css-flexbox/alignment` and `css/css-grid/alignment` were used as ground truth.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/d7a77a76f9114c3295372c0cc74899a9
Requested by: @nicoburns