### PR TITLE
Block: clamp and synthesize scroll-container baselines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 
 ### Fixed
 
+- Block: the baselines contributed by in-flow children that are scroll containers are now clamped to the child's border box, and a scroll-container child with no natural baseline synthesizes one at its border-box bottom edge, matching the existing flexbox/grid behaviour per the [CSSWG resolution](https://github.com/w3c/csswg-drafts/issues/7660). Previously baselines of clipped content could leak outside an `overflow: hidden` child, and an empty scroll-container child contributed no baseline
+
 - Grid: items with an `auto` block-axis margin no longer participate in baseline alignment, per [CSS Align §9.5](https://www.w3.org/TR/css-align-3/#baseline-align-self). Such items are no longer baseline-shimmed (their auto margin aligns them instead), and they are no longer selected as the item the grid container's own first baseline is generated from, matching the existing flexbox behaviour
 
 - Flexbox: a flex item's cross-axis size is now only treated as definite (for resolving percentage sizes of its descendants) when the item is stretched or its cross size style resolves to a definite size, per [CSS Flexbox §4.5](https://www.w3.org/TR/css-flexbox-1/#definite-sizes). Previously content-derived cross sizes of non-stretched items were incorrectly used as percentage resolution bases

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -1468,8 +1468,25 @@ fn perform_final_layout_on_in_flow_children(
 
             // A block container's first baseline is the first baseline of its first in-flow child
             // that has one.
+            //
+            // Scroll containers' baselines are determined from their content as if scrolled to the
+            // initial position, but are additionally clamped to their border box. A scroll container
+            // with no baseline synthesizes one from its border-box bottom edge.
+            // See https://github.com/w3c/csswg-drafts/issues/7660
             if first_baseline.is_none() {
-                first_baseline = item_layout.baselines.first.map(|baseline| location.y + baseline);
+                let child_baseline = if item.overflow.y.is_scroll_container() {
+                    Some(
+                        item_layout
+                            .baselines
+                            .first
+                            .unwrap_or(item_layout.size.height)
+                            .min(item_layout.size.height)
+                            .max(0.0),
+                    )
+                } else {
+                    item_layout.baselines.first
+                };
+                first_baseline = child_baseline.map(|baseline| location.y + baseline);
             }
 
             // Defer `set_unrounded_layout` to the post-loop pass in `compute_inner` so that

--- a/test_fixtures/blockflex/blockflex_baseline_overflow_hidden_clamp.html
+++ b/test_fixtures/blockflex/blockflex_baseline_overflow_hidden_clamp.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; align-items: baseline; width: 200px; height: 120px;">
+  <div style="display: block; width: 40px; padding-bottom: 20px;">
+    <div style="display: block; overflow: hidden; width: 30px; height: 30px;">
+      <div style="display: flex; width: 30px;">
+        <div style="width: 10px; height: 40px;"></div>
+      </div>
+    </div>
+  </div>
+  <div style="display: block; width: 40px; height: 80px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/hand_written/baseline.rs
+++ b/tests/hand_written/baseline.rs
@@ -1,14 +1,14 @@
 #[cfg(test)]
 mod baseline {
     use taffy::prelude::*;
-    use taffy::{Baselines, LayoutInput, LayoutOutput};
+    use taffy::{Baselines, LayoutInput, LayoutOutput, Overflow, Point};
 
     /// A node context that pairs an intrinsic size with a first-baseline offset
     /// (measured from the node's top edge in the block axis).
     #[derive(Debug, Clone, Copy)]
     struct BaselineContext {
         size: Size<f32>,
-        baseline_y: f32,
+        baseline_y: Option<f32>,
     }
 
     fn baseline_measure_function(
@@ -18,11 +18,7 @@ mod baseline {
         _style: &Style,
     ) -> LayoutOutput {
         let Some(context) = context else { return LayoutOutput::DEFAULT };
-        LayoutOutput::from_sizes_and_baselines(
-            context.size,
-            Rect::ZERO,
-            Baselines::from_first(Some(context.baseline_y)),
-        )
+        LayoutOutput::from_sizes_and_baselines(context.size, Rect::ZERO, Baselines::from_first(context.baseline_y))
     }
 
     /// Two flex items with different intrinsic baselines are aligned along their baselines
@@ -36,7 +32,7 @@ mod baseline {
         let child_a = taffy
             .new_leaf_with_context(
                 Style::default(),
-                BaselineContext { size: Size { width: 50.0, height: 50.0 }, baseline_y: 40.0 },
+                BaselineContext { size: Size { width: 50.0, height: 50.0 }, baseline_y: Some(40.0) },
             )
             .unwrap();
 
@@ -44,7 +40,7 @@ mod baseline {
         let child_b = taffy
             .new_leaf_with_context(
                 Style::default(),
-                BaselineContext { size: Size { width: 30.0, height: 30.0 }, baseline_y: 20.0 },
+                BaselineContext { size: Size { width: 30.0, height: 30.0 }, baseline_y: Some(20.0) },
             )
             .unwrap();
 
@@ -75,6 +71,199 @@ mod baseline {
         assert_eq!(layout_a.location.y + 40.0, layout_b.location.y + 20.0);
     }
 
+    /// A block container child that is a scroll container and has no baseline of its own
+    /// synthesizes a baseline from its border-box bottom edge, which propagates to the
+    /// block container's first baseline.
+    /// See <https://github.com/w3c/csswg-drafts/issues/7660>
+    #[test]
+    fn block_scroll_container_child_without_baseline_synthesizes_from_border_box() {
+        let mut taffy: TaffyTree<BaselineContext> = TaffyTree::new();
+
+        // An empty `overflow: hidden` block, 30x30
+        let scroll_child = taffy
+            .new_leaf_with_context(
+                Style {
+                    display: Display::Block,
+                    overflow: Point { x: Overflow::Hidden, y: Overflow::Hidden },
+                    size: Size { width: length(30.0), height: length(30.0) },
+                    ..Default::default()
+                },
+                BaselineContext { size: Size { width: 30.0, height: 30.0 }, baseline_y: None },
+            )
+            .unwrap();
+
+        // A block container wrapping the scroll container, with bottom padding so that the
+        // synthesized baseline (30) differs from the wrapper's border-box bottom edge (50).
+        let item_a = taffy
+            .new_with_children(
+                Style {
+                    display: Display::Block,
+                    size: Size { width: length(40.0), height: auto() },
+                    padding: Rect { left: zero(), right: zero(), top: zero(), bottom: length(20.0) },
+                    ..Default::default()
+                },
+                &[scroll_child],
+            )
+            .unwrap();
+
+        // Reference item: 40x80 box with baseline 10px from the top
+        let item_b = taffy
+            .new_leaf_with_context(
+                Style::default(),
+                BaselineContext { size: Size { width: 40.0, height: 80.0 }, baseline_y: Some(10.0) },
+            )
+            .unwrap();
+
+        let root = taffy
+            .new_with_children(
+                Style {
+                    display: Display::Flex,
+                    flex_direction: FlexDirection::Row,
+                    align_items: Some(AlignItems::BASELINE),
+                    size: Size { width: length(200.0), height: length(120.0) },
+                    ..Default::default()
+                },
+                &[item_a, item_b],
+            )
+            .unwrap();
+
+        taffy.compute_layout_with_measure(root, Size::MAX_CONTENT, baseline_measure_function).unwrap();
+
+        // Item A's baseline is synthesized at the scroll container's bottom border edge (30),
+        // not at item A's own bottom edge (50). Item A sets the max baseline, so it sits at
+        // the top and item B is shifted down by (30 - 10) = 20px.
+        assert_eq!(taffy.layout(item_a).unwrap().location.y, 0.0);
+        assert_eq!(taffy.layout(item_b).unwrap().location.y, 20.0);
+    }
+
+    /// A block container child that is NOT a scroll container and has no baseline
+    /// contributes no baseline to its block container parent.
+    #[test]
+    fn block_non_scroll_container_child_without_baseline_contributes_nothing() {
+        let mut taffy: TaffyTree<BaselineContext> = TaffyTree::new();
+
+        // An empty `overflow: visible` block, 30x30
+        let plain_child = taffy
+            .new_leaf_with_context(
+                Style {
+                    display: Display::Block,
+                    size: Size { width: length(30.0), height: length(30.0) },
+                    ..Default::default()
+                },
+                BaselineContext { size: Size { width: 30.0, height: 30.0 }, baseline_y: None },
+            )
+            .unwrap();
+
+        let item_a = taffy
+            .new_with_children(
+                Style {
+                    display: Display::Block,
+                    size: Size { width: length(40.0), height: auto() },
+                    padding: Rect { left: zero(), right: zero(), top: zero(), bottom: length(20.0) },
+                    ..Default::default()
+                },
+                &[plain_child],
+            )
+            .unwrap();
+
+        // Reference item: 40x80 box with baseline 10px from the top
+        let item_b = taffy
+            .new_leaf_with_context(
+                Style::default(),
+                BaselineContext { size: Size { width: 40.0, height: 80.0 }, baseline_y: Some(10.0) },
+            )
+            .unwrap();
+
+        let root = taffy
+            .new_with_children(
+                Style {
+                    display: Display::Flex,
+                    flex_direction: FlexDirection::Row,
+                    align_items: Some(AlignItems::BASELINE),
+                    size: Size { width: length(200.0), height: length(120.0) },
+                    ..Default::default()
+                },
+                &[item_a, item_b],
+            )
+            .unwrap();
+
+        taffy.compute_layout_with_measure(root, Size::MAX_CONTENT, baseline_measure_function).unwrap();
+
+        // Item A has no baseline, so the flexbox algorithm synthesizes one at its border-box
+        // bottom edge (50). Item B is shifted down by (50 - 10) = 40px.
+        assert_eq!(taffy.layout(item_a).unwrap().location.y, 0.0);
+        assert_eq!(taffy.layout(item_b).unwrap().location.y, 40.0);
+    }
+
+    /// A block container child that is a scroll container contributes its content baseline
+    /// clamped to its border box, so baselines of clipped content cannot leak below the
+    /// child's border-box bottom edge.
+    /// See <https://github.com/w3c/csswg-drafts/issues/7660>
+    #[test]
+    fn block_scroll_container_child_baseline_is_clamped_to_border_box() {
+        let mut taffy: TaffyTree<BaselineContext> = TaffyTree::new();
+
+        // Content with a baseline 48px from the top, inside a 30px tall scroll container
+        let content = taffy
+            .new_leaf_with_context(
+                Style { display: Display::Block, ..Default::default() },
+                BaselineContext { size: Size { width: 30.0, height: 60.0 }, baseline_y: Some(48.0) },
+            )
+            .unwrap();
+
+        let scroll_child = taffy
+            .new_with_children(
+                Style {
+                    display: Display::Block,
+                    overflow: Point { x: Overflow::Hidden, y: Overflow::Hidden },
+                    size: Size { width: length(30.0), height: length(30.0) },
+                    ..Default::default()
+                },
+                &[content],
+            )
+            .unwrap();
+
+        let item_a = taffy
+            .new_with_children(
+                Style {
+                    display: Display::Block,
+                    size: Size { width: length(40.0), height: auto() },
+                    padding: Rect { left: zero(), right: zero(), top: zero(), bottom: length(20.0) },
+                    ..Default::default()
+                },
+                &[scroll_child],
+            )
+            .unwrap();
+
+        // Reference item: 40x80 box with baseline 10px from the top
+        let item_b = taffy
+            .new_leaf_with_context(
+                Style::default(),
+                BaselineContext { size: Size { width: 40.0, height: 80.0 }, baseline_y: Some(10.0) },
+            )
+            .unwrap();
+
+        let root = taffy
+            .new_with_children(
+                Style {
+                    display: Display::Flex,
+                    flex_direction: FlexDirection::Row,
+                    align_items: Some(AlignItems::BASELINE),
+                    size: Size { width: length(200.0), height: length(120.0) },
+                    ..Default::default()
+                },
+                &[item_a, item_b],
+            )
+            .unwrap();
+
+        taffy.compute_layout_with_measure(root, Size::MAX_CONTENT, baseline_measure_function).unwrap();
+
+        // The content baseline (48) is clamped to the scroll container's border-box height (30).
+        // Item A's baseline is 30, so item B is shifted down by (30 - 10) = 20px.
+        assert_eq!(taffy.layout(item_a).unwrap().location.y, 0.0);
+        assert_eq!(taffy.layout(item_b).unwrap().location.y, 20.0);
+    }
+
     /// Sanity-check: without `align-items: baseline`, items align at the cross-start edge
     /// regardless of the baseline reported by the measure function.
     #[test]
@@ -84,13 +273,13 @@ mod baseline {
         let child_a = taffy
             .new_leaf_with_context(
                 Style::default(),
-                BaselineContext { size: Size { width: 50.0, height: 50.0 }, baseline_y: 40.0 },
+                BaselineContext { size: Size { width: 50.0, height: 50.0 }, baseline_y: Some(40.0) },
             )
             .unwrap();
         let child_b = taffy
             .new_leaf_with_context(
                 Style::default(),
-                BaselineContext { size: Size { width: 30.0, height: 30.0 }, baseline_y: 20.0 },
+                BaselineContext { size: Size { width: 30.0, height: 30.0 }, baseline_y: Some(20.0) },
             )
             .unwrap();
 

--- a/tests/xml/blockflex/blockflex_baseline_overflow_hidden_clamp__border_box_ltr.xml
+++ b/tests/xml/blockflex/blockflex_baseline_overflow_hidden_clamp__border_box_ltr.xml
@@ -1,0 +1,27 @@
+<test name="blockflex_baseline_overflow_hidden_clamp__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" align-items="baseline" width="200px" height="120px">
+      <div display="block" direction="ltr" width="40px" padding-bottom="20px">
+        <div display="block" direction="ltr" overflow-x="hidden" overflow-y="hidden" scrollbar-width="15" width="30px" height="30px">
+          <div display="flex" direction="ltr" width="30px">
+            <div direction="ltr" width="10px" height="40px"/>
+          </div>
+        </div>
+      </div>
+      <div display="block" direction="ltr" width="40px" height="80px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="120">
+      <node x="0" y="50" width="40" height="50">
+        <node x="0" y="0" width="30" height="30" scroll_width="0" scroll_height="10">
+          <node x="0" y="0" width="30" height="40">
+            <node x="0" y="0" width="10" height="40"/>
+          </node>
+        </node>
+      </node>
+      <node x="40" y="0" width="40" height="80"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/blockflex/blockflex_baseline_overflow_hidden_clamp__border_box_rtl.xml
+++ b/tests/xml/blockflex/blockflex_baseline_overflow_hidden_clamp__border_box_rtl.xml
@@ -1,0 +1,27 @@
+<test name="blockflex_baseline_overflow_hidden_clamp__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" align-items="baseline" width="200px" height="120px">
+      <div display="block" direction="rtl" width="40px" padding-bottom="20px">
+        <div display="block" direction="rtl" overflow-x="hidden" overflow-y="hidden" scrollbar-width="15" width="30px" height="30px">
+          <div display="flex" direction="rtl" width="30px">
+            <div direction="rtl" width="10px" height="40px"/>
+          </div>
+        </div>
+      </div>
+      <div display="block" direction="rtl" width="40px" height="80px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="120">
+      <node x="160" y="50" width="40" height="50">
+        <node x="10" y="0" width="30" height="30" scroll_width="0" scroll_height="10">
+          <node x="0" y="0" width="30" height="40">
+            <node x="20" y="0" width="10" height="40"/>
+          </node>
+        </node>
+      </node>
+      <node x="120" y="0" width="40" height="80"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/blockflex/blockflex_baseline_overflow_hidden_clamp__content_box_ltr.xml
+++ b/tests/xml/blockflex/blockflex_baseline_overflow_hidden_clamp__content_box_ltr.xml
@@ -1,0 +1,27 @@
+<test name="blockflex_baseline_overflow_hidden_clamp__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" align-items="baseline" width="200px" height="120px">
+      <div display="block" box-sizing="content-box" direction="ltr" width="40px" padding-bottom="20px">
+        <div display="block" box-sizing="content-box" direction="ltr" overflow-x="hidden" overflow-y="hidden" scrollbar-width="15" width="30px" height="30px">
+          <div display="flex" box-sizing="content-box" direction="ltr" width="30px">
+            <div box-sizing="content-box" direction="ltr" width="10px" height="40px"/>
+          </div>
+        </div>
+      </div>
+      <div display="block" box-sizing="content-box" direction="ltr" width="40px" height="80px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="120">
+      <node x="0" y="50" width="40" height="50">
+        <node x="0" y="0" width="30" height="30" scroll_width="0" scroll_height="10">
+          <node x="0" y="0" width="30" height="40">
+            <node x="0" y="0" width="10" height="40"/>
+          </node>
+        </node>
+      </node>
+      <node x="40" y="0" width="40" height="80"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/blockflex/blockflex_baseline_overflow_hidden_clamp__content_box_rtl.xml
+++ b/tests/xml/blockflex/blockflex_baseline_overflow_hidden_clamp__content_box_rtl.xml
@@ -1,0 +1,27 @@
+<test name="blockflex_baseline_overflow_hidden_clamp__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" align-items="baseline" width="200px" height="120px">
+      <div display="block" box-sizing="content-box" direction="rtl" width="40px" padding-bottom="20px">
+        <div display="block" box-sizing="content-box" direction="rtl" overflow-x="hidden" overflow-y="hidden" scrollbar-width="15" width="30px" height="30px">
+          <div display="flex" box-sizing="content-box" direction="rtl" width="30px">
+            <div box-sizing="content-box" direction="rtl" width="10px" height="40px"/>
+          </div>
+        </div>
+      </div>
+      <div display="block" box-sizing="content-box" direction="rtl" width="40px" height="80px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="120">
+      <node x="160" y="50" width="40" height="50">
+        <node x="10" y="0" width="30" height="30" scroll_width="0" scroll_height="10">
+          <node x="0" y="0" width="30" height="40">
+            <node x="20" y="0" width="10" height="40"/>
+          </node>
+        </node>
+      </node>
+      <node x="120" y="0" width="40" height="80"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -4944,6 +4944,26 @@ mod block {
 
 mod blockflex {
     #[test]
+    fn blockflex_baseline_overflow_hidden_clamp__border_box_ltr() {
+        crate::run_xml_test("blockflex", "blockflex_baseline_overflow_hidden_clamp__border_box_ltr");
+    }
+
+    #[test]
+    fn blockflex_baseline_overflow_hidden_clamp__content_box_ltr() {
+        crate::run_xml_test("blockflex", "blockflex_baseline_overflow_hidden_clamp__content_box_ltr");
+    }
+
+    #[test]
+    fn blockflex_baseline_overflow_hidden_clamp__border_box_rtl() {
+        crate::run_xml_test("blockflex", "blockflex_baseline_overflow_hidden_clamp__border_box_rtl");
+    }
+
+    #[test]
+    fn blockflex_baseline_overflow_hidden_clamp__content_box_rtl() {
+        crate::run_xml_test("blockflex", "blockflex_baseline_overflow_hidden_clamp__content_box_rtl");
+    }
+
+    #[test]
     fn blockflex_block_in_flex_column__border_box_ltr() {
         crate::run_xml_test("blockflex", "blockflex_block_in_flex_column__border_box_ltr");
     }


### PR DESCRIPTION
# Objective

Give block layout the same scroll-container baseline treatment as flexbox/grid, per the CSSWG resolution in [w3c/csswg-drafts#7660](https://github.com/w3c/csswg-drafts/issues/7660): a scroll container's baseline is determined from its content as if scrolled to the initial position but clamped to its border box, and when it has no natural baseline, one is synthesized at its border-box bottom edge.

In `perform_final_layout_on_in_flow_children`, for each in-flow child that is a scroll container (`overflow.y.is_scroll_container()`):

```rust
let child_baseline = if item.overflow.y.is_scroll_container() {
    Some(item_layout.baselines.first.unwrap_or(item_layout.size.height).min(item_layout.size.height).max(0.0))
} else {
    item_layout.baselines.first // unchanged: no baseline => contributes nothing
};
first_baseline = child_baseline.map(|baseline| location.y + baseline);
```

Fixes WPT [`css/CSS2/linebox/baseline-block-with-overflow-001.html`](https://wpt.fyi/results/css/CSS2/linebox/baseline-block-with-overflow-001.html) in Blitz: previously (a) the baseline of clipped text inside a block `overflow: hidden` child leaked out and the outer inline-block aligned to it, and (b) an empty `overflow: hidden` child contributed no baseline where browsers synthesize one at its bottom border edge.

## Context

- Mirrors the existing flexbox logic (`clamp_to_border_box` / `.unwrap_or(size.height)` in `src/compute/flexbox.rs`) and grid behaviour.
- Tests:
  - Generated fixture `test_fixtures/blockflex/blockflex_baseline_overflow_hidden_clamp.html` covers the clamping case (a block scroll-container child with taller content, baseline-aligned in a flex container).
  - Hand-written tests in `tests/hand_written/baseline.rs` cover baseline synthesis for a scroll-container child with no natural baseline, clamping, and that a non-scroll-container child without a baseline still contributes nothing. Chrome does not propagate the synthesized empty-scroll-container baseline in flexbox first-baseline contexts (it does in inline-block contexts, which taffy doesn't model), so the synthesis case cannot be expressed as a gentest.
- CHANGELOG.md updated under "Fixed".

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/e9fbc6900f2c469d84ca90d71a628d7b
Requested by: @nicoburns