### PR TITLE
Only include a container's own end padding in content_size for scroll containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 ### Fixed
 
+- Block/Flexbox/Grid: a container's own end-side padding (right padding for LTR, left padding for RTL, and bottom padding) is now only included in its `content_size` when the container is a scroll container (i.e. has `overflow` other than `visible`/`clip` in either axis). Per the [CSS Overflow spec](https://www.w3.org/TR/css-overflow-3/#scrollable), boxes that are not scroll containers do not extend their scrollable overflow region by their own padding, so overflowing content within an ordinary padded box no longer propagates spuriously enlarged content sizes to ancestor scroll containers
+
 - Grid: the first baselines of grid items which are scroll containers are now clamped to the item's border box (matching the existing flexbox behaviour, per the [CSSWG resolution](https://github.com/w3c/csswg-drafts/issues/7660))
 
 - Flexbox: items with `align-self: baseline` and an `auto` cross-axis margin no longer participate in baseline alignment, per [CSS Flexbox §8.3](https://www.w3.org/TR/css-flexbox-1/#baseline-participation). Previously such items were still counted when deciding whether a line performs baseline alignment, had their baselines measured, and could affect the container's own first baseline

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -735,10 +735,14 @@ fn compute_inner(
 
     #[cfg(feature = "content_size")]
     {
-        // The container's own padding at the end of the content is part of its scrollable
-        // overflow region, so it is included in the in-flow content size.
-        inflow_content_size.width += if direction.is_rtl() { resolved_padding.left } else { resolved_padding.right };
-        inflow_content_size.height += resolved_padding.bottom;
+        // A scroll container's own padding at the end of the content is part of its scrollable
+        // overflow region, so it is included in the in-flow content size. Boxes that are not
+        // scroll containers do not extend their overflow region by their own padding.
+        if is_scroll_container {
+            inflow_content_size.width +=
+                if direction.is_rtl() { resolved_padding.left } else { resolved_padding.right };
+            inflow_content_size.height += resolved_padding.bottom;
+        }
         output.content_size = inflow_content_size.f32_max(absolute_content_size);
     }
 

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -168,6 +168,9 @@ struct AlgoConstants {
     content_box_inset: Rect<f32>,
     /// The size reserved for scrollbar gutters in each axis
     scrollbar_gutter: Point<f32>,
+    /// Whether the node being laid out is a scroll container
+    #[cfg(feature = "content_size")]
+    is_scroll_container: bool,
     /// The gap of this section
     gap: Size<f32>,
     /// The align_items property of this node
@@ -543,6 +546,11 @@ fn compute_constants(
         Overflow::Scroll => style.scrollbar_width(),
         _ => 0.0,
     });
+    #[cfg(feature = "content_size")]
+    let is_scroll_container = {
+        let overflow = style.overflow();
+        overflow.x.is_scroll_container() || overflow.y.is_scroll_container()
+    };
     let mut content_box_inset = padding + border;
     content_box_inset.bottom += scrollbar_gutter.y;
 
@@ -587,6 +595,8 @@ fn compute_constants(
         gap,
         content_box_inset,
         scrollbar_gutter,
+        #[cfg(feature = "content_size")]
+        is_scroll_container,
         align_items,
         align_content,
         justify_content,
@@ -2540,12 +2550,19 @@ fn final_layout_pass(
         }
     }
 
-    content_size.width += if constants.layout_direction.is_rtl() {
-        constants.content_box_inset.left - constants.border.left - constants.scrollbar_gutter.x
-    } else {
-        constants.content_box_inset.right - constants.border.right - constants.scrollbar_gutter.x
-    };
-    content_size.height += constants.content_box_inset.bottom - constants.border.bottom - constants.scrollbar_gutter.y;
+    // A scroll container's own padding at the end of the content is part of its scrollable
+    // overflow region, so it is included in the content size. Boxes that are not scroll
+    // containers do not extend their overflow region by their own padding.
+    #[cfg(feature = "content_size")]
+    if constants.is_scroll_container {
+        content_size.width += if constants.layout_direction.is_rtl() {
+            constants.content_box_inset.left - constants.border.left - constants.scrollbar_gutter.x
+        } else {
+            constants.content_box_inset.right - constants.border.right - constants.scrollbar_gutter.x
+        };
+        content_size.height +=
+            constants.content_box_inset.bottom - constants.border.bottom - constants.scrollbar_gutter.y;
+    }
 
     content_size
 }

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -87,6 +87,11 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
         Overflow::Scroll => style.scrollbar_width(),
         _ => 0.0,
     });
+    #[cfg(feature = "content_size")]
+    let is_scroll_container = {
+        let overflow = style.overflow();
+        overflow.x.is_scroll_container() || overflow.y.is_scroll_container()
+    };
     let mut content_box_inset = padding_border;
     content_box_inset.bottom += scrollbar_gutter.y;
 
@@ -787,13 +792,16 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
         item.y_position + item.baseline.unwrap_or(item.height)
     };
 
-    // The container's own padding at the end of the content is part of its scrollable
-    // overflow region, so it is included in the in-flow content size.
+    // A scroll container's own padding at the end of the content is part of its scrollable
+    // overflow region, so it is included in the in-flow content size. Boxes that are not
+    // scroll containers do not extend their overflow region by their own padding.
     #[cfg(feature = "content_size")]
     let content_size = {
         let mut content_size = item_content_size_contribution;
-        content_size.width += if direction.is_rtl() { padding.left } else { padding.right };
-        content_size.height += padding.bottom;
+        if is_scroll_container {
+            content_size.width += if direction.is_rtl() { padding.left } else { padding.right };
+            content_size.height += padding.bottom;
+        }
         content_size.f32_max(absolute_content_size)
     };
     #[cfg(not(feature = "content_size"))]

--- a/tests/hand_written/scroll_size.rs
+++ b/tests/hand_written/scroll_size.rs
@@ -100,6 +100,37 @@ fn content_size_includes_the_containers_own_padding() {
 }
 
 #[test]
+fn content_size_excludes_the_own_padding_of_a_non_scroll_container() {
+    for display in [Display::Block, Display::Flex, Display::Grid] {
+        for (top, bottom) in [(PADDING, 0.0), (0.0, PADDING), (PADDING, PADDING), (0.0, 0.0)] {
+            let mut tree = new_test_tree();
+            let child = tree
+                .new_leaf(Style { size: Size { width: length(100.0), height: length(CONTENT) }, ..Default::default() })
+                .unwrap();
+            let node = tree
+                .new_with_children(
+                    Style {
+                        display,
+                        box_sizing: BoxSizing::BorderBox,
+                        size: Size { width: length(300.0), height: length(CONTAINER) },
+                        padding: edge(top, bottom),
+                        ..Default::default()
+                    },
+                    &[child],
+                )
+                .unwrap();
+
+            tree.compute_layout(node, Size::MAX_CONTENT).unwrap();
+            let layout = tree.layout(node).unwrap();
+
+            // A box that is not a scroll container does not extend its scrollable overflow
+            // region by its own padding: only the content contributes.
+            assert_eq!(layout.content_size.height, top + CONTENT, "{display:?} with padding {top}/{bottom}");
+        }
+    }
+}
+
+#[test]
 fn scroll_height_accounts_for_the_containers_own_padding() {
     for display in [Display::Block, Display::Flex, Display::Grid] {
         for (top, bottom) in [(PADDING, 0.0), (0.0, PADDING), (PADDING, PADDING), (0.0, 0.0)] {


### PR DESCRIPTION
# Objective

Fix ordinary (non-scroll-container) padded boxes propagating spuriously enlarged content sizes to ancestor scroll containers. In Blitz this manifested as a spurious ~34px horizontal scroll on https://csskit.rs at a 1200px viewport: the page's `footer` (a padded block whose child `<p>` has negative horizontal margins pulling it into the padding) reported `content_size.width = 1234`, which propagated up to the root and made the document horizontally scrollable.

Per [CSS Overflow](https://www.w3.org/TR/css-overflow-3/#scrollable), a *scroll container's* own end-side padding is part of its scrollable overflow region, but a box that is not a scroll container does not extend its overflow region by its own padding. Browsers behave this way: content overflowing into (or past) a non-scroll-container's padding does not enlarge the scrollable overflow contributed to ancestors.

The block, flexbox and grid algorithms now only add the container's own end-side padding (right for LTR, left for RTL, plus bottom) to `content_size` when the container is a scroll container:

```rust
if is_scroll_container {
    content_size.width += if direction.is_rtl() { padding.left } else { padding.right };
    content_size.height += padding.bottom;
}
```

For flexbox this required threading an `is_scroll_container` flag through `AlgoConstants` (cfg-gated on `content_size`).

## Context

- The unconditional padding addition was introduced to match browser `scrollWidth`/`scrollHeight` semantics for scroll containers; this PR keeps that behaviour for scroll containers (the existing `content_size_includes_the_containers_own_padding` / `scroll_height_accounts_for_the_containers_own_padding` tests still pass) and only removes it for non-scroll-containers.
- Added a `content_size_excludes_the_own_padding_of_a_non_scroll_container` test covering Block/Flex/Grid.
- Full test suite passes (5829 tests), plus a CHANGELOG entry under Unreleased → Fixed.
- Verified downstream in Blitz: with this fix the csskit.rs root goes from `content_size=1234x3246, scroll_width=34` to `content_size=1200x3246, scroll_width=0` (companion Blitz PR bumps the taffy rev).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/b6f5529e9a3e4823b603788b475ab109
Requested by: @nicoburns