### PR TITLE
Grid: keep internal representation in logical order for RTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
 
 - `DetailedGridTracksInfo` (behind the `detailed_layout_info` feature) now exposes a single `positions: Vec<Line<f32>>` field containing the start and end position of each track relative to the grid container's border box, replacing the previous `gutters` and `sizes` fields. Unlike the previous fields, these positions account for content alignment (`align-content`/`justify-content`). Collapsed tracks are included as zero-width entries, so indices remain 1:1 with track numbers. Track sizes and gutters can be derived from the positions (`size = end - start`; gutter = distance between adjacent tracks)
 
+- Grid: for `direction: rtl` grid containers, all internal grid data structures and the `detailed_layout_info` output (`DetailedGridInfo`) are now in *logical* order (line 1 = inline-start = the right-hand side in RTL), matching LTR. Previously RTL grids were internally mirrored into visual order, so `DetailedGridTracksInfo` column track positions and `DetailedGridItemsInfo` column line numbers were reported in visual (left-to-right) order. RTL is now applied purely when assigning physical geometry, and the rendered layout is unchanged
+
 - Flexbox/Block: absolutely positioned children are no longer measured when both of their dimensions are already known (e.g. from explicit sizes or insets), matching the existing grid behaviour
 
 ### Fixed

--- a/src/compute/grid/alignment.rs
+++ b/src/compute/grid/alignment.rs
@@ -51,10 +51,11 @@ pub(super) fn align_tracks(
         0.0
     };
 
-    // Compute offsets
+    // Compute offsets. Tracks are stored in logical order; when the axis is reversed (RTL)
+    // physical offsets are assigned right-to-left by iterating the tracks in reverse.
     let mut total_offset = origin + empty_grid_offset;
     let mut seen_non_collapsed_track = false;
-    tracks.iter_mut().enumerate().for_each(|(i, track)| {
+    let mut position_track = |i: usize, track: &mut GridTrack| {
         // Odd tracks are gutters (but slices are zero-indexed, so odd tracks have even indices)
         let is_gutter = i % 2 == 0;
         let is_non_collapsed_track = !is_gutter && !track.is_collapsed;
@@ -73,7 +74,12 @@ pub(super) fn align_tracks(
         if is_non_collapsed_track {
             seen_non_collapsed_track = true;
         }
-    });
+    };
+    if axis_is_reversed {
+        tracks.iter_mut().rev().enumerate().for_each(|(i, track)| position_track(i, track));
+    } else {
+        tracks.iter_mut().enumerate().for_each(|(i, track)| position_track(i, track));
+    }
 }
 
 /// Align and size a grid item into it's final position

--- a/src/compute/grid/implicit_grid.rs
+++ b/src/compute/grid/implicit_grid.rs
@@ -2,7 +2,7 @@
 //! to reduce the number of allocations required when creating a grid.
 use crate::geometry::Line;
 use crate::style::{GenericGridPlacement, GridPlacement};
-use crate::{CheapCloneStr, Direction, GridItemStyle};
+use crate::{CheapCloneStr, GridItemStyle};
 use core::cmp::{max, min};
 
 use super::types::TrackCounts;
@@ -19,13 +19,12 @@ use super::{OriginZeroLine, MAX_OZ_LINE, MIN_OZ_LINE};
 pub(crate) fn compute_grid_size_estimate<'a, S: GridItemStyle + 'a>(
     explicit_col_count: u16,
     explicit_row_count: u16,
-    direction: Direction,
     child_styles_iter: impl Iterator<Item = S>,
 ) -> (TrackCounts, TrackCounts) {
     // Iterate over children, producing an estimate of the min and max grid lines (in origin-zero coordinates where)
     // along with the span of each item
     let (col_min, col_max, col_max_span, row_min, row_max, row_max_span) =
-        get_known_child_positions(child_styles_iter, explicit_col_count, explicit_row_count, direction);
+        get_known_child_positions(child_styles_iter, explicit_col_count, explicit_row_count);
 
     // Compute *track* count estimates for each axis from:
     //   - The explicit track counts
@@ -66,7 +65,6 @@ fn get_known_child_positions<'a, S: GridItemStyle + 'a>(
     children_iter: impl Iterator<Item = S>,
     explicit_col_count: u16,
     explicit_row_count: u16,
-    direction: Direction,
 ) -> (OriginZeroLine, OriginZeroLine, u16, OriginZeroLine, OriginZeroLine, u16) {
     let (mut col_min, mut col_max, mut col_max_span) = (OriginZeroLine(0), OriginZeroLine(0), 0);
     let (mut row_min, mut row_max, mut row_max_span) = (OriginZeroLine(0), OriginZeroLine(0), 0);
@@ -76,20 +74,10 @@ fn get_known_child_positions<'a, S: GridItemStyle + 'a>(
 
         // Note: that the children reference the lines in between (and around) the tracks not tracks themselves,
         // and thus we must subtract 1 to get an accurate estimate of the number of tracks
-        let (mut child_col_min, mut child_col_max, child_col_span) =
+        let (child_col_min, child_col_max, child_col_span) =
             child_min_line_max_line_span::<S::CustomIdent>(col_line, explicit_col_count);
         let (child_row_min, child_row_max, child_row_span) =
             child_min_line_max_line_span::<S::CustomIdent>(row_line, explicit_row_count);
-
-        // Placement mirrors horizontal spans in RTL, so mirror known column line bounds here
-        // to keep implicit-grid pre-sizing consistent with actual placement.
-        if direction.is_rtl() && (child_col_min != OriginZeroLine(0) || child_col_max != OriginZeroLine(0)) {
-            let explicit_col_end_line = explicit_col_count as i16;
-            let mirrored_min = OriginZeroLine(explicit_col_end_line - child_col_max.0);
-            let mirrored_max = OriginZeroLine(explicit_col_end_line - child_col_min.0);
-            child_col_min = mirrored_min;
-            child_col_max = mirrored_max;
-        }
 
         col_min = min(col_min, child_col_min);
         col_max = max(col_max, child_col_max);
@@ -218,7 +206,6 @@ mod tests {
         use super::super::compute_grid_size_estimate;
         use crate::compute::grid::util::test_helpers::*;
         use crate::style_helpers::*;
-        use crate::Direction;
 
         #[test]
         fn explicit_grid_sizing_with_children() {
@@ -229,7 +216,7 @@ mod tests {
                 (line(-4), auto(), line(-2), auto()).into_grid_child(),
             ];
             let (inline, block) =
-                compute_grid_size_estimate(explicit_col_count, explicit_row_count, Direction::Ltr, child_styles.iter());
+                compute_grid_size_estimate(explicit_col_count, explicit_row_count, child_styles.iter());
             assert_eq!(inline.negative_implicit, 0);
             assert_eq!(inline.explicit, explicit_col_count);
             assert_eq!(inline.positive_implicit, 0);
@@ -247,7 +234,7 @@ mod tests {
                 (line(4), auto(), line(3), auto()).into_grid_child(),
             ];
             let (inline, block) =
-                compute_grid_size_estimate(explicit_col_count, explicit_row_count, Direction::Ltr, child_styles.iter());
+                compute_grid_size_estimate(explicit_col_count, explicit_row_count, child_styles.iter());
             assert_eq!(inline.negative_implicit, 1);
             assert_eq!(inline.explicit, explicit_col_count);
             assert_eq!(inline.positive_implicit, 0);

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -699,7 +699,17 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
             // the track that precedes it.
             /// Resolve a grid line used as an inline-start edge to a physical right x-position (RTL)
             fn rtl_line_as_start_edge(tracks: &[GridTrack], index: usize) -> f32 {
-                tracks[index].offset
+                if tracks.len() > index + 1 {
+                    // The gutter's offset is the physical right edge of the track that follows the line
+                    tracks[index].offset
+                } else if index == 0 {
+                    tracks[0].offset
+                } else {
+                    // No track follows the line: resolve to the line itself, which is the physical
+                    // left edge of the track that precedes it (the trailing gutter is assigned its
+                    // offset before any alignment offset is applied, so it cannot be used here)
+                    tracks[index - 1].offset
+                }
             }
             /// Resolve a grid line used as an inline-end edge to a physical left x-position (RTL)
             fn rtl_line_as_end_edge(tracks: &[GridTrack], index: usize) -> f32 {

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -875,8 +875,10 @@ impl DetailedGridInfo {
     /// Returns `None` if `item_index` is out of bounds.
     pub fn item_grid_area(&self, item_index: usize) -> Option<(Point<f32>, Size<f32>)> {
         let item = self.items.get(item_index)?;
-        let left = self.columns.positions[item.column_start as usize - 1].start;
-        let right = self.columns.positions[item.column_end as usize - 2].end;
+        let start_col = self.columns.positions[item.column_start as usize - 1];
+        let end_col = self.columns.positions[item.column_end as usize - 2];
+        let left = f32_min(start_col.start, end_col.start);
+        let right = f32_max(start_col.end, end_col.end);
         let top = self.rows.positions[item.row_start as usize - 1].start;
         let bottom = self.rows.positions[item.row_end as usize - 2].end;
         Some((Point { x: left, y: top }, Size { width: right - left, height: bottom - top }))

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -19,10 +19,10 @@ use placement::place_grid_items;
 use track_sizing::{
     determine_if_item_crosses_flexible_or_intrinsic_tracks, resolve_item_track_indexes, track_sizing_algorithm,
 };
-use types::{CellOccupancyMatrix, GridTrack, NamedLineResolver, TrackCounts};
+use types::{CellOccupancyMatrix, GridTrack, NamedLineResolver};
 
 #[cfg(feature = "detailed_layout_info")]
-use types::{GridItem, GridTrackKind};
+use types::{GridItem, GridTrackKind, TrackCounts};
 
 pub(crate) use types::{GridCoordinate, GridLine, OriginZeroLine, MAX_GRID_TRACKS, MAX_OZ_LINE, MIN_OZ_LINE};
 
@@ -223,7 +223,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
     // Estimate the number of rows and columns in the implicit grid (= the entire grid)
     // This is necessary as part of placement. Doing it early here is a perf optimisation to reduce allocations.
     let (est_col_counts, est_row_counts) =
-        compute_grid_size_estimate(explicit_col_count, explicit_row_count, direction, child_styles_iter);
+        compute_grid_size_estimate(explicit_col_count, explicit_row_count, child_styles_iter);
 
     // 4. Grid Item Placement
     // Match items (children) to a definite grid position (row start/end and column start/end position)
@@ -241,7 +241,6 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
         &mut cell_occupancy_matrix,
         &mut items,
         in_flow_children_iter,
-        direction,
         style.grid_auto_flow(),
         align_items.unwrap_or(AlignItems::STRETCH),
         justify_items.unwrap_or(AlignItems::STRETCH),
@@ -257,25 +256,13 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
     // This resolves the min and max track sizing functions for all tracks and gutters
     let mut columns = GridTrackVec::new();
     let mut rows = GridTrackVec::new();
-    let mut column_track_counts_for_init = final_col_counts;
-    if direction.is_rtl() && final_col_counts.explicit <= 1 {
-        column_track_counts_for_init.negative_implicit = final_col_counts.positive_implicit;
-        column_track_counts_for_init.positive_implicit = final_col_counts.negative_implicit;
-    }
     initialize_grid_tracks(
         &mut columns,
-        column_track_counts_for_init,
+        final_col_counts,
         &style,
         AbsoluteAxis::Horizontal,
         col_auto_repetition_count,
-        |column_index| {
-            let occupancy_index = if direction.is_rtl() {
-                rtl_column_occupancy_index_for_initialization(column_index, final_col_counts)
-            } else {
-                column_index
-            };
-            cell_occupancy_matrix.column_is_occupied(occupancy_index)
-        },
+        |column_index| cell_occupancy_matrix.column_is_occupied(column_index),
     );
     initialize_grid_tracks(
         &mut rows,
@@ -285,9 +272,6 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
         row_auto_repetition_count,
         |row_index| cell_occupancy_matrix.row_is_occupied(row_index),
     );
-    if direction.is_rtl() {
-        reverse_non_gutter_tracks(&mut columns, final_col_counts);
-    }
 
     drop(grid_template_rows);
     drop(grid_template_columns);
@@ -608,11 +592,22 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
 
     // Position in-flow children (stored in items vector)
     for (index, item) in items.iter_mut().enumerate() {
+        // Tracks are stored in logical order. In RTL the physical offsets are assigned
+        // right-to-left, so an item's physical left edge is derived from its logical end
+        // line and its physical right edge from its logical start line.
         let grid_area = Rect {
             top: rows[item.row_indexes.start as usize + 1].offset,
             bottom: rows[item.row_indexes.end as usize].offset,
-            left: columns[item.column_indexes.start as usize + 1].offset,
-            right: columns[item.column_indexes.end as usize].offset,
+            left: if direction.is_rtl() {
+                columns[item.column_indexes.end as usize - 1].offset
+            } else {
+                columns[item.column_indexes.start as usize + 1].offset
+            },
+            right: if direction.is_rtl() {
+                columns[item.column_indexes.start as usize].offset
+            } else {
+                columns[item.column_indexes.end as usize].offset
+            },
         };
         #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
         let (overflow_contribution, y_position, height) = align_and_position_item(
@@ -668,21 +663,8 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
                 .into_origin_zero(final_col_counts.explicit)
                 .resolve_absolutely_positioned_grid_tracks()
                 .map(|maybe_grid_line| {
-                    maybe_grid_line
-                        .map(|line: OriginZeroLine| {
-                            if direction.is_rtl() {
-                                OriginZeroLine(final_col_counts.explicit as i16 - line.0)
-                            } else {
-                                line
-                            }
-                        })
-                        .and_then(|line| line.try_into_track_vec_index(final_col_counts))
+                    maybe_grid_line.and_then(|line: OriginZeroLine| line.try_into_track_vec_index(final_col_counts))
                 });
-            let maybe_col_indexes = if direction.is_rtl() {
-                Line { start: maybe_col_indexes.end, end: maybe_col_indexes.start }
-            } else {
-                maybe_col_indexes
-            };
             // Convert grid-row-{start/end} into Option's of indexes into the row vector
             // The Option is None if the style property is Auto and an unresolvable Span
             let maybe_row_indexes = name_resolver
@@ -710,6 +692,46 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
                     tracks[index].offset
                 }
             }
+            // In RTL, tracks remain in logical order but physical offsets are assigned
+            // right-to-left: a line used as an inline-start edge resolves to the physical
+            // *right* edge of the track that follows it (its gutter's offset), and a line
+            // used as an inline-end edge resolves to the physical *left* edge (offset) of
+            // the track that precedes it.
+            /// Resolve a grid line used as an inline-start edge to a physical right x-position (RTL)
+            fn rtl_line_as_start_edge(tracks: &[GridTrack], index: usize) -> f32 {
+                tracks[index].offset
+            }
+            /// Resolve a grid line used as an inline-end edge to a physical left x-position (RTL)
+            fn rtl_line_as_end_edge(tracks: &[GridTrack], index: usize) -> f32 {
+                if index == 0 {
+                    tracks[0].offset
+                } else {
+                    tracks[index - 1].offset
+                }
+            }
+
+            // In RTL the item's physical left edge derives from its logical end line and its
+            // physical right edge from its logical start line.
+            let (grid_area_left, grid_area_right) = if direction.is_rtl() {
+                (
+                    maybe_col_indexes
+                        .end
+                        .map(|index| rtl_line_as_end_edge(&columns, index))
+                        .unwrap_or(border.left + scrollbar_gutter.x),
+                    maybe_col_indexes
+                        .start
+                        .map(|index| rtl_line_as_start_edge(&columns, index))
+                        .unwrap_or(container_border_box.width - border.right),
+                )
+            } else {
+                (
+                    maybe_col_indexes.start.map(|index| line_as_start_edge(&columns, index)).unwrap_or(border.left),
+                    maybe_col_indexes
+                        .end
+                        .map(|index| line_as_end_edge(&columns, index))
+                        .unwrap_or(container_border_box.width - border.right - scrollbar_gutter.x),
+                )
+            };
 
             let grid_area = Rect {
                 top: maybe_row_indexes.start.map(|index| line_as_start_edge(&rows, index)).unwrap_or(border.top),
@@ -717,20 +739,8 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
                     .end
                     .map(|index| line_as_end_edge(&rows, index))
                     .unwrap_or(container_border_box.height - border.bottom - scrollbar_gutter.y),
-                left: maybe_col_indexes.start.map(|index| line_as_start_edge(&columns, index)).unwrap_or_else(|| {
-                    if direction.is_rtl() {
-                        border.left + scrollbar_gutter.x
-                    } else {
-                        border.left
-                    }
-                }),
-                right: maybe_col_indexes.end.map(|index| line_as_end_edge(&columns, index)).unwrap_or_else(|| {
-                    if direction.is_rtl() {
-                        container_border_box.width - border.right
-                    } else {
-                        container_border_box.width - border.right - scrollbar_gutter.x
-                    }
-                }),
+                left: grid_area_left,
+                right: grid_area_right,
             };
             drop(child_style);
 
@@ -829,54 +839,6 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
         scrollable_overflow_rect,
         Baselines::from_first(grid_container_baseline),
     )
-}
-
-/// Reverses only non-gutter column tracks in-place while preserving line/gutter slots.
-fn reverse_non_gutter_tracks(tracks: &mut [GridTrack], track_counts: TrackCounts) {
-    // When the explicit grid has 0/1 tracks, visual RTL mirroring is entirely determined by implicit tracks.
-    // Reverse all non-gutter tracks in that case.
-    if track_counts.explicit <= 1 {
-        const MIN_TRACK_VEC_LEN_TO_REVERSE_COLUMNS: usize = 5;
-        if tracks.len() < MIN_TRACK_VEC_LEN_TO_REVERSE_COLUMNS {
-            return;
-        }
-        let mut left = 1;
-        let mut right = tracks.len() - 2;
-        while left < right {
-            tracks.swap(left, right);
-            left += 2;
-            right = right.saturating_sub(2);
-        }
-        return;
-    }
-
-    let explicit_track_count = track_counts.explicit as usize;
-    if explicit_track_count < 2 {
-        return;
-    }
-
-    let mut left = track_counts.negative_implicit as usize;
-    let mut right = left + explicit_track_count - 1;
-    while left < right {
-        tracks.swap((2 * left) + 1, (2 * right) + 1);
-        left += 1;
-        right = right.saturating_sub(1);
-    }
-}
-
-/// Maps initialized column indexes to occupancy-matrix indexes for auto-fit collapsing in RTL.
-fn rtl_column_occupancy_index_for_initialization(column_index: usize, track_counts: TrackCounts) -> usize {
-    if track_counts.explicit <= 1 {
-        return track_counts.len() - column_index - 1;
-    }
-
-    let explicit_start = track_counts.negative_implicit as usize;
-    let explicit_end = explicit_start + track_counts.explicit as usize;
-    if (explicit_start..explicit_end).contains(&column_index) {
-        explicit_start + (explicit_end - column_index - 1)
-    } else {
-        column_index
-    }
 }
 
 /// Information from the computation of grid

--- a/src/compute/grid/placement.rs
+++ b/src/compute/grid/placement.rs
@@ -7,76 +7,21 @@ use crate::geometry::{AbsoluteAxis, InBothAbsAxis};
 use crate::style::{AlignItems, GridAutoFlow, OriginZeroGridPlacement};
 use crate::tree::NodeId;
 use crate::util::sys::Vec;
-use crate::{CoreStyle, Direction, GridItemStyle};
+use crate::{CoreStyle, GridItemStyle};
 
 #[inline]
-/// Returns whether placement/search should run in reverse for this axis.
-fn axis_is_reversed(direction: Direction, axis: AbsoluteAxis) -> bool {
-    direction.is_rtl() && axis == AbsoluteAxis::Horizontal
+/// Advances the cursor by one track.
+fn advance_position(position: OriginZeroLine) -> OriginZeroLine {
+    OriginZeroLine(position.0.saturating_add(1))
 }
 
 #[inline]
-/// Advances the cursor by one track in the active search direction.
-fn advance_position(position: OriginZeroLine, axis_is_reversed: bool) -> OriginZeroLine {
-    if axis_is_reversed {
-        OriginZeroLine(position.0.saturating_sub(1))
-    } else {
-        OriginZeroLine(position.0.saturating_add(1))
-    }
-}
-
-#[inline]
-/// Returns the initial search line for sparse/dense placement in the given axis direction.
-fn search_start_line(
-    grid_start_line: OriginZeroLine,
-    grid_end_line: OriginZeroLine,
-    axis_is_reversed: bool,
-) -> OriginZeroLine {
-    if axis_is_reversed {
-        grid_end_line - 1
-    } else {
-        grid_start_line
-    }
-}
-
-#[inline]
-/// Resolves an indefinite span at `position`, respecting the active axis direction.
-fn resolve_indefinite_grid_span(position: OriginZeroLine, span: u16, axis_is_reversed: bool) -> Line<OriginZeroLine> {
+/// Resolves an indefinite span starting at `position`.
+fn resolve_indefinite_grid_span(position: OriginZeroLine, span: u16) -> Line<OriginZeroLine> {
     let position = position.0 as i32;
     let span = span as i32;
     let line = |value: i32| OriginZeroLine(value.clamp(i16::MIN as i32, i16::MAX as i32) as i16);
-    if axis_is_reversed {
-        Line { start: line(position - span + 1), end: line(position + 1) }
-    } else {
-        Line { start: line(position), end: line(position + span) }
-    }
-}
-
-#[inline]
-/// Mirrors a horizontal span around the explicit grid width.
-fn mirror_horizontal_span(span: Line<OriginZeroLine>, explicit_col_count: u16) -> Line<OriginZeroLine> {
-    let explicit_col_end_line = explicit_col_count as i16;
-    Line {
-        start: OriginZeroLine(explicit_col_end_line - span.end.0),
-        end: OriginZeroLine(explicit_col_end_line - span.start.0),
-    }
-}
-
-#[inline]
-/// Mirrors horizontal spans for RTL while leaving all other spans unchanged.
-fn maybe_mirror_span(
-    span: Line<OriginZeroLine>,
-    axis: AbsoluteAxis,
-    direction: Direction,
-    explicit_col_count: u16,
-) -> Line<OriginZeroLine> {
-    if axis == AbsoluteAxis::Horizontal && direction.is_rtl() {
-        // Clamp into the limited grid before mirroring so that placements outside of the limited
-        // grid mirror to the same tracks as their clamped equivalents
-        mirror_horizontal_span(clamp_span_to_limited_grid(span, MIN_OZ_LINE, MAX_OZ_LINE), explicit_col_count)
-    } else {
-        span
-    }
+    Line { start: line(position), end: line(position + span) }
 }
 
 /// 8.5. Grid Item Placement Algorithm
@@ -88,7 +33,6 @@ pub(super) fn place_grid_items<'a, S, ChildIter>(
     cell_occupancy_matrix: &mut CellOccupancyMatrix,
     items: &mut Vec<GridItem>,
     children_iter: impl Fn() -> ChildIter,
-    direction: Direction,
     grid_auto_flow: GridAutoFlow,
     align_items: AlignItems,
     justify_items: AlignItems,
@@ -126,8 +70,7 @@ pub(super) fn place_grid_items<'a, S, ChildIter>(
             #[cfg(test)]
             println!("Definite Item {idx}\n==============");
 
-            let (row_span, col_span) =
-                place_definite_grid_item(child_placement, primary_axis, direction, explicit_col_count);
+            let (row_span, col_span) = place_definite_grid_item(child_placement, primary_axis);
             record_grid_placement(
                 cell_occupancy_matrix,
                 items,
@@ -137,8 +80,6 @@ pub(super) fn place_grid_items<'a, S, ChildIter>(
                 align_items,
                 justify_items,
                 primary_axis,
-                direction,
-                explicit_col_count,
                 row_span,
                 col_span,
                 CellOccupancyState::DefinitelyPlaced,
@@ -157,13 +98,8 @@ pub(super) fn place_grid_items<'a, S, ChildIter>(
             #[cfg(test)]
             println!("Definite Secondary Item {idx}\n==============");
 
-            let (primary_span, secondary_span) = place_definite_secondary_axis_item(
-                &*cell_occupancy_matrix,
-                child_placement,
-                grid_auto_flow,
-                direction,
-                explicit_col_count,
-            );
+            let (primary_span, secondary_span) =
+                place_definite_secondary_axis_item(&*cell_occupancy_matrix, child_placement, grid_auto_flow);
 
             record_grid_placement(
                 cell_occupancy_matrix,
@@ -174,8 +110,6 @@ pub(super) fn place_grid_items<'a, S, ChildIter>(
                 align_items,
                 justify_items,
                 primary_axis,
-                direction,
-                explicit_col_count,
                 primary_span,
                 secondary_span,
                 CellOccupancyState::AutoPlaced,
@@ -204,18 +138,8 @@ pub(super) fn place_grid_items<'a, S, ChildIter>(
     let primary_axis = grid_auto_flow.primary_axis();
     let secondary_axis = primary_axis.other_axis();
     let primary_axis_grid_start_line = cell_occupancy_matrix.track_counts(primary_axis).implicit_start_line();
-    let primary_axis_grid_end_line = cell_occupancy_matrix.track_counts(primary_axis).implicit_end_line();
     let secondary_axis_grid_start_line = cell_occupancy_matrix.track_counts(secondary_axis).implicit_start_line();
-    let secondary_axis_grid_end_line = cell_occupancy_matrix.track_counts(secondary_axis).implicit_end_line();
-    let primary_axis_is_reversed = axis_is_reversed(direction, primary_axis);
-    let grid_start_position = (
-        search_start_line(primary_axis_grid_start_line, primary_axis_grid_end_line, primary_axis_is_reversed),
-        search_start_line(
-            secondary_axis_grid_start_line,
-            secondary_axis_grid_end_line,
-            axis_is_reversed(direction, secondary_axis),
-        ),
-    );
+    let grid_start_position = (primary_axis_grid_start_line, secondary_axis_grid_start_line);
     let mut grid_position = grid_start_position;
     let mut idx = 0;
     children_iter()
@@ -232,8 +156,6 @@ pub(super) fn place_grid_items<'a, S, ChildIter>(
                 child_placement,
                 grid_auto_flow,
                 grid_position,
-                direction,
-                explicit_col_count,
             );
 
             // Record item
@@ -246,8 +168,6 @@ pub(super) fn place_grid_items<'a, S, ChildIter>(
                 align_items,
                 justify_items,
                 primary_axis,
-                direction,
-                explicit_col_count,
                 primary_span,
                 secondary_span,
                 CellOccupancyState::AutoPlaced,
@@ -255,10 +175,9 @@ pub(super) fn place_grid_items<'a, S, ChildIter>(
 
             // If using the "dense" placement algorithm then reset the grid position back to grid_start_position ready for the next item
             // Otherwise set it to the position of the current item so that the next item it placed after it.
-            grid_position = match (grid_auto_flow.is_dense(), primary_axis_is_reversed) {
-                (true, _) => grid_start_position,
-                (false, false) => (primary_span.end, secondary_span.start),
-                (false, true) => (primary_span.start, secondary_span.start),
+            grid_position = match grid_auto_flow.is_dense() {
+                true => grid_start_position,
+                false => (primary_span.end, secondary_span.start),
             };
         });
 }
@@ -268,22 +187,10 @@ pub(super) fn place_grid_items<'a, S, ChildIter>(
 fn place_definite_grid_item(
     placement: InBothAbsAxis<Line<OriginZeroGridPlacement>>,
     primary_axis: AbsoluteAxis,
-    direction: Direction,
-    explicit_col_count: u16,
 ) -> (Line<OriginZeroLine>, Line<OriginZeroLine>) {
     // Resolve spans to tracks
-    let primary_span = maybe_mirror_span(
-        placement.get(primary_axis).resolve_definite_grid_lines(),
-        primary_axis,
-        direction,
-        explicit_col_count,
-    );
-    let secondary_span = maybe_mirror_span(
-        placement.get(primary_axis.other_axis()).resolve_definite_grid_lines(),
-        primary_axis.other_axis(),
-        direction,
-        explicit_col_count,
-    );
+    let primary_span = placement.get(primary_axis).resolve_definite_grid_lines();
+    let secondary_span = placement.get(primary_axis.other_axis()).resolve_definite_grid_lines();
 
     (primary_span, secondary_span)
 }
@@ -294,56 +201,28 @@ fn place_definite_secondary_axis_item(
     cell_occupancy_matrix: &CellOccupancyMatrix,
     placement: InBothAbsAxis<Line<OriginZeroGridPlacement>>,
     auto_flow: GridAutoFlow,
-    direction: Direction,
-    explicit_col_count: u16,
 ) -> (Line<OriginZeroLine>, Line<OriginZeroLine>) {
     let primary_axis = auto_flow.primary_axis();
     let secondary_axis = primary_axis.other_axis();
-    let primary_axis_is_reversed = axis_is_reversed(direction, primary_axis);
     let primary_axis_grid_start_line = cell_occupancy_matrix.track_counts(primary_axis).implicit_start_line();
-    let primary_axis_grid_end_line = cell_occupancy_matrix.track_counts(primary_axis).implicit_end_line();
 
-    let secondary_axis_placement = maybe_mirror_span(
-        placement.get(secondary_axis).resolve_definite_grid_lines(),
-        secondary_axis,
-        direction,
-        explicit_col_count,
-    );
+    let secondary_axis_placement = placement.get(secondary_axis).resolve_definite_grid_lines();
     let starting_position = match auto_flow.is_dense() {
-        true => search_start_line(primary_axis_grid_start_line, primary_axis_grid_end_line, primary_axis_is_reversed),
-        false => {
-            let lookup_result = if primary_axis_is_reversed {
-                cell_occupancy_matrix.first_of_type(
-                    primary_axis,
-                    secondary_axis_placement.start,
-                    CellOccupancyState::AutoPlaced,
-                )
-            } else {
-                cell_occupancy_matrix.last_of_type(
-                    primary_axis,
-                    secondary_axis_placement.start,
-                    CellOccupancyState::AutoPlaced,
-                )
-            };
-            lookup_result.unwrap_or(search_start_line(
-                primary_axis_grid_start_line,
-                primary_axis_grid_end_line,
-                primary_axis_is_reversed,
-            ))
-        }
+        true => primary_axis_grid_start_line,
+        false => cell_occupancy_matrix
+            .last_of_type(primary_axis, secondary_axis_placement.start, CellOccupancyState::AutoPlaced)
+            .unwrap_or(primary_axis_grid_start_line),
     };
     let primary_axis_span = placement.get(primary_axis).indefinite_span();
 
     let mut position: OriginZeroLine = starting_position;
     loop {
-        let primary_axis_placement =
-            resolve_indefinite_grid_span(position, primary_axis_span, primary_axis_is_reversed);
+        let primary_axis_placement = resolve_indefinite_grid_span(position, primary_axis_span);
 
         let collision = cell_occupancy_matrix.line_area_collision_jump(
             primary_axis,
             primary_axis_placement,
             secondary_axis_placement,
-            primary_axis_is_reversed,
         );
 
         match collision {
@@ -360,13 +239,9 @@ fn place_indefinitely_positioned_item(
     placement: InBothAbsAxis<Line<OriginZeroGridPlacement>>,
     auto_flow: GridAutoFlow,
     grid_position: (OriginZeroLine, OriginZeroLine),
-    direction: Direction,
-    explicit_col_count: u16,
 ) -> (Line<OriginZeroLine>, Line<OriginZeroLine>) {
     let primary_axis = auto_flow.primary_axis();
     let secondary_axis = primary_axis.other_axis();
-    let primary_axis_is_reversed = axis_is_reversed(direction, primary_axis);
-    let secondary_axis_is_reversed = axis_is_reversed(direction, secondary_axis);
 
     let primary_placement_style = placement.get(primary_axis);
     let secondary_placement_style = placement.get(secondary_axis);
@@ -376,34 +251,19 @@ fn place_indefinitely_positioned_item(
     let primary_axis_grid_start_line = cell_occupancy_matrix.track_counts(primary_axis).implicit_start_line();
     let primary_axis_grid_end_line = cell_occupancy_matrix.track_counts(primary_axis).implicit_end_line();
     let secondary_axis_grid_start_line = cell_occupancy_matrix.track_counts(secondary_axis).implicit_start_line();
-    let secondary_axis_grid_end_line = cell_occupancy_matrix.track_counts(secondary_axis).implicit_end_line();
-    let primary_start_position =
-        search_start_line(primary_axis_grid_start_line, primary_axis_grid_end_line, primary_axis_is_reversed);
-    let secondary_start_position =
-        search_start_line(secondary_axis_grid_start_line, secondary_axis_grid_end_line, secondary_axis_is_reversed);
 
     let (mut primary_idx, mut secondary_idx) = grid_position;
 
     if has_definite_primary_axis_position {
-        let primary_span = maybe_mirror_span(
-            primary_placement_style.resolve_definite_grid_lines(),
-            primary_axis,
-            direction,
-            explicit_col_count,
-        );
+        let primary_span = primary_placement_style.resolve_definite_grid_lines();
 
         // Compute secondary axis starting position for search
         secondary_idx = match auto_flow.is_dense() {
             // If auto-flow is dense then we always search from the first track
-            true => secondary_start_position,
+            true => secondary_axis_grid_start_line,
             false => {
-                let should_advance_secondary = if primary_axis_is_reversed {
-                    primary_span.start > primary_idx
-                } else {
-                    primary_span.start < primary_idx
-                };
-                if should_advance_secondary {
-                    advance_position(secondary_idx, secondary_axis_is_reversed)
+                if primary_span.start < primary_idx {
+                    advance_position(secondary_idx)
                 } else {
                     secondary_idx
                 }
@@ -413,16 +273,11 @@ fn place_indefinitely_positioned_item(
         // Item has fixed primary axis position: so we simply increment the secondary axis position
         // until we find a space that the item fits in
         loop {
-            let secondary_span =
-                resolve_indefinite_grid_span(secondary_idx, secondary_span, secondary_axis_is_reversed);
+            let secondary_span = resolve_indefinite_grid_span(secondary_idx, secondary_span);
 
             // If area is occupied, jump the index past the collision and try again
-            let collision = cell_occupancy_matrix.line_area_collision_jump(
-                secondary_axis,
-                secondary_span,
-                primary_span,
-                secondary_axis_is_reversed,
-            );
+            let collision =
+                cell_occupancy_matrix.line_area_collision_jump(secondary_axis, secondary_span, primary_span);
             if let Some(next_position) = collision {
                 secondary_idx = next_position;
                 continue;
@@ -442,26 +297,21 @@ fn place_indefinitely_positioned_item(
         // existent tracks, and then we reset the primary axis back to zero and increment the secondary axis index.
         // We continue in this vein until we find a space that the item fits in.
         loop {
-            let primary_span = resolve_indefinite_grid_span(primary_idx, primary_span, primary_axis_is_reversed);
-            let secondary_span =
-                resolve_indefinite_grid_span(secondary_idx, secondary_span, secondary_axis_is_reversed);
+            let primary_span = resolve_indefinite_grid_span(primary_idx, primary_span);
+            let secondary_span = resolve_indefinite_grid_span(secondary_idx, secondary_span);
 
             // If the primary index is out of bounds, then increment the secondary index and reset the primary
             // index back to the start of the grid
-            let primary_out_of_bounds = if primary_axis_is_reversed {
-                primary_span.start < primary_axis_grid_start_line
-            } else {
-                primary_span.end > primary_axis_grid_end_line
-            };
+            let primary_out_of_bounds = primary_span.end > primary_axis_grid_end_line;
             if primary_out_of_bounds {
                 // If the span is out of bounds even at the search start position then it can never fit,
                 // as searching only ever moves the span further away from the start of the grid. Bail out
                 // and let `record_grid_placement` clamp the placement into the limited grid
-                if primary_idx == primary_start_position {
+                if primary_idx == primary_axis_grid_start_line {
                     return (primary_span, secondary_span);
                 }
-                secondary_idx = advance_position(secondary_idx, secondary_axis_is_reversed);
-                primary_idx = primary_start_position;
+                secondary_idx = advance_position(secondary_idx);
+                primary_idx = primary_axis_grid_start_line;
                 continue;
             }
 
@@ -469,14 +319,10 @@ fn place_indefinitely_positioned_item(
             // secondary axis tracks it spans are entirely unoccupied. Jump the secondary index
             // past any non-empty tracks in the spanned stripe.
             if spans_all_primary_tracks {
-                match cell_occupancy_matrix.occupied_track_jump(
-                    secondary_axis,
-                    secondary_span,
-                    secondary_axis_is_reversed,
-                ) {
+                match cell_occupancy_matrix.occupied_track_jump(secondary_axis, secondary_span) {
                     Some(next_position) => {
                         secondary_idx = next_position;
-                        primary_idx = primary_start_position;
+                        primary_idx = primary_axis_grid_start_line;
                         continue;
                     }
                     None => return (primary_span, secondary_span),
@@ -484,12 +330,7 @@ fn place_indefinitely_positioned_item(
             }
 
             // If area is occupied, jump the primary index past the collision and try again
-            let collision = cell_occupancy_matrix.line_area_collision_jump(
-                primary_axis,
-                primary_span,
-                secondary_span,
-                primary_axis_is_reversed,
-            );
+            let collision = cell_occupancy_matrix.line_area_collision_jump(primary_axis, primary_span, secondary_span);
             if let Some(next_position) = collision {
                 primary_idx = next_position;
                 continue;
@@ -505,26 +346,10 @@ fn place_indefinitely_positioned_item(
 /// Items placed outside of the limited grid are clamped into it.
 ///
 /// See: <https://www.w3.org/TR/css-grid-1/#overlarge-grids>
-fn clamp_span_to_limited_grid(span: Line<OriginZeroLine>, min_line: i16, max_line: i16) -> Line<OriginZeroLine> {
-    let start = span.start.0.clamp(min_line, max_line - 1);
-    let end = span.end.0.clamp(start + 1, max_line);
+fn clamp_span_to_limited_grid(span: Line<OriginZeroLine>) -> Line<OriginZeroLine> {
+    let start = span.start.0.clamp(MIN_OZ_LINE, MAX_OZ_LINE - 1);
+    let end = span.end.0.clamp(start + 1, MAX_OZ_LINE);
     Line { start: OriginZeroLine(start), end: OriginZeroLine(end) }
-}
-
-/// Clamps a span using bounds transformed into the axis's placement coordinates.
-fn clamp_span_for_axis(
-    span: Line<OriginZeroLine>,
-    axis: AbsoluteAxis,
-    direction: Direction,
-    explicit_col_count: u16,
-) -> Line<OriginZeroLine> {
-    let (min_line, max_line) = if axis == AbsoluteAxis::Horizontal && direction.is_rtl() {
-        let explicit_end = explicit_col_count as i16;
-        (explicit_end - MAX_OZ_LINE, explicit_end - MIN_OZ_LINE)
-    } else {
-        (MIN_OZ_LINE, MAX_OZ_LINE)
-    };
-    clamp_span_to_limited_grid(span, min_line, max_line)
 }
 
 /// Record the grid item in both CellOccupancyMatric and the GridItems list
@@ -539,8 +364,6 @@ fn record_grid_placement<S: GridItemStyle>(
     parent_align_items: AlignItems,
     parent_justify_items: AlignItems,
     primary_axis: AbsoluteAxis,
-    direction: Direction,
-    explicit_col_count: u16,
     primary_span: Line<OriginZeroLine>,
     secondary_span: Line<OriginZeroLine>,
     placement_type: CellOccupancyState,
@@ -552,8 +375,8 @@ fn record_grid_placement<S: GridItemStyle>(
 
     // Clamp placements into the limited grid to prevent arithmetic overflow when growing the
     // implicit grid (https://www.w3.org/TR/css-grid-1/#overlarge-grids)
-    let primary_span = clamp_span_for_axis(primary_span, primary_axis, direction, explicit_col_count);
-    let secondary_span = clamp_span_for_axis(secondary_span, primary_axis.other_axis(), direction, explicit_col_count);
+    let primary_span = clamp_span_to_limited_grid(primary_span);
+    let secondary_span = clamp_span_to_limited_grid(secondary_span);
 
     // Mark area of grid as occupied
     cell_occupancy_matrix.mark_area_as(primary_axis, primary_span, secondary_span, placement_type);
@@ -594,7 +417,6 @@ mod tests {
         use crate::compute::grid::OriginZeroLine;
         use crate::prelude::*;
         use crate::style::GridAutoFlow;
-        use crate::Direction;
 
         use super::super::place_grid_items;
 
@@ -611,8 +433,7 @@ mod tests {
             // Setup test
             let children_iter = || children.iter().map(|(index, style, _)| (*index, NodeId::from(*index), style));
             let child_styles_iter = children.iter().map(|(_, style, _)| style);
-            let estimated_sizes =
-                compute_grid_size_estimate(explicit_col_count, explicit_row_count, Direction::Ltr, child_styles_iter);
+            let estimated_sizes = compute_grid_size_estimate(explicit_col_count, explicit_row_count, child_styles_iter);
             let mut items = Vec::new();
             let mut cell_occupancy_matrix =
                 CellOccupancyMatrix::with_track_counts(estimated_sizes.0, estimated_sizes.1);
@@ -625,7 +446,6 @@ mod tests {
                 &mut cell_occupancy_matrix,
                 &mut items,
                 children_iter,
-                Direction::Ltr,
                 flow,
                 AlignSelf::START,
                 AlignSelf::START,
@@ -844,7 +664,7 @@ mod tests {
         }
 
         #[test]
-        fn test_rtl_overlarge_placement_uses_mirrored_limits() {
+        fn test_overlarge_placement_is_clamped() {
             let explicit_col_count = 9_000;
             let explicit_row_count = 0;
             let style = (line(-19_005), auto(), auto(), auto()).into_grid_child();
@@ -852,7 +672,6 @@ mod tests {
             let estimated_sizes = compute_grid_size_estimate(
                 explicit_col_count,
                 explicit_row_count,
-                Direction::Rtl,
                 children.iter().map(|(_, style)| style),
             );
             let mut items = Vec::new();
@@ -865,39 +684,25 @@ mod tests {
                 &mut cell_occupancy_matrix,
                 &mut items,
                 || children.iter().map(|(index, style)| (*index, NodeId::from(*index), style)),
-                Direction::Rtl,
                 GridAutoFlow::Row,
                 AlignSelf::START,
                 AlignSelf::START,
                 &name_resolver,
             );
-            assert_eq!(items[0].column, Line { start: OriginZeroLine(18_999), end: OriginZeroLine(19_000) });
+            assert_eq!(items[0].column, Line { start: OriginZeroLine(-10_000), end: OriginZeroLine(-9_999) });
         }
     }
 
     #[test]
     fn auto_placement_cursor_saturates_at_integer_bounds() {
-        assert_eq!(advance_position(OriginZeroLine(i16::MAX), false), OriginZeroLine(i16::MAX));
-        assert_eq!(advance_position(OriginZeroLine(i16::MIN), true), OriginZeroLine(i16::MIN));
+        assert_eq!(advance_position(OriginZeroLine(i16::MAX)), OriginZeroLine(i16::MAX));
     }
 
     #[test]
     fn indefinite_spans_saturate_at_integer_bounds() {
         assert_eq!(
-            resolve_indefinite_grid_span(OriginZeroLine(i16::MAX), 1, false),
+            resolve_indefinite_grid_span(OriginZeroLine(i16::MAX), 1),
             Line { start: OriginZeroLine(i16::MAX), end: OriginZeroLine(i16::MAX) }
         );
-        assert_eq!(
-            resolve_indefinite_grid_span(OriginZeroLine(i16::MIN), 1, true),
-            Line { start: OriginZeroLine(i16::MIN), end: OriginZeroLine(i16::MIN + 1) }
-        );
-    }
-
-    #[test]
-    fn rtl_spans_are_clamped_in_mirrored_coordinates() {
-        let logical_span = Line { start: OriginZeroLine(-10_000), end: OriginZeroLine(-9_999) };
-        let mirrored_span = maybe_mirror_span(logical_span, AbsoluteAxis::Horizontal, Direction::Rtl, 9_000);
-        assert_eq!(mirrored_span, Line { start: OriginZeroLine(18_999), end: OriginZeroLine(19_000) });
-        assert_eq!(clamp_span_for_axis(mirrored_span, AbsoluteAxis::Horizontal, Direction::Rtl, 9_000), mirrored_span);
     }
 }

--- a/src/compute/grid/types/cell_occupancy.rs
+++ b/src/compute/grid/types/cell_occupancy.rs
@@ -125,24 +125,13 @@ impl TrackIntervals {
     }
 
     /// Find the extent of the occupied interval which an auto-placement search along the track
-    /// would collide with last: the end of the last overlapping interval when searching forwards,
-    /// or the start of the first overlapping interval when searching backwards (`reversed ==
-    /// true`). Returns the extremal occupied cell of that interval (which may lie outside
-    /// `range`: every search position before the returned extent also collides with the
-    /// interval), or `None` if the range is entirely unoccupied.
-    fn collision_extent(&self, range: &Range<i16>, reversed: bool) -> Option<i16> {
-        if reversed {
-            let interval = self.intervals.iter().find(|interval| interval.overlaps(range))?;
-            Some(interval.range.start)
-        } else {
-            let interval = self.intervals.iter().rev().find(|interval| interval.overlaps(range))?;
-            Some(interval.range.end - 1)
-        }
-    }
-
-    /// The start line of the first (lowest coordinate) cell with the specified state, if any
-    fn first_of_state(&self, state: CellOccupancyState) -> Option<i16> {
-        self.intervals.iter().find(|interval| interval.state == state).map(|interval| interval.range.start)
+    /// would collide with last: the end of the last overlapping interval. Returns the extremal
+    /// occupied cell of that interval (which may lie outside `range`: every search position
+    /// before the returned extent also collides with the interval), or `None` if the range is
+    /// entirely unoccupied.
+    fn collision_extent(&self, range: &Range<i16>) -> Option<i16> {
+        let interval = self.intervals.iter().rev().find(|interval| interval.overlaps(range))?;
+        Some(interval.range.end - 1)
     }
 
     /// The start line of the last (highest coordinate) cell with the specified state, if any
@@ -291,7 +280,7 @@ impl CellOccupancyMatrix {
         primary_span: Line<OriginZeroLine>,
         secondary_span: Line<OriginZeroLine>,
     ) -> bool {
-        self.line_area_collision_jump(primary_axis, primary_span, secondary_span, false).is_none()
+        self.line_area_collision_jump(primary_axis, primary_span, secondary_span).is_none()
     }
 
     /// Checks the specified area for occupied cells (`primary_span` and `secondary_span` are
@@ -305,7 +294,6 @@ impl CellOccupancyMatrix {
         primary_axis: AbsoluteAxis,
         primary_span: Line<OriginZeroLine>,
         secondary_span: Line<OriginZeroLine>,
-        reversed: bool,
     ) -> Option<OriginZeroLine> {
         let track_lists = self.track_lists(primary_axis.other_axis());
         let secondary_counts = self.track_counts(primary_axis.other_axis());
@@ -320,51 +308,32 @@ impl CellOccupancyMatrix {
 
         let mut extent: Option<i16> = None;
         for secondary_index in secondary_start..secondary_end {
-            let Some(cell) = track_lists[secondary_index as usize].collision_extent(&primary_range, reversed) else {
+            let Some(cell) = track_lists[secondary_index as usize].collision_extent(&primary_range) else {
                 continue;
             };
             extent = Some(match extent {
                 None => cell,
-                Some(best) => {
-                    if reversed {
-                        min(best, cell)
-                    } else {
-                        max(best, cell)
-                    }
-                }
+                Some(best) => max(best, cell),
             });
         }
 
-        extent.map(|cell| if reversed { OriginZeroLine(cell - 1) } else { OriginZeroLine(cell + 1) })
+        extent.map(|cell| OriginZeroLine(cell + 1))
     }
 
     /// Given a span of tracks in `axis` (in OriginZero coordinates), returns the next search
     /// position past all non-empty tracks within the span, or `None` if all tracks within the
     /// span are entirely unoccupied. Used to place items which span every track in the other
     /// axis (such items can only fit in a stripe of entirely unoccupied tracks).
-    pub fn occupied_track_jump(
-        &self,
-        axis: AbsoluteAxis,
-        span: Line<OriginZeroLine>,
-        reversed: bool,
-    ) -> Option<OriginZeroLine> {
+    pub fn occupied_track_jump(&self, axis: AbsoluteAxis, span: Line<OriginZeroLine>) -> Option<OriginZeroLine> {
         let counts = self.track_counts(axis);
         let track_lists = self.track_lists(axis);
         let range = counts.oz_line_range_to_track_range(span);
         let start = max(range.start, 0);
         let end = min(range.end, track_lists.len() as i16);
-        let found = if !reversed {
-            (start..end).rev().find(|&index| !track_lists[index as usize].is_empty())
-        } else {
-            (start..end).find(|&index| !track_lists[index as usize].is_empty())
-        };
+        let found = (start..end).rev().find(|&index| !track_lists[index as usize].is_empty());
         found.map(|track_index| {
             let line = counts.track_to_prev_oz_line(track_index as u16);
-            if reversed {
-                OriginZeroLine(line.0 - 1)
-            } else {
-                line + 1
-            }
+            line + 1
         })
     }
 
@@ -403,25 +372,6 @@ impl CellOccupancyMatrix {
             return None;
         }
         track_lists[track_computed_index as usize].last_of_state(kind).map(OriginZeroLine)
-    }
-
-    /// Given an axis and a track index
-    /// Search forwards from the start of the track and find the first grid cell matching the specified state (if any)
-    /// Return the index of that cell or None.
-    pub fn first_of_type(
-        &self,
-        track_type: AbsoluteAxis,
-        start_at: OriginZeroLine,
-        kind: CellOccupancyState,
-    ) -> Option<OriginZeroLine> {
-        let track_counts = self.track_counts(track_type.other_axis());
-        let track_computed_index = track_counts.oz_line_to_next_track(start_at);
-        let track_lists = self.track_lists(track_type.other_axis());
-        if track_computed_index < 0 || track_computed_index >= track_lists.len() as i16 {
-            // Index out of bounds: no tracks to search
-            return None;
-        }
-        track_lists[track_computed_index as usize].first_of_state(kind).map(OriginZeroLine)
     }
 }
 
@@ -487,27 +437,21 @@ mod tests {
             let mut track = TrackIntervals::default();
             track.paint(2..4, AutoPlaced);
             track.paint(6..8, DefinitelyPlaced);
-            // Forward search: the last cell of the last overlapping interval
-            assert_eq!(track.collision_extent(&(0..10), false), Some(7));
-            assert_eq!(track.collision_extent(&(0..7), false), Some(7));
-            assert_eq!(track.collision_extent(&(0..6), false), Some(3));
-            assert_eq!(track.collision_extent(&(4..6), false), None);
-            // Reverse search: the first cell of the first overlapping interval
-            assert_eq!(track.collision_extent(&(0..10), true), Some(2));
-            assert_eq!(track.collision_extent(&(3..10), true), Some(2));
-            assert_eq!(track.collision_extent(&(4..10), true), Some(6));
+            // The last cell of the last overlapping interval
+            assert_eq!(track.collision_extent(&(0..10)), Some(7));
+            assert_eq!(track.collision_extent(&(0..7)), Some(7));
+            assert_eq!(track.collision_extent(&(0..6)), Some(3));
+            assert_eq!(track.collision_extent(&(4..6)), None);
         }
 
         #[test]
-        fn first_and_last_of_state_ignore_other_states() {
+        fn last_of_state_ignores_other_states() {
             let mut track = TrackIntervals::default();
             track.paint(0..2, DefinitelyPlaced);
             track.paint(2..4, AutoPlaced);
             track.paint(6..8, AutoPlaced);
             track.paint(8..9, DefinitelyPlaced);
-            assert_eq!(track.first_of_state(AutoPlaced), Some(2));
             assert_eq!(track.last_of_state(AutoPlaced), Some(7));
-            assert_eq!(track.first_of_state(DefinitelyPlaced), Some(0));
             assert_eq!(track.last_of_state(DefinitelyPlaced), Some(8));
         }
 
@@ -560,26 +504,11 @@ mod tests {
                 CellOccupancyMatrix::with_track_counts(TrackCounts::from_raw(0, 4, 0), TrackCounts::from_raw(0, 4, 0));
             matrix.mark_area_as(Horizontal, line(1, 3), line(0, 1), AutoPlaced);
 
-            // Forwards: jump past the end of the last colliding interval
-            assert_eq!(
-                matrix.line_area_collision_jump(Horizontal, line(0, 2), line(0, 1), false),
-                Some(OriginZeroLine(3))
-            );
-            assert_eq!(
-                matrix.line_area_collision_jump(Horizontal, line(0, 4), line(0, 1), false),
-                Some(OriginZeroLine(3))
-            );
-            // Backwards: jump past the start of the first colliding interval
-            assert_eq!(
-                matrix.line_area_collision_jump(Horizontal, line(2, 4), line(0, 1), true),
-                Some(OriginZeroLine(0))
-            );
-            assert_eq!(
-                matrix.line_area_collision_jump(Horizontal, line(0, 4), line(0, 1), true),
-                Some(OriginZeroLine(0))
-            );
+            // Jump past the end of the last colliding interval
+            assert_eq!(matrix.line_area_collision_jump(Horizontal, line(0, 2), line(0, 1)), Some(OriginZeroLine(3)));
+            assert_eq!(matrix.line_area_collision_jump(Horizontal, line(0, 4), line(0, 1)), Some(OriginZeroLine(3)));
             // No collision in a different row
-            assert_eq!(matrix.line_area_collision_jump(Horizontal, line(0, 4), line(1, 2), false), None);
+            assert_eq!(matrix.line_area_collision_jump(Horizontal, line(0, 4), line(1, 2)), None);
         }
 
         #[test]
@@ -589,9 +518,8 @@ mod tests {
             matrix.mark_area_as(Horizontal, line(0, 1), line(1, 2), AutoPlaced);
 
             // Vertical (row) tracks: row 1 is occupied
-            assert_eq!(matrix.occupied_track_jump(Vertical, line(0, 4), false), Some(OriginZeroLine(2)));
-            assert_eq!(matrix.occupied_track_jump(Vertical, line(0, 4), true), Some(OriginZeroLine(0)));
-            assert_eq!(matrix.occupied_track_jump(Vertical, line(2, 4), false), None);
+            assert_eq!(matrix.occupied_track_jump(Vertical, line(0, 4)), Some(OriginZeroLine(2)));
+            assert_eq!(matrix.occupied_track_jump(Vertical, line(2, 4)), None);
         }
     }
 }

--- a/tests/hand_written/detailed_grid_info.rs
+++ b/tests/hand_written/detailed_grid_info.rs
@@ -45,4 +45,32 @@ mod detailed_grid_info {
         // out of bounds index
         assert_eq!(info.item_grid_area(2), None);
     }
+
+    #[test]
+    fn item_grid_area_rtl() {
+        let mut tree: TaffyTree<()> = TaffyTree::new();
+        let child = tree.new_leaf(Style::default()).unwrap();
+        let container = tree
+            .new_with_children(
+                Style {
+                    display: Display::Grid,
+                    direction: taffy::style::Direction::Rtl,
+                    size: Size { width: Dimension::from_length(100.0), height: Dimension::from_length(50.0) },
+                    grid_template_columns: vec![length(40.0), length(60.0)],
+                    grid_template_rows: vec![length(50.0)],
+                    ..Default::default()
+                },
+                &[child],
+            )
+            .unwrap();
+
+        tree.compute_layout(container, Size::MAX_CONTENT).unwrap();
+        let info = detailed_grid_info(&tree, container);
+
+        // Tracks are in logical order with physical coordinates: logical column track 1 is
+        // physically rightmost in RTL, and item_grid_area returns the physical rectangle
+        assert_eq!(info.columns.positions[0], Line { start: 60.0, end: 100.0 });
+        assert_eq!(info.columns.positions[1], Line { start: 0.0, end: 60.0 });
+        assert_eq!(info.item_grid_area(0), Some((Point { x: 60.0, y: 0.0 }, Size { width: 40.0, height: 50.0 })));
+    }
 }


### PR DESCRIPTION
# Objective

Refactor the CSS Grid `direction: rtl` implementation so that all internal indices and data structures stay in **logical** order (line 1 = inline-start), with RTL handled purely at the geometry-assignment stage. Rendered geometry is unchanged — this is a pure internal-representation refactor.

Previously RTL grids were mirrored into *visual* order early in the pipeline:
- `placement.rs` mirrored item column placements around the explicit grid (`maybe_mirror_span`/`mirror_horizontal_span`) and reversed the auto-placement search direction for the horizontal axis
- `implicit_grid.rs` mirrored known column bounds when estimating implicit track counts
- `mod.rs` swapped negative/positive implicit counts for initialization, remapped occupancy indices (`rtl_column_occupancy_index_for_initialization`), physically reversed the column track vector (`reverse_non_gutter_tracks`), and mirrored absolute-item column line indices

All of that is removed. Instead:
- Placement, occupancy (`CellOccupancyMatrix`), `TrackCounts` and the column `GridTrack` vector are logical-order for LTR and RTL alike; reverse-search machinery in `cell_occupancy.rs` (`reversed` params, `first_of_state`) is deleted
- `align_tracks` assigns physical `track.offset`s right-to-left in RTL by iterating the (logical-order) track vector in reverse; the existing `justify-content` keyword reversal (`AlignContentKeyword::reversed()`) is kept as it is genuinely geometric
- In-flow item grid areas and absolutely-positioned item grid areas map logical lines to physical edges at geometry time (in RTL a logical start line yields the physical right edge, a logical end line the physical left edge)

Consequently the `detailed_layout_info` output is now logical-order for RTL: `DetailedGridTracksInfo.positions` (introduced in #1131) lists tracks in logical order (each entry still holding physical left/right x-positions), and `DetailedGridItemsInfo` column line numbers are logical. `CHANGELOG.md` documents this under Unreleased. One placement unit test that asserted mirrored RTL coordinates was rewritten to assert logical clamping instead; no fixtures or generated tests were modified.

## Context

Rebased on `main` after #1131 merged. The full Chrome-generated test suite (including all `*rtl*` fixtures) passes unchanged: `cargo test --workspace --all-features` is green, confirming identical rendered geometry.

This refactor will simplify the remaining detailed-info RTL handling in the in-flight #1132 (e.g. `finalize_line_names` RTL mirroring becomes unnecessary once the representation is logical-order).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/253040f0c41742e9b31de7b98509e1f6
Requested by: @nicoburns