### PR TITLE
Implement the layout-affecting parts of CSS layout and paint containment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,20 @@
 
 - `Dimension` also supports the `content` keyword (`Dimension::content()`, CSS `content`), which indicates an automatic size based on the box's content. This keyword is only valid for `flex-basis`, where it sizes the item based on its content (ignoring its main size property) when computing its flex base size. In any other context (e.g. `width`/`height`) it behaves as `auto`
 
+- Support for the layout-affecting parts of the `layout` and `paint` values of the CSS `contain` property via a new `Contain` bitflags style type, a new `Style::contain` field and a new (defaulted) `CoreStyle::contain` trait method:
+  - `Contain::LAYOUT` (layout containment): the box establishes an independent formatting context (its margins do not collapse with those of its children, it contains its own floats, and it avoids external floats) and its baseline is suppressed (boxes requiring a baseline synthesize one from its border box)
+  - `Contain::PAINT` (paint containment): the box establishes an independent formatting context like layout containment, but its baseline is not suppressed. Paint containment's other effects (clipping, containing absolutely-positioned descendants, stacking context) do not affect layout and are not implemented
+  - Layout and paint containment also prevent the box's overflowing content from contributing to its ancestors' scrollable overflow regions: layout containment treats such overflow as ink overflow, and paint containment clips it. The contained box's own `scrollable_overflow_rect` still includes its overflowing content
+
+  The CSS parser (`parse` feature) accepts `none | content | [ layout || style || paint ]` for the `contain` property: `content` maps to `LAYOUT | PAINT`, and the `style` keyword is accepted but ignored as it does not affect layout. The `strict`, `size` and `inline-size` values are not supported as size containment is not implemented
+
 ### Changed
 
 - Flexbox/Block: absolutely positioned children are no longer measured when both of their dimensions are already known (e.g. from explicit sizes or insets), matching the existing grid behaviour
 
 ### Fixed
+
+- Block/float: the height of overflowing in-flow content of a nested block no longer contributes to the height of the block formatting context root as if it were floated content. Previously an auto-height BFC root containing a block whose in-flow content overflowed it (e.g. a fixed-height block with taller content) was incorrectly extended to contain that overflowing content
 
 - Block: the baselines contributed by in-flow children that are scroll containers are now clamped to the child's border box, and a scroll-container child with no natural baseline synthesizes one at its border-box bottom edge, matching the existing flexbox/grid behaviour per the [CSSWG resolution](https://github.com/w3c/csswg-drafts/issues/7660). Previously baselines of clipped content could leak outside an `overflow: hidden` child, and an empty scroll-container child contributed no baseline
 

--- a/scripts/gentest/src/main.rs
+++ b/scripts/gentest/src/main.rs
@@ -663,6 +663,8 @@ fn generate_node(w: &mut XmlWriter, node: &Value) {
         maybe_write(w, "scrollbar-width", get_num_attr(&style["scrollbarWidth"], None));
     }
 
+    maybe_write(w, "contain", get_str_attr(&style["contain"], Some("none")));
+
     maybe_write(w, "text-align", get_str_attr(&style["textAlign"], None));
     maybe_write(w, "align-items", get_str_attr(&style["alignItems"], None));
     maybe_write(w, "align-self", get_str_attr(&style["alignSelf"], None));

--- a/scripts/gentest/test_helper.js
+++ b/scripts/gentest/test_helper.js
@@ -233,6 +233,8 @@ function describeElement(e) {
       overflowY: parseEnum(e.style.overflowY),
       scrollbarWidth: getScrollBarWidth(),
 
+      contain: parseEnum(e.style.contain),
+
       alignItems: parseEnum(e.style.alignItems),
       alignSelf: parseEnum(e.style.alignSelf),
       justifyItems: parseEnum(e.style.justifyItems),

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -10,8 +10,8 @@ use crate::util::sys::Vec;
 use crate::util::MaybeMath;
 use crate::util::{MaybeResolve, ResolveOrZero};
 use crate::{
-    BlockContainerStyle, BlockItemStyle, BoxGenerationMode, BoxSizing, Dimension, Direction, LayoutBlockContainer,
-    RequestedAxis, TextAlign,
+    BlockContainerStyle, BlockItemStyle, BoxGenerationMode, BoxSizing, Contain, Dimension, Direction,
+    LayoutBlockContainer, RequestedAxis, TextAlign,
 };
 
 #[cfg(feature = "float_layout")]
@@ -48,7 +48,7 @@ impl BlockFormattingContext {
             y_offset: 0.0,
             insets: [0.0, 0.0],
             content_box_insets: [0.0, 0.0],
-            float_content_contribution: 0.0,
+            float_content_contribution: f32::NEG_INFINITY,
             is_root: true,
             #[cfg(feature = "float_layout")]
             adjoining_floats: [false, false],
@@ -71,7 +71,8 @@ pub struct BlockContext<'bfc> {
     insets: [f32; 2],
     /// The x-insets of the content box
     content_box_insets: [f32; 2],
-    /// The height that floats take up in the element
+    /// The height that floats take up in the element (`f32::NEG_INFINITY` if the element's
+    /// subtree does not contain any floats)
     float_content_contribution: f32,
     /// Whether the node is the root of the Block Formatting Context is belongs to.
     is_root: bool,
@@ -97,7 +98,7 @@ impl BlockContext<'_> {
             y_offset: self.y_offset + additional_y_offset,
             insets,
             content_box_insets: insets,
-            float_content_contribution: 0.0,
+            float_content_contribution: f32::NEG_INFINITY,
             is_root: false,
             // Floats adjoining the parent's current strut also adjoin this block's top strut
             // (if this block's top margin collapses with its first child's, which is checked separately)
@@ -312,6 +313,8 @@ struct BlockItem {
 
     /// The overflow style of the item
     overflow: Point<Overflow>,
+    /// The contain style of the item
+    contain: Contain,
     /// The width of the item's scrollbars (if it has scrollbars)
     scrollbar_width: f32,
 
@@ -354,9 +357,13 @@ pub fn compute_block_layout(
     // Pull these out earlier to avoid borrowing issues
     let overflow = style.overflow();
     let is_scroll_container = overflow.x.is_scroll_container() || overflow.y.is_scroll_container();
+    let contain = style.contain();
     // css-align-3 §5.1.1: a non-`normal` `align-content` makes a block container establish an
     // independent formatting context. <https://drafts.csswg.org/css-align-3/#distribution-block>
-    let establishes_new_bfc = is_scroll_container || style.align_content().is_some();
+    // Layout and paint containment also establish an independent formatting context.
+    // <https://drafts.csswg.org/css-contain-2/#containment-layout>
+    let establishes_new_bfc =
+        is_scroll_container || style.align_content().is_some() || contain.establishes_independent_formatting_context();
     let aspect_ratio = style.aspect_ratio();
     let padding = style.padding().resolve_or_zero(parent_size.width, |val, basis| tree.calc(val, basis));
     let border = style.border().resolve_or_zero(parent_size.width, |val, basis| tree.calc(val, basis));
@@ -413,7 +420,7 @@ pub fn compute_block_layout(
 
     // Unwrap the block formatting context if one was passed, or else create a new one
     debug_log!("BLOCK");
-    match block_ctx {
+    let mut output = match block_ctx {
         Some(inherited_bfc) if !establishes_new_bfc => compute_inner(
             tree,
             node_id,
@@ -430,7 +437,14 @@ pub fn compute_block_layout(
                 &mut root_ctx,
             )
         }
+    };
+
+    // Layout containment suppresses the box's baseline for baseline-alignment purposes
+    if contain.suppresses_baseline() {
+        output.baselines = Baselines::NONE;
     }
+
+    output
 }
 
 /// Computes the layout of [`LayoutBlockContainer`] according to the block layout algorithm
@@ -511,7 +525,9 @@ fn compute_inner(
 
     let overflow = style.overflow();
     let is_scroll_container = overflow.x.is_scroll_container() || overflow.y.is_scroll_container();
-    let establishes_new_bfc = is_scroll_container || style.align_content().is_some();
+    let establishes_new_bfc = is_scroll_container
+        || style.align_content().is_some()
+        || style.contain().establishes_independent_formatting_context();
 
     // Determine margin collapsing behaviour
     let own_margins_collapse_with_children = Line {
@@ -669,6 +685,7 @@ fn compute_inner(
                             layout.size,
                             layout.scrollable_overflow_rect,
                             item.overflow,
+                            item.contain,
                             is_scroll_container,
                         ));
                     }
@@ -807,9 +824,15 @@ fn generate_item_list(
             let is_table = child_style.is_table();
             let is_replaced = child_style.is_compressible_replaced();
             let is_scroll_container = overflow.x.is_scroll_container() || overflow.y.is_scroll_container();
+            let contain = child_style.contain();
+            let establishes_independent_fc = contain.establishes_independent_formatting_context();
 
-            let is_in_same_bfc: bool =
-                is_block && !is_table && position != Position::Absolute && is_not_floated && !is_scroll_container;
+            let is_in_same_bfc: bool = is_block
+                && !is_table
+                && position != Position::Absolute
+                && is_not_floated
+                && !is_scroll_container
+                && !establishes_independent_fc;
 
             BlockItem {
                 node_id: child_node_id,
@@ -838,6 +861,7 @@ fn generate_item_list(
                     .maybe_apply_aspect_ratio(aspect_ratio)
                     .maybe_add(box_sizing_adjustment),
                 overflow,
+                contain,
                 scrollbar_width: child_style.scrollbar_width(),
                 position,
                 inset: child_style.inset(),
@@ -1120,6 +1144,7 @@ fn perform_final_layout_on_in_flow_children(
                         item_layout.size,
                         item_layout.scrollable_overflow_rect,
                         item.overflow,
+                        item.contain,
                         is_scroll_container,
                     ));
                 }
@@ -1518,6 +1543,7 @@ fn perform_final_layout_on_in_flow_children(
                     final_size,
                     item_layout.scrollable_overflow_rect,
                     item.overflow,
+                    item.contain,
                     is_scroll_container,
                 ));
             }
@@ -1853,6 +1879,7 @@ fn perform_absolute_layout_on_absolute_children(
                 final_size,
                 layout_output.scrollable_overflow_rect,
                 item.overflow,
+                item.contain,
                 is_scroll_container,
             ));
         }

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -825,14 +825,13 @@ fn generate_item_list(
             let is_replaced = child_style.is_compressible_replaced();
             let is_scroll_container = overflow.x.is_scroll_container() || overflow.y.is_scroll_container();
             let contain = child_style.contain();
-            let establishes_independent_fc = contain.establishes_independent_formatting_context();
 
             let is_in_same_bfc: bool = is_block
                 && !is_table
                 && position != Position::Absolute
                 && is_not_floated
                 && !is_scroll_container
-                && !establishes_independent_fc;
+                && !contain.establishes_independent_formatting_context();
 
             BlockItem {
                 node_id: child_node_id,

--- a/src/compute/common/scrollable_overflow.rs
+++ b/src/compute/common/scrollable_overflow.rs
@@ -1,6 +1,6 @@
 //! Generic CSS scrollable overflow code that is shared between all CSS algorithms.
 use crate::geometry::{Point, Rect, Size};
-use crate::style::Overflow;
+use crate::style::{Contain, Overflow};
 use crate::util::sys::{f32_max, f32_min};
 
 #[inline(always)]
@@ -19,17 +19,22 @@ use crate::util::sys::{f32_max, f32_min};
 /// scrollable overflow region (<https://www.w3.org/TR/css-overflow-3/#scrollable>). This
 /// exclusion only applies when the parent is a scroll container: boxes with `overflow: visible`
 /// have no unreachable region of their own, so all of their content contributes.
+///
+/// A box whose containment contains its scrollable overflow (layout or paint containment)
+/// contributes only its border box, regardless of its overflow style.
 pub(crate) fn compute_scrollable_overflow_contribution(
     location: Point<f32>,
     size: Size<f32>,
     scrollable_overflow_rect: Rect<f32>,
     overflow: Point<Overflow>,
+    contain: Contain,
     parent_is_scroll_container: bool,
 ) -> Rect<f32> {
     let is_scroll_container = overflow.x.is_scroll_container() || overflow.y.is_scroll_container();
+    let overflow_is_contained = contain.contains_scrollable_overflow();
     let propagates = Point {
-        x: !is_scroll_container && overflow.x == Overflow::Visible,
-        y: !is_scroll_container && overflow.y == Overflow::Visible,
+        x: !is_scroll_container && !overflow_is_contained && overflow.x == Overflow::Visible,
+        y: !is_scroll_container && !overflow_is_contained && overflow.y == Overflow::Visible,
     };
     let end_extent = Size {
         width: if propagates.x { f32_max(size.width, scrollable_overflow_rect.right) } else { size.width },

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -2,8 +2,8 @@
 use crate::compute::common::alignment::{compute_alignment_offset, resolve_self_alignment_safety};
 use crate::geometry::{Line, Point, Rect, Size};
 use crate::style::{
-    AlignContent, AlignContentKeyword, AlignItems, AlignItemsKeyword, AlignSelf, AvailableSpace, JustifyContent,
-    LengthPercentageAuto, Overflow, Position,
+    AlignContent, AlignContentKeyword, AlignItems, AlignItemsKeyword, AlignSelf, AvailableSpace, Contain,
+    JustifyContent, LengthPercentageAuto, Overflow, Position,
 };
 use crate::style::{CoreStyle, FlexDirection, FlexboxContainerStyle, FlexboxItemStyle};
 use crate::style_helpers::{TaffyMaxContent, TaffyMinContent};
@@ -46,6 +46,8 @@ struct FlexItem {
 
     /// The overflow style of the item
     overflow: Point<Overflow>,
+    /// The contain style of the item
+    contain: Contain,
     /// The width of the scrollbars (if it has any)
     scrollbar_width: f32,
     /// The flex shrink style of the item
@@ -234,6 +236,7 @@ pub fn compute_flexbox_layout(
     let style = tree.get_flexbox_container_style(node);
 
     // Pull these out earlier to avoid borrowing issues
+    let contain = style.contain();
     let aspect_ratio = style.aspect_ratio();
     let padding = style.padding().resolve_or_zero(parent_size.width, |val, basis| tree.calc(val, basis));
     let border = style.border().resolve_or_zero(parent_size.width, |val, basis| tree.calc(val, basis));
@@ -304,11 +307,18 @@ pub fn compute_flexbox_layout(
         .known_dimensions_are_definite
         .zip_map(known_dimensions, |is_definite, known_dimension| is_definite || known_dimension.is_none());
 
-    compute_preliminary(
+    let mut output = compute_preliminary(
         tree,
         node,
         LayoutInput { known_dimensions: styled_based_known_dimensions, known_dimensions_are_definite, ..inputs },
-    )
+    );
+
+    // Layout containment suppresses the box's baseline for baseline-alignment purposes
+    if contain.suppresses_baseline() {
+        output.baselines = Baselines::NONE;
+    }
+
+    output
 }
 
 /// Compute a preliminary size for an item
@@ -702,6 +712,7 @@ fn generate_anonymous_flex_items(
                     constants.is_column,
                 ),
                 overflow: child_style.overflow(),
+                contain: child_style.contain(),
                 scrollbar_width: child_style.scrollbar_width(),
                 flex_grow: child_style.flex_grow(),
                 flex_shrink: child_style.flex_shrink(),
@@ -2457,6 +2468,7 @@ fn calculate_flex_item(
             size,
             scrollable_overflow_rect,
             item.overflow,
+            item.contain,
             constants.is_scroll_container,
         ));
     }
@@ -2612,6 +2624,7 @@ fn perform_absolute_layout_on_absolute_children(
         }
 
         let overflow = child_style.overflow();
+        let contain = child_style.contain();
         let scrollbar_width = child_style.scrollbar_width();
         let aspect_ratio = child_style.aspect_ratio();
         let align_self = child_style.align_self().unwrap_or(constants.align_items).resolve_self_relative(
@@ -2990,6 +3003,7 @@ fn perform_absolute_layout_on_absolute_children(
                 final_size,
                 layout_output.scrollable_overflow_rect,
                 overflow,
+                contain,
                 constants.is_scroll_container,
             ));
         }

--- a/src/compute/grid/alignment.rs
+++ b/src/compute/grid/alignment.rs
@@ -95,6 +95,8 @@ pub(super) fn align_and_position_item(
     let style = tree.get_grid_child_style(node);
 
     let overflow = style.overflow();
+    #[cfg(feature = "content_size")]
+    let contain = style.contain();
     let scrollbar_width = style.scrollbar_width();
     let aspect_ratio = style.aspect_ratio();
     // Resolve writing-mode-relative self-start/self-end keywords against the item's own
@@ -401,6 +403,7 @@ pub(super) fn align_and_position_item(
             Size { width, height },
             layout_output.scrollable_overflow_rect,
             overflow,
+            contain,
             container_is_scroll_container,
         )
     };

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -45,6 +45,24 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
     node: NodeId,
     inputs: LayoutInput,
 ) -> LayoutOutput {
+    let contain = tree.get_grid_container_style(node).contain();
+
+    let mut output = compute_grid_layout_inner(tree, node, inputs);
+
+    // Layout containment suppresses the box's baseline for baseline-alignment purposes
+    if contain.suppresses_baseline() {
+        output.baselines = Baselines::NONE;
+    }
+
+    output
+}
+
+/// The main body of the grid layout algorithm
+fn compute_grid_layout_inner<Tree: LayoutGridContainer>(
+    tree: &mut Tree,
+    node: NodeId,
+    inputs: LayoutInput,
+) -> LayoutOutput {
     let LayoutInput { known_dimensions, parent_size, available_space, run_mode, .. } = inputs;
 
     let style = tree.get_grid_container_style(node);

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -45,28 +45,11 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
     node: NodeId,
     inputs: LayoutInput,
 ) -> LayoutOutput {
-    let contain = tree.get_grid_container_style(node).contain();
-
-    let mut output = compute_grid_layout_inner(tree, node, inputs);
-
-    // Layout containment suppresses the box's baseline for baseline-alignment purposes
-    if contain.suppresses_baseline() {
-        output.baselines = Baselines::NONE;
-    }
-
-    output
-}
-
-/// The main body of the grid layout algorithm
-fn compute_grid_layout_inner<Tree: LayoutGridContainer>(
-    tree: &mut Tree,
-    node: NodeId,
-    inputs: LayoutInput,
-) -> LayoutOutput {
     let LayoutInput { known_dimensions, parent_size, available_space, run_mode, .. } = inputs;
 
     let style = tree.get_grid_container_style(node);
     let direction = style.direction();
+    let contain = style.contain();
 
     // 1. Compute "available grid space"
     // https://www.w3.org/TR/css-grid-1/#available-grid-space
@@ -803,7 +786,10 @@ fn compute_grid_layout_inner<Tree: LayoutGridContainer>(
     }
 
     // Determine the grid container baseline(s) (currently we only compute the first baseline)
-    let grid_container_baseline: f32 = {
+    // Layout containment suppresses the box's baseline for baseline-alignment purposes
+    let grid_container_baseline: Option<f32> = if contain.suppresses_baseline() {
+        None
+    } else {
         // Sort items by row start position so that we can iterate items in groups which are in the same row
         items.sort_by_key(|item| item.row_indexes.start);
 
@@ -820,7 +806,7 @@ fn compute_grid_layout_inner<Tree: LayoutGridContainer>(
             .find(|item| item.participates_in_baseline_alignment())
             .unwrap_or(&first_row_items[0]);
 
-        item.y_position + item.baseline.unwrap_or(item.height)
+        Some(item.y_position + item.baseline.unwrap_or(item.height))
     };
 
     // A scroll container's own padding at the end of the content is part of its scrollable
@@ -841,7 +827,7 @@ fn compute_grid_layout_inner<Tree: LayoutGridContainer>(
     LayoutOutput::from_sizes_and_baselines(
         container_border_box,
         scrollable_overflow_rect,
-        Baselines::from_first(Some(grid_container_baseline)),
+        Baselines::from_first(grid_container_baseline),
     )
 }
 

--- a/src/compute/leaf.rs
+++ b/src/compute/leaf.rs
@@ -79,6 +79,7 @@ where
         || style.overflow().x.is_scroll_container()
         || style.overflow().y.is_scroll_container()
         || style.position() == Position::Absolute
+        || style.contain().establishes_independent_formatting_context()
         || padding.top > 0.0
         || padding.bottom > 0.0
         || border.top > 0.0

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -178,6 +178,12 @@ pub trait CoreStyle {
     fn border(&self) -> Rect<LengthPercentage> {
         Style::<Self::CustomIdent>::DEFAULT.border
     }
+
+    /// The layout-affecting parts of the CSS `contain` property that apply to this node
+    #[inline(always)]
+    fn contain(&self) -> Contain {
+        Contain::NONE
+    }
 }
 
 /// Sets the layout used for the children of this node
@@ -398,6 +404,150 @@ crate::util::parse::impl_parse_for_keyword_enum!(Overflow,
     "scroll" => Scroll,
 );
 
+/// The layout-affecting parts of the CSS `contain` property.
+///
+/// Containment limits the ways in which a box's contents can affect layout outside of the box
+/// (and vice versa). Taffy implements the layout-relevant containment types:
+///
+///   - [`Contain::LAYOUT`]: the box establishes an independent formatting context, and is treated
+///     as having no baseline for baseline-alignment purposes (layout containment).
+///   - [`Contain::PAINT`]: the box establishes an independent formatting context. Paint
+///     containment's other effects (clipping, containing absolutely-positioned descendants,
+///     stacking context) are outside of Taffy's scope.
+///
+/// The `style` containment type has no effect on layout and is therefore not represented
+/// (it is accepted and ignored when parsing). Size and inline-size containment are not
+/// currently implemented.
+///
+/// <https://developer.mozilla.org/en-US/docs/Web/CSS/contain>
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct Contain(u8);
+
+impl Contain {
+    /// No containment (the default)
+    pub const NONE: Contain = Contain(0);
+    /// Layout containment: the box establishes an independent formatting context and is treated
+    /// as having no baseline for baseline-alignment purposes.
+    /// <https://drafts.csswg.org/css-contain-2/#containment-layout>
+    pub const LAYOUT: Contain = Contain(1 << 0);
+    /// Paint containment: the box establishes an independent formatting context. Its other
+    /// effects don't affect layout.
+    /// <https://drafts.csswg.org/css-contain-2/#containment-paint>
+    pub const PAINT: Contain = Contain(1 << 1);
+    /// The containment implied by `contain: content` (`layout paint`, ignoring style containment)
+    pub const CONTENT: Contain = Contain(Contain::LAYOUT.0 | Contain::PAINT.0);
+
+    /// The default containment (no containment)
+    pub const DEFAULT: Contain = Contain::NONE;
+
+    /// Returns whether `self` contains all of the containment types in `other`
+    #[inline(always)]
+    pub const fn contains(self, other: Contain) -> bool {
+        self.0 & other.0 == other.0
+    }
+
+    /// Returns whether `self` contains any of the containment types in `other`
+    #[inline(always)]
+    pub const fn intersects(self, other: Contain) -> bool {
+        self.0 & other.0 != 0
+    }
+
+    /// Returns the union of the containment types in `self` and `other`
+    #[inline(always)]
+    pub const fn union(self, other: Contain) -> Contain {
+        Contain(self.0 | other.0)
+    }
+
+    /// Whether this containment causes the box to establish an independent formatting context
+    /// (both layout and paint containment do)
+    #[inline(always)]
+    pub const fn establishes_independent_formatting_context(self) -> bool {
+        self.intersects(Contain::LAYOUT.union(Contain::PAINT))
+    }
+
+    /// Whether this containment suppresses the box's baseline for baseline-alignment purposes
+    /// (layout containment does, paint containment does not)
+    #[inline(always)]
+    pub const fn suppresses_baseline(self) -> bool {
+        self.contains(Contain::LAYOUT)
+    }
+
+    /// Whether this containment prevents the box's overflowing content from contributing to an
+    /// ancestor's scrollable overflow region (layout containment treats such overflow as ink
+    /// overflow; paint containment clips it)
+    #[inline(always)]
+    pub const fn contains_scrollable_overflow(self) -> bool {
+        self.intersects(Contain::LAYOUT.union(Contain::PAINT))
+    }
+}
+
+impl core::ops::BitOr for Contain {
+    type Output = Contain;
+    #[inline(always)]
+    fn bitor(self, rhs: Contain) -> Contain {
+        self.union(rhs)
+    }
+}
+
+impl core::ops::BitOrAssign for Contain {
+    #[inline(always)]
+    fn bitor_assign(&mut self, rhs: Contain) {
+        *self = self.union(rhs);
+    }
+}
+
+#[cfg(feature = "parse")]
+impl crate::util::parse::FromCss for Contain {
+    fn from_css<'i>(input: &mut crate::util::parse::Parser<'i, '_>) -> crate::util::parse::CssParseResult<'i, Self> {
+        /// Duplicate-detection bit for the ignored `style` keyword, which does not map to a
+        /// `Contain` flag
+        const STYLE_BIT: u8 = 1 << 6;
+
+        let mut flags = Contain::NONE;
+        let mut seen: u8 = 0;
+
+        loop {
+            let ident = input.expect_ident()?.clone();
+            let (flag, seen_bit) = cssparser::match_ignore_ascii_case! { &*ident,
+                // Single-keyword values (only valid on their own; `parse_entirely` in the
+                // `FromStr` impl rejects trailing keywords, and a leading keyword before them
+                // is rejected by the `seen != 0` check below)
+                "none" | "content" => {
+                    if seen != 0 || !input.is_exhausted() {
+                        return Err(input.new_unexpected_token_error(crate::util::parse::Token::Ident(ident)));
+                    }
+                    return Ok(cssparser::match_ignore_ascii_case! { &*ident,
+                        "content" => Contain::CONTENT,
+                        _ => Contain::NONE,
+                    });
+                },
+                "layout" => (Contain::LAYOUT, Contain::LAYOUT.0),
+                "paint" => (Contain::PAINT, Contain::PAINT.0),
+                // `style` containment has no layout effect: accept and ignore it so that real
+                // CSS values round-trip
+                "style" => (Contain::NONE, STYLE_BIT),
+                _ => {
+                    return Err(input.new_unexpected_token_error(crate::util::parse::Token::Ident(ident)));
+                }
+            };
+
+            // Reject duplicate keywords
+            if seen & seen_bit != 0 {
+                return Err(input.new_unexpected_token_error(crate::util::parse::Token::Ident(ident)));
+            }
+            seen |= seen_bit;
+            flags |= flag;
+
+            if input.is_exhausted() {
+                return Ok(flags);
+            }
+        }
+    }
+}
+#[cfg(feature = "parse")]
+crate::util::parse::from_str_from_css!(Contain);
+
 /// Sets the direction of text, table and grid columns, and horizontal overflow.
 /// <https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/direction>
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
@@ -463,6 +613,8 @@ pub struct Style<S: CheapCloneStr = DefaultCheapStr> {
     pub overflow: Point<Overflow>,
     /// How much space (in points) should be reserved for the scrollbars of `Overflow::Scroll` and `Overflow::Auto` nodes.
     pub scrollbar_width: f32,
+    /// The layout-affecting parts of the CSS `contain` property
+    pub contain: Contain,
 
     #[cfg(feature = "float_layout")]
     /// Should the box be floated
@@ -614,6 +766,7 @@ impl<S: CheapCloneStr> Style<S> {
         direction: Direction::Ltr,
         overflow: Point { x: Overflow::Visible, y: Overflow::Visible },
         scrollbar_width: 0.0,
+        contain: Contain::NONE,
         #[cfg(feature = "float_layout")]
         float: Float::None,
         #[cfg(feature = "float_layout")]
@@ -759,6 +912,10 @@ impl<S: CheapCloneStr> CoreStyle for Style<S> {
     fn border(&self) -> Rect<LengthPercentage> {
         self.border
     }
+    #[inline(always)]
+    fn contain(&self) -> Contain {
+        self.contain
+    }
 }
 
 impl<T: CoreStyle> CoreStyle for &'_ T {
@@ -827,6 +984,10 @@ impl<T: CoreStyle> CoreStyle for &'_ T {
     #[inline(always)]
     fn border(&self) -> Rect<LengthPercentage> {
         (*self).border()
+    }
+    #[inline(always)]
+    fn contain(&self) -> Contain {
+        (*self).contain()
     }
 }
 
@@ -1265,6 +1426,7 @@ mod tests {
             direction: Default::default(),
             overflow: Default::default(),
             scrollbar_width: 0.0,
+            contain: Default::default(),
             position: Default::default(),
             #[cfg(feature = "flexbox")]
             flex_direction: Default::default(),
@@ -1325,6 +1487,35 @@ mod tests {
 
         assert_eq!(Style::DEFAULT, Style::<DefaultCheapStr>::default());
         assert_eq!(Style::DEFAULT, old_defaults);
+    }
+
+    #[test]
+    #[cfg(feature = "parse")]
+    fn parse_contain() {
+        use super::Contain;
+
+        fn parse(input: &str) -> Contain {
+            input.parse().unwrap()
+        }
+
+        assert_eq!(parse("none"), Contain::NONE);
+        assert_eq!(parse("content"), Contain::LAYOUT | Contain::PAINT);
+        assert_eq!(parse("layout"), Contain::LAYOUT);
+        assert_eq!(parse("style"), Contain::NONE);
+        assert_eq!(parse("paint"), Contain::PAINT);
+        assert_eq!(parse("layout paint"), Contain::LAYOUT | Contain::PAINT);
+        assert_eq!(parse("paint layout"), Contain::LAYOUT | Contain::PAINT);
+        assert_eq!(parse("layout paint style"), Contain::LAYOUT | Contain::PAINT);
+        assert_eq!(parse("Paint LAYOUT"), Contain::LAYOUT | Contain::PAINT);
+        assert!("paint paint".parse::<Contain>().is_err());
+
+        assert!("".parse::<Contain>().is_err());
+        assert!("banana".parse::<Contain>().is_err());
+        assert!("layout layout".parse::<Contain>().is_err());
+        assert!("none layout".parse::<Contain>().is_err());
+        assert!("layout none".parse::<Contain>().is_err());
+        assert!("content layout".parse::<Contain>().is_err());
+        assert!("layout content".parse::<Contain>().is_err());
     }
 
     // NOTE: Please feel free the update the sizes in this test as required. This test is here to prevent unintentional size changes
@@ -1397,12 +1588,12 @@ mod tests {
         assert_type_size::<GridTemplateComponent<String>>(56);
         assert_type_size::<GridPlacement<String>>(32);
         assert_type_size::<Line<GridPlacement<String>>>(64);
-        assert_type_size::<Style<String>>(552);
+        assert_type_size::<Style<String>>(560);
 
         // String-type dependent (Arc<str>)
         assert_type_size::<GridTemplateComponent<Arc<str>>>(56);
         assert_type_size::<GridPlacement<Arc<str>>>(24);
         assert_type_size::<Line<GridPlacement<Arc<str>>>>(48);
-        assert_type_size::<Style<Arc<str>>>(520);
+        assert_type_size::<Style<Arc<str>>>(528);
     }
 }

--- a/test_fixtures/contain/contain_content_block.html
+++ b/test_fixtures/contain/contain_content_block.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px; border: 2px solid black;">
+  <div style="display: block; height: 10px; margin-bottom: 10px;"></div>
+  <div style="display: block; contain: content;">
+    <div style="display: block; height: 10px; margin-top: 20px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_layout_block_avoids_float.html
+++ b/test_fixtures/contain/contain_layout_block_avoids_float.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px;">
+  <div style="display: block; float: left; width: 30px; height: 30px;"></div>
+  <div style="display: block; contain: layout; height: 50px;">
+    <div style="display: block; height: 10px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_layout_block_contains_floats.html
+++ b/test_fixtures/contain/contain_layout_block_contains_floats.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px;">
+  <div style="display: block; contain: layout;">
+    <div style="display: block; float: left; width: 30px; height: 30px;"></div>
+  </div>
+  <div style="display: block; height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_layout_block_margin_collapse.html
+++ b/test_fixtures/contain/contain_layout_block_margin_collapse.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px; border: 2px solid black;">
+  <div style="display: block; height: 10px; margin-bottom: 10px;"></div>
+  <div style="display: block; contain: layout;">
+    <div style="display: block; height: 10px; margin-top: 20px; margin-bottom: 20px;"></div>
+  </div>
+  <div style="display: block; height: 10px; margin-top: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_layout_flex_baseline.html
+++ b/test_fixtures/contain/contain_layout_flex_baseline.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 200px; align-items: baseline;">
+  <div style="width: 50px; height: 60px;">
+    <div style="width: 50px; height: 30px;"></div>
+  </div>
+  <div style="contain: layout; width: 50px; height: 20px;">
+    <div style="width: 50px; height: 10px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_paint_block_contains_floats.html
+++ b/test_fixtures/contain/contain_paint_block_contains_floats.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px;">
+  <div style="display: block; contain: paint;">
+    <div style="display: block; float: left; width: 30px; height: 30px;"></div>
+  </div>
+  <div style="display: block; height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_paint_block_margin_collapse.html
+++ b/test_fixtures/contain/contain_paint_block_margin_collapse.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px; border: 2px solid black;">
+  <div style="display: block; height: 10px; margin-bottom: 10px;"></div>
+  <div style="display: block; contain: paint;">
+    <div style="display: block; height: 10px; margin-top: 20px; margin-bottom: 20px;"></div>
+  </div>
+  <div style="display: block; height: 10px; margin-top: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/contain/contain_paint_flex_baseline.html
+++ b/test_fixtures/contain/contain_paint_flex_baseline.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 200px; align-items: baseline;">
+  <div style="width: 50px; height: 60px;">
+    <div style="width: 50px; height: 30px;"></div>
+  </div>
+  <div style="contain: paint; width: 50px; height: 20px;">
+    <div style="width: 50px; height: 10px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/xml.rs
+++ b/tests/xml.rs
@@ -256,6 +256,7 @@ fn build_style<S: CheapCloneStr>(xnode: roxmltree::Node) -> taffy::Style<S> {
             y: parse_or_default(xnode.attribute("overflow-y")),
         },
         scrollbar_width: parse_or_default(xnode.attribute("scrollbar-width")),
+        contain: parse_or_default(xnode.attribute("contain")),
         float: parse_or_default(xnode.attribute("float")),
         clear: parse_or_default(xnode.attribute("clear")),
         position: parse_or_default(xnode.attribute("position")),

--- a/tests/xml/contain/contain_content_block__border_box_ltr.xml
+++ b/tests/xml/contain/contain_content_block__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="contain_content_block__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <div display="block" direction="ltr" height="10px" margin-bottom="10px"/>
+      <div display="block" direction="ltr" contain="content">
+        <div display="block" direction="ltr" height="10px" margin-top="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="54">
+      <node x="2" y="2" width="96" height="10"/>
+      <node x="2" y="22" width="96" height="30">
+        <node x="0" y="20" width="96" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_content_block__border_box_rtl.xml
+++ b/tests/xml/contain/contain_content_block__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="contain_content_block__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <div display="block" direction="rtl" height="10px" margin-bottom="10px"/>
+      <div display="block" direction="rtl" contain="content">
+        <div display="block" direction="rtl" height="10px" margin-top="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="54">
+      <node x="2" y="2" width="96" height="10"/>
+      <node x="2" y="22" width="96" height="30">
+        <node x="0" y="20" width="96" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_content_block__content_box_ltr.xml
+++ b/tests/xml/contain/contain_content_block__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="contain_content_block__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <div display="block" box-sizing="content-box" direction="ltr" height="10px" margin-bottom="10px"/>
+      <div display="block" box-sizing="content-box" direction="ltr" contain="content">
+        <div display="block" box-sizing="content-box" direction="ltr" height="10px" margin-top="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="104" height="54">
+      <node x="2" y="2" width="100" height="10"/>
+      <node x="2" y="22" width="100" height="30">
+        <node x="0" y="20" width="100" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_content_block__content_box_rtl.xml
+++ b/tests/xml/contain/contain_content_block__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="contain_content_block__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <div display="block" box-sizing="content-box" direction="rtl" height="10px" margin-bottom="10px"/>
+      <div display="block" box-sizing="content-box" direction="rtl" contain="content">
+        <div display="block" box-sizing="content-box" direction="rtl" height="10px" margin-top="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="104" height="54">
+      <node x="2" y="2" width="100" height="10"/>
+      <node x="2" y="22" width="100" height="30">
+        <node x="0" y="20" width="100" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_block_avoids_float__border_box_ltr.xml
+++ b/tests/xml/contain/contain_layout_block_avoids_float__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="contain_layout_block_avoids_float__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px">
+      <div display="block" direction="ltr" float="left" width="30px" height="30px"/>
+      <div display="block" direction="ltr" contain="layout" height="50px">
+        <div display="block" direction="ltr" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="50">
+      <node x="0" y="0" width="30" height="30"/>
+      <node x="30" y="0" width="70" height="50">
+        <node x="0" y="0" width="70" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_block_avoids_float__border_box_rtl.xml
+++ b/tests/xml/contain/contain_layout_block_avoids_float__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="contain_layout_block_avoids_float__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px">
+      <div display="block" direction="rtl" float="left" width="30px" height="30px"/>
+      <div display="block" direction="rtl" contain="layout" height="50px">
+        <div display="block" direction="rtl" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="50">
+      <node x="0" y="0" width="30" height="30"/>
+      <node x="30" y="0" width="70" height="50">
+        <node x="0" y="0" width="70" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_block_avoids_float__content_box_ltr.xml
+++ b/tests/xml/contain/contain_layout_block_avoids_float__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="contain_layout_block_avoids_float__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" float="left" width="30px" height="30px"/>
+      <div display="block" box-sizing="content-box" direction="ltr" contain="layout" height="50px">
+        <div display="block" box-sizing="content-box" direction="ltr" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="50">
+      <node x="0" y="0" width="30" height="30"/>
+      <node x="30" y="0" width="70" height="50">
+        <node x="0" y="0" width="70" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_block_avoids_float__content_box_rtl.xml
+++ b/tests/xml/contain/contain_layout_block_avoids_float__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="contain_layout_block_avoids_float__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" float="left" width="30px" height="30px"/>
+      <div display="block" box-sizing="content-box" direction="rtl" contain="layout" height="50px">
+        <div display="block" box-sizing="content-box" direction="rtl" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="50">
+      <node x="0" y="0" width="30" height="30"/>
+      <node x="30" y="0" width="70" height="50">
+        <node x="0" y="0" width="70" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_block_contains_floats__border_box_ltr.xml
+++ b/tests/xml/contain/contain_layout_block_contains_floats__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="contain_layout_block_contains_floats__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px">
+      <div display="block" direction="ltr" contain="layout">
+        <div display="block" direction="ltr" float="left" width="30px" height="30px"/>
+      </div>
+      <div display="block" direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="40">
+      <node x="0" y="0" width="100" height="30">
+        <node x="0" y="0" width="30" height="30"/>
+      </node>
+      <node x="0" y="30" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_block_contains_floats__border_box_rtl.xml
+++ b/tests/xml/contain/contain_layout_block_contains_floats__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="contain_layout_block_contains_floats__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px">
+      <div display="block" direction="rtl" contain="layout">
+        <div display="block" direction="rtl" float="left" width="30px" height="30px"/>
+      </div>
+      <div display="block" direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="40">
+      <node x="0" y="0" width="100" height="30">
+        <node x="0" y="0" width="30" height="30"/>
+      </node>
+      <node x="0" y="30" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_block_contains_floats__content_box_ltr.xml
+++ b/tests/xml/contain/contain_layout_block_contains_floats__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="contain_layout_block_contains_floats__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" contain="layout">
+        <div display="block" box-sizing="content-box" direction="ltr" float="left" width="30px" height="30px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="40">
+      <node x="0" y="0" width="100" height="30">
+        <node x="0" y="0" width="30" height="30"/>
+      </node>
+      <node x="0" y="30" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_block_contains_floats__content_box_rtl.xml
+++ b/tests/xml/contain/contain_layout_block_contains_floats__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="contain_layout_block_contains_floats__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" contain="layout">
+        <div display="block" box-sizing="content-box" direction="rtl" float="left" width="30px" height="30px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="40">
+      <node x="0" y="0" width="100" height="30">
+        <node x="0" y="0" width="30" height="30"/>
+      </node>
+      <node x="0" y="30" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_block_margin_collapse__border_box_ltr.xml
+++ b/tests/xml/contain/contain_layout_block_margin_collapse__border_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="contain_layout_block_margin_collapse__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <div display="block" direction="ltr" height="10px" margin-bottom="10px"/>
+      <div display="block" direction="ltr" contain="layout">
+        <div display="block" direction="ltr" height="10px" margin-top="20px" margin-bottom="20px"/>
+      </div>
+      <div display="block" direction="ltr" height="10px" margin-top="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="94">
+      <node x="2" y="2" width="96" height="10"/>
+      <node x="2" y="22" width="96" height="50">
+        <node x="0" y="20" width="96" height="10"/>
+      </node>
+      <node x="2" y="82" width="96" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_block_margin_collapse__border_box_rtl.xml
+++ b/tests/xml/contain/contain_layout_block_margin_collapse__border_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="contain_layout_block_margin_collapse__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <div display="block" direction="rtl" height="10px" margin-bottom="10px"/>
+      <div display="block" direction="rtl" contain="layout">
+        <div display="block" direction="rtl" height="10px" margin-top="20px" margin-bottom="20px"/>
+      </div>
+      <div display="block" direction="rtl" height="10px" margin-top="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="94">
+      <node x="2" y="2" width="96" height="10"/>
+      <node x="2" y="22" width="96" height="50">
+        <node x="0" y="20" width="96" height="10"/>
+      </node>
+      <node x="2" y="82" width="96" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_block_margin_collapse__content_box_ltr.xml
+++ b/tests/xml/contain/contain_layout_block_margin_collapse__content_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="contain_layout_block_margin_collapse__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <div display="block" box-sizing="content-box" direction="ltr" height="10px" margin-bottom="10px"/>
+      <div display="block" box-sizing="content-box" direction="ltr" contain="layout">
+        <div display="block" box-sizing="content-box" direction="ltr" height="10px" margin-top="20px" margin-bottom="20px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="ltr" height="10px" margin-top="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="104" height="94">
+      <node x="2" y="2" width="100" height="10"/>
+      <node x="2" y="22" width="100" height="50">
+        <node x="0" y="20" width="100" height="10"/>
+      </node>
+      <node x="2" y="82" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_block_margin_collapse__content_box_rtl.xml
+++ b/tests/xml/contain/contain_layout_block_margin_collapse__content_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="contain_layout_block_margin_collapse__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <div display="block" box-sizing="content-box" direction="rtl" height="10px" margin-bottom="10px"/>
+      <div display="block" box-sizing="content-box" direction="rtl" contain="layout">
+        <div display="block" box-sizing="content-box" direction="rtl" height="10px" margin-top="20px" margin-bottom="20px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="rtl" height="10px" margin-top="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="104" height="94">
+      <node x="2" y="2" width="100" height="10"/>
+      <node x="2" y="22" width="100" height="50">
+        <node x="0" y="20" width="100" height="10"/>
+      </node>
+      <node x="2" y="82" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_flex_baseline__border_box_ltr.xml
+++ b/tests/xml/contain/contain_layout_flex_baseline__border_box_ltr.xml
@@ -1,0 +1,23 @@
+<test name="contain_layout_flex_baseline__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" align-items="baseline" width="200px">
+      <div direction="ltr" width="50px" height="60px">
+        <div direction="ltr" width="50px" height="30px"/>
+      </div>
+      <div direction="ltr" contain="layout" width="50px" height="20px">
+        <div direction="ltr" width="50px" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="60">
+      <node x="0" y="0" width="50" height="60">
+        <node x="0" y="0" width="50" height="30"/>
+      </node>
+      <node x="50" y="10" width="50" height="20">
+        <node x="0" y="0" width="50" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_flex_baseline__border_box_rtl.xml
+++ b/tests/xml/contain/contain_layout_flex_baseline__border_box_rtl.xml
@@ -1,0 +1,23 @@
+<test name="contain_layout_flex_baseline__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" align-items="baseline" width="200px">
+      <div direction="rtl" width="50px" height="60px">
+        <div direction="rtl" width="50px" height="30px"/>
+      </div>
+      <div direction="rtl" contain="layout" width="50px" height="20px">
+        <div direction="rtl" width="50px" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="60">
+      <node x="150" y="0" width="50" height="60">
+        <node x="0" y="0" width="50" height="30"/>
+      </node>
+      <node x="100" y="10" width="50" height="20">
+        <node x="0" y="0" width="50" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_flex_baseline__content_box_ltr.xml
+++ b/tests/xml/contain/contain_layout_flex_baseline__content_box_ltr.xml
@@ -1,0 +1,23 @@
+<test name="contain_layout_flex_baseline__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" align-items="baseline" width="200px">
+      <div box-sizing="content-box" direction="ltr" width="50px" height="60px">
+        <div box-sizing="content-box" direction="ltr" width="50px" height="30px"/>
+      </div>
+      <div box-sizing="content-box" direction="ltr" contain="layout" width="50px" height="20px">
+        <div box-sizing="content-box" direction="ltr" width="50px" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="60">
+      <node x="0" y="0" width="50" height="60">
+        <node x="0" y="0" width="50" height="30"/>
+      </node>
+      <node x="50" y="10" width="50" height="20">
+        <node x="0" y="0" width="50" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_layout_flex_baseline__content_box_rtl.xml
+++ b/tests/xml/contain/contain_layout_flex_baseline__content_box_rtl.xml
@@ -1,0 +1,23 @@
+<test name="contain_layout_flex_baseline__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" align-items="baseline" width="200px">
+      <div box-sizing="content-box" direction="rtl" width="50px" height="60px">
+        <div box-sizing="content-box" direction="rtl" width="50px" height="30px"/>
+      </div>
+      <div box-sizing="content-box" direction="rtl" contain="layout" width="50px" height="20px">
+        <div box-sizing="content-box" direction="rtl" width="50px" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="60">
+      <node x="150" y="0" width="50" height="60">
+        <node x="0" y="0" width="50" height="30"/>
+      </node>
+      <node x="100" y="10" width="50" height="20">
+        <node x="0" y="0" width="50" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_paint_block_contains_floats__border_box_ltr.xml
+++ b/tests/xml/contain/contain_paint_block_contains_floats__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="contain_paint_block_contains_floats__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px">
+      <div display="block" direction="ltr" contain="paint">
+        <div display="block" direction="ltr" float="left" width="30px" height="30px"/>
+      </div>
+      <div display="block" direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="40">
+      <node x="0" y="0" width="100" height="30">
+        <node x="0" y="0" width="30" height="30"/>
+      </node>
+      <node x="0" y="30" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_paint_block_contains_floats__border_box_rtl.xml
+++ b/tests/xml/contain/contain_paint_block_contains_floats__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="contain_paint_block_contains_floats__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px">
+      <div display="block" direction="rtl" contain="paint">
+        <div display="block" direction="rtl" float="left" width="30px" height="30px"/>
+      </div>
+      <div display="block" direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="40">
+      <node x="0" y="0" width="100" height="30">
+        <node x="0" y="0" width="30" height="30"/>
+      </node>
+      <node x="0" y="30" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_paint_block_contains_floats__content_box_ltr.xml
+++ b/tests/xml/contain/contain_paint_block_contains_floats__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="contain_paint_block_contains_floats__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" contain="paint">
+        <div display="block" box-sizing="content-box" direction="ltr" float="left" width="30px" height="30px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="ltr" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="40">
+      <node x="0" y="0" width="100" height="30">
+        <node x="0" y="0" width="30" height="30"/>
+      </node>
+      <node x="0" y="30" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_paint_block_contains_floats__content_box_rtl.xml
+++ b/tests/xml/contain/contain_paint_block_contains_floats__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="contain_paint_block_contains_floats__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" contain="paint">
+        <div display="block" box-sizing="content-box" direction="rtl" float="left" width="30px" height="30px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="rtl" height="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="40">
+      <node x="0" y="0" width="100" height="30">
+        <node x="0" y="0" width="30" height="30"/>
+      </node>
+      <node x="0" y="30" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_paint_block_margin_collapse__border_box_ltr.xml
+++ b/tests/xml/contain/contain_paint_block_margin_collapse__border_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="contain_paint_block_margin_collapse__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <div display="block" direction="ltr" height="10px" margin-bottom="10px"/>
+      <div display="block" direction="ltr" contain="paint">
+        <div display="block" direction="ltr" height="10px" margin-top="20px" margin-bottom="20px"/>
+      </div>
+      <div display="block" direction="ltr" height="10px" margin-top="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="94">
+      <node x="2" y="2" width="96" height="10"/>
+      <node x="2" y="22" width="96" height="50">
+        <node x="0" y="20" width="96" height="10"/>
+      </node>
+      <node x="2" y="82" width="96" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_paint_block_margin_collapse__border_box_rtl.xml
+++ b/tests/xml/contain/contain_paint_block_margin_collapse__border_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="contain_paint_block_margin_collapse__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <div display="block" direction="rtl" height="10px" margin-bottom="10px"/>
+      <div display="block" direction="rtl" contain="paint">
+        <div display="block" direction="rtl" height="10px" margin-top="20px" margin-bottom="20px"/>
+      </div>
+      <div display="block" direction="rtl" height="10px" margin-top="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="94">
+      <node x="2" y="2" width="96" height="10"/>
+      <node x="2" y="22" width="96" height="50">
+        <node x="0" y="20" width="96" height="10"/>
+      </node>
+      <node x="2" y="82" width="96" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_paint_block_margin_collapse__content_box_ltr.xml
+++ b/tests/xml/contain/contain_paint_block_margin_collapse__content_box_ltr.xml
@@ -1,0 +1,21 @@
+<test name="contain_paint_block_margin_collapse__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <div display="block" box-sizing="content-box" direction="ltr" height="10px" margin-bottom="10px"/>
+      <div display="block" box-sizing="content-box" direction="ltr" contain="paint">
+        <div display="block" box-sizing="content-box" direction="ltr" height="10px" margin-top="20px" margin-bottom="20px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="ltr" height="10px" margin-top="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="104" height="94">
+      <node x="2" y="2" width="100" height="10"/>
+      <node x="2" y="22" width="100" height="50">
+        <node x="0" y="20" width="100" height="10"/>
+      </node>
+      <node x="2" y="82" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_paint_block_margin_collapse__content_box_rtl.xml
+++ b/tests/xml/contain/contain_paint_block_margin_collapse__content_box_rtl.xml
@@ -1,0 +1,21 @@
+<test name="contain_paint_block_margin_collapse__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px" border-top="2px" border-left="2px" border-bottom="2px" border-right="2px">
+      <div display="block" box-sizing="content-box" direction="rtl" height="10px" margin-bottom="10px"/>
+      <div display="block" box-sizing="content-box" direction="rtl" contain="paint">
+        <div display="block" box-sizing="content-box" direction="rtl" height="10px" margin-top="20px" margin-bottom="20px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="rtl" height="10px" margin-top="10px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="104" height="94">
+      <node x="2" y="2" width="100" height="10"/>
+      <node x="2" y="22" width="100" height="50">
+        <node x="0" y="20" width="100" height="10"/>
+      </node>
+      <node x="2" y="82" width="100" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_paint_flex_baseline__border_box_ltr.xml
+++ b/tests/xml/contain/contain_paint_flex_baseline__border_box_ltr.xml
@@ -1,0 +1,23 @@
+<test name="contain_paint_flex_baseline__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" align-items="baseline" width="200px">
+      <div direction="ltr" width="50px" height="60px">
+        <div direction="ltr" width="50px" height="30px"/>
+      </div>
+      <div direction="ltr" contain="paint" width="50px" height="20px">
+        <div direction="ltr" width="50px" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="60">
+      <node x="0" y="0" width="50" height="60">
+        <node x="0" y="0" width="50" height="30"/>
+      </node>
+      <node x="50" y="20" width="50" height="20">
+        <node x="0" y="0" width="50" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_paint_flex_baseline__border_box_rtl.xml
+++ b/tests/xml/contain/contain_paint_flex_baseline__border_box_rtl.xml
@@ -1,0 +1,23 @@
+<test name="contain_paint_flex_baseline__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" align-items="baseline" width="200px">
+      <div direction="rtl" width="50px" height="60px">
+        <div direction="rtl" width="50px" height="30px"/>
+      </div>
+      <div direction="rtl" contain="paint" width="50px" height="20px">
+        <div direction="rtl" width="50px" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="60">
+      <node x="150" y="0" width="50" height="60">
+        <node x="0" y="0" width="50" height="30"/>
+      </node>
+      <node x="100" y="20" width="50" height="20">
+        <node x="0" y="0" width="50" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_paint_flex_baseline__content_box_ltr.xml
+++ b/tests/xml/contain/contain_paint_flex_baseline__content_box_ltr.xml
@@ -1,0 +1,23 @@
+<test name="contain_paint_flex_baseline__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" align-items="baseline" width="200px">
+      <div box-sizing="content-box" direction="ltr" width="50px" height="60px">
+        <div box-sizing="content-box" direction="ltr" width="50px" height="30px"/>
+      </div>
+      <div box-sizing="content-box" direction="ltr" contain="paint" width="50px" height="20px">
+        <div box-sizing="content-box" direction="ltr" width="50px" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="60">
+      <node x="0" y="0" width="50" height="60">
+        <node x="0" y="0" width="50" height="30"/>
+      </node>
+      <node x="50" y="20" width="50" height="20">
+        <node x="0" y="0" width="50" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/contain/contain_paint_flex_baseline__content_box_rtl.xml
+++ b/tests/xml/contain/contain_paint_flex_baseline__content_box_rtl.xml
@@ -1,0 +1,23 @@
+<test name="contain_paint_flex_baseline__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" align-items="baseline" width="200px">
+      <div box-sizing="content-box" direction="rtl" width="50px" height="60px">
+        <div box-sizing="content-box" direction="rtl" width="50px" height="30px"/>
+      </div>
+      <div box-sizing="content-box" direction="rtl" contain="paint" width="50px" height="20px">
+        <div box-sizing="content-box" direction="rtl" width="50px" height="10px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="60">
+      <node x="150" y="0" width="50" height="60">
+        <node x="0" y="0" width="50" height="30"/>
+      </node>
+      <node x="100" y="20" width="50" height="20">
+        <node x="0" y="0" width="50" height="10"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -5446,6 +5446,168 @@ mod blockgrid {
     }
 }
 
+mod contain {
+    #[test]
+    fn contain_content_block__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_content_block__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_content_block__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_content_block__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_content_block__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_content_block__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_content_block__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_content_block__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_layout_block_avoids_float__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_layout_block_avoids_float__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_layout_block_avoids_float__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_layout_block_avoids_float__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_layout_block_avoids_float__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_layout_block_avoids_float__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_layout_block_avoids_float__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_layout_block_avoids_float__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_layout_block_contains_floats__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_layout_block_contains_floats__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_layout_block_contains_floats__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_layout_block_contains_floats__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_layout_block_contains_floats__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_layout_block_contains_floats__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_layout_block_contains_floats__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_layout_block_contains_floats__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_layout_block_margin_collapse__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_layout_block_margin_collapse__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_layout_block_margin_collapse__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_layout_block_margin_collapse__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_layout_block_margin_collapse__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_layout_block_margin_collapse__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_layout_block_margin_collapse__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_layout_block_margin_collapse__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_layout_flex_baseline__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_layout_flex_baseline__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_layout_flex_baseline__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_layout_flex_baseline__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_layout_flex_baseline__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_layout_flex_baseline__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_layout_flex_baseline__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_layout_flex_baseline__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_paint_block_contains_floats__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_paint_block_contains_floats__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_paint_block_contains_floats__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_paint_block_contains_floats__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_paint_block_contains_floats__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_paint_block_contains_floats__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_paint_block_contains_floats__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_paint_block_contains_floats__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_paint_block_margin_collapse__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_paint_block_margin_collapse__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_paint_block_margin_collapse__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_paint_block_margin_collapse__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_paint_block_margin_collapse__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_paint_block_margin_collapse__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_paint_block_margin_collapse__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_paint_block_margin_collapse__content_box_rtl");
+    }
+
+    #[test]
+    fn contain_paint_flex_baseline__border_box_ltr() {
+        crate::run_xml_test("contain", "contain_paint_flex_baseline__border_box_ltr");
+    }
+
+    #[test]
+    fn contain_paint_flex_baseline__content_box_ltr() {
+        crate::run_xml_test("contain", "contain_paint_flex_baseline__content_box_ltr");
+    }
+
+    #[test]
+    fn contain_paint_flex_baseline__border_box_rtl() {
+        crate::run_xml_test("contain", "contain_paint_flex_baseline__border_box_rtl");
+    }
+
+    #[test]
+    fn contain_paint_flex_baseline__content_box_rtl() {
+        crate::run_xml_test("contain", "contain_paint_flex_baseline__content_box_rtl");
+    }
+}
+
 mod flex {
     #[test]
     fn absolute_aspect_ratio_aspect_ratio_overrides_height_of_full_inset__border_box_ltr() {


### PR DESCRIPTION
# Objective

Add a `contain` style to Taffy with `layout` and `paint` flags, and implement their layout effects. Based on the previously-reverted #1106, but with all size / inline-size containment stripped out.

New style API:

```rust
pub struct Contain(u8); // bitflags: NONE, LAYOUT, PAINT, CONTENT (= LAYOUT | PAINT)

pub struct Style { pub contain: Contain, ... }

pub trait CoreStyle {
    fn contain(&self) -> Contain { Contain::NONE } // defaulted
}
```

Implemented effects (both `layout` and `paint`, since both force an independent formatting context):

- Block: a contained box establishes a new BFC — margins don't collapse with its children, it contains its own floats, and it avoids external floats
- Overflow: a contained box's overflowing content no longer contributes to its ancestors' scrollable overflow regions (layout containment treats it as ink overflow; paint containment clips it). The box's own `scrollable_overflow_rect` still includes it
- `layout` only: the box's baseline is suppressed for baseline-alignment purposes in block, flexbox and grid containers (a synthesized border-box baseline is used where one is required)

CSS parsing (`parse` feature) accepts `none | content | [ layout || style || paint ]`; `style` is accepted and ignored (no layout effect); `strict` / `size` / `inline-size` are rejected as size containment is not implemented.

Also fixes a preexisting block/float bug this work surfaced: overflowing in-flow content of a nested block no longer contributes to the height of its BFC root as if it were floated content (`float_content_contribution` now starts at `NEG_INFINITY` instead of the content edge).

CHANGELOG.md is updated under Added/Fixed.

## Context

- Inspiration commit (reverted): DioxusLabs/taffy@20f04b9f7ebe37e5d661e3fb82e1bd4d9ca37147 / #1106
- Gentest support added (`contain` attribute in fixtures/helper/xml runner) with new generated fixtures under `test_fixtures/contain/` covering margin collapsing, float containment/avoidance, `contain: content`, and flex baseline suppression for both `layout` and `paint`
- A companion Blitz PR wires up `contain: layout` / `contain: paint` from Stylo (link to follow)

## Feedback wanted

- Whether `Contain` as a minimal hand-rolled bitflags type (rather than a `bitflags!` dependency or an enum) is the preferred representation
- The scrollable-overflow semantics: both containment types stop propagation to ancestors but keep the box's own `scrollable_overflow_rect` unclipped — for `paint` a consumer may additionally want to clip when painting

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/c903534a83f54a6daf2f68f4cc38cf72
Requested by: @nicoburns