### PR TITLE
DetailedGridInfo: replace gutters/sizes with per-track positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 
 ### Changed
 
+- `DetailedGridTracksInfo` (behind the `detailed_layout_info` feature) now exposes a single `positions: Vec<Line<f32>>` field containing the start and end position of each track relative to the grid container's border box, replacing the previous `gutters` and `sizes` fields. Unlike the previous fields, these positions account for content alignment (`align-content`/`justify-content`). Collapsed tracks are included as zero-width entries, so indices remain 1:1 with track numbers. Track sizes and gutters can be derived from the positions (`size = end - start`; gutter = distance between adjacent tracks)
+
 - Flexbox/Block: absolutely positioned children are no longer measured when both of their dimensions are already known (e.g. from explicit sizes or insets), matching the existing grid behaviour
 
 ### Fixed

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -902,34 +902,21 @@ pub struct DetailedGridTracksInfo {
     /// Number of trailing implicit grid tracks
     pub positive_implicit_tracks: u16,
 
-    /// Gutters between tracks
-    pub gutters: Vec<f32>,
-    /// The used size of the tracks
-    pub sizes: Vec<f32>,
+    /// The start and end position of each track relative to the grid container's border box.
+    /// These positions account for the container's border and padding, the `gap` property,
+    /// content alignment (`align-content`/`justify-content`), and collapsed tracks.
+    pub positions: Vec<Line<f32>>,
 }
 
 #[cfg(feature = "detailed_layout_info")]
 impl DetailedGridTracksInfo {
-    /// Get the base_size of [`GridTrack`] with a kind [`types::GridTrackKind`]
-    #[inline(always)]
-    fn grid_track_base_size_of_kind(grid_tracks: &[GridTrack], kind: GridTrackKind) -> Vec<f32> {
+    /// Get the start and end position of each track relative to the grid container's border box
+    fn positions_from_grid_track_layout(grid_tracks: &[GridTrack]) -> Vec<Line<f32>> {
         grid_tracks
             .iter()
-            .filter_map(|track| match track.kind == kind {
-                true => Some(track.base_size),
-                false => None,
-            })
+            .filter(|track| track.kind == GridTrackKind::Track)
+            .map(|track| Line { start: track.offset, end: track.offset + track.base_size })
             .collect()
-    }
-
-    /// Get the sizes of the gutters
-    fn gutters_from_grid_track_layout(grid_tracks: &[GridTrack]) -> Vec<f32> {
-        DetailedGridTracksInfo::grid_track_base_size_of_kind(grid_tracks, GridTrackKind::Gutter)
-    }
-
-    /// Get the sizes of the tracks
-    fn sizes_from_grid_track_layout(grid_tracks: &[GridTrack]) -> Vec<f32> {
-        DetailedGridTracksInfo::grid_track_base_size_of_kind(grid_tracks, GridTrackKind::Track)
     }
 
     /// Construct DetailedGridTracksInfo from TrackCounts and GridTracks
@@ -938,8 +925,7 @@ impl DetailedGridTracksInfo {
             negative_implicit_tracks: track_count.negative_implicit,
             explicit_tracks: track_count.explicit,
             positive_implicit_tracks: track_count.positive_implicit,
-            gutters: DetailedGridTracksInfo::gutters_from_grid_track_layout(&grid_tracks),
-            sizes: DetailedGridTracksInfo::sizes_from_grid_track_layout(&grid_tracks),
+            positions: DetailedGridTracksInfo::positions_from_grid_track_layout(&grid_tracks),
         }
     }
 }


### PR DESCRIPTION
# Objective

`DetailedGridTracksInfo` previously exposed `gutters: Vec<f32>` and `sizes: Vec<f32>` containing raw track/gutter base sizes. These did not account for content alignment (`align-content`/`justify-content`): alignment distribution is applied via per-track offsets, not gutter sizes, so reconstructing track positions by summing `sizes` + `gutters` misplaced tracks whenever there was free space (e.g. `space-between`, `center`).

This PR replaces both fields with a single `positions: Vec<Line<f32>>`:

```rust
pub struct DetailedGridTracksInfo {
    pub negative_implicit_tracks: u16,
    pub explicit_tracks: u16,
    pub positive_implicit_tracks: u16,
    /// The start and end position of each track relative to the
    /// grid container's border box
    pub positions: Vec<Line<f32>>,
}
```

Each entry is `Line { start: track.offset, end: track.offset + track.base_size }`, captured after alignment/final positioning, so positions account for border/padding, `gap`, content alignment, RTL mirroring, and auto-fit track collapsing. Collapsed tracks are included as zero-width entries, so indices remain 1:1 with track numbers and the 1-indexed line numbers in `DetailedGridItemsInfo` stay valid. Sizes and gutters remain derivable (`size = end - start`; gutter = next track's `start` minus previous track's `end`). Memory usage is unchanged (one Vec of 2n floats instead of two Vecs totalling 2n+1 floats).

## Context

Follows discussion about whether `DetailedGridInfo` gutters should be adjusted by content alignment. Changelog entry added under "Changed" in CHANGELOG.md (this repo's release notes file).


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/5815c8cd4de24c1eafec49021786ea4b
Requested by: @nicoburns