### PR TITLE
Flexbox: only treat stretched or definitely-sized cross-axis sizes as definite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 
 ### Fixed
 
+- Flexbox: a flex item's cross-axis size is now only treated as definite (for resolving percentage sizes of its descendants) when the item is stretched or its cross size style resolves to a definite size, per [CSS Flexbox §4.5](https://www.w3.org/TR/css-flexbox-1/#definite-sizes). Previously content-derived cross sizes of non-stretched items were incorrectly used as percentage resolution bases
+
 - Flexbox: skip the automatic min-content measurement when an item's minimum main size is already resolved from its style or overflow. Previously this fallback was evaluated eagerly and could cause nested flex layouts with explicit minimum sizes to perform unnecessary recursive measurements
 
 - Block/Flexbox/Grid: content overflowing a box past its scroll origin (the inline-start/block-start edge, e.g. an absolutely positioned child with a negative position) no longer inflates the box's `content_size`. Per the [CSS Overflow spec](https://www.w3.org/TR/css-overflow-3/#scrollable), the scrollable overflow region only extends from the scroll origin towards the inline-end/block-end directions, so such content is unreachable and does not contribute to scrollable overflow. Additionally, block layout now correctly measures absolutely positioned children from the inline-end edge in RTL when computing their `content_size` contribution, matching the existing flexbox and grid behaviour

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -194,6 +194,11 @@ struct AlgoConstants {
     has_definite_main_size: bool,
     /// Whether the node has a known cross size which is definite
     has_definite_cross_size: bool,
+    /// Whether the cross-axis space that non-stretched items are fit-content sized into is
+    /// definite (either the node's cross size is definite, or the cross-axis available space is).
+    /// A size resolved by fit-content sizing against definite available space is itself definite
+    /// (see <https://www.w3.org/TR/css-sizing-3/#definite>).
+    cross_axis_available_space_is_definite: bool,
 
     /// The size of the virtual container containing the flex items.
     container_size: Size<f32>,
@@ -317,6 +322,7 @@ fn compute_preliminary(tree: &mut impl LayoutFlexboxContainer, node: NodeId, inp
         known_dimensions,
         inputs.known_dimensions_are_definite,
         parent_size,
+        available_space,
     );
 
     // 9. Flex Layout Algorithm
@@ -514,6 +520,7 @@ fn compute_constants(
     known_dimensions: Size<Option<f32>>,
     known_dimensions_are_definite: Size<bool>,
     parent_size: Size<Option<f32>>,
+    available_space: Size<AvailableSpace>,
 ) -> AlgoConstants {
     let dir = style.flex_direction();
     let is_row = dir.is_row();
@@ -564,6 +571,8 @@ fn compute_constants(
     let known_main_size_is_definite = known_dimensions_are_definite.main(dir);
     let has_definite_main_size = known_main_size_is_definite && known_dimensions.main(dir).is_some();
     let has_definite_cross_size = known_dimensions_are_definite.cross(dir) && known_dimensions.cross(dir).is_some();
+    let cross_axis_available_space_is_definite =
+        has_definite_cross_size || matches!(available_space.cross(dir), AvailableSpace::Definite(_));
     let gap = style.gap().resolve_or_zero(node_inner_size.or(Size::zero()), |val, basis| tree.calc(val, basis));
 
     let container_size = Size::zero();
@@ -605,6 +614,7 @@ fn compute_constants(
         known_main_size_is_definite,
         has_definite_main_size,
         has_definite_cross_size,
+        cross_axis_available_space_is_definite,
         container_size,
         inner_container_size,
     }
@@ -1209,17 +1219,28 @@ fn collect_balanced_flex_lines<'a>(
 /// has a definite main size or the item's used flex basis is definite.
 /// See <https://www.w3.org/TR/css-flexbox-1/#definite-sizes>
 #[inline]
-fn item_definiteness(dir: FlexDirection, has_definite_main_size: bool, item: &FlexItem) -> Size<bool> {
+fn item_definiteness(
+    dir: FlexDirection,
+    has_definite_main_size: bool,
+    cross_axis_available_space_is_definite: bool,
+    item: &FlexItem,
+) -> Size<bool> {
     let main_is_definite = has_definite_main_size || item.flex_basis_is_definite;
+
     // An item's cross size is definite if it is stretched (it stretches to the flex line, whose
-    // size is known by the time the item's final layout is performed), or if its cross size
-    // style resolved to a definite size. Widths are always definite as they resolve via
-    // fit-content against definite available space.
-    let is_stretched = !item.margin_is_auto.cross_start(dir)
-        && !item.margin_is_auto.cross_end(dir)
-        && (item.size_style.cross(dir).is_stretch()
-            || (item.align_self == AlignSelf::STRETCH && item.size_style.cross(dir).is_auto()));
-    let cross_is_definite = !dir.is_row() || is_stretched || item.size.cross(dir).is_some();
+    // size is known by the time the item's final layout is performed), or if its cross size style
+    // resolved to a definite size. Additionally, a non-stretched item's cross *width* is fit-content
+    // sized, and a size resolved by fit-content sizing against definite available space is itself
+    // definite (<https://www.w3.org/TR/css-sizing-3/#definite>). The same does not apply to cross
+    // heights, which are content-based and therefore indefinite when not stretched.
+
+    let has_cross_auto_margins = item.margin_is_auto.cross_start(dir) || item.margin_is_auto.cross_end(dir);
+    let cross_size = item.size_style.cross(dir);
+    let is_stretched = !has_cross_auto_margins
+        && (cross_size.is_stretch() || (item.align_self == AlignSelf::STRETCH && cross_size.is_auto()));
+    let cross_is_definite =
+        is_stretched || item.size.cross(dir).is_some() || (!dir.is_row() && cross_axis_available_space_is_definite);
+
     Size { width: true, height: true }.with_main(dir, main_is_definite).with_cross(dir, cross_is_definite)
 }
 
@@ -1757,6 +1778,7 @@ fn determine_hypothetical_cross_size(
                     known_dimensions_are_definite: item_definiteness(
                         constants.dir,
                         constants.has_definite_main_size,
+                        constants.cross_axis_available_space_is_definite,
                         child,
                     ),
                     parent_size: constants.node_inner_size,
@@ -1830,6 +1852,7 @@ fn calculate_children_base_lines(
                     known_dimensions_are_definite: item_definiteness(
                         constants.dir,
                         constants.has_definite_main_size,
+                        constants.cross_axis_available_space_is_definite,
                         child,
                     ),
                     parent_size: constants.node_inner_size,
@@ -2325,10 +2348,12 @@ fn calculate_flex_item(
     container_size: Size<f32>,
     node_inner_size: Size<Option<f32>>,
     has_definite_main_size: bool,
+    cross_axis_available_space_is_definite: bool,
     direction: FlexDirection,
     layout_direction: Direction,
 ) {
-    let item_definiteness = item_definiteness(direction, has_definite_main_size, item);
+    let item_definiteness =
+        item_definiteness(direction, has_definite_main_size, cross_axis_available_space_is_definite, item);
     let layout_output = tree.compute_child_layout(
         item.node,
         LayoutInput {
@@ -2454,6 +2479,7 @@ fn calculate_layout_line(
     container_size: Size<f32>,
     node_inner_size: Size<Option<f32>>,
     has_definite_main_size: bool,
+    cross_axis_available_space_is_definite: bool,
     padding_border: Rect<f32>,
     direction: FlexDirection,
     layout_direction: Direction,
@@ -2485,6 +2511,7 @@ fn calculate_layout_line(
                 container_size,
                 node_inner_size,
                 has_definite_main_size,
+                cross_axis_available_space_is_definite,
                 direction,
                 layout_direction,
             );
@@ -2504,6 +2531,7 @@ fn calculate_layout_line(
                 container_size,
                 node_inner_size,
                 has_definite_main_size,
+                cross_axis_available_space_is_definite,
                 direction,
                 layout_direction,
             );
@@ -2544,6 +2572,7 @@ fn final_layout_pass(
                 constants.container_size,
                 constants.node_inner_size,
                 constants.has_definite_main_size,
+                constants.cross_axis_available_space_is_definite,
                 constants.content_box_inset,
                 constants.dir,
                 constants.layout_direction,
@@ -2562,6 +2591,7 @@ fn final_layout_pass(
                 constants.container_size,
                 constants.node_inner_size,
                 constants.has_definite_main_size,
+                constants.cross_axis_available_space_is_definite,
                 constants.content_box_inset,
                 constants.dir,
                 constants.layout_direction,

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -1219,13 +1219,9 @@ fn collect_balanced_flex_lines<'a>(
 /// has a definite main size or the item's used flex basis is definite.
 /// See <https://www.w3.org/TR/css-flexbox-1/#definite-sizes>
 #[inline]
-fn item_known_dimension_definiteness(
-    dir: FlexDirection,
-    has_definite_main_size: bool,
-    cross_axis_available_space_is_definite: bool,
-    item: &FlexItem,
-) -> Size<bool> {
-    let main_is_definite = has_definite_main_size || item.flex_basis_is_definite;
+fn item_known_dimension_definiteness(constants: &AlgoConstants, item: &FlexItem) -> Size<bool> {
+    let dir = constants.dir;
+    let main_is_definite = constants.has_definite_main_size || item.flex_basis_is_definite;
 
     // An item's cross size is definite if it is stretched (it stretches to the flex line, whose
     // size is known by the time the item's final layout is performed), or if its cross size style
@@ -1238,8 +1234,9 @@ fn item_known_dimension_definiteness(
     let cross_size = item.size_style.cross(dir);
     let is_stretched = !has_cross_auto_margins
         && (cross_size.is_stretch() || (item.align_self == AlignSelf::STRETCH && cross_size.is_auto()));
-    let cross_is_definite =
-        is_stretched || item.size.cross(dir).is_some() || (!dir.is_row() && cross_axis_available_space_is_definite);
+    let cross_is_definite = is_stretched
+        || item.size.cross(dir).is_some()
+        || (!dir.is_row() && constants.cross_axis_available_space_is_definite);
 
     Size { width: true, height: true }.with_main(dir, main_is_definite).with_cross(dir, cross_is_definite)
 }
@@ -1775,12 +1772,7 @@ fn determine_hypothetical_cross_size(
                         width: if constants.is_row { child.target_size.width.into() } else { child_cross },
                         height: if constants.is_row { child_cross } else { child.target_size.height.into() },
                     },
-                    known_dimensions_are_definite: item_known_dimension_definiteness(
-                        constants.dir,
-                        constants.has_definite_main_size,
-                        constants.cross_axis_available_space_is_definite,
-                        child,
-                    ),
+                    known_dimensions_are_definite: item_known_dimension_definiteness(constants, child),
                     parent_size: constants.node_inner_size,
                     available_space: Size {
                         width: if constants.is_row { child_known_main } else { child_available_cross },
@@ -1849,12 +1841,7 @@ fn calculate_children_base_lines(
                             child.target_size.height.into()
                         },
                     },
-                    known_dimensions_are_definite: item_known_dimension_definiteness(
-                        constants.dir,
-                        constants.has_definite_main_size,
-                        constants.cross_axis_available_space_is_definite,
-                        child,
-                    ),
+                    known_dimensions_are_definite: item_known_dimension_definiteness(constants, child),
                     parent_size: constants.node_inner_size,
                     available_space: Size {
                         width: if constants.is_row {
@@ -2345,19 +2332,13 @@ fn calculate_flex_item(
     line_offset_cross: f32,
     #[cfg(feature = "content_size")] total_content_size: &mut Size<f32>,
     #[cfg(feature = "content_size")] border: Rect<f32>,
-    container_size: Size<f32>,
-    node_inner_size: Size<Option<f32>>,
-    has_definite_main_size: bool,
-    cross_axis_available_space_is_definite: bool,
-    direction: FlexDirection,
-    layout_direction: Direction,
+    constants: &AlgoConstants,
 ) {
-    let item_known_dimension_definiteness = item_known_dimension_definiteness(
-        direction,
-        has_definite_main_size,
-        cross_axis_available_space_is_definite,
-        item,
-    );
+    let container_size = constants.container_size;
+    let node_inner_size = constants.node_inner_size;
+    let direction = constants.dir;
+    let layout_direction = constants.layout_direction;
+    let item_known_dimension_definiteness = item_known_dimension_definiteness(constants, item);
     let layout_output = tree.compute_child_layout(
         item.node,
         LayoutInput {
@@ -2480,14 +2461,12 @@ fn calculate_layout_line(
     total_offset_cross: &mut f32,
     #[cfg(feature = "content_size")] content_size: &mut Size<f32>,
     #[cfg(feature = "content_size")] border: Rect<f32>,
-    container_size: Size<f32>,
-    node_inner_size: Size<Option<f32>>,
-    has_definite_main_size: bool,
-    cross_axis_available_space_is_definite: bool,
-    padding_border: Rect<f32>,
-    direction: FlexDirection,
-    layout_direction: Direction,
+    constants: &AlgoConstants,
 ) {
+    let container_size = constants.container_size;
+    let padding_border = constants.content_box_inset;
+    let direction = constants.dir;
+    let layout_direction = constants.layout_direction;
     let mut total_offset_main = if layout_direction.is_rtl() && direction.is_row() {
         container_size.width - padding_border.main_end(direction)
     } else {
@@ -2512,12 +2491,7 @@ fn calculate_layout_line(
                 content_size,
                 #[cfg(feature = "content_size")]
                 border,
-                container_size,
-                node_inner_size,
-                has_definite_main_size,
-                cross_axis_available_space_is_definite,
-                direction,
-                layout_direction,
+                constants,
             );
         }
     } else {
@@ -2532,12 +2506,7 @@ fn calculate_layout_line(
                 content_size,
                 #[cfg(feature = "content_size")]
                 border,
-                container_size,
-                node_inner_size,
-                has_definite_main_size,
-                cross_axis_available_space_is_definite,
-                direction,
-                layout_direction,
+                constants,
             );
         }
     }
@@ -2573,13 +2542,7 @@ fn final_layout_pass(
                 &mut content_size,
                 #[cfg(feature = "content_size")]
                 constants.border,
-                constants.container_size,
-                constants.node_inner_size,
-                constants.has_definite_main_size,
-                constants.cross_axis_available_space_is_definite,
-                constants.content_box_inset,
-                constants.dir,
-                constants.layout_direction,
+                constants,
             );
         }
     } else {
@@ -2592,13 +2555,7 @@ fn final_layout_pass(
                 &mut content_size,
                 #[cfg(feature = "content_size")]
                 constants.border,
-                constants.container_size,
-                constants.node_inner_size,
-                constants.has_definite_main_size,
-                constants.cross_axis_available_space_is_definite,
-                constants.content_box_inset,
-                constants.dir,
-                constants.layout_direction,
+                constants,
             );
         }
     }

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -1219,7 +1219,7 @@ fn collect_balanced_flex_lines<'a>(
 /// has a definite main size or the item's used flex basis is definite.
 /// See <https://www.w3.org/TR/css-flexbox-1/#definite-sizes>
 #[inline]
-fn item_definiteness(
+fn item_known_dimension_definiteness(
     dir: FlexDirection,
     has_definite_main_size: bool,
     cross_axis_available_space_is_definite: bool,
@@ -1775,7 +1775,7 @@ fn determine_hypothetical_cross_size(
                         width: if constants.is_row { child.target_size.width.into() } else { child_cross },
                         height: if constants.is_row { child_cross } else { child.target_size.height.into() },
                     },
-                    known_dimensions_are_definite: item_definiteness(
+                    known_dimensions_are_definite: item_known_dimension_definiteness(
                         constants.dir,
                         constants.has_definite_main_size,
                         constants.cross_axis_available_space_is_definite,
@@ -1849,7 +1849,7 @@ fn calculate_children_base_lines(
                             child.target_size.height.into()
                         },
                     },
-                    known_dimensions_are_definite: item_definiteness(
+                    known_dimensions_are_definite: item_known_dimension_definiteness(
                         constants.dir,
                         constants.has_definite_main_size,
                         constants.cross_axis_available_space_is_definite,
@@ -2352,8 +2352,12 @@ fn calculate_flex_item(
     direction: FlexDirection,
     layout_direction: Direction,
 ) {
-    let item_definiteness =
-        item_definiteness(direction, has_definite_main_size, cross_axis_available_space_is_definite, item);
+    let item_known_dimension_definiteness = item_known_dimension_definiteness(
+        direction,
+        has_definite_main_size,
+        cross_axis_available_space_is_definite,
+        item,
+    );
     let layout_output = tree.compute_child_layout(
         item.node,
         LayoutInput {
@@ -2361,7 +2365,7 @@ fn calculate_flex_item(
             sizing_mode: SizingMode::ContentSize,
             axis: RequestedAxis::Both,
             known_dimensions: item.target_size.map(|s| s.into()),
-            known_dimensions_are_definite: item_definiteness,
+            known_dimensions_are_definite: item_known_dimension_definiteness,
             parent_size: node_inner_size,
             available_space: container_size.map(|s| s.into()),
             vertical_margins_are_collapsible: Line::FALSE,

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -1209,9 +1209,18 @@ fn collect_balanced_flex_lines<'a>(
 /// has a definite main size or the item's used flex basis is definite.
 /// See <https://www.w3.org/TR/css-flexbox-1/#definite-sizes>
 #[inline]
-fn item_definiteness(constants: &AlgoConstants, item: &FlexItem) -> Size<bool> {
-    let main_is_definite = constants.has_definite_main_size || item.flex_basis_is_definite;
-    Size { width: true, height: true }.with_main(constants.dir, main_is_definite)
+fn item_definiteness(dir: FlexDirection, has_definite_main_size: bool, item: &FlexItem) -> Size<bool> {
+    let main_is_definite = has_definite_main_size || item.flex_basis_is_definite;
+    // An item's cross size is definite if it is stretched (it stretches to the flex line, whose
+    // size is known by the time the item's final layout is performed), or if its cross size
+    // style resolved to a definite size. Widths are always definite as they resolve via
+    // fit-content against definite available space.
+    let is_stretched = !item.margin_is_auto.cross_start(dir)
+        && !item.margin_is_auto.cross_end(dir)
+        && (item.size_style.cross(dir).is_stretch()
+            || (item.align_self == AlignSelf::STRETCH && item.size_style.cross(dir).is_auto()));
+    let cross_is_definite = !dir.is_row() || is_stretched || item.size.cross(dir).is_some();
+    Size { width: true, height: true }.with_main(dir, main_is_definite).with_cross(dir, cross_is_definite)
 }
 
 /// Determine the container's main size (if not already known)
@@ -1745,7 +1754,11 @@ fn determine_hypothetical_cross_size(
                         width: if constants.is_row { child.target_size.width.into() } else { child_cross },
                         height: if constants.is_row { child_cross } else { child.target_size.height.into() },
                     },
-                    known_dimensions_are_definite: item_definiteness(constants, child),
+                    known_dimensions_are_definite: item_definiteness(
+                        constants.dir,
+                        constants.has_definite_main_size,
+                        child,
+                    ),
                     parent_size: constants.node_inner_size,
                     available_space: Size {
                         width: if constants.is_row { child_known_main } else { child_available_cross },
@@ -1814,7 +1827,11 @@ fn calculate_children_base_lines(
                             child.target_size.height.into()
                         },
                     },
-                    known_dimensions_are_definite: item_definiteness(constants, child),
+                    known_dimensions_are_definite: item_definiteness(
+                        constants.dir,
+                        constants.has_definite_main_size,
+                        child,
+                    ),
                     parent_size: constants.node_inner_size,
                     available_space: Size {
                         width: if constants.is_row {
@@ -2311,8 +2328,7 @@ fn calculate_flex_item(
     direction: FlexDirection,
     layout_direction: Direction,
 ) {
-    let item_definiteness =
-        Size { width: true, height: true }.with_main(direction, has_definite_main_size || item.flex_basis_is_definite);
+    let item_definiteness = item_definiteness(direction, has_definite_main_size, item);
     let layout_output = tree.compute_child_layout(
         item.node,
         LayoutInput {

--- a/test_fixtures/blockflex/blockflex_percentage_height_in_stretched_flex_item.html
+++ b/test_fixtures/blockflex/blockflex_percentage_height_in_stretched_flex_item.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; width: 100px; height: 100px;">
+  <div style="display: block; width: 50px;">
+    <div style="display: block; height: 50%;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/blockflex/blockflex_percentage_height_in_unstretched_flex_item.html
+++ b/test_fixtures/blockflex/blockflex_percentage_height_in_unstretched_flex_item.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; width: 100px; height: 100px; align-items: flex-start;">
+  <div style="display: block; width: 50px;">
+    <div style="display: block; height: 50%;">
+      <div style="display: block; width: 20px; height: 20px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/blockflex/blockflex_percentage_height_in_stretched_flex_item__border_box_ltr.xml
+++ b/tests/xml/blockflex/blockflex_percentage_height_in_stretched_flex_item__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="blockflex_percentage_height_in_stretched_flex_item__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" width="100px" height="100px">
+      <div display="block" direction="ltr" width="50px">
+        <div display="block" direction="ltr" height="50%"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="50" height="100">
+        <node x="0" y="0" width="50" height="50"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/blockflex/blockflex_percentage_height_in_stretched_flex_item__border_box_rtl.xml
+++ b/tests/xml/blockflex/blockflex_percentage_height_in_stretched_flex_item__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="blockflex_percentage_height_in_stretched_flex_item__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" width="100px" height="100px">
+      <div display="block" direction="rtl" width="50px">
+        <div display="block" direction="rtl" height="50%"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="50" y="0" width="50" height="100">
+        <node x="0" y="0" width="50" height="50"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/blockflex/blockflex_percentage_height_in_stretched_flex_item__content_box_ltr.xml
+++ b/tests/xml/blockflex/blockflex_percentage_height_in_stretched_flex_item__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="blockflex_percentage_height_in_stretched_flex_item__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" width="100px" height="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" width="50px">
+        <div display="block" box-sizing="content-box" direction="ltr" height="50%"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="50" height="100">
+        <node x="0" y="0" width="50" height="50"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/blockflex/blockflex_percentage_height_in_stretched_flex_item__content_box_rtl.xml
+++ b/tests/xml/blockflex/blockflex_percentage_height_in_stretched_flex_item__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="blockflex_percentage_height_in_stretched_flex_item__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" width="100px" height="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" width="50px">
+        <div display="block" box-sizing="content-box" direction="rtl" height="50%"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="50" y="0" width="50" height="100">
+        <node x="0" y="0" width="50" height="50"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/blockflex/blockflex_percentage_height_in_unstretched_flex_item__border_box_ltr.xml
+++ b/tests/xml/blockflex/blockflex_percentage_height_in_unstretched_flex_item__border_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="blockflex_percentage_height_in_unstretched_flex_item__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" align-items="flex-start" width="100px" height="100px">
+      <div display="block" direction="ltr" width="50px">
+        <div display="block" direction="ltr" height="50%">
+          <div display="block" direction="ltr" width="20px" height="20px"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="50" height="20">
+        <node x="0" y="0" width="50" height="20">
+          <node x="0" y="0" width="20" height="20"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/blockflex/blockflex_percentage_height_in_unstretched_flex_item__border_box_rtl.xml
+++ b/tests/xml/blockflex/blockflex_percentage_height_in_unstretched_flex_item__border_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="blockflex_percentage_height_in_unstretched_flex_item__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" align-items="flex-start" width="100px" height="100px">
+      <div display="block" direction="rtl" width="50px">
+        <div display="block" direction="rtl" height="50%">
+          <div display="block" direction="rtl" width="20px" height="20px"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="50" y="0" width="50" height="20">
+        <node x="0" y="0" width="50" height="20">
+          <node x="30" y="0" width="20" height="20"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/blockflex/blockflex_percentage_height_in_unstretched_flex_item__content_box_ltr.xml
+++ b/tests/xml/blockflex/blockflex_percentage_height_in_unstretched_flex_item__content_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="blockflex_percentage_height_in_unstretched_flex_item__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" align-items="flex-start" width="100px" height="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" width="50px">
+        <div display="block" box-sizing="content-box" direction="ltr" height="50%">
+          <div display="block" box-sizing="content-box" direction="ltr" width="20px" height="20px"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="0" y="0" width="50" height="20">
+        <node x="0" y="0" width="50" height="20">
+          <node x="0" y="0" width="20" height="20"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/blockflex/blockflex_percentage_height_in_unstretched_flex_item__content_box_rtl.xml
+++ b/tests/xml/blockflex/blockflex_percentage_height_in_unstretched_flex_item__content_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="blockflex_percentage_height_in_unstretched_flex_item__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" align-items="flex-start" width="100px" height="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" width="50px">
+        <div display="block" box-sizing="content-box" direction="rtl" height="50%">
+          <div display="block" box-sizing="content-box" direction="rtl" width="20px" height="20px"/>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100">
+      <node x="50" y="0" width="50" height="20">
+        <node x="0" y="0" width="50" height="20">
+          <node x="30" y="0" width="20" height="20"/>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -5022,6 +5022,46 @@ mod blockflex {
     fn blockflex_overflow_hidden__content_box_rtl() {
         crate::run_xml_test("blockflex", "blockflex_overflow_hidden__content_box_rtl");
     }
+
+    #[test]
+    fn blockflex_percentage_height_in_stretched_flex_item__border_box_ltr() {
+        crate::run_xml_test("blockflex", "blockflex_percentage_height_in_stretched_flex_item__border_box_ltr");
+    }
+
+    #[test]
+    fn blockflex_percentage_height_in_stretched_flex_item__content_box_ltr() {
+        crate::run_xml_test("blockflex", "blockflex_percentage_height_in_stretched_flex_item__content_box_ltr");
+    }
+
+    #[test]
+    fn blockflex_percentage_height_in_stretched_flex_item__border_box_rtl() {
+        crate::run_xml_test("blockflex", "blockflex_percentage_height_in_stretched_flex_item__border_box_rtl");
+    }
+
+    #[test]
+    fn blockflex_percentage_height_in_stretched_flex_item__content_box_rtl() {
+        crate::run_xml_test("blockflex", "blockflex_percentage_height_in_stretched_flex_item__content_box_rtl");
+    }
+
+    #[test]
+    fn blockflex_percentage_height_in_unstretched_flex_item__border_box_ltr() {
+        crate::run_xml_test("blockflex", "blockflex_percentage_height_in_unstretched_flex_item__border_box_ltr");
+    }
+
+    #[test]
+    fn blockflex_percentage_height_in_unstretched_flex_item__content_box_ltr() {
+        crate::run_xml_test("blockflex", "blockflex_percentage_height_in_unstretched_flex_item__content_box_ltr");
+    }
+
+    #[test]
+    fn blockflex_percentage_height_in_unstretched_flex_item__border_box_rtl() {
+        crate::run_xml_test("blockflex", "blockflex_percentage_height_in_unstretched_flex_item__border_box_rtl");
+    }
+
+    #[test]
+    fn blockflex_percentage_height_in_unstretched_flex_item__content_box_rtl() {
+        crate::run_xml_test("blockflex", "blockflex_percentage_height_in_unstretched_flex_item__content_box_rtl");
+    }
 }
 
 mod blockgrid {


### PR DESCRIPTION
# Objective

Fix flex-item cross-axis definiteness for percentage resolution, found while investigating failing css-flexbox "percentage sizes" WPT tests in blitz. Split out from #1121 (flexbox half; block half is #1122).

`item_definiteness` previously returned `true` for the cross axis unconditionally, so content-derived cross sizes of non-stretched flex items were used as definite bases for descendants' percentage heights. Per [CSS Flexbox §4.5](https://www.w3.org/TR/css-flexbox-1/#definite-sizes), an item's cross size is only definite when the item is stretched or its cross-size style resolves to a definite size:

```rust
let is_stretched = !has_cross_auto_margins
    && (cross_size.is_stretch() || (item.align_self == AlignSelf::STRETCH && cross_size.is_auto()));
let cross_is_definite =
    is_stretched || item.size.cross(dir).is_some() || (!dir.is_row() && cross_axis_available_space_is_definite);
```

Cross *widths* (column containers) additionally count as definite when the container's cross-axis available space is definite: a non-stretched item's width is fit-content sized, and a size resolved by fit-content sizing against definite available space is itself definite ([css-sizing-3 §definite](https://www.w3.org/TR/css-sizing-3/#definite)). This is threaded through a new `AlgoConstants::cross_axis_available_space_is_definite` computed in `compute_constants` from `known_dimensions_are_definite` / `available_space`, rather than the previous blanket "widths are always definite" assumption.

## Context

- Verified against WPT css-flexbox: together with the block companion PR, these fix `percentage-heights-001`/`-015`, `position-relative-percentage-top-002..005`, `position-relative-stretch-height-001`, and `flexbox_align-items-stretch-4` with no subtest regressions (full-suite before/after runs in blitz).
- Adds Chrome-generated gentest fixtures: `blockflex_percentage_height_in_stretched_flex_item`, `blockflex_percentage_height_in_unstretched_flex_item`.
- CHANGELOG.md updated.
- `cargo test`, `cargo fmt`, `cargo clippy` all pass locally.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/690f30760ca34875b6ccc5a19d315066
Requested by: @nicoburns