### PR TITLE
Avoid unnecessary flex item min-content measurement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 ### Fixed
 
+- Flexbox: skip the automatic min-content measurement when an item's minimum main size is already resolved from its style or overflow. Previously this fallback was evaluated eagerly and could cause nested flex layouts with explicit minimum sizes to perform unnecessary recursive measurements
+
 - Block/Flexbox/Grid: content overflowing a box past its scroll origin (the inline-start/block-start edge, e.g. an absolutely positioned child with a negative position) no longer inflates the box's `content_size`. Per the [CSS Overflow spec](https://www.w3.org/TR/css-overflow-3/#scrollable), the scrollable overflow region only extends from the scroll origin towards the inline-end/block-end directions, so such content is unreachable and does not contribute to scrollable overflow. Additionally, block layout now correctly measures absolutely positioned children from the inline-end edge in RTL when computing their `content_size` contribution, matching the existing flexbox and grid behaviour
 
 - Flexbox: free space absorbed by main-axis `auto` margins is no longer also distributed by `justify-content`. Previously an item with e.g. `margin: 0 auto` inside a `justify-content: center` container was pushed past the centre by an extra half of the free space, as the same free space was counted twice (once by the auto margins and once by the alignment step). Per [CSS Flexbox §9.5](https://www.w3.org/TR/css-flexbox-1/#algo-main-align), auto margins consume all of the positive free space, leaving none for `justify-content`

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -1005,7 +1005,7 @@ fn determine_flex_base_size(
         let style_min_main_size =
             child.min_size.or(child.overflow.map(Overflow::maybe_into_automatic_min_size).into()).main(dir);
 
-        child.resolved_minimum_main_size = style_min_main_size.unwrap_or({
+        child.resolved_minimum_main_size = style_min_main_size.unwrap_or_else(|| {
             let min_content_main_size = {
                 let child_available_space = Size::MIN_CONTENT.with_cross(dir, cross_axis_available_space);
 

--- a/tests/hand_written/measure.rs
+++ b/tests/hand_written/measure.rs
@@ -333,6 +333,30 @@ mod measure {
     }
 
     #[test]
+    fn explicit_min_main_size_skips_min_content_measurement() {
+        fn assert_not_min_content(
+            inputs: LayoutInput,
+            _node_id: NodeId,
+            _context: Option<&mut ()>,
+            _style: &Style,
+        ) -> LayoutOutput {
+            assert_ne!(inputs.available_space.width, AvailableSpace::MinContent);
+            LayoutOutput::from_outer_size(Size { width: 10.0, height: 10.0 })
+        }
+
+        let mut taffy = TaffyTree::new();
+        let child = taffy
+            .new_leaf_with_context(
+                Style { min_size: Size { width: length(10.0), height: auto() }, ..Default::default() },
+                (),
+            )
+            .unwrap();
+        let root = taffy.new_with_children(Style::default(), &[child]).unwrap();
+
+        taffy.compute_layout_with_measure(root, Size::MAX_CONTENT, assert_not_min_content).unwrap();
+    }
+
+    #[test]
     fn measure_absolute_child() {
         let mut taffy = new_test_tree();
         let child = taffy


### PR DESCRIPTION
# Objective

Avoid measuring a flex item's min-content size when its minimum main size has already been resolved from its style or overflow.

`Option::unwrap_or` eagerly evaluates its argument, so the automatic-minimum fallback called `tree.measure_child_size` even when `style_min_main_size` was `Some`. Switching to `unwrap_or_else` preserves the fallback for `None` while skipping discarded work for `Some`.

In a temporary 500-node nested-layout benchmark, the explicit-minimum case improved from ~35.2 ms to ~7.0 ms, while the no-minimum control remained around ~5.3 ms. A separate minimal 500-node chain on current `main` showed a median improvement from ~0.83 ms to ~0.58 ms, with its no-minimum control effectively unchanged (~0.83 ms to ~0.82 ms).

## Context

The skipped fallback has no required result when the minimum is already resolved: its measured value was discarded. The focused regression test gives a measured flex item an explicit `min-width` and verifies that the measure callback is not invoked with `AvailableSpace::MinContent`.

Validation:

- `cargo fmt --all -- --check`
- `cargo test --test hand_written explicit_min_main_size_skips_min_content_measurement`
- `cargo test --tests`
- `cargo clippy --workspace -- -D warnings`

The performance fix is also recorded in the Unreleased section of `CHANGELOG.md`.
