### PR TITLE
Skip measuring absolutely positioned children when both dimensions are known

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
 
 - `Dimension` also supports the `content` keyword (`Dimension::content()`, CSS `content`), which indicates an automatic size based on the box's content. This keyword is only valid for `flex-basis`, where it sizes the item based on its content (ignoring its main size property) when computing its flex base size. In any other context (e.g. `width`/`height`) it behaves as `auto`
 
+### Changed
+
+- Flexbox/Block: absolutely positioned children are no longer measured when both of their dimensions are already known (e.g. from explicit sizes or insets), matching the existing grid behaviour
+
 ### Fixed
 
 - Flexbox: skip the automatic min-content measurement when an item's minimum main size is already resolved from its style or overflow. Previously this fallback was evaluated eagerly and could cause nested flex layouts with explicit minimum sizes to perform unnecessary recursive measurements

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -1662,19 +1662,24 @@ fn perform_absolute_layout_on_absolute_children(
             known_dimensions = known_dimensions.maybe_apply_aspect_ratio(aspect_ratio).maybe_clamp(min_size, max_size);
         }
 
-        let measured_size = tree.measure_child_size_both(
-            item.node_id,
-            known_dimensions,
-            area_size.map(Some),
-            Size {
-                width: AvailableSpace::Definite(area_width.maybe_clamp(min_size.width, max_size.width)),
-                height: AvailableSpace::Definite(area_height.maybe_clamp(min_size.height, max_size.height)),
-            },
-            SizingMode::ContentSize,
-            Line::FALSE,
-        );
-
-        let final_size = known_dimensions.unwrap_or(measured_size).maybe_clamp(min_size, max_size);
+        let final_size = match (known_dimensions.width, known_dimensions.height) {
+            (Some(width), Some(height)) => Size { width, height },
+            _ => {
+                let measured_size = tree.measure_child_size_both(
+                    item.node_id,
+                    known_dimensions,
+                    area_size.map(Some),
+                    Size {
+                        width: AvailableSpace::Definite(area_width.maybe_clamp(min_size.width, max_size.width)),
+                        height: AvailableSpace::Definite(area_height.maybe_clamp(min_size.height, max_size.height)),
+                    },
+                    SizingMode::ContentSize,
+                    Line::FALSE,
+                );
+                known_dimensions.unwrap_or(measured_size)
+            }
+        }
+        .maybe_clamp(min_size, max_size);
 
         let layout_output = tree.perform_child_layout(
             item.node_id,

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -2681,18 +2681,26 @@ fn perform_absolute_layout_on_absolute_children(
             known_dimensions.height = Some(f32_max(new_height_raw, 0.0));
             known_dimensions = known_dimensions.maybe_apply_aspect_ratio(aspect_ratio).maybe_clamp(min_size, max_size);
         }
-        let measured_size = tree.measure_child_size_both(
-            child,
-            known_dimensions,
-            constants.node_inner_size,
-            Size {
-                width: AvailableSpace::Definite(container_width.maybe_clamp(min_size.width, max_size.width)),
-                height: AvailableSpace::Definite(container_height.maybe_clamp(min_size.height, max_size.height)),
-            },
-            SizingMode::InherentSize,
-            Line::FALSE,
-        );
-        let final_size = known_dimensions.unwrap_or(measured_size).maybe_clamp(min_size, max_size);
+        let final_size = match (known_dimensions.width, known_dimensions.height) {
+            (Some(width), Some(height)) => Size { width, height },
+            _ => {
+                let measured_size = tree.measure_child_size_both(
+                    child,
+                    known_dimensions,
+                    constants.node_inner_size,
+                    Size {
+                        width: AvailableSpace::Definite(container_width.maybe_clamp(min_size.width, max_size.width)),
+                        height: AvailableSpace::Definite(
+                            container_height.maybe_clamp(min_size.height, max_size.height),
+                        ),
+                    },
+                    SizingMode::InherentSize,
+                    Line::FALSE,
+                );
+                known_dimensions.unwrap_or(measured_size)
+            }
+        }
+        .maybe_clamp(min_size, max_size);
 
         let layout_output = tree.perform_child_layout(
             child,


### PR DESCRIPTION
# Objective

Avoid an unnecessary child measurement, in the same spirit as #1119. In the flexbox and block absolute-positioning paths, `measure_child_size_both` was called unconditionally and then combined via `known_dimensions.unwrap_or(measured_size)` — wasting the measurement whenever both dimensions were already known (from explicit sizes, insets, or sizing keywords).

Both call sites now follow the guard grid already uses (`perform_alignment_and_position` in `src/compute/grid/alignment.rs`):

```rust
let final_size = match (known_dimensions.width, known_dimensions.height) {
    (Some(width), Some(height)) => Size { width, height },
    _ => {
        let measured_size = tree.measure_child_size_both(/* unchanged args */);
        known_dimensions.unwrap_or(measured_size)
    }
}
.maybe_clamp(min_size, max_size);
```

No behaviour change: when either dimension was unknown the measurement happens exactly as before, and when both were known the measured result was discarded anyway.

## Context

Follow-up to #1119, which removed the equivalent eager measurement in `determine_flex_base_size`. `cargo test --workspace` passes (5861 tests).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/6fcfe49dc7f141ceb68ac8b5e766a7c1
Requested by: @nicoburns