### PR TITLE
Fix percentage height resolution basis and relative percentage insets in block/flexbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@
 
 ### Fixed
 
+- Block: a container's `min-height` alone no longer acts as the resolution basis for the percentage heights of its children when the container's own height is indefinite. Per [CSS 2 §10.5](https://www.w3.org/TR/CSS22/visudet.html#the-height-property), such percentages resolve as `auto`
+
+- Block: percentage vertical insets (`top`/`bottom`) of relatively positioned children now resolve against the containing block's height when it is definite. Previously they always resolved against a zero basis, so e.g. `top: 50%` had no effect
+
+- Flexbox: a flex item's cross size is now only treated as definite when the item is stretched (via `align-self: stretch` or a cross-axis `stretch` size) or has a definite cross size style, per [CSS Flexbox §4.5](https://www.w3.org/TR/css-flexbox-1/#definite-sizes). Previously a non-stretched item's content-derived cross size was treated as definite, so percentage heights of its descendants incorrectly resolved against it instead of behaving as `auto`
+
 - Flexbox: skip the automatic min-content measurement when an item's minimum main size is already resolved from its style or overflow. Previously this fallback was evaluated eagerly and could cause nested flex layouts with explicit minimum sizes to perform unnecessary recursive measurements
 
 - Block/Flexbox/Grid: content overflowing a box past its scroll origin (the inline-start/block-start edge, e.g. an absolutely positioned child with a negative position) no longer inflates the box's `content_size`. Per the [CSS Overflow spec](https://www.w3.org/TR/css-overflow-3/#scrollable), the scrollable overflow region only extends from the scroll origin towards the inline-end/block-end directions, so such content is unreachable and does not contribute to scrollable overflow. Additionally, block layout now correctly measures absolutely positioned children from the inline-end edge in RTL when computing their `content_size` contribution, matching the existing flexbox and grid behaviour

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -564,7 +564,7 @@ fn compute_inner(
     }
 
     let container_percentage_resolution_height =
-        percentage_basis_dimensions.height.or(size.height.maybe_max(min_size.height)).or(min_size.height);
+        percentage_basis_dimensions.height.or(size.height.maybe_max(min_size.height));
 
     // 3. Perform final item layout and return content height
     //
@@ -1314,9 +1314,11 @@ fn perform_final_layout_on_in_flow_children(
             };
 
             // Resolve item inset
-            let inset = item.inset.zip_size(Size { width: container_inner_width, height: 0.0 }, |p, s| {
-                p.maybe_resolve(s, |val, basis| tree.calc(val, basis))
-            });
+            let inset_percentage_basis =
+                Size { width: Some(container_inner_width), height: container_percentage_resolution_height };
+            let inset = item
+                .inset
+                .zip_size(inset_percentage_basis, |p, s| p.maybe_resolve(s, |val, basis| tree.calc(val, basis)));
             let inset_offset = Point {
                 x: if direction.is_rtl() {
                     inset.right.map(|x| -x).or(inset.left).unwrap_or(0.0)

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -1209,9 +1209,18 @@ fn collect_balanced_flex_lines<'a>(
 /// has a definite main size or the item's used flex basis is definite.
 /// See <https://www.w3.org/TR/css-flexbox-1/#definite-sizes>
 #[inline]
-fn item_definiteness(constants: &AlgoConstants, item: &FlexItem) -> Size<bool> {
-    let main_is_definite = constants.has_definite_main_size || item.flex_basis_is_definite;
-    Size { width: true, height: true }.with_main(constants.dir, main_is_definite)
+fn item_definiteness(dir: FlexDirection, has_definite_main_size: bool, item: &FlexItem) -> Size<bool> {
+    let main_is_definite = has_definite_main_size || item.flex_basis_is_definite;
+    // An item's cross size is definite if it is stretched (it stretches to the flex line, whose
+    // size is known by the time the item's final layout is performed), or if its cross size
+    // style resolved to a definite size. Widths are always definite as they resolve via
+    // fit-content against definite available space.
+    let is_stretched = !item.margin_is_auto.cross_start(dir)
+        && !item.margin_is_auto.cross_end(dir)
+        && (item.size_style.cross(dir).is_stretch()
+            || (item.align_self == AlignSelf::STRETCH && item.size_style.cross(dir).is_auto()));
+    let cross_is_definite = !dir.is_row() || is_stretched || item.size.cross(dir).is_some();
+    Size { width: true, height: true }.with_main(dir, main_is_definite).with_cross(dir, cross_is_definite)
 }
 
 /// Determine the container's main size (if not already known)
@@ -1745,7 +1754,11 @@ fn determine_hypothetical_cross_size(
                         width: if constants.is_row { child.target_size.width.into() } else { child_cross },
                         height: if constants.is_row { child_cross } else { child.target_size.height.into() },
                     },
-                    known_dimensions_are_definite: item_definiteness(constants, child),
+                    known_dimensions_are_definite: item_definiteness(
+                        constants.dir,
+                        constants.has_definite_main_size,
+                        child,
+                    ),
                     parent_size: constants.node_inner_size,
                     available_space: Size {
                         width: if constants.is_row { child_known_main } else { child_available_cross },
@@ -1814,7 +1827,11 @@ fn calculate_children_base_lines(
                             child.target_size.height.into()
                         },
                     },
-                    known_dimensions_are_definite: item_definiteness(constants, child),
+                    known_dimensions_are_definite: item_definiteness(
+                        constants.dir,
+                        constants.has_definite_main_size,
+                        child,
+                    ),
                     parent_size: constants.node_inner_size,
                     available_space: Size {
                         width: if constants.is_row {
@@ -2311,8 +2328,7 @@ fn calculate_flex_item(
     direction: FlexDirection,
     layout_direction: Direction,
 ) {
-    let item_definiteness =
-        Size { width: true, height: true }.with_main(direction, has_definite_main_size || item.flex_basis_is_definite);
+    let item_definiteness = item_definiteness(direction, has_definite_main_size, item);
     let layout_output = tree.compute_child_layout(
         item.node,
         LayoutInput {

--- a/test_fixtures/block/block_percentage_height_with_min_height_parent.html
+++ b/test_fixtures/block/block_percentage_height_with_min_height_parent.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px; min-height: 80px;">
+  <div style="display: block; height: 50%;">
+    <div style="display: block; width: 20px; height: 20px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/block/block_relative_inset_percentage_auto_height.html
+++ b/test_fixtures/block/block_relative_inset_percentage_auto_height.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px;">
+  <div style="display: block; position: relative; top: 50%; width: 20px; height: 20px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/block/block_relative_inset_percentage_definite_height.html
+++ b/test_fixtures/block/block_relative_inset_percentage_definite_height.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px; height: 200px;">
+  <div style="display: block; position: relative; top: 50%; left: 10%; width: 20px; height: 20px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/blockflex/blockflex_percentage_height_in_auto_height_flex_item.html
+++ b/test_fixtures/blockflex/blockflex_percentage_height_in_auto_height_flex_item.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; width: 100px;">
+  <div style="display: block; width: 50px; min-height: 0px;">
+    <div style="display: block; height: 50%;">
+      <div style="display: block; width: 50px; height: 50px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/blockflex/blockflex_percentage_height_in_stretched_flex_item.html
+++ b/test_fixtures/blockflex/blockflex_percentage_height_in_stretched_flex_item.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; width: 100px; height: 100px;">
+  <div style="display: block; width: 50px;">
+    <div style="display: block; height: 50%;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/blockflex/blockflex_percentage_height_in_unstretched_flex_item.html
+++ b/test_fixtures/blockflex/blockflex_percentage_height_in_unstretched_flex_item.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; width: 100px; height: 100px; align-items: flex-start;">
+  <div style="display: block; width: 50px;">
+    <div style="display: block; height: 50%;">
+      <div style="display: block; width: 20px; height: 20px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/block/block_percentage_height_with_min_height_parent__border_box_ltr.xml
+++ b/tests/xml/block/block_percentage_height_with_min_height_parent__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="block_percentage_height_with_min_height_parent__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px" min-height="80px">
+      <div display="block" direction="ltr" height="50%">
+        <div display="block" direction="ltr" width="20px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="80">
+      <node x="0" y="0" width="100" height="20">
+        <node x="0" y="0" width="20" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_percentage_height_with_min_height_parent__border_box_rtl.xml
+++ b/tests/xml/block/block_percentage_height_with_min_height_parent__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="block_percentage_height_with_min_height_parent__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px" min-height="80px">
+      <div display="block" direction="rtl" height="50%">
+        <div display="block" direction="rtl" width="20px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="80">
+      <node x="0" y="0" width="100" height="20">
+        <node x="80" y="0" width="20" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_percentage_height_with_min_height_parent__content_box_ltr.xml
+++ b/tests/xml/block/block_percentage_height_with_min_height_parent__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="block_percentage_height_with_min_height_parent__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px" min-height="80px">
+      <div display="block" box-sizing="content-box" direction="ltr" height="50%">
+        <div display="block" box-sizing="content-box" direction="ltr" width="20px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="80">
+      <node x="0" y="0" width="100" height="20">
+        <node x="0" y="0" width="20" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_percentage_height_with_min_height_parent__content_box_rtl.xml
+++ b/tests/xml/block/block_percentage_height_with_min_height_parent__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="block_percentage_height_with_min_height_parent__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px" min-height="80px">
+      <div display="block" box-sizing="content-box" direction="rtl" height="50%">
+        <div display="block" box-sizing="content-box" direction="rtl" width="20px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="80">
+      <node x="0" y="0" width="100" height="20">
+        <node x="80" y="0" width="20" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_relative_inset_percentage_auto_height__border_box_ltr.xml
+++ b/tests/xml/block/block_relative_inset_percentage_auto_height__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="block_relative_inset_percentage_auto_height__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px">
+      <div display="block" direction="ltr" width="20px" height="20px" top="50%"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="20">
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_relative_inset_percentage_auto_height__border_box_rtl.xml
+++ b/tests/xml/block/block_relative_inset_percentage_auto_height__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="block_relative_inset_percentage_auto_height__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px">
+      <div display="block" direction="rtl" width="20px" height="20px" top="50%"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="20">
+      <node x="80" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_relative_inset_percentage_auto_height__content_box_ltr.xml
+++ b/tests/xml/block/block_relative_inset_percentage_auto_height__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="block_relative_inset_percentage_auto_height__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" width="20px" height="20px" top="50%"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="20">
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_relative_inset_percentage_auto_height__content_box_rtl.xml
+++ b/tests/xml/block/block_relative_inset_percentage_auto_height__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="block_relative_inset_percentage_auto_height__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" width="20px" height="20px" top="50%"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="20">
+      <node x="80" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_relative_inset_percentage_definite_height__border_box_ltr.xml
+++ b/tests/xml/block/block_relative_inset_percentage_definite_height__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="block_relative_inset_percentage_definite_height__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px" height="200px">
+      <div display="block" direction="ltr" width="20px" height="20px" top="50%" left="10%"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="200">
+      <node x="10" y="100" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_relative_inset_percentage_definite_height__border_box_rtl.xml
+++ b/tests/xml/block/block_relative_inset_percentage_definite_height__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="block_relative_inset_percentage_definite_height__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px" height="200px">
+      <div display="block" direction="rtl" width="20px" height="20px" top="50%" left="10%"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="200">
+      <node x="90" y="100" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_relative_inset_percentage_definite_height__content_box_ltr.xml
+++ b/tests/xml/block/block_relative_inset_percentage_definite_height__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="block_relative_inset_percentage_definite_height__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px" height="200px">
+      <div display="block" box-sizing="content-box" direction="ltr" width="20px" height="20px" top="50%" left="10%"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="200">
+      <node x="10" y="100" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_relative_inset_percentage_definite_height__content_box_rtl.xml
+++ b/tests/xml/block/block_relative_inset_percentage_definite_height__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="block_relative_inset_percentage_definite_height__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px" height="200px">
+      <div display="block" box-sizing="content-box" direction="rtl" width="20px" height="20px" top="50%" left="10%"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="200">
+      <node x="90" y="100" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/blockflex/blockflex_percentage_height_in_auto_height_flex_item__border_box_ltr.xml
+++ b/tests/xml/blockflex/blockflex_percentage_height_in_auto_height_flex_item__border_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="blockflex_percentage_height_in_auto_height_flex_item__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" width="100px">
+      <div display="block" direction="ltr" width="50px" min-height="0px">
+        <div display="block" direction="ltr" height="50%">
+          <div display="block" direction="ltr" width="50px" height="50px"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="50">
+      <node x="0" y="0" width="50" height="50">
+        <node x="0" y="0" width="50" height="25">
+          <node x="0" y="0" width="50" height="50"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/blockflex/blockflex_percentage_height_in_auto_height_flex_item__border_box_rtl.xml
+++ b/tests/xml/blockflex/blockflex_percentage_height_in_auto_height_flex_item__border_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="blockflex_percentage_height_in_auto_height_flex_item__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" width="100px">
+      <div display="block" direction="rtl" width="50px" min-height="0px">
+        <div display="block" direction="rtl" height="50%">
+          <div display="block" direction="rtl" width="50px" height="50px"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="50">
+      <node x="50" y="0" width="50" height="50">
+        <node x="0" y="0" width="50" height="25">
+          <node x="0" y="0" width="50" height="50"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/blockflex/blockflex_percentage_height_in_auto_height_flex_item__content_box_ltr.xml
+++ b/tests/xml/blockflex/blockflex_percentage_height_in_auto_height_flex_item__content_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="blockflex_percentage_height_in_auto_height_flex_item__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" width="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" width="50px" min-height="0px">
+        <div display="block" box-sizing="content-box" direction="ltr" height="50%">
+          <div display="block" box-sizing="content-box" direction="ltr" width="50px" height="50px"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="50">
+      <node x="0" y="0" width="50" height="50">
+        <node x="0" y="0" width="50" height="25">
+          <node x="0" y="0" width="50" height="50"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/blockflex/blockflex_percentage_height_in_auto_height_flex_item__content_box_rtl.xml
+++ b/tests/xml/blockflex/blockflex_percentage_height_in_auto_height_flex_item__content_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="blockflex_percentage_height_in_auto_height_flex_item__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" width="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" width="50px" min-height="0px">
+        <div display="block" box-sizing="content-box" direction="rtl" height="50%">
+          <div display="block" box-sizing="content-box" direction="rtl" width="50px" height="50px"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="50">
+      <node x="50" y="0" width="50" height="50">
+        <node x="0" y="0" width="50" height="25">
+          <node x="0" y="0" width="50" height="50"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/blockflex/blockflex_percentage_height_in_stretched_flex_item__border_box_ltr.xml
+++ b/tests/xml/blockflex/blockflex_percentage_height_in_stretched_flex_item__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="blockflex_percentage_height_in_stretched_flex_item__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" width="100px" height="100px">
+      <div display="block" direction="ltr" width="50px">
+        <div display="block" direction="ltr" height="50%"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="50" height="100">
+        <node x="0" y="0" width="50" height="50"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/blockflex/blockflex_percentage_height_in_stretched_flex_item__border_box_rtl.xml
+++ b/tests/xml/blockflex/blockflex_percentage_height_in_stretched_flex_item__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="blockflex_percentage_height_in_stretched_flex_item__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" width="100px" height="100px">
+      <div display="block" direction="rtl" width="50px">
+        <div display="block" direction="rtl" height="50%"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="50" y="0" width="50" height="100">
+        <node x="0" y="0" width="50" height="50"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/blockflex/blockflex_percentage_height_in_stretched_flex_item__content_box_ltr.xml
+++ b/tests/xml/blockflex/blockflex_percentage_height_in_stretched_flex_item__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="blockflex_percentage_height_in_stretched_flex_item__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" width="100px" height="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" width="50px">
+        <div display="block" box-sizing="content-box" direction="ltr" height="50%"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="50" height="100">
+        <node x="0" y="0" width="50" height="50"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/blockflex/blockflex_percentage_height_in_stretched_flex_item__content_box_rtl.xml
+++ b/tests/xml/blockflex/blockflex_percentage_height_in_stretched_flex_item__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="blockflex_percentage_height_in_stretched_flex_item__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" width="100px" height="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" width="50px">
+        <div display="block" box-sizing="content-box" direction="rtl" height="50%"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="50" y="0" width="50" height="100">
+        <node x="0" y="0" width="50" height="50"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/blockflex/blockflex_percentage_height_in_unstretched_flex_item__border_box_ltr.xml
+++ b/tests/xml/blockflex/blockflex_percentage_height_in_unstretched_flex_item__border_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="blockflex_percentage_height_in_unstretched_flex_item__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" align-items="flex-start" width="100px" height="100px">
+      <div display="block" direction="ltr" width="50px">
+        <div display="block" direction="ltr" height="50%">
+          <div display="block" direction="ltr" width="20px" height="20px"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="50" height="20">
+        <node x="0" y="0" width="50" height="20">
+          <node x="0" y="0" width="20" height="20"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/blockflex/blockflex_percentage_height_in_unstretched_flex_item__border_box_rtl.xml
+++ b/tests/xml/blockflex/blockflex_percentage_height_in_unstretched_flex_item__border_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="blockflex_percentage_height_in_unstretched_flex_item__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" align-items="flex-start" width="100px" height="100px">
+      <div display="block" direction="rtl" width="50px">
+        <div display="block" direction="rtl" height="50%">
+          <div display="block" direction="rtl" width="20px" height="20px"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="50" y="0" width="50" height="20">
+        <node x="0" y="0" width="50" height="20">
+          <node x="30" y="0" width="20" height="20"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/blockflex/blockflex_percentage_height_in_unstretched_flex_item__content_box_ltr.xml
+++ b/tests/xml/blockflex/blockflex_percentage_height_in_unstretched_flex_item__content_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="blockflex_percentage_height_in_unstretched_flex_item__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" align-items="flex-start" width="100px" height="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" width="50px">
+        <div display="block" box-sizing="content-box" direction="ltr" height="50%">
+          <div display="block" box-sizing="content-box" direction="ltr" width="20px" height="20px"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="50" height="20">
+        <node x="0" y="0" width="50" height="20">
+          <node x="0" y="0" width="20" height="20"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/blockflex/blockflex_percentage_height_in_unstretched_flex_item__content_box_rtl.xml
+++ b/tests/xml/blockflex/blockflex_percentage_height_in_unstretched_flex_item__content_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="blockflex_percentage_height_in_unstretched_flex_item__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" align-items="flex-start" width="100px" height="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" width="50px">
+        <div display="block" box-sizing="content-box" direction="rtl" height="50%">
+          <div display="block" box-sizing="content-box" direction="rtl" width="20px" height="20px"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="50" y="0" width="50" height="20">
+        <node x="0" y="0" width="50" height="20">
+          <node x="30" y="0" width="20" height="20"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -4822,6 +4822,66 @@ mod block {
     }
 
     #[test]
+    fn block_percentage_height_with_min_height_parent__border_box_ltr() {
+        crate::run_xml_test("block", "block_percentage_height_with_min_height_parent__border_box_ltr");
+    }
+
+    #[test]
+    fn block_percentage_height_with_min_height_parent__content_box_ltr() {
+        crate::run_xml_test("block", "block_percentage_height_with_min_height_parent__content_box_ltr");
+    }
+
+    #[test]
+    fn block_percentage_height_with_min_height_parent__border_box_rtl() {
+        crate::run_xml_test("block", "block_percentage_height_with_min_height_parent__border_box_rtl");
+    }
+
+    #[test]
+    fn block_percentage_height_with_min_height_parent__content_box_rtl() {
+        crate::run_xml_test("block", "block_percentage_height_with_min_height_parent__content_box_rtl");
+    }
+
+    #[test]
+    fn block_relative_inset_percentage_auto_height__border_box_ltr() {
+        crate::run_xml_test("block", "block_relative_inset_percentage_auto_height__border_box_ltr");
+    }
+
+    #[test]
+    fn block_relative_inset_percentage_auto_height__content_box_ltr() {
+        crate::run_xml_test("block", "block_relative_inset_percentage_auto_height__content_box_ltr");
+    }
+
+    #[test]
+    fn block_relative_inset_percentage_auto_height__border_box_rtl() {
+        crate::run_xml_test("block", "block_relative_inset_percentage_auto_height__border_box_rtl");
+    }
+
+    #[test]
+    fn block_relative_inset_percentage_auto_height__content_box_rtl() {
+        crate::run_xml_test("block", "block_relative_inset_percentage_auto_height__content_box_rtl");
+    }
+
+    #[test]
+    fn block_relative_inset_percentage_definite_height__border_box_ltr() {
+        crate::run_xml_test("block", "block_relative_inset_percentage_definite_height__border_box_ltr");
+    }
+
+    #[test]
+    fn block_relative_inset_percentage_definite_height__content_box_ltr() {
+        crate::run_xml_test("block", "block_relative_inset_percentage_definite_height__content_box_ltr");
+    }
+
+    #[test]
+    fn block_relative_inset_percentage_definite_height__border_box_rtl() {
+        crate::run_xml_test("block", "block_relative_inset_percentage_definite_height__border_box_rtl");
+    }
+
+    #[test]
+    fn block_relative_inset_percentage_definite_height__content_box_rtl() {
+        crate::run_xml_test("block", "block_relative_inset_percentage_definite_height__content_box_rtl");
+    }
+
+    #[test]
     fn block_scrollbar_rtl__border_box_ltr() {
         crate::run_xml_test("block", "block_scrollbar_rtl__border_box_ltr");
     }
@@ -5021,6 +5081,66 @@ mod blockflex {
     #[test]
     fn blockflex_overflow_hidden__content_box_rtl() {
         crate::run_xml_test("blockflex", "blockflex_overflow_hidden__content_box_rtl");
+    }
+
+    #[test]
+    fn blockflex_percentage_height_in_auto_height_flex_item__border_box_ltr() {
+        crate::run_xml_test("blockflex", "blockflex_percentage_height_in_auto_height_flex_item__border_box_ltr");
+    }
+
+    #[test]
+    fn blockflex_percentage_height_in_auto_height_flex_item__content_box_ltr() {
+        crate::run_xml_test("blockflex", "blockflex_percentage_height_in_auto_height_flex_item__content_box_ltr");
+    }
+
+    #[test]
+    fn blockflex_percentage_height_in_auto_height_flex_item__border_box_rtl() {
+        crate::run_xml_test("blockflex", "blockflex_percentage_height_in_auto_height_flex_item__border_box_rtl");
+    }
+
+    #[test]
+    fn blockflex_percentage_height_in_auto_height_flex_item__content_box_rtl() {
+        crate::run_xml_test("blockflex", "blockflex_percentage_height_in_auto_height_flex_item__content_box_rtl");
+    }
+
+    #[test]
+    fn blockflex_percentage_height_in_stretched_flex_item__border_box_ltr() {
+        crate::run_xml_test("blockflex", "blockflex_percentage_height_in_stretched_flex_item__border_box_ltr");
+    }
+
+    #[test]
+    fn blockflex_percentage_height_in_stretched_flex_item__content_box_ltr() {
+        crate::run_xml_test("blockflex", "blockflex_percentage_height_in_stretched_flex_item__content_box_ltr");
+    }
+
+    #[test]
+    fn blockflex_percentage_height_in_stretched_flex_item__border_box_rtl() {
+        crate::run_xml_test("blockflex", "blockflex_percentage_height_in_stretched_flex_item__border_box_rtl");
+    }
+
+    #[test]
+    fn blockflex_percentage_height_in_stretched_flex_item__content_box_rtl() {
+        crate::run_xml_test("blockflex", "blockflex_percentage_height_in_stretched_flex_item__content_box_rtl");
+    }
+
+    #[test]
+    fn blockflex_percentage_height_in_unstretched_flex_item__border_box_ltr() {
+        crate::run_xml_test("blockflex", "blockflex_percentage_height_in_unstretched_flex_item__border_box_ltr");
+    }
+
+    #[test]
+    fn blockflex_percentage_height_in_unstretched_flex_item__content_box_ltr() {
+        crate::run_xml_test("blockflex", "blockflex_percentage_height_in_unstretched_flex_item__content_box_ltr");
+    }
+
+    #[test]
+    fn blockflex_percentage_height_in_unstretched_flex_item__border_box_rtl() {
+        crate::run_xml_test("blockflex", "blockflex_percentage_height_in_unstretched_flex_item__border_box_rtl");
+    }
+
+    #[test]
+    fn blockflex_percentage_height_in_unstretched_flex_item__content_box_rtl() {
+        crate::run_xml_test("blockflex", "blockflex_percentage_height_in_unstretched_flex_item__content_box_rtl");
     }
 }
 


### PR DESCRIPTION
# Objective

Fix three related percentage-resolution bugs found while investigating the failing "percentage sizes" group of css-flexbox WPT tests in blitz:

1. **Block: `min-height` incorrectly established the percentage-height basis.** In `compute_inner`, `container_percentage_resolution_height` had a trailing `.or(min_size.height)`, so children with percentage heights resolved against the container's `min-height` even when the container's height was indefinite. They now resolve as `auto` per CSS 2 §10.5.

2. **Block: percentage `top`/`bottom` on relatively positioned children always resolved to 0.** `perform_final_layout_on_in_flow_children` resolved insets against a hard-coded `height: 0.0` basis. They now resolve against `container_percentage_resolution_height` (the containing block's height when definite, `None` otherwise).

3. **Flexbox: non-stretched flex items' content-derived cross sizes were treated as definite.** `item_definiteness` returned `true` for the cross axis unconditionally, so percentage heights of descendants resolved against the item's content-derived height. The cross size is now only definite when the item is stretched (`align-self: stretch` with auto cross size, or a cross-axis `stretch` size, without auto cross margins) or its cross size style resolved to a definite value (per [CSS Flexbox §4.5](https://www.w3.org/TR/css-flexbox-1/#definite-sizes)). Widths remain always-definite since they resolve via fit-content against definite available space.

## Context

Verified against the WPT css-flexbox suite via blitz's WPT runner (with taffy patched in): **8 tests fixed, 0 subtest regressions** (subtests passed 3942 → 3967 out of 5747):

- `percentage-heights-001`, `percentage-heights-015`
- `position-relative-percentage-top-002` … `-005`
- `position-relative-stretch-height-001`
- `flexbox_align-items-stretch-4`

New generated tests (Chrome-verified fixtures) cover: percentage height in stretched/unstretched/auto-height flex items, relative percentage insets against definite/auto container heights, and percentage height with a `min-height`-only parent.

`cargo test`, `cargo fmt` and `cargo clippy --workspace` are clean.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/690f30760ca34875b6ccc5a19d315066
Requested by: @nicoburns