### PR TITLE
Block: fix percentage height resolution basis and relative percentage insets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 
 ### Fixed
 
+- Block: a container's `min-height` alone no longer acts as the resolution basis for the percentage heights of its children when the container's own height is indefinite. Per [CSS 2 §10.5](https://www.w3.org/TR/CSS22/visudet.html#the-height-property), such percentages resolve as `auto`
+
+- Block: percentage vertical insets (`top`/`bottom`) of relatively positioned children now resolve against the containing block's height when it is definite. Previously they always resolved against a zero basis, so e.g. `top: 50%` had no effect
+
 - Flexbox: skip the automatic min-content measurement when an item's minimum main size is already resolved from its style or overflow. Previously this fallback was evaluated eagerly and could cause nested flex layouts with explicit minimum sizes to perform unnecessary recursive measurements
 
 - Block/Flexbox/Grid: content overflowing a box past its scroll origin (the inline-start/block-start edge, e.g. an absolutely positioned child with a negative position) no longer inflates the box's `content_size`. Per the [CSS Overflow spec](https://www.w3.org/TR/css-overflow-3/#scrollable), the scrollable overflow region only extends from the scroll origin towards the inline-end/block-end directions, so such content is unreachable and does not contribute to scrollable overflow. Additionally, block layout now correctly measures absolutely positioned children from the inline-end edge in RTL when computing their `content_size` contribution, matching the existing flexbox and grid behaviour

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -564,7 +564,7 @@ fn compute_inner(
     }
 
     let container_percentage_resolution_height =
-        percentage_basis_dimensions.height.or(size.height.maybe_max(min_size.height)).or(min_size.height);
+        percentage_basis_dimensions.height.or(size.height.maybe_max(min_size.height));
 
     // 3. Perform final item layout and return content height
     //
@@ -1314,9 +1314,11 @@ fn perform_final_layout_on_in_flow_children(
             };
 
             // Resolve item inset
-            let inset = item.inset.zip_size(Size { width: container_inner_width, height: 0.0 }, |p, s| {
-                p.maybe_resolve(s, |val, basis| tree.calc(val, basis))
-            });
+            let inset_percentage_basis =
+                Size { width: Some(container_inner_width), height: container_percentage_resolution_height };
+            let inset = item
+                .inset
+                .zip_size(inset_percentage_basis, |p, s| p.maybe_resolve(s, |val, basis| tree.calc(val, basis)));
             let inset_offset = Point {
                 x: if direction.is_rtl() {
                     inset.right.map(|x| -x).or(inset.left).unwrap_or(0.0)

--- a/test_fixtures/block/block_percentage_height_with_min_height_parent.html
+++ b/test_fixtures/block/block_percentage_height_with_min_height_parent.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px; min-height: 80px;">
+  <div style="display: block; height: 50%;">
+    <div style="display: block; width: 20px; height: 20px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/block/block_relative_inset_percentage_auto_height.html
+++ b/test_fixtures/block/block_relative_inset_percentage_auto_height.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px;">
+  <div style="display: block; position: relative; top: 50%; width: 20px; height: 20px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/block/block_relative_inset_percentage_definite_height.html
+++ b/test_fixtures/block/block_relative_inset_percentage_definite_height.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px; height: 200px;">
+  <div style="display: block; position: relative; top: 50%; left: 10%; width: 20px; height: 20px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/blockflex/blockflex_percentage_height_in_auto_height_flex_item.html
+++ b/test_fixtures/blockflex/blockflex_percentage_height_in_auto_height_flex_item.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; width: 100px;">
+  <div style="display: block; width: 50px; min-height: 0px;">
+    <div style="display: block; height: 50%;">
+      <div style="display: block; width: 50px; height: 50px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/block/block_percentage_height_with_min_height_parent__border_box_ltr.xml
+++ b/tests/xml/block/block_percentage_height_with_min_height_parent__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="block_percentage_height_with_min_height_parent__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px" min-height="80px">
+      <div display="block" direction="ltr" height="50%">
+        <div display="block" direction="ltr" width="20px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="80">
+      <node x="0" y="0" width="100" height="20">
+        <node x="0" y="0" width="20" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_percentage_height_with_min_height_parent__border_box_rtl.xml
+++ b/tests/xml/block/block_percentage_height_with_min_height_parent__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="block_percentage_height_with_min_height_parent__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px" min-height="80px">
+      <div display="block" direction="rtl" height="50%">
+        <div display="block" direction="rtl" width="20px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="80">
+      <node x="0" y="0" width="100" height="20">
+        <node x="80" y="0" width="20" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_percentage_height_with_min_height_parent__content_box_ltr.xml
+++ b/tests/xml/block/block_percentage_height_with_min_height_parent__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="block_percentage_height_with_min_height_parent__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px" min-height="80px">
+      <div display="block" box-sizing="content-box" direction="ltr" height="50%">
+        <div display="block" box-sizing="content-box" direction="ltr" width="20px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="80">
+      <node x="0" y="0" width="100" height="20">
+        <node x="0" y="0" width="20" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_percentage_height_with_min_height_parent__content_box_rtl.xml
+++ b/tests/xml/block/block_percentage_height_with_min_height_parent__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="block_percentage_height_with_min_height_parent__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px" min-height="80px">
+      <div display="block" box-sizing="content-box" direction="rtl" height="50%">
+        <div display="block" box-sizing="content-box" direction="rtl" width="20px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="80">
+      <node x="0" y="0" width="100" height="20">
+        <node x="80" y="0" width="20" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_relative_inset_percentage_auto_height__border_box_ltr.xml
+++ b/tests/xml/block/block_relative_inset_percentage_auto_height__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="block_relative_inset_percentage_auto_height__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px">
+      <div display="block" direction="ltr" width="20px" height="20px" top="50%"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="20">
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_relative_inset_percentage_auto_height__border_box_rtl.xml
+++ b/tests/xml/block/block_relative_inset_percentage_auto_height__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="block_relative_inset_percentage_auto_height__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px">
+      <div display="block" direction="rtl" width="20px" height="20px" top="50%"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="20">
+      <node x="80" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_relative_inset_percentage_auto_height__content_box_ltr.xml
+++ b/tests/xml/block/block_relative_inset_percentage_auto_height__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="block_relative_inset_percentage_auto_height__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" width="20px" height="20px" top="50%"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="20">
+      <node x="0" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_relative_inset_percentage_auto_height__content_box_rtl.xml
+++ b/tests/xml/block/block_relative_inset_percentage_auto_height__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="block_relative_inset_percentage_auto_height__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" width="20px" height="20px" top="50%"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="20">
+      <node x="80" y="0" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_relative_inset_percentage_definite_height__border_box_ltr.xml
+++ b/tests/xml/block/block_relative_inset_percentage_definite_height__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="block_relative_inset_percentage_definite_height__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px" height="200px">
+      <div display="block" direction="ltr" width="20px" height="20px" top="50%" left="10%"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="200">
+      <node x="10" y="100" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_relative_inset_percentage_definite_height__border_box_rtl.xml
+++ b/tests/xml/block/block_relative_inset_percentage_definite_height__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="block_relative_inset_percentage_definite_height__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px" height="200px">
+      <div display="block" direction="rtl" width="20px" height="20px" top="50%" left="10%"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="200">
+      <node x="90" y="100" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_relative_inset_percentage_definite_height__content_box_ltr.xml
+++ b/tests/xml/block/block_relative_inset_percentage_definite_height__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="block_relative_inset_percentage_definite_height__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px" height="200px">
+      <div display="block" box-sizing="content-box" direction="ltr" width="20px" height="20px" top="50%" left="10%"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="200">
+      <node x="10" y="100" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_relative_inset_percentage_definite_height__content_box_rtl.xml
+++ b/tests/xml/block/block_relative_inset_percentage_definite_height__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="block_relative_inset_percentage_definite_height__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px" height="200px">
+      <div display="block" box-sizing="content-box" direction="rtl" width="20px" height="20px" top="50%" left="10%"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="200">
+      <node x="90" y="100" width="20" height="20"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/blockflex/blockflex_percentage_height_in_auto_height_flex_item__border_box_ltr.xml
+++ b/tests/xml/blockflex/blockflex_percentage_height_in_auto_height_flex_item__border_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="blockflex_percentage_height_in_auto_height_flex_item__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" width="100px">
+      <div display="block" direction="ltr" width="50px" min-height="0px">
+        <div display="block" direction="ltr" height="50%">
+          <div display="block" direction="ltr" width="50px" height="50px"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="50">
+      <node x="0" y="0" width="50" height="50">
+        <node x="0" y="0" width="50" height="25">
+          <node x="0" y="0" width="50" height="50"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/blockflex/blockflex_percentage_height_in_auto_height_flex_item__border_box_rtl.xml
+++ b/tests/xml/blockflex/blockflex_percentage_height_in_auto_height_flex_item__border_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="blockflex_percentage_height_in_auto_height_flex_item__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" width="100px">
+      <div display="block" direction="rtl" width="50px" min-height="0px">
+        <div display="block" direction="rtl" height="50%">
+          <div display="block" direction="rtl" width="50px" height="50px"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="50">
+      <node x="50" y="0" width="50" height="50">
+        <node x="0" y="0" width="50" height="25">
+          <node x="0" y="0" width="50" height="50"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/blockflex/blockflex_percentage_height_in_auto_height_flex_item__content_box_ltr.xml
+++ b/tests/xml/blockflex/blockflex_percentage_height_in_auto_height_flex_item__content_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="blockflex_percentage_height_in_auto_height_flex_item__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" width="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" width="50px" min-height="0px">
+        <div display="block" box-sizing="content-box" direction="ltr" height="50%">
+          <div display="block" box-sizing="content-box" direction="ltr" width="50px" height="50px"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="50">
+      <node x="0" y="0" width="50" height="50">
+        <node x="0" y="0" width="50" height="25">
+          <node x="0" y="0" width="50" height="50"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/blockflex/blockflex_percentage_height_in_auto_height_flex_item__content_box_rtl.xml
+++ b/tests/xml/blockflex/blockflex_percentage_height_in_auto_height_flex_item__content_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="blockflex_percentage_height_in_auto_height_flex_item__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" width="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" width="50px" min-height="0px">
+        <div display="block" box-sizing="content-box" direction="rtl" height="50%">
+          <div display="block" box-sizing="content-box" direction="rtl" width="50px" height="50px"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="50">
+      <node x="50" y="0" width="50" height="50">
+        <node x="0" y="0" width="50" height="25">
+          <node x="0" y="0" width="50" height="50"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -4822,6 +4822,66 @@ mod block {
     }
 
     #[test]
+    fn block_percentage_height_with_min_height_parent__border_box_ltr() {
+        crate::run_xml_test("block", "block_percentage_height_with_min_height_parent__border_box_ltr");
+    }
+
+    #[test]
+    fn block_percentage_height_with_min_height_parent__content_box_ltr() {
+        crate::run_xml_test("block", "block_percentage_height_with_min_height_parent__content_box_ltr");
+    }
+
+    #[test]
+    fn block_percentage_height_with_min_height_parent__border_box_rtl() {
+        crate::run_xml_test("block", "block_percentage_height_with_min_height_parent__border_box_rtl");
+    }
+
+    #[test]
+    fn block_percentage_height_with_min_height_parent__content_box_rtl() {
+        crate::run_xml_test("block", "block_percentage_height_with_min_height_parent__content_box_rtl");
+    }
+
+    #[test]
+    fn block_relative_inset_percentage_auto_height__border_box_ltr() {
+        crate::run_xml_test("block", "block_relative_inset_percentage_auto_height__border_box_ltr");
+    }
+
+    #[test]
+    fn block_relative_inset_percentage_auto_height__content_box_ltr() {
+        crate::run_xml_test("block", "block_relative_inset_percentage_auto_height__content_box_ltr");
+    }
+
+    #[test]
+    fn block_relative_inset_percentage_auto_height__border_box_rtl() {
+        crate::run_xml_test("block", "block_relative_inset_percentage_auto_height__border_box_rtl");
+    }
+
+    #[test]
+    fn block_relative_inset_percentage_auto_height__content_box_rtl() {
+        crate::run_xml_test("block", "block_relative_inset_percentage_auto_height__content_box_rtl");
+    }
+
+    #[test]
+    fn block_relative_inset_percentage_definite_height__border_box_ltr() {
+        crate::run_xml_test("block", "block_relative_inset_percentage_definite_height__border_box_ltr");
+    }
+
+    #[test]
+    fn block_relative_inset_percentage_definite_height__content_box_ltr() {
+        crate::run_xml_test("block", "block_relative_inset_percentage_definite_height__content_box_ltr");
+    }
+
+    #[test]
+    fn block_relative_inset_percentage_definite_height__border_box_rtl() {
+        crate::run_xml_test("block", "block_relative_inset_percentage_definite_height__border_box_rtl");
+    }
+
+    #[test]
+    fn block_relative_inset_percentage_definite_height__content_box_rtl() {
+        crate::run_xml_test("block", "block_relative_inset_percentage_definite_height__content_box_rtl");
+    }
+
+    #[test]
     fn block_scrollbar_rtl__border_box_ltr() {
         crate::run_xml_test("block", "block_scrollbar_rtl__border_box_ltr");
     }
@@ -5021,6 +5081,26 @@ mod blockflex {
     #[test]
     fn blockflex_overflow_hidden__content_box_rtl() {
         crate::run_xml_test("blockflex", "blockflex_overflow_hidden__content_box_rtl");
+    }
+
+    #[test]
+    fn blockflex_percentage_height_in_auto_height_flex_item__border_box_ltr() {
+        crate::run_xml_test("blockflex", "blockflex_percentage_height_in_auto_height_flex_item__border_box_ltr");
+    }
+
+    #[test]
+    fn blockflex_percentage_height_in_auto_height_flex_item__content_box_ltr() {
+        crate::run_xml_test("blockflex", "blockflex_percentage_height_in_auto_height_flex_item__content_box_ltr");
+    }
+
+    #[test]
+    fn blockflex_percentage_height_in_auto_height_flex_item__border_box_rtl() {
+        crate::run_xml_test("blockflex", "blockflex_percentage_height_in_auto_height_flex_item__border_box_rtl");
+    }
+
+    #[test]
+    fn blockflex_percentage_height_in_auto_height_flex_item__content_box_rtl() {
+        crate::run_xml_test("blockflex", "blockflex_percentage_height_in_auto_height_flex_item__content_box_rtl");
     }
 }
 


### PR DESCRIPTION
# Objective

Fix two percentage-resolution bugs in block layout found while investigating failing css-flexbox "percentage sizes" WPT tests in blitz. Split out from #1121 (block half; flexbox half is a separate PR).

1. **`min-height` no longer establishes a percentage-height basis by itself.** `container_percentage_resolution_height` had a trailing `.or(min_size.height)`, so children of a block with an indefinite height but a `min-height` resolved percentage heights against the `min-height`. Per [CSS 2 §10.5](https://www.w3.org/TR/CSS22/visudet.html#the-height-property) they should resolve as `auto`:

```diff
 let container_percentage_resolution_height =
-    percentage_basis_dimensions.height.or(size.height.maybe_max(min_size.height)).or(min_size.height);
+    percentage_basis_dimensions.height.or(size.height.maybe_max(min_size.height));
```

2. **Percentage `top`/`bottom` on `position: relative` block children now resolve against the containing block's height.** `perform_final_layout_on_in_flow_children` resolved insets against a hard-coded `height: 0.0` basis, so e.g. `top: 50%` always resolved to 0. The vertical basis is now the container's percentage-resolution height (definite height, else absent → treated as auto).

## Context

- Verified against WPT css-flexbox: together with the flexbox companion PR, these fix `percentage-heights-001`/`-015`, `position-relative-percentage-top-002..005`, `position-relative-stretch-height-001`, and `flexbox_align-items-stretch-4` with no subtest regressions (full-suite before/after runs in blitz).
- Adds Chrome-generated gentest fixtures: `block_percentage_height_with_min_height_parent`, `block_relative_inset_percentage_auto_height`, `block_relative_inset_percentage_definite_height`, `blockflex_percentage_height_in_auto_height_flex_item`.
- CHANGELOG.md updated.
- `cargo test`, `cargo fmt`, `cargo clippy` all pass locally.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/690f30760ca34875b6ccc5a19d315066
Requested by: @nicoburns