### PR TITLE
DetailedGridInfo: add `item_grid_area` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 
   The CSS parser (`parse` feature) accepts `none | content | [ layout || style || paint ]` for the `contain` property: `content` maps to `LAYOUT | PAINT`, and the `style` keyword is accepted but ignored as it does not affect layout. The `strict`, `size` and `inline-size` values are not supported as size containment is not implemented
 
-- `DetailedGridInfo` (behind the `detailed_layout_info` feature) gains an `item_grid_area(item_index)` method returning the rectangle (`Rect<f32>`) of the grid area occupied by an item, relative to the grid container's border box
+- `DetailedGridInfo` (behind the `detailed_layout_info` feature) gains an `item_grid_area(item_index)` method returning the location and size (`(Point<f32>, Size<f32>)`) of the grid area occupied by an item, relative to the grid container's border box
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 
   The CSS parser (`parse` feature) accepts `none | content | [ layout || style || paint ]` for the `contain` property: `content` maps to `LAYOUT | PAINT`, and the `style` keyword is accepted but ignored as it does not affect layout. The `strict`, `size` and `inline-size` values are not supported as size containment is not implemented
 
+- `DetailedGridInfo` (behind the `detailed_layout_info` feature) gains an `item_grid_area(item_index)` method returning the rectangle (`Rect<f32>`) of the grid area occupied by an item, relative to the grid container's border box
+
 ### Changed
 
 - `DetailedGridTracksInfo` (behind the `detailed_layout_info` feature) now exposes a single `positions: Vec<Line<f32>>` field containing the start and end position of each track relative to the grid container's border box, replacing the previous `gutters` and `sizes` fields. Unlike the previous fields, these positions account for content alignment (`align-content`/`justify-content`). Collapsed tracks are included as zero-width entries, so indices remain 1:1 with track numbers. Track sizes and gutters can be derived from the positions (`size = end - start`; gutter = distance between adjacent tracks)

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -1,7 +1,7 @@
 //! This module is a partial implementation of the CSS Grid Level 1 specification
 //! <https://www.w3.org/TR/css-grid-1>
 use crate::geometry::{AbsoluteAxis, AbstractAxis, InBothAbsAxis};
-use crate::geometry::{Line, Rect, Size};
+use crate::geometry::{Line, Point, Rect, Size};
 use crate::style::{AlignItems, AvailableSpace, Overflow, Position};
 use crate::tree::{Baselines, Layout, LayoutInput, LayoutOutput, LayoutPartialTreeExt, NodeId, RunMode, SizingMode};
 use crate::util::debug::debug_log;
@@ -893,23 +893,21 @@ pub struct DetailedGridInfo {
 
 #[cfg(feature = "detailed_layout_info")]
 impl DetailedGridInfo {
-    /// Compute the rectangle of the grid area occupied by the item at `item_index` (an index
-    /// into [`DetailedGridInfo::items`]), relative to the grid container's border box.
+    /// Compute the location and size of the grid area occupied by the item at `item_index` (an
+    /// index into [`DetailedGridInfo::items`]), relative to the grid container's border box.
     ///
     /// The edges resolve to the edges of the tracks bounding the item's grid area (a start line
     /// resolves to the start of the track that follows it and an end line to the end of the track
-    /// that precedes it), so the rectangle excludes any gutter or content-alignment spacing
-    /// around the area.
+    /// that precedes it), so the area excludes any gutter or content-alignment spacing around it.
     ///
     /// Returns `None` if `item_index` is out of bounds.
-    pub fn item_grid_area(&self, item_index: usize) -> Option<Rect<f32>> {
+    pub fn item_grid_area(&self, item_index: usize) -> Option<(Point<f32>, Size<f32>)> {
         let item = self.items.get(item_index)?;
-        Some(Rect {
-            left: self.columns.positions[item.column_start as usize - 1].start,
-            right: self.columns.positions[item.column_end as usize - 2].end,
-            top: self.rows.positions[item.row_start as usize - 1].start,
-            bottom: self.rows.positions[item.row_end as usize - 2].end,
-        })
+        let left = self.columns.positions[item.column_start as usize - 1].start;
+        let right = self.columns.positions[item.column_end as usize - 2].end;
+        let top = self.rows.positions[item.row_start as usize - 1].start;
+        let bottom = self.rows.positions[item.row_end as usize - 2].end;
+        Some((Point { x: left, y: top }, Size { width: right - left, height: bottom - top }))
     }
 }
 

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -891,6 +891,28 @@ pub struct DetailedGridInfo {
     pub items: Vec<DetailedGridItemsInfo>,
 }
 
+#[cfg(feature = "detailed_layout_info")]
+impl DetailedGridInfo {
+    /// Compute the rectangle of the grid area occupied by the item at `item_index` (an index
+    /// into [`DetailedGridInfo::items`]), relative to the grid container's border box.
+    ///
+    /// The edges resolve to the edges of the tracks bounding the item's grid area (a start line
+    /// resolves to the start of the track that follows it and an end line to the end of the track
+    /// that precedes it), so the rectangle excludes any gutter or content-alignment spacing
+    /// around the area.
+    ///
+    /// Returns `None` if `item_index` is out of bounds.
+    pub fn item_grid_area(&self, item_index: usize) -> Option<Rect<f32>> {
+        let item = self.items.get(item_index)?;
+        Some(Rect {
+            left: self.columns.positions[item.column_start as usize - 1].start,
+            right: self.columns.positions[item.column_end as usize - 2].end,
+            top: self.rows.positions[item.row_start as usize - 1].start,
+            bottom: self.rows.positions[item.row_end as usize - 2].end,
+        })
+    }
+}
+
 /// Information from the computation of grids tracks
 #[derive(Debug, Clone, PartialEq)]
 #[cfg(feature = "detailed_layout_info")]

--- a/tests/hand_written.rs
+++ b/tests/hand_written.rs
@@ -4,6 +4,7 @@ mod hand_written {
     mod block_replaced;
     mod border_and_padding;
     mod caching;
+    mod detailed_grid_info;
     #[cfg(feature = "flexbox_balance")]
     mod flex_line_count;
     mod floats;

--- a/tests/hand_written/detailed_grid_info.rs
+++ b/tests/hand_written/detailed_grid_info.rs
@@ -1,0 +1,48 @@
+#[cfg(all(feature = "detailed_layout_info", feature = "grid"))]
+mod detailed_grid_info {
+    use taffy::prelude::*;
+    use taffy::{DetailedGridInfo, DetailedLayoutInfo, Rect};
+
+    fn detailed_grid_info(tree: &TaffyTree, node: NodeId) -> &DetailedGridInfo {
+        match tree.detailed_layout_info(node) {
+            DetailedLayoutInfo::Grid(info) => info,
+            _ => panic!("expected detailed grid info"),
+        }
+    }
+
+    #[test]
+    fn item_grid_area() {
+        let mut tree: TaffyTree<()> = TaffyTree::new();
+        let child_a = tree.new_leaf(Style::default()).unwrap();
+        let child_b = tree
+            .new_leaf(Style {
+                grid_row: line(2),
+                grid_column: Line { start: line(1), end: line(3) },
+                ..Default::default()
+            })
+            .unwrap();
+        let container = tree
+            .new_with_children(
+                Style {
+                    display: Display::Grid,
+                    grid_template_columns: vec![length(40.0), length(60.0)],
+                    grid_template_rows: vec![length(50.0), length(30.0)],
+                    gap: length(10.0),
+                    padding: Rect { left: length(5.0), right: length(5.0), top: length(5.0), bottom: length(5.0) },
+                    ..Default::default()
+                },
+                &[child_a, child_b],
+            )
+            .unwrap();
+
+        tree.compute_layout(container, Size::MAX_CONTENT).unwrap();
+        let info = detailed_grid_info(&tree, container);
+
+        // child_a is auto-placed into row 1 / column 1
+        assert_eq!(info.item_grid_area(0), Some(Rect { left: 5.0, right: 45.0, top: 5.0, bottom: 55.0 }));
+        // child_b spans both columns in row 2
+        assert_eq!(info.item_grid_area(1), Some(Rect { left: 5.0, right: 115.0, top: 65.0, bottom: 95.0 }));
+        // out of bounds index
+        assert_eq!(info.item_grid_area(2), None);
+    }
+}

--- a/tests/hand_written/detailed_grid_info.rs
+++ b/tests/hand_written/detailed_grid_info.rs
@@ -1,7 +1,7 @@
 #[cfg(all(feature = "detailed_layout_info", feature = "grid"))]
 mod detailed_grid_info {
     use taffy::prelude::*;
-    use taffy::{DetailedGridInfo, DetailedLayoutInfo, Rect};
+    use taffy::{DetailedGridInfo, DetailedLayoutInfo, Point, Rect};
 
     fn detailed_grid_info(tree: &TaffyTree, node: NodeId) -> &DetailedGridInfo {
         match tree.detailed_layout_info(node) {
@@ -39,9 +39,9 @@ mod detailed_grid_info {
         let info = detailed_grid_info(&tree, container);
 
         // child_a is auto-placed into row 1 / column 1
-        assert_eq!(info.item_grid_area(0), Some(Rect { left: 5.0, right: 45.0, top: 5.0, bottom: 55.0 }));
+        assert_eq!(info.item_grid_area(0), Some((Point { x: 5.0, y: 5.0 }, Size { width: 40.0, height: 50.0 })));
         // child_b spans both columns in row 2
-        assert_eq!(info.item_grid_area(1), Some(Rect { left: 5.0, right: 115.0, top: 65.0, bottom: 95.0 }));
+        assert_eq!(info.item_grid_area(1), Some((Point { x: 5.0, y: 65.0 }, Size { width: 110.0, height: 30.0 })));
         // out of bounds index
         assert_eq!(info.item_grid_area(2), None);
     }


### PR DESCRIPTION
# Objective

Add a convenience method to `DetailedGridInfo` (behind the `detailed_layout_info` feature) that returns the location and size of the grid area occupied by an item, given its index into `items`:

```rust
pub fn item_grid_area(&self, item_index: usize) -> Option<(Point<f32>, Size<f32>)>
```

The location is relative to the grid container's border box, derived from the item's 1-indexed bounding grid lines and the per-track `positions` added in #1131:

```rust
left   = columns.positions[column_start - 1].start
right  = columns.positions[column_end - 2].end
top    = rows.positions[row_start - 1].start
bottom = rows.positions[row_end - 2].end
// -> (Point { x: left, y: top }, Size { width: right - left, height: bottom - top })
```

i.e. each edge resolves to the edge of the bounding track, so the area excludes gutters and content-alignment spacing around it. Returns `None` for an out-of-bounds index.

## Context

Follow-up to #1131 (per-track positions in detailed grid info). Changelog entry added under Unreleased (this repo uses `CHANGELOG.md`; there is no `RELEASES.md`).


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/5815c8cd4de24c1eafec49021786ea4b
Requested by: @nicoburns