### PR TITLE
Flexbox: fix container baseline for column-reverse containers

### DIFF
--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -494,15 +494,23 @@ fn compute_preliminary(tree: &mut impl LayoutFlexboxContainer, node: NodeId, inp
 
     // 8.5. Flex Container Baselines: calculate the flex container's first baseline
     // See https://www.w3.org/TR/css-flexbox-1/#flex-baselines
-    // For wrap-reverse containers the cross-start-most line is the last line rather than the first,
-    // and it is that line which the container's first baseline is generated from.
+    // The baselines are generated from the startmost flex line, where "startmost" refers to the
+    // line's visual position: for wrap-reverse containers the cross axis is flipped, so the
+    // startmost line is the last line in flex-line order rather than the first.
     let first_line = if constants.is_wrap_reverse { flex_lines.last() } else { flex_lines.first() };
     let first_vertical_baseline = first_line.and_then(|line| {
-        line.items
-            .iter()
-            .find(|item| constants.is_column || item.participates_in_baseline_alignment(constants.dir))
-            .or_else(|| line.items.iter().next())
-            .map(|child| child.baseline)
+        if constants.is_column {
+            // For column containers the baseline is generated from the startmost item in the line,
+            // which for reverse-direction containers is the last item in flex order.
+            let item = if constants.dir.is_reverse() { line.items.last() } else { line.items.first() };
+            item.map(|child| child.baseline)
+        } else {
+            line.items
+                .iter()
+                .find(|item| item.participates_in_baseline_alignment(constants.dir))
+                .or_else(|| line.items.iter().next())
+                .map(|child| child.baseline)
+        }
     });
 
     LayoutOutput::from_sizes_and_baselines(

--- a/test_fixtures/flex/flex_container_baseline_column_reverse.html
+++ b/test_fixtures/flex/flex_container_baseline_column_reverse.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    The first baseline of a column-reverse flex container is generated from the startmost
+    (visually topmost) item, which is the last item in flex order.
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 200px; height: 200px; align-items: baseline;">
+  <div style="width: 50px; height: 100px;"></div>
+  <div style="width: 60px; height: 90px; flex-direction: column-reverse;">
+    <div style="width: 60px; height: 20px;"></div>
+    <div style="width: 60px; height: 30px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/flex_container_baseline_column_reverse_wrap_reverse.html
+++ b/test_fixtures/flex/flex_container_baseline_column_reverse_wrap_reverse.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    The first baseline of a multi-line column-reverse wrap-reverse flex container is generated
+    from the startmost item (last in flex order) of the startmost (visually leftmost) flex line,
+    which is the last line in flex-line order.
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 300px; height: 200px; align-items: baseline;">
+  <div style="width: 50px; height: 150px;"></div>
+  <div style="width: 120px; height: 130px; flex-direction: column-reverse; flex-wrap: wrap-reverse; align-content: flex-start;">
+    <div style="width: 40px; height: 60px;"></div>
+    <div style="width: 40px; height: 60px;"></div>
+    <div style="width: 40px; height: 50px;"></div>
+    <div style="width: 40px; height: 40px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/flex_container_baseline_wrap_reverse_multiline.html
+++ b/test_fixtures/flex/flex_container_baseline_wrap_reverse_multiline.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    The first baseline of a multi-line wrap-reverse flex container is generated from the first
+    flex line (in flex-line order), even though wrap-reverse places that line at the cross end.
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 200px; height: 200px; align-items: baseline;">
+  <div style="width: 50px; height: 100px;"></div>
+  <div style="width: 100px; height: 120px; flex-wrap: wrap-reverse; align-items: baseline; align-content: flex-start;">
+    <div style="width: 60px; height: 20px;"></div>
+    <div style="width: 40px; height: 40px;"></div>
+    <div style="width: 60px; height: 30px;"></div>
+    <div style="width: 40px; height: 10px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/flex_container_baseline_wrap_reverse_multiline_column.html
+++ b/test_fixtures/flex/flex_container_baseline_wrap_reverse_multiline_column.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    The first baseline of a multi-line wrap-reverse column flex container is generated from the
+    first flex line (in flex-line order), even though wrap-reverse places that line at the cross end.
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 200px; height: 200px; align-items: baseline;">
+  <div style="width: 50px; height: 100px;"></div>
+  <div style="width: 120px; height: 100px; flex-direction: column; flex-wrap: wrap-reverse; align-content: flex-start;">
+    <div style="width: 40px; height: 60px;"></div>
+    <div style="width: 40px; height: 60px;"></div>
+    <div style="width: 40px; height: 60px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/flex_container_baseline_wrap_reverse_multiline_text.html
+++ b/test_fixtures/flex/flex_container_baseline_wrap_reverse_multiline_text.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    The first baseline of a multi-line wrap-reverse flex container with baseline-aligned items
+    containing text is generated from the first flex line (in flex-line order).
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 300px; height: 200px; align-items: baseline;">
+  <div style="width: 50px; height: 100px;"></div>
+  <div style="width: 100px; height: 120px; flex-wrap: wrap-reverse; align-content: flex-start;">
+    <div style="width: 60px; align-self: baseline;">HH</div>
+    <div style="width: 40px; height: 40px;"></div>
+    <div style="width: 60px; height: 30px;"></div>
+    <div style="width: 40px; height: 10px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/flex/flex_container_baseline_column_reverse__border_box_ltr.xml
+++ b/tests/xml/flex/flex_container_baseline_column_reverse__border_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="flex_container_baseline_column_reverse__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" align-items="baseline" width="200px" height="200px">
+      <div direction="ltr" width="50px" height="100px"/>
+      <div direction="ltr" flex-direction="column-reverse" width="60px" height="90px">
+        <div direction="ltr" width="60px" height="20px"/>
+        <div direction="ltr" width="60px" height="30px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="0" y="0" width="50" height="100"/>
+      <node x="50" y="30" width="60" height="90">
+        <node x="0" y="70" width="60" height="20"/>
+        <node x="0" y="40" width="60" height="30"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_container_baseline_column_reverse__border_box_rtl.xml
+++ b/tests/xml/flex/flex_container_baseline_column_reverse__border_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="flex_container_baseline_column_reverse__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" align-items="baseline" width="200px" height="200px">
+      <div direction="rtl" width="50px" height="100px"/>
+      <div direction="rtl" flex-direction="column-reverse" width="60px" height="90px">
+        <div direction="rtl" width="60px" height="20px"/>
+        <div direction="rtl" width="60px" height="30px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="150" y="0" width="50" height="100"/>
+      <node x="90" y="30" width="60" height="90">
+        <node x="0" y="70" width="60" height="20"/>
+        <node x="0" y="40" width="60" height="30"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_container_baseline_column_reverse__content_box_ltr.xml
+++ b/tests/xml/flex/flex_container_baseline_column_reverse__content_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="flex_container_baseline_column_reverse__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" align-items="baseline" width="200px" height="200px">
+      <div box-sizing="content-box" direction="ltr" width="50px" height="100px"/>
+      <div box-sizing="content-box" direction="ltr" flex-direction="column-reverse" width="60px" height="90px">
+        <div box-sizing="content-box" direction="ltr" width="60px" height="20px"/>
+        <div box-sizing="content-box" direction="ltr" width="60px" height="30px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="0" y="0" width="50" height="100"/>
+      <node x="50" y="30" width="60" height="90">
+        <node x="0" y="70" width="60" height="20"/>
+        <node x="0" y="40" width="60" height="30"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_container_baseline_column_reverse__content_box_rtl.xml
+++ b/tests/xml/flex/flex_container_baseline_column_reverse__content_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="flex_container_baseline_column_reverse__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" align-items="baseline" width="200px" height="200px">
+      <div box-sizing="content-box" direction="rtl" width="50px" height="100px"/>
+      <div box-sizing="content-box" direction="rtl" flex-direction="column-reverse" width="60px" height="90px">
+        <div box-sizing="content-box" direction="rtl" width="60px" height="20px"/>
+        <div box-sizing="content-box" direction="rtl" width="60px" height="30px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="150" y="0" width="50" height="100"/>
+      <node x="90" y="30" width="60" height="90">
+        <node x="0" y="70" width="60" height="20"/>
+        <node x="0" y="40" width="60" height="30"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_container_baseline_column_reverse_wrap_reverse__border_box_ltr.xml
+++ b/tests/xml/flex/flex_container_baseline_column_reverse_wrap_reverse__border_box_ltr.xml
@@ -1,0 +1,25 @@
+<test name="flex_container_baseline_column_reverse_wrap_reverse__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" align-items="baseline" width="300px" height="200px">
+      <div direction="ltr" width="50px" height="150px"/>
+      <div direction="ltr" flex-direction="column-reverse" flex-wrap="wrap-reverse" align-content="flex-start" width="120px" height="130px">
+        <div direction="ltr" width="40px" height="60px"/>
+        <div direction="ltr" width="40px" height="60px"/>
+        <div direction="ltr" width="40px" height="50px"/>
+        <div direction="ltr" width="40px" height="40px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="200">
+      <node x="0" y="0" width="50" height="150"/>
+      <node x="50" y="70" width="120" height="130">
+        <node x="80" y="70" width="40" height="60"/>
+        <node x="80" y="10" width="40" height="60"/>
+        <node x="40" y="80" width="40" height="50"/>
+        <node x="40" y="40" width="40" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_container_baseline_column_reverse_wrap_reverse__border_box_rtl.xml
+++ b/tests/xml/flex/flex_container_baseline_column_reverse_wrap_reverse__border_box_rtl.xml
@@ -1,0 +1,25 @@
+<test name="flex_container_baseline_column_reverse_wrap_reverse__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" align-items="baseline" width="300px" height="200px">
+      <div direction="rtl" width="50px" height="150px"/>
+      <div direction="rtl" flex-direction="column-reverse" flex-wrap="wrap-reverse" align-content="flex-start" width="120px" height="130px">
+        <div direction="rtl" width="40px" height="60px"/>
+        <div direction="rtl" width="40px" height="60px"/>
+        <div direction="rtl" width="40px" height="50px"/>
+        <div direction="rtl" width="40px" height="40px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="200">
+      <node x="250" y="0" width="50" height="150"/>
+      <node x="130" y="70" width="120" height="130">
+        <node x="0" y="70" width="40" height="60"/>
+        <node x="0" y="10" width="40" height="60"/>
+        <node x="40" y="80" width="40" height="50"/>
+        <node x="40" y="40" width="40" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_container_baseline_column_reverse_wrap_reverse__content_box_ltr.xml
+++ b/tests/xml/flex/flex_container_baseline_column_reverse_wrap_reverse__content_box_ltr.xml
@@ -1,0 +1,25 @@
+<test name="flex_container_baseline_column_reverse_wrap_reverse__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" align-items="baseline" width="300px" height="200px">
+      <div box-sizing="content-box" direction="ltr" width="50px" height="150px"/>
+      <div box-sizing="content-box" direction="ltr" flex-direction="column-reverse" flex-wrap="wrap-reverse" align-content="flex-start" width="120px" height="130px">
+        <div box-sizing="content-box" direction="ltr" width="40px" height="60px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="60px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="50px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="40px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="200">
+      <node x="0" y="0" width="50" height="150"/>
+      <node x="50" y="70" width="120" height="130">
+        <node x="80" y="70" width="40" height="60"/>
+        <node x="80" y="10" width="40" height="60"/>
+        <node x="40" y="80" width="40" height="50"/>
+        <node x="40" y="40" width="40" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_container_baseline_column_reverse_wrap_reverse__content_box_rtl.xml
+++ b/tests/xml/flex/flex_container_baseline_column_reverse_wrap_reverse__content_box_rtl.xml
@@ -1,0 +1,25 @@
+<test name="flex_container_baseline_column_reverse_wrap_reverse__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" align-items="baseline" width="300px" height="200px">
+      <div box-sizing="content-box" direction="rtl" width="50px" height="150px"/>
+      <div box-sizing="content-box" direction="rtl" flex-direction="column-reverse" flex-wrap="wrap-reverse" align-content="flex-start" width="120px" height="130px">
+        <div box-sizing="content-box" direction="rtl" width="40px" height="60px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="60px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="50px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="40px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="200">
+      <node x="250" y="0" width="50" height="150"/>
+      <node x="130" y="70" width="120" height="130">
+        <node x="0" y="70" width="40" height="60"/>
+        <node x="0" y="10" width="40" height="60"/>
+        <node x="40" y="80" width="40" height="50"/>
+        <node x="40" y="40" width="40" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_container_baseline_wrap_reverse_multiline__border_box_ltr.xml
+++ b/tests/xml/flex/flex_container_baseline_wrap_reverse_multiline__border_box_ltr.xml
@@ -1,0 +1,25 @@
+<test name="flex_container_baseline_wrap_reverse_multiline__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" align-items="baseline" width="200px" height="200px">
+      <div direction="ltr" width="50px" height="100px"/>
+      <div direction="ltr" flex-wrap="wrap-reverse" align-items="baseline" align-content="flex-start" width="100px" height="120px">
+        <div direction="ltr" width="60px" height="20px"/>
+        <div direction="ltr" width="40px" height="40px"/>
+        <div direction="ltr" width="60px" height="30px"/>
+        <div direction="ltr" width="40px" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="0" y="0" width="50" height="100"/>
+      <node x="50" y="20" width="100" height="120">
+        <node x="0" y="100" width="60" height="20"/>
+        <node x="60" y="80" width="40" height="40"/>
+        <node x="0" y="50" width="60" height="30"/>
+        <node x="60" y="70" width="40" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_container_baseline_wrap_reverse_multiline__border_box_rtl.xml
+++ b/tests/xml/flex/flex_container_baseline_wrap_reverse_multiline__border_box_rtl.xml
@@ -1,0 +1,25 @@
+<test name="flex_container_baseline_wrap_reverse_multiline__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" align-items="baseline" width="200px" height="200px">
+      <div direction="rtl" width="50px" height="100px"/>
+      <div direction="rtl" flex-wrap="wrap-reverse" align-items="baseline" align-content="flex-start" width="100px" height="120px">
+        <div direction="rtl" width="60px" height="20px"/>
+        <div direction="rtl" width="40px" height="40px"/>
+        <div direction="rtl" width="60px" height="30px"/>
+        <div direction="rtl" width="40px" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="150" y="0" width="50" height="100"/>
+      <node x="50" y="20" width="100" height="120">
+        <node x="40" y="100" width="60" height="20"/>
+        <node x="0" y="80" width="40" height="40"/>
+        <node x="40" y="50" width="60" height="30"/>
+        <node x="0" y="70" width="40" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_container_baseline_wrap_reverse_multiline__content_box_ltr.xml
+++ b/tests/xml/flex/flex_container_baseline_wrap_reverse_multiline__content_box_ltr.xml
@@ -1,0 +1,25 @@
+<test name="flex_container_baseline_wrap_reverse_multiline__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" align-items="baseline" width="200px" height="200px">
+      <div box-sizing="content-box" direction="ltr" width="50px" height="100px"/>
+      <div box-sizing="content-box" direction="ltr" flex-wrap="wrap-reverse" align-items="baseline" align-content="flex-start" width="100px" height="120px">
+        <div box-sizing="content-box" direction="ltr" width="60px" height="20px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="40px"/>
+        <div box-sizing="content-box" direction="ltr" width="60px" height="30px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="0" y="0" width="50" height="100"/>
+      <node x="50" y="20" width="100" height="120">
+        <node x="0" y="100" width="60" height="20"/>
+        <node x="60" y="80" width="40" height="40"/>
+        <node x="0" y="50" width="60" height="30"/>
+        <node x="60" y="70" width="40" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_container_baseline_wrap_reverse_multiline__content_box_rtl.xml
+++ b/tests/xml/flex/flex_container_baseline_wrap_reverse_multiline__content_box_rtl.xml
@@ -1,0 +1,25 @@
+<test name="flex_container_baseline_wrap_reverse_multiline__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" align-items="baseline" width="200px" height="200px">
+      <div box-sizing="content-box" direction="rtl" width="50px" height="100px"/>
+      <div box-sizing="content-box" direction="rtl" flex-wrap="wrap-reverse" align-items="baseline" align-content="flex-start" width="100px" height="120px">
+        <div box-sizing="content-box" direction="rtl" width="60px" height="20px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="40px"/>
+        <div box-sizing="content-box" direction="rtl" width="60px" height="30px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="150" y="0" width="50" height="100"/>
+      <node x="50" y="20" width="100" height="120">
+        <node x="40" y="100" width="60" height="20"/>
+        <node x="0" y="80" width="40" height="40"/>
+        <node x="40" y="50" width="60" height="30"/>
+        <node x="0" y="70" width="40" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_container_baseline_wrap_reverse_multiline_column__border_box_ltr.xml
+++ b/tests/xml/flex/flex_container_baseline_wrap_reverse_multiline_column__border_box_ltr.xml
@@ -1,0 +1,23 @@
+<test name="flex_container_baseline_wrap_reverse_multiline_column__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" align-items="baseline" width="200px" height="200px">
+      <div direction="ltr" width="50px" height="100px"/>
+      <div direction="ltr" flex-direction="column" flex-wrap="wrap-reverse" align-content="flex-start" width="120px" height="100px">
+        <div direction="ltr" width="40px" height="60px"/>
+        <div direction="ltr" width="40px" height="60px"/>
+        <div direction="ltr" width="40px" height="60px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="0" y="0" width="50" height="100"/>
+      <node x="50" y="40" width="120" height="100">
+        <node x="80" y="0" width="40" height="60"/>
+        <node x="40" y="0" width="40" height="60"/>
+        <node x="0" y="0" width="40" height="60"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_container_baseline_wrap_reverse_multiline_column__border_box_rtl.xml
+++ b/tests/xml/flex/flex_container_baseline_wrap_reverse_multiline_column__border_box_rtl.xml
@@ -1,0 +1,23 @@
+<test name="flex_container_baseline_wrap_reverse_multiline_column__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" align-items="baseline" width="200px" height="200px">
+      <div direction="rtl" width="50px" height="100px"/>
+      <div direction="rtl" flex-direction="column" flex-wrap="wrap-reverse" align-content="flex-start" width="120px" height="100px">
+        <div direction="rtl" width="40px" height="60px"/>
+        <div direction="rtl" width="40px" height="60px"/>
+        <div direction="rtl" width="40px" height="60px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="150" y="0" width="50" height="100"/>
+      <node x="30" y="40" width="120" height="100">
+        <node x="0" y="0" width="40" height="60"/>
+        <node x="40" y="0" width="40" height="60"/>
+        <node x="80" y="0" width="40" height="60"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_container_baseline_wrap_reverse_multiline_column__content_box_ltr.xml
+++ b/tests/xml/flex/flex_container_baseline_wrap_reverse_multiline_column__content_box_ltr.xml
@@ -1,0 +1,23 @@
+<test name="flex_container_baseline_wrap_reverse_multiline_column__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" align-items="baseline" width="200px" height="200px">
+      <div box-sizing="content-box" direction="ltr" width="50px" height="100px"/>
+      <div box-sizing="content-box" direction="ltr" flex-direction="column" flex-wrap="wrap-reverse" align-content="flex-start" width="120px" height="100px">
+        <div box-sizing="content-box" direction="ltr" width="40px" height="60px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="60px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="60px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="0" y="0" width="50" height="100"/>
+      <node x="50" y="40" width="120" height="100">
+        <node x="80" y="0" width="40" height="60"/>
+        <node x="40" y="0" width="40" height="60"/>
+        <node x="0" y="0" width="40" height="60"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_container_baseline_wrap_reverse_multiline_column__content_box_rtl.xml
+++ b/tests/xml/flex/flex_container_baseline_wrap_reverse_multiline_column__content_box_rtl.xml
@@ -1,0 +1,23 @@
+<test name="flex_container_baseline_wrap_reverse_multiline_column__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" align-items="baseline" width="200px" height="200px">
+      <div box-sizing="content-box" direction="rtl" width="50px" height="100px"/>
+      <div box-sizing="content-box" direction="rtl" flex-direction="column" flex-wrap="wrap-reverse" align-content="flex-start" width="120px" height="100px">
+        <div box-sizing="content-box" direction="rtl" width="40px" height="60px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="60px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="60px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="150" y="0" width="50" height="100"/>
+      <node x="30" y="40" width="120" height="100">
+        <node x="0" y="0" width="40" height="60"/>
+        <node x="40" y="0" width="40" height="60"/>
+        <node x="80" y="0" width="40" height="60"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_container_baseline_wrap_reverse_multiline_text__border_box_ltr.xml
+++ b/tests/xml/flex/flex_container_baseline_wrap_reverse_multiline_text__border_box_ltr.xml
@@ -1,0 +1,27 @@
+<test name="flex_container_baseline_wrap_reverse_multiline_text__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" align-items="baseline" width="300px" height="200px">
+      <div direction="ltr" width="50px" height="100px"/>
+      <div direction="ltr" flex-wrap="wrap-reverse" align-content="flex-start" width="100px" height="120px">
+        <text direction="ltr" align-self="baseline" width="60px">
+          HH
+        </text>
+        <div direction="ltr" width="40px" height="40px"/>
+        <div direction="ltr" width="60px" height="30px"/>
+        <div direction="ltr" width="40px" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="200">
+      <node x="0" y="0" width="50" height="100"/>
+      <node x="50" y="20" width="100" height="120">
+        <node x="0" y="110" width="60" height="10"/>
+        <node x="60" y="80" width="40" height="40"/>
+        <node x="0" y="50" width="60" height="30"/>
+        <node x="60" y="70" width="40" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_container_baseline_wrap_reverse_multiline_text__border_box_rtl.xml
+++ b/tests/xml/flex/flex_container_baseline_wrap_reverse_multiline_text__border_box_rtl.xml
@@ -1,0 +1,27 @@
+<test name="flex_container_baseline_wrap_reverse_multiline_text__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" align-items="baseline" width="300px" height="200px">
+      <div direction="rtl" width="50px" height="100px"/>
+      <div direction="rtl" flex-wrap="wrap-reverse" align-content="flex-start" width="100px" height="120px">
+        <text direction="rtl" align-self="baseline" width="60px">
+          HH
+        </text>
+        <div direction="rtl" width="40px" height="40px"/>
+        <div direction="rtl" width="60px" height="30px"/>
+        <div direction="rtl" width="40px" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="200">
+      <node x="250" y="0" width="50" height="100"/>
+      <node x="150" y="20" width="100" height="120">
+        <node x="40" y="110" width="60" height="10"/>
+        <node x="0" y="80" width="40" height="40"/>
+        <node x="40" y="50" width="60" height="30"/>
+        <node x="0" y="70" width="40" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_container_baseline_wrap_reverse_multiline_text__content_box_ltr.xml
+++ b/tests/xml/flex/flex_container_baseline_wrap_reverse_multiline_text__content_box_ltr.xml
@@ -1,0 +1,27 @@
+<test name="flex_container_baseline_wrap_reverse_multiline_text__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" align-items="baseline" width="300px" height="200px">
+      <div box-sizing="content-box" direction="ltr" width="50px" height="100px"/>
+      <div box-sizing="content-box" direction="ltr" flex-wrap="wrap-reverse" align-content="flex-start" width="100px" height="120px">
+        <text box-sizing="content-box" direction="ltr" align-self="baseline" width="60px">
+          HH
+        </text>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="40px"/>
+        <div box-sizing="content-box" direction="ltr" width="60px" height="30px"/>
+        <div box-sizing="content-box" direction="ltr" width="40px" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="200">
+      <node x="0" y="0" width="50" height="100"/>
+      <node x="50" y="20" width="100" height="120">
+        <node x="0" y="110" width="60" height="10"/>
+        <node x="60" y="80" width="40" height="40"/>
+        <node x="0" y="50" width="60" height="30"/>
+        <node x="60" y="70" width="40" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_container_baseline_wrap_reverse_multiline_text__content_box_rtl.xml
+++ b/tests/xml/flex/flex_container_baseline_wrap_reverse_multiline_text__content_box_rtl.xml
@@ -1,0 +1,27 @@
+<test name="flex_container_baseline_wrap_reverse_multiline_text__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" align-items="baseline" width="300px" height="200px">
+      <div box-sizing="content-box" direction="rtl" width="50px" height="100px"/>
+      <div box-sizing="content-box" direction="rtl" flex-wrap="wrap-reverse" align-content="flex-start" width="100px" height="120px">
+        <text box-sizing="content-box" direction="rtl" align-self="baseline" width="60px">
+          HH
+        </text>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="40px"/>
+        <div box-sizing="content-box" direction="rtl" width="60px" height="30px"/>
+        <div box-sizing="content-box" direction="rtl" width="40px" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="200">
+      <node x="250" y="0" width="50" height="100"/>
+      <node x="150" y="20" width="100" height="120">
+        <node x="40" y="110" width="60" height="10"/>
+        <node x="0" y="80" width="40" height="40"/>
+        <node x="40" y="50" width="60" height="30"/>
+        <node x="0" y="70" width="40" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -11922,6 +11922,106 @@ mod flex {
     }
 
     #[test]
+    fn flex_container_baseline_column_reverse__border_box_ltr() {
+        crate::run_xml_test("flex", "flex_container_baseline_column_reverse__border_box_ltr");
+    }
+
+    #[test]
+    fn flex_container_baseline_column_reverse__content_box_ltr() {
+        crate::run_xml_test("flex", "flex_container_baseline_column_reverse__content_box_ltr");
+    }
+
+    #[test]
+    fn flex_container_baseline_column_reverse__border_box_rtl() {
+        crate::run_xml_test("flex", "flex_container_baseline_column_reverse__border_box_rtl");
+    }
+
+    #[test]
+    fn flex_container_baseline_column_reverse__content_box_rtl() {
+        crate::run_xml_test("flex", "flex_container_baseline_column_reverse__content_box_rtl");
+    }
+
+    #[test]
+    fn flex_container_baseline_column_reverse_wrap_reverse__border_box_ltr() {
+        crate::run_xml_test("flex", "flex_container_baseline_column_reverse_wrap_reverse__border_box_ltr");
+    }
+
+    #[test]
+    fn flex_container_baseline_column_reverse_wrap_reverse__content_box_ltr() {
+        crate::run_xml_test("flex", "flex_container_baseline_column_reverse_wrap_reverse__content_box_ltr");
+    }
+
+    #[test]
+    fn flex_container_baseline_column_reverse_wrap_reverse__border_box_rtl() {
+        crate::run_xml_test("flex", "flex_container_baseline_column_reverse_wrap_reverse__border_box_rtl");
+    }
+
+    #[test]
+    fn flex_container_baseline_column_reverse_wrap_reverse__content_box_rtl() {
+        crate::run_xml_test("flex", "flex_container_baseline_column_reverse_wrap_reverse__content_box_rtl");
+    }
+
+    #[test]
+    fn flex_container_baseline_wrap_reverse_multiline__border_box_ltr() {
+        crate::run_xml_test("flex", "flex_container_baseline_wrap_reverse_multiline__border_box_ltr");
+    }
+
+    #[test]
+    fn flex_container_baseline_wrap_reverse_multiline__content_box_ltr() {
+        crate::run_xml_test("flex", "flex_container_baseline_wrap_reverse_multiline__content_box_ltr");
+    }
+
+    #[test]
+    fn flex_container_baseline_wrap_reverse_multiline__border_box_rtl() {
+        crate::run_xml_test("flex", "flex_container_baseline_wrap_reverse_multiline__border_box_rtl");
+    }
+
+    #[test]
+    fn flex_container_baseline_wrap_reverse_multiline__content_box_rtl() {
+        crate::run_xml_test("flex", "flex_container_baseline_wrap_reverse_multiline__content_box_rtl");
+    }
+
+    #[test]
+    fn flex_container_baseline_wrap_reverse_multiline_column__border_box_ltr() {
+        crate::run_xml_test("flex", "flex_container_baseline_wrap_reverse_multiline_column__border_box_ltr");
+    }
+
+    #[test]
+    fn flex_container_baseline_wrap_reverse_multiline_column__content_box_ltr() {
+        crate::run_xml_test("flex", "flex_container_baseline_wrap_reverse_multiline_column__content_box_ltr");
+    }
+
+    #[test]
+    fn flex_container_baseline_wrap_reverse_multiline_column__border_box_rtl() {
+        crate::run_xml_test("flex", "flex_container_baseline_wrap_reverse_multiline_column__border_box_rtl");
+    }
+
+    #[test]
+    fn flex_container_baseline_wrap_reverse_multiline_column__content_box_rtl() {
+        crate::run_xml_test("flex", "flex_container_baseline_wrap_reverse_multiline_column__content_box_rtl");
+    }
+
+    #[test]
+    fn flex_container_baseline_wrap_reverse_multiline_text__border_box_ltr() {
+        crate::run_xml_test("flex", "flex_container_baseline_wrap_reverse_multiline_text__border_box_ltr");
+    }
+
+    #[test]
+    fn flex_container_baseline_wrap_reverse_multiline_text__content_box_ltr() {
+        crate::run_xml_test("flex", "flex_container_baseline_wrap_reverse_multiline_text__content_box_ltr");
+    }
+
+    #[test]
+    fn flex_container_baseline_wrap_reverse_multiline_text__border_box_rtl() {
+        crate::run_xml_test("flex", "flex_container_baseline_wrap_reverse_multiline_text__border_box_rtl");
+    }
+
+    #[test]
+    fn flex_container_baseline_wrap_reverse_multiline_text__content_box_rtl() {
+        crate::run_xml_test("flex", "flex_container_baseline_wrap_reverse_multiline_text__content_box_rtl");
+    }
+
+    #[test]
     fn flex_direction_column__border_box_ltr() {
         crate::run_xml_test("flex", "flex_direction_column__border_box_ltr");
     }


### PR DESCRIPTION
# Objective

Fix the flex container baseline computation so that it matches browsers (and the current css-flexbox-1 ED wording, https://drafts.csswg.org/css-flexbox-1/#flex-baselines) for reverse-direction containers. This is what causes Blitz to fail WPT tests `css/css-flexbox/flexbox-baseline-multi-line-horiz-004.html` and `css/css-flexbox/flexbox-baseline-multi-line-vert-002.html`.

## Context

The original hypothesis was that the wrap-reverse line selection was wrong (that the first baseline should come from the first flex line in flex-line order regardless of wrap direction, per the css-flexbox-1 TR wording). However, empirical testing against Chrome (both via gentest fixtures with the container nested in a baseline-aligning flex parent, and via headless Chrome measurements of the inline baseline export) shows Chrome consistently generates the first baseline from the **visually startmost** line — for wrap-reverse that is the *last* line in flex-line order, which is what taffy already does. The current ED spec text agrees: "startmost flex line", where startmost links to the writing-mode (visual) definition of start.

The actual bug making the two WPT tests fail is on the column side: for `column-reverse` containers taffy took the baseline of the *first* item in flex order, which is positioned at the visual *bottom*. Browsers use the startmost (visually topmost) item, which for reverse-direction containers is the last item in flex order. In the WPT reftests it is the *reference* page (which uses `column-reverse` / single-line column containers) that taffy renders wrong, producing the observed ~15px baseline offset.

Pseudo-diff of the fix in `compute_flexbox_layout`:

```rust
  // line selection unchanged (visually startmost line):
  let first_line = if constants.is_wrap_reverse { flex_lines.last() } else { flex_lines.first() };
  let first_vertical_baseline = first_line.and_then(|line| {
-     line.items.iter()
-         .find(|item| constants.is_column || item.participates_in_baseline_alignment(constants.dir))
-         .or_else(|| line.items.iter().next())
-         .map(|child| child.baseline)
+     if constants.is_column {
+         // startmost item: last in flex order for reverse-direction containers
+         let item = if constants.dir.is_reverse() { line.items.last() } else { line.items.first() };
+         item.map(|child| child.baseline)
+     } else {
+         line.items.iter()
+             .find(|item| item.participates_in_baseline_alignment(constants.dir))
+             .or_else(|| line.items.iter().next())
+             .map(|child| child.baseline)
+     }
  });
```

New generated test fixtures cover:
- row wrap-reverse multi-line first baseline (with and without a text item participating in baseline alignment) — regression tests locking in the existing (correct) behavior
- column wrap-reverse multi-line
- column-reverse single-line (previously wrong)
- column-reverse + wrap-reverse multi-line (previously wrong)

All fixtures regenerated from Chrome via `just gentest`; `cargo test --workspace`, `cargo fmt` and `cargo clippy` pass.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/1674564446a64939b4972322b4f46da4
Requested by: @nicoburns