### PR TITLE
Flexbox: don't double-count free space absorbed by main-axis auto margins in justify-content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 ### Fixed
 
+- Flexbox: free space absorbed by main-axis `auto` margins is no longer also distributed by `justify-content`. Previously an item with e.g. `margin: 0 auto` inside a `justify-content: center` container was pushed past the centre by an extra half of the free space, as the same free space was counted twice (once by the auto margins and once by the alignment step). Per [CSS Flexbox §9.5](https://www.w3.org/TR/css-flexbox-1/#algo-main-align), auto margins consume all of the positive free space, leaving none for `justify-content`
+
 - Block/Flexbox/Grid: a container's own end-side padding (right padding for LTR, left padding for RTL, and bottom padding) is now only included in its `content_size` when the container is a scroll container (i.e. has `overflow` other than `visible`/`clip` in either axis). Per the [CSS Overflow spec](https://www.w3.org/TR/css-overflow-3/#scrollable), boxes that are not scroll containers do not extend their scrollable overflow region by their own padding, so overflowing content within an ordinary padded box no longer propagates spuriously enlarged content sizes to ancestor scroll containers
 
 - Grid: the first baselines of grid items which are scroll containers are now clamped to the item's border box (matching the existing flexbox behaviour, per the [CSSWG resolution](https://github.com/w3c/csswg-drafts/issues/7660))

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -2027,7 +2027,7 @@ fn distribute_remaining_free_space(flex_lines: &mut [FlexLine], constants: &Algo
         let total_main_axis_gap = sum_axis_gaps(constants.gap.main(constants.dir), line.items.len());
         let used_space: f32 = total_main_axis_gap
             + line.items.iter().map(|child| child.outer_target_size.main(constants.dir)).sum::<f32>();
-        let free_space = constants.inner_container_size.main(constants.dir) - used_space;
+        let mut free_space = constants.inner_container_size.main(constants.dir) - used_space;
         let mut num_auto_margins = 0;
 
         for child in line.items.iter_mut() {
@@ -2058,6 +2058,9 @@ fn distribute_remaining_free_space(flex_lines: &mut [FlexLine], constants: &Algo
                     }
                 }
             }
+
+            // The auto margins have absorbed all of the free space, leaving none for `justify-content`
+            free_space = 0.0;
         }
 
         let num_items = line.items.len();

--- a/test_fixtures/flex/margin_auto_left_and_right_justify_center.html
+++ b/test_fixtures/flex/margin_auto_left_and_right_justify_center.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 200px; height: 200px; justify-content: center;">
+  <div style="width: 50px; height: 50px; margin-left: auto; margin-right: auto;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/margin_auto_left_justify_flex_end.html
+++ b/test_fixtures/flex/margin_auto_left_justify_flex_end.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 200px; height: 200px; justify-content: flex-end;">
+  <div style="width: 50px; height: 50px; margin-left: auto;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/margin_auto_multiple_children_row_justify_center.html
+++ b/test_fixtures/flex/margin_auto_multiple_children_row_justify_center.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 200px; height: 200px; justify-content: center;">
+  <div style="width: 50px; height: 50px; margin-right: auto;"></div>
+  <div style="width: 50px; height: 50px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/margin_auto_right_justify_center.html
+++ b/test_fixtures/flex/margin_auto_right_justify_center.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 200px; height: 200px; justify-content: center;">
+  <div style="width: 50px; height: 50px; margin-right: auto;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/margin_auto_top_and_bottom_justify_center_column.html
+++ b/test_fixtures/flex/margin_auto_top_and_bottom_justify_center_column.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 200px; height: 200px; flex-direction: column; justify-content: center;">
+  <div style="width: 50px; height: 50px; margin-top: auto; margin-bottom: auto;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/flex/margin_auto_left_and_right_justify_center__border_box_ltr.xml
+++ b/tests/xml/flex/margin_auto_left_and_right_justify_center__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="margin_auto_left_and_right_justify_center__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" justify-content="center" width="200px" height="200px">
+      <div direction="ltr" width="50px" height="50px" margin-left="auto" margin-right="auto"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="75" y="0" width="50" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/margin_auto_left_and_right_justify_center__border_box_rtl.xml
+++ b/tests/xml/flex/margin_auto_left_and_right_justify_center__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="margin_auto_left_and_right_justify_center__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" justify-content="center" width="200px" height="200px">
+      <div direction="rtl" width="50px" height="50px" margin-left="auto" margin-right="auto"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="75" y="0" width="50" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/margin_auto_left_and_right_justify_center__content_box_ltr.xml
+++ b/tests/xml/flex/margin_auto_left_and_right_justify_center__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="margin_auto_left_and_right_justify_center__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" justify-content="center" width="200px" height="200px">
+      <div box-sizing="content-box" direction="ltr" width="50px" height="50px" margin-left="auto" margin-right="auto"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="75" y="0" width="50" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/margin_auto_left_and_right_justify_center__content_box_rtl.xml
+++ b/tests/xml/flex/margin_auto_left_and_right_justify_center__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="margin_auto_left_and_right_justify_center__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" justify-content="center" width="200px" height="200px">
+      <div box-sizing="content-box" direction="rtl" width="50px" height="50px" margin-left="auto" margin-right="auto"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="75" y="0" width="50" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/margin_auto_left_justify_flex_end__border_box_ltr.xml
+++ b/tests/xml/flex/margin_auto_left_justify_flex_end__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="margin_auto_left_justify_flex_end__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" justify-content="flex-end" width="200px" height="200px">
+      <div direction="ltr" width="50px" height="50px" margin-left="auto"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="150" y="0" width="50" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/margin_auto_left_justify_flex_end__border_box_rtl.xml
+++ b/tests/xml/flex/margin_auto_left_justify_flex_end__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="margin_auto_left_justify_flex_end__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" justify-content="flex-end" width="200px" height="200px">
+      <div direction="rtl" width="50px" height="50px" margin-left="auto"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="150" y="0" width="50" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/margin_auto_left_justify_flex_end__content_box_ltr.xml
+++ b/tests/xml/flex/margin_auto_left_justify_flex_end__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="margin_auto_left_justify_flex_end__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" justify-content="flex-end" width="200px" height="200px">
+      <div box-sizing="content-box" direction="ltr" width="50px" height="50px" margin-left="auto"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="150" y="0" width="50" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/margin_auto_left_justify_flex_end__content_box_rtl.xml
+++ b/tests/xml/flex/margin_auto_left_justify_flex_end__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="margin_auto_left_justify_flex_end__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" justify-content="flex-end" width="200px" height="200px">
+      <div box-sizing="content-box" direction="rtl" width="50px" height="50px" margin-left="auto"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="150" y="0" width="50" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/margin_auto_multiple_children_row_justify_center__border_box_ltr.xml
+++ b/tests/xml/flex/margin_auto_multiple_children_row_justify_center__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="margin_auto_multiple_children_row_justify_center__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" justify-content="center" width="200px" height="200px">
+      <div direction="ltr" width="50px" height="50px" margin-right="auto"/>
+      <div direction="ltr" width="50px" height="50px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="0" y="0" width="50" height="50"/>
+      <node x="150" y="0" width="50" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/margin_auto_multiple_children_row_justify_center__border_box_rtl.xml
+++ b/tests/xml/flex/margin_auto_multiple_children_row_justify_center__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="margin_auto_multiple_children_row_justify_center__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" justify-content="center" width="200px" height="200px">
+      <div direction="rtl" width="50px" height="50px" margin-right="auto"/>
+      <div direction="rtl" width="50px" height="50px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="50" y="0" width="50" height="50"/>
+      <node x="0" y="0" width="50" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/margin_auto_multiple_children_row_justify_center__content_box_ltr.xml
+++ b/tests/xml/flex/margin_auto_multiple_children_row_justify_center__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="margin_auto_multiple_children_row_justify_center__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" justify-content="center" width="200px" height="200px">
+      <div box-sizing="content-box" direction="ltr" width="50px" height="50px" margin-right="auto"/>
+      <div box-sizing="content-box" direction="ltr" width="50px" height="50px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="0" y="0" width="50" height="50"/>
+      <node x="150" y="0" width="50" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/margin_auto_multiple_children_row_justify_center__content_box_rtl.xml
+++ b/tests/xml/flex/margin_auto_multiple_children_row_justify_center__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="margin_auto_multiple_children_row_justify_center__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" justify-content="center" width="200px" height="200px">
+      <div box-sizing="content-box" direction="rtl" width="50px" height="50px" margin-right="auto"/>
+      <div box-sizing="content-box" direction="rtl" width="50px" height="50px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="50" y="0" width="50" height="50"/>
+      <node x="0" y="0" width="50" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/margin_auto_right_justify_center__border_box_ltr.xml
+++ b/tests/xml/flex/margin_auto_right_justify_center__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="margin_auto_right_justify_center__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" justify-content="center" width="200px" height="200px">
+      <div direction="ltr" width="50px" height="50px" margin-right="auto"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="0" y="0" width="50" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/margin_auto_right_justify_center__border_box_rtl.xml
+++ b/tests/xml/flex/margin_auto_right_justify_center__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="margin_auto_right_justify_center__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" justify-content="center" width="200px" height="200px">
+      <div direction="rtl" width="50px" height="50px" margin-right="auto"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="0" y="0" width="50" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/margin_auto_right_justify_center__content_box_ltr.xml
+++ b/tests/xml/flex/margin_auto_right_justify_center__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="margin_auto_right_justify_center__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" justify-content="center" width="200px" height="200px">
+      <div box-sizing="content-box" direction="ltr" width="50px" height="50px" margin-right="auto"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="0" y="0" width="50" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/margin_auto_right_justify_center__content_box_rtl.xml
+++ b/tests/xml/flex/margin_auto_right_justify_center__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="margin_auto_right_justify_center__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" justify-content="center" width="200px" height="200px">
+      <div box-sizing="content-box" direction="rtl" width="50px" height="50px" margin-right="auto"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="0" y="0" width="50" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/margin_auto_top_and_bottom_justify_center_column__border_box_ltr.xml
+++ b/tests/xml/flex/margin_auto_top_and_bottom_justify_center_column__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="margin_auto_top_and_bottom_justify_center_column__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" flex-direction="column" justify-content="center" width="200px" height="200px">
+      <div direction="ltr" width="50px" height="50px" margin-top="auto" margin-bottom="auto"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="0" y="75" width="50" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/margin_auto_top_and_bottom_justify_center_column__border_box_rtl.xml
+++ b/tests/xml/flex/margin_auto_top_and_bottom_justify_center_column__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="margin_auto_top_and_bottom_justify_center_column__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" flex-direction="column" justify-content="center" width="200px" height="200px">
+      <div direction="rtl" width="50px" height="50px" margin-top="auto" margin-bottom="auto"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="150" y="75" width="50" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/margin_auto_top_and_bottom_justify_center_column__content_box_ltr.xml
+++ b/tests/xml/flex/margin_auto_top_and_bottom_justify_center_column__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="margin_auto_top_and_bottom_justify_center_column__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" flex-direction="column" justify-content="center" width="200px" height="200px">
+      <div box-sizing="content-box" direction="ltr" width="50px" height="50px" margin-top="auto" margin-bottom="auto"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="0" y="75" width="50" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/margin_auto_top_and_bottom_justify_center_column__content_box_rtl.xml
+++ b/tests/xml/flex/margin_auto_top_and_bottom_justify_center_column__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="margin_auto_top_and_bottom_justify_center_column__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" flex-direction="column" justify-content="center" width="200px" height="200px">
+      <div box-sizing="content-box" direction="rtl" width="50px" height="50px" margin-top="auto" margin-bottom="auto"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="150" y="75" width="50" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -14866,6 +14866,26 @@ mod flex {
     }
 
     #[test]
+    fn margin_auto_left_and_right_justify_center__border_box_ltr() {
+        crate::run_xml_test("flex", "margin_auto_left_and_right_justify_center__border_box_ltr");
+    }
+
+    #[test]
+    fn margin_auto_left_and_right_justify_center__content_box_ltr() {
+        crate::run_xml_test("flex", "margin_auto_left_and_right_justify_center__content_box_ltr");
+    }
+
+    #[test]
+    fn margin_auto_left_and_right_justify_center__border_box_rtl() {
+        crate::run_xml_test("flex", "margin_auto_left_and_right_justify_center__border_box_rtl");
+    }
+
+    #[test]
+    fn margin_auto_left_and_right_justify_center__content_box_rtl() {
+        crate::run_xml_test("flex", "margin_auto_left_and_right_justify_center__content_box_rtl");
+    }
+
+    #[test]
     fn margin_auto_left_and_right_stretch__border_box_ltr() {
         crate::run_xml_test("flex", "margin_auto_left_and_right_stretch__border_box_ltr");
     }
@@ -14923,6 +14943,26 @@ mod flex {
     #[test]
     fn margin_auto_left_fix_right_child_bigger_than_parent__content_box_rtl() {
         crate::run_xml_test("flex", "margin_auto_left_fix_right_child_bigger_than_parent__content_box_rtl");
+    }
+
+    #[test]
+    fn margin_auto_left_justify_flex_end__border_box_ltr() {
+        crate::run_xml_test("flex", "margin_auto_left_justify_flex_end__border_box_ltr");
+    }
+
+    #[test]
+    fn margin_auto_left_justify_flex_end__content_box_ltr() {
+        crate::run_xml_test("flex", "margin_auto_left_justify_flex_end__content_box_ltr");
+    }
+
+    #[test]
+    fn margin_auto_left_justify_flex_end__border_box_rtl() {
+        crate::run_xml_test("flex", "margin_auto_left_justify_flex_end__border_box_rtl");
+    }
+
+    #[test]
+    fn margin_auto_left_justify_flex_end__content_box_rtl() {
+        crate::run_xml_test("flex", "margin_auto_left_justify_flex_end__content_box_rtl");
     }
 
     #[test]
@@ -15006,6 +15046,26 @@ mod flex {
     }
 
     #[test]
+    fn margin_auto_multiple_children_row_justify_center__border_box_ltr() {
+        crate::run_xml_test("flex", "margin_auto_multiple_children_row_justify_center__border_box_ltr");
+    }
+
+    #[test]
+    fn margin_auto_multiple_children_row_justify_center__content_box_ltr() {
+        crate::run_xml_test("flex", "margin_auto_multiple_children_row_justify_center__content_box_ltr");
+    }
+
+    #[test]
+    fn margin_auto_multiple_children_row_justify_center__border_box_rtl() {
+        crate::run_xml_test("flex", "margin_auto_multiple_children_row_justify_center__border_box_rtl");
+    }
+
+    #[test]
+    fn margin_auto_multiple_children_row_justify_center__content_box_rtl() {
+        crate::run_xml_test("flex", "margin_auto_multiple_children_row_justify_center__content_box_rtl");
+    }
+
+    #[test]
     fn margin_auto_right__border_box_ltr() {
         crate::run_xml_test("flex", "margin_auto_right__border_box_ltr");
     }
@@ -15026,6 +15086,26 @@ mod flex {
     }
 
     #[test]
+    fn margin_auto_right_justify_center__border_box_ltr() {
+        crate::run_xml_test("flex", "margin_auto_right_justify_center__border_box_ltr");
+    }
+
+    #[test]
+    fn margin_auto_right_justify_center__content_box_ltr() {
+        crate::run_xml_test("flex", "margin_auto_right_justify_center__content_box_ltr");
+    }
+
+    #[test]
+    fn margin_auto_right_justify_center__border_box_rtl() {
+        crate::run_xml_test("flex", "margin_auto_right_justify_center__border_box_rtl");
+    }
+
+    #[test]
+    fn margin_auto_right_justify_center__content_box_rtl() {
+        crate::run_xml_test("flex", "margin_auto_right_justify_center__content_box_rtl");
+    }
+
+    #[test]
     fn margin_auto_top__border_box_ltr() {
         crate::run_xml_test("flex", "margin_auto_top__border_box_ltr");
     }
@@ -15043,6 +15123,26 @@ mod flex {
     #[test]
     fn margin_auto_top__content_box_rtl() {
         crate::run_xml_test("flex", "margin_auto_top__content_box_rtl");
+    }
+
+    #[test]
+    fn margin_auto_top_and_bottom_justify_center_column__border_box_ltr() {
+        crate::run_xml_test("flex", "margin_auto_top_and_bottom_justify_center_column__border_box_ltr");
+    }
+
+    #[test]
+    fn margin_auto_top_and_bottom_justify_center_column__content_box_ltr() {
+        crate::run_xml_test("flex", "margin_auto_top_and_bottom_justify_center_column__content_box_ltr");
+    }
+
+    #[test]
+    fn margin_auto_top_and_bottom_justify_center_column__border_box_rtl() {
+        crate::run_xml_test("flex", "margin_auto_top_and_bottom_justify_center_column__border_box_rtl");
+    }
+
+    #[test]
+    fn margin_auto_top_and_bottom_justify_center_column__content_box_rtl() {
+        crate::run_xml_test("flex", "margin_auto_top_and_bottom_justify_center_column__content_box_rtl");
     }
 
     #[test]


### PR DESCRIPTION
# Objective

Fix flex items with main-axis `auto` margins being mis-positioned when the container also has `justify-content` other than `flex-start`.

Found via bulma.io: `.bd-home-intro-content` (`margin: 0 auto; max-width: 35rem`) inside `.bd-home-intro-body` (`display: flex; justify-content: center`) rendered shifted right by half the free space instead of centered.

## Context

In `distribute_remaining_free_space` (CSS Flexbox §9.5), positive free space is first distributed equally among main-axis `auto` margins — but the *same* `free_space` value was then also passed to the `justify-content` alignment step. The item was therefore offset twice: once by the resolved auto margins and once by the alignment offset. E.g. with `justify-content: center`:

```text
container 200px, item 50px, margin-left/right: auto
free space = 150 → margins = 75/75 → item at x=75
buggy: + justify-content center offset of 150/2 → item at x=150
```

Per the spec, auto margins absorb *all* of the positive free space ("If the remaining free space is positive and at least one main-axis margin on this line is `auto`, distribute the free space equally among these margins"), so the alignment step should see zero free space. The fix zeroes `free_space` after distributing it to auto margins.

New gentest fixtures (Chrome-generated expectations) cover row/column, single/double auto margins, single-sided auto margin with `flex-end`, and multiple children; all 20 new generated tests fail before the fix and pass after. CHANGELOG.md updated (crate has no RELEASES.md).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/d32178d897a241fd810293d1d6c58041
Requested by: @nicoburns