### PR TITLE
DetailedGridInfo: add ability to resolve grid area rectangles

### DIFF
--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -889,6 +889,7 @@ pub struct DetailedGridInfo<S: CheapCloneStr = DefaultCheapStr> {
 
 #[cfg(feature = "detailed_layout_info")]
 impl<S: CheapCloneStr> DetailedGridTracksInfo<S> {
+    /// Resolve an absolute placement in this axis to physical start and end coordinates
     fn resolve_absolute_grid_axis(
         &self,
         placement: Line<GridPlacement<S>>,

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -24,7 +24,7 @@ use types::{CellOccupancyMatrix, GridTrack, NamedLineResolver};
 #[cfg(feature = "detailed_layout_info")]
 use crate::sys::{DefaultCheapStr, String};
 #[cfg(feature = "detailed_layout_info")]
-use crate::CheapCloneStr;
+use crate::{CheapCloneStr, GridPlacement, OriginZeroGridPlacement};
 #[cfg(feature = "detailed_layout_info")]
 use types::{GridItem, GridTrackKind, TrackCounts};
 
@@ -228,9 +228,9 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
 
     // Build the per-line names of the explicit grid from the name resolver's collected pairs
     #[cfg(feature = "detailed_layout_info")]
-    let detailed_column_line_names = name_resolver.detailed_line_names(AbsoluteAxis::Horizontal);
+    let mut detailed_column_line_names = name_resolver.detailed_line_names(AbsoluteAxis::Horizontal);
     #[cfg(feature = "detailed_layout_info")]
-    let detailed_row_line_names = name_resolver.detailed_line_names(AbsoluteAxis::Vertical);
+    let mut detailed_row_line_names = name_resolver.detailed_line_names(AbsoluteAxis::Vertical);
 
     // 3. Implicit Grid: Estimate Track Counts
     // Estimate the number of rows and columns in the implicit grid (= the entire grid)
@@ -791,6 +791,9 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
         }
     });
 
+    #[cfg(feature = "detailed_layout_info")]
+    name_resolver.populate_detailed_line_resolvers(&mut detailed_row_line_names, &mut detailed_column_line_names);
+
     // Set detailed grid information
     #[cfg(feature = "detailed_layout_info")]
     tree.set_detailed_grid_info(
@@ -885,6 +888,57 @@ pub struct DetailedGridInfo<S: CheapCloneStr = DefaultCheapStr> {
 }
 
 #[cfg(feature = "detailed_layout_info")]
+impl<S: CheapCloneStr> DetailedGridTracksInfo<S> {
+    fn resolve_absolute_grid_axis(
+        &self,
+        placement: Line<GridPlacement<S>>,
+        padding_start: f32,
+        padding_end: f32,
+        is_reversed: bool,
+    ) -> Line<f32> {
+        let track_counts = TrackCounts {
+            negative_implicit: self.negative_implicit_tracks,
+            explicit: self.explicit_tracks,
+            positive_implicit: self.positive_implicit_tracks,
+        };
+        let min_line = -(track_counts.negative_implicit as i16);
+        let max_line = (track_counts.explicit + track_counts.positive_implicit) as i16;
+        let placement = self
+            .line_names
+            .resolve_line_names(&placement, self.explicit_tracks)
+            .into_origin_zero(self.explicit_tracks)
+            .map(|placement| match placement {
+                OriginZeroGridPlacement::Line(line) if line.0 < min_line || line.0 > max_line => {
+                    OriginZeroGridPlacement::Auto
+                }
+                placement => placement,
+            })
+            .resolve_absolutely_positioned_grid_tracks()
+            .map(|line| line.and_then(|line| line.try_into_track_vec_index(track_counts).map(|index| index / 2)));
+        let start_position = placement
+            .start
+            .and_then(|line| {
+                self.positions
+                    .get(line)
+                    .map(|track| if is_reversed { track.end } else { track.start })
+                    .or_else(|| self.positions.last().map(|track| if is_reversed { track.start } else { track.end }))
+            })
+            .unwrap_or(if is_reversed { padding_end } else { padding_start });
+        let end_position = placement
+            .end
+            .and_then(|line| {
+                line.checked_sub(1)
+                    .and_then(|line| self.positions.get(line))
+                    .map(|track| if is_reversed { track.start } else { track.end })
+                    .or_else(|| self.positions.first().map(|track| if is_reversed { track.end } else { track.start }))
+            })
+            .unwrap_or(if is_reversed { padding_start } else { padding_end });
+
+        Line { start: f32_min(start_position, end_position), end: f32_max(start_position, end_position) }
+    }
+}
+
+#[cfg(feature = "detailed_layout_info")]
 impl<S: CheapCloneStr> DetailedGridInfo<S> {
     /// Write the used row track sizes and line names to the passed writer in the resolved value
     /// format of the `grid-template-rows` property
@@ -910,6 +964,25 @@ impl<S: CheapCloneStr> DetailedGridInfo<S> {
     /// `grid-template-columns` property (see <https://www.w3.org/TR/css-grid-1/#resolved-track-list>)
     pub fn grid_template_columns(&self) -> String {
         self.columns.to_track_list_string()
+    }
+
+    /// Resolve the physical grid area for an absolutely positioned box from its grid placement.
+    /// The padding box and returned area use coordinates relative to the grid container's border box.
+    pub fn resolve_absolute_grid_area(
+        &self,
+        grid_row: Line<GridPlacement<S>>,
+        grid_column: Line<GridPlacement<S>>,
+        direction: Direction,
+        padding_box: Rect<f32>,
+    ) -> Rect<f32> {
+        let columns = self.columns.resolve_absolute_grid_axis(
+            grid_column,
+            padding_box.left,
+            padding_box.right,
+            direction.is_rtl(),
+        );
+        let rows = self.rows.resolve_absolute_grid_axis(grid_row, padding_box.top, padding_box.bottom, false);
+        Rect { left: columns.start, right: columns.end, top: rows.start, bottom: rows.end }
     }
 
     /// Compute the location and size of the grid area occupied by the item at `item_index` (an

--- a/src/compute/grid/types/named.rs
+++ b/src/compute/grid/types/named.rs
@@ -46,6 +46,13 @@ impl<T: CheapCloneStr> Borrow<str> for StrHasher<T> {
     }
 }
 
+type NamedGridLinesMap<S> = Map<StrHasher<S>, Vec<u32>>;
+
+struct NamedLineResolverAxis<'a, S: CheapCloneStr> {
+    lines: &'a NamedGridLinesMap<S>,
+    explicit_track_count: u16,
+}
+
 /// Resolver that takes grid lines names and area names as input and can then be used to
 /// resolve line names of grid placement properties into line numbers.
 pub(crate) struct NamedLineResolver<S: CheapCloneStr> {
@@ -80,6 +87,142 @@ pub(crate) struct NamedLineResolver<S: CheapCloneStr> {
 /// Utility function to create or update an entry in a line name map
 fn upsert_line_name_map<S: CheapCloneStr>(map: &mut Map<StrHasher<S>, Vec<u32>>, key: S, value: u32) {
     map.entry(StrHasher(key)).and_modify(|lines| lines.push(value)).or_insert_with(|| single_value_vec(value));
+}
+
+impl<S: CheapCloneStr> NamedLineResolverAxis<'_, S> {
+    fn resolve_line_names(&self, line: &Line<GridPlacement<S>>) -> Line<NonNamedGridPlacement> {
+        let start_holder;
+        let start_line_resolved = if let GridPlacement::NamedLine(name, idx) = &line.start {
+            start_holder =
+                GridPlacement::Line(self.find_line_index(name, *idx as i32, GridAreaEnd::Start, &|lines| lines));
+            &start_holder
+        } else {
+            &line.start
+        };
+
+        let end_holder;
+        let end_line_resolved = if let GridPlacement::NamedLine(name, idx) = &line.end {
+            end_holder = GridPlacement::Line(self.find_line_index(name, *idx as i32, GridAreaEnd::End, &|lines| lines));
+            &end_holder
+        } else {
+            &line.end
+        };
+
+        // If both the *-start and *-end values of its grid-placement properties specify a line, its grid span is implicit.
+        // If it has an explicit span value, its grid span is explicit.
+        // Otherwise, its grid span is automatic:
+        //   - if it is subgridded in that axis, its grid span is determined from its <line-name-list>;
+        //   - otherwise its grid span is 1.
+        //
+        // <https://drafts.csswg.org/css-grid-2/#grid-span>
+        match (&start_line_resolved, &end_line_resolved) {
+            (GridPlacement::Line(start_line), GridPlacement::NamedSpan(name, idx)) => {
+                let normalized_start_line = if start_line.as_i16() > 0 {
+                    start_line.as_i16() as u32
+                } else {
+                    (self.explicit_track_count as i32 + 1 + start_line.as_i16() as i32).max(0) as u32
+                };
+                let end_line = self.find_line_index(name, *idx as i32, GridAreaEnd::End, &|lines| {
+                    let point = lines.partition_point(|line| *line <= normalized_start_line);
+                    &lines[point..]
+                });
+                Line { start: NonNamedGridPlacement::Line(*start_line), end: NonNamedGridPlacement::Line(end_line) }
+            }
+            (GridPlacement::NamedSpan(name, idx), GridPlacement::Line(end_line)) => {
+                let normalized_end_line = if end_line.as_i16() > 0 {
+                    end_line.as_i16() as u32
+                } else {
+                    (self.explicit_track_count as i32 + 1 + end_line.as_i16() as i32).max(0) as u32
+                };
+                let start_line = self.find_line_index(name, *idx as i32, GridAreaEnd::Start, &|lines| {
+                    let point = lines.partition_point(|line| *line < normalized_end_line);
+                    &lines[..point]
+                });
+                Line { start: NonNamedGridPlacement::Line(start_line), end: NonNamedGridPlacement::Line(*end_line) }
+            }
+            (start, end) => Line {
+                start: match start {
+                    GridPlacement::Auto => NonNamedGridPlacement::Auto,
+                    GridPlacement::Line(grid_line) => NonNamedGridPlacement::Line(*grid_line),
+                    GridPlacement::Span(span) => NonNamedGridPlacement::Span(*span),
+                    GridPlacement::NamedSpan(_, _) => NonNamedGridPlacement::Span(1),
+                    _ => unreachable!(),
+                },
+                end: match end {
+                    GridPlacement::Auto => NonNamedGridPlacement::Auto,
+                    GridPlacement::Line(grid_line) => NonNamedGridPlacement::Line(*grid_line),
+                    GridPlacement::Span(span) => NonNamedGridPlacement::Span(*span),
+                    GridPlacement::NamedSpan(_, _) => NonNamedGridPlacement::Span(1),
+                    _ => unreachable!(),
+                },
+            },
+        }
+    }
+
+    /// Resolve the grid line for a named grid line or span
+    fn find_line_index(
+        &self,
+        name: &S,
+        idx: i32,
+        end: GridAreaEnd,
+        filter_lines: &dyn Fn(&[u32]) -> &[u32],
+    ) -> GridLine {
+        let name = name.as_ref();
+        let mut idx = idx;
+        let explicit_track_count = self.explicit_track_count as i32;
+
+        // An index of 0 is used to represent "no index specified".
+        if idx == 0 {
+            idx = 1;
+        }
+
+        fn get_line(lines: &[u32], explicit_track_count: i32, idx: i32) -> i16 {
+            let abs_idx = idx.unsigned_abs() as usize;
+            let line = if abs_idx <= lines.len() {
+                if idx > 0 {
+                    lines[abs_idx - 1] as i64
+                } else {
+                    lines[lines.len() - abs_idx] as i64
+                }
+            } else {
+                let remaining_lines = (abs_idx - lines.len()) as i64 * idx.signum() as i64;
+                if idx > 0 {
+                    explicit_track_count as i64 + 1 + remaining_lines
+                } else {
+                    -(explicit_track_count as i64 + 1 + remaining_lines)
+                }
+            };
+            line.clamp(i16::MIN as i64, i16::MAX as i64) as i16
+        }
+
+        // Lookup lines
+        if let Some(lines) = self.lines.get(name) {
+            return GridLine::from(get_line(filter_lines(lines), explicit_track_count, idx));
+        }
+
+        // TODO: eliminate string allocations
+        let implicit_name = match end {
+            GridAreaEnd::Start => format!("{name}-start"),
+            GridAreaEnd::End => format!("{name}-end"),
+        };
+        if let Some(lines) = self.lines.get(&*implicit_name) {
+            return GridLine::from(get_line(filter_lines(lines), explicit_track_count, idx));
+        }
+
+        // The CSS Grid specification has a weird quirk where it matches non-existent line names
+        // to the first (positive) implicit line in the grid
+        //
+        // We add/subtract 2 to the explicit track count because (in each axis) a grid has one more explicit
+        // grid line than it has tracks. And the fallback line is the line *after* that.
+        //
+        // See: <https://github.com/w3c/csswg-drafts/issues/966#issuecomment-277042153>
+        let line = if idx > 0 {
+            explicit_track_count as i64 + 1 + idx as i64
+        } else {
+            -(explicit_track_count as i64 + 1 + idx as i64)
+        };
+        GridLine::from(line.clamp(i16::MIN as i64, i16::MAX as i64) as i16)
+    }
 }
 
 impl<S: CheapCloneStr> NamedLineResolver<S> {
@@ -328,164 +471,21 @@ impl<S: CheapCloneStr> NamedLineResolver<S> {
         line: &Line<GridPlacement<S>>,
         axis: GridAreaAxis,
     ) -> Line<NonNamedGridPlacement> {
-        let start_holder;
-        let start_line_resolved = if let GridPlacement::NamedLine(name, idx) = &line.start {
-            start_holder =
-                GridPlacement::Line(self.find_line_index(name, *idx as i32, axis, GridAreaEnd::Start, &|lines| lines));
-            &start_holder
-        } else {
-            &line.start
-        };
-
-        let end_holder;
-        let end_line_resolved = if let GridPlacement::NamedLine(name, idx) = &line.end {
-            end_holder =
-                GridPlacement::Line(self.find_line_index(name, *idx as i32, axis, GridAreaEnd::End, &|lines| lines));
-            &end_holder
-        } else {
-            &line.end
-        };
-
-        // If both the *-start and *-end values of its grid-placement properties specify a line, its grid span is implicit.
-        // If it has an explicit span value, its grid span is explicit.
-        // Otherwise, its grid span is automatic:
-        //   - if it is subgridded in that axis, its grid span is determined from its <line-name-list>;
-        //   - otherwise its grid span is 1.
-        //
-        // <https://drafts.csswg.org/css-grid-2/#grid-span>
-        match (&start_line_resolved, &end_line_resolved) {
-            (GridPlacement::Line(start_line), GridPlacement::NamedSpan(name, idx)) => {
-                let explicit_track_count = match axis {
-                    GridAreaAxis::Row => self.explicit_row_count as i32,
-                    GridAreaAxis::Column => self.explicit_column_count as i32,
-                };
-                let normalized_start_line = if start_line.as_i16() > 0 {
-                    start_line.as_i16() as u32
-                } else {
-                    (explicit_track_count + 1 + start_line.as_i16() as i32).max(0) as u32
-                };
-                let end_line = self.find_line_index(name, *idx as i32, axis, GridAreaEnd::End, &|lines| {
-                    let point = lines.partition_point(|line| *line <= normalized_start_line);
-                    &lines[point..]
-                });
-                Line { start: NonNamedGridPlacement::Line(*start_line), end: NonNamedGridPlacement::Line(end_line) }
+        match axis {
+            GridAreaAxis::Row => {
+                NamedLineResolverAxis { lines: &self.row_lines, explicit_track_count: self.explicit_row_count }
             }
-            (GridPlacement::NamedSpan(name, idx), GridPlacement::Line(end_line)) => {
-                let explicit_track_count = match axis {
-                    GridAreaAxis::Row => self.explicit_row_count as i32,
-                    GridAreaAxis::Column => self.explicit_column_count as i32,
-                };
-                let normalized_end_line = if end_line.as_i16() > 0 {
-                    end_line.as_i16() as u32
-                } else {
-                    (explicit_track_count + 1 + end_line.as_i16() as i32).max(0) as u32
-                };
-                let start_line = self.find_line_index(name, *idx as i32, axis, GridAreaEnd::Start, &|lines| {
-                    let point = lines.partition_point(|line| *line < normalized_end_line);
-                    &lines[..point]
-                });
-                Line { start: NonNamedGridPlacement::Line(start_line), end: NonNamedGridPlacement::Line(*end_line) }
+            GridAreaAxis::Column => {
+                NamedLineResolverAxis { lines: &self.column_lines, explicit_track_count: self.explicit_column_count }
             }
-            (start, end) => Line {
-                start: match start {
-                    GridPlacement::Auto => NonNamedGridPlacement::Auto,
-                    GridPlacement::Line(grid_line) => NonNamedGridPlacement::Line(*grid_line),
-                    GridPlacement::Span(span) => NonNamedGridPlacement::Span(*span),
-                    GridPlacement::NamedSpan(_, _) => NonNamedGridPlacement::Span(1),
-                    _ => unreachable!(),
-                },
-                end: match end {
-                    GridPlacement::Auto => NonNamedGridPlacement::Auto,
-                    GridPlacement::Line(grid_line) => NonNamedGridPlacement::Line(*grid_line),
-                    GridPlacement::Span(span) => NonNamedGridPlacement::Span(*span),
-                    GridPlacement::NamedSpan(_, _) => NonNamedGridPlacement::Span(1),
-                    _ => unreachable!(),
-                },
-            },
         }
+        .resolve_line_names(line)
     }
 
-    /// Resolve the grid line for a named grid line or span
-    fn find_line_index(
-        &self,
-        name: &S,
-        idx: i32,
-        axis: GridAreaAxis,
-        end: GridAreaEnd,
-        filter_lines: &dyn Fn(&[u32]) -> &[u32],
-    ) -> GridLine {
-        let name = name.as_ref();
-        let mut idx = idx;
-        let explicit_track_count = match axis {
-            GridAreaAxis::Row => self.explicit_row_count as i32,
-            GridAreaAxis::Column => self.explicit_column_count as i32,
-        };
-
-        // An index of 0 is used to represent "no index specified".
-        if idx == 0 {
-            idx = 1;
-        }
-
-        fn get_line(lines: &[u32], explicit_track_count: i32, idx: i32) -> i16 {
-            let abs_idx = idx.unsigned_abs() as usize;
-            let line = if abs_idx <= lines.len() {
-                if idx > 0 {
-                    lines[abs_idx - 1] as i64
-                } else {
-                    lines[lines.len() - abs_idx] as i64
-                }
-            } else {
-                let remaining_lines = (abs_idx - lines.len()) as i64 * idx.signum() as i64;
-                if idx > 0 {
-                    explicit_track_count as i64 + 1 + remaining_lines
-                } else {
-                    -(explicit_track_count as i64 + 1 + remaining_lines)
-                }
-            };
-            line.clamp(i16::MIN as i64, i16::MAX as i64) as i16
-        }
-
-        // Lookup lines
-        let line_lookup = match axis {
-            GridAreaAxis::Row => &self.row_lines,
-            GridAreaAxis::Column => &self.column_lines,
-        };
-        if let Some(lines) = line_lookup.get(name) {
-            return GridLine::from(get_line(filter_lines(lines), explicit_track_count, idx));
-        } else {
-            // TODO: eliminate string allocations
-            match end {
-                GridAreaEnd::Start => {
-                    let implicit_name = format!("{name}-start");
-                    if let Some(lines) = line_lookup.get(&*implicit_name) {
-                        // println!("IMPLICIT COL {implicit_name}");
-                        return GridLine::from(get_line(filter_lines(lines), explicit_track_count, idx));
-                    }
-                }
-                GridAreaEnd::End => {
-                    let implicit_name = format!("{name}-end");
-                    if let Some(lines) = line_lookup.get(&*implicit_name) {
-                        // println!("IMPLICIT ROW {implicit_name}");
-                        return GridLine::from(get_line(filter_lines(lines), explicit_track_count, idx));
-                    }
-                }
-            }
-        }
-
-        // The CSS Grid specification has a weird quirk where it matches non-existent line names
-        // to the first (positive) implicit line in the grid
-        //
-        // We add/subtract 2 to the explicit track count because (in each axis) a grid has one more explicit
-        // grid line than it has tracks. And the fallback line is the line *after* that.
-        //
-        // See: <https://github.com/w3c/csswg-drafts/issues/966#issuecomment-277042153>
-        let line = if idx > 0 {
-            explicit_track_count as i64 + 1 + idx as i64
-        } else {
-            -(explicit_track_count as i64 + 1 + idx as i64)
-        };
-
-        GridLine::from(line.clamp(i16::MIN as i64, i16::MAX as i64) as i16)
+    #[cfg(feature = "detailed_layout_info")]
+    pub(crate) fn populate_detailed_line_resolvers(self, rows: &mut GridLineNames<S>, columns: &mut GridLineNames<S>) {
+        rows.resolver = self.row_lines;
+        columns.resolver = self.column_lines;
     }
 
     /// Get the number of columns defined by the grid areas
@@ -565,6 +565,7 @@ pub struct GridLineNames<S: CheapCloneStr = DefaultCheapStr> {
     /// Offsets into `names`: line `i`'s names are `names[offsets[i]..offsets[i + 1]]`.
     /// Either empty (no named lines) or of length `line count + 1`.
     offsets: Vec<u32>,
+    resolver: NamedGridLinesMap<S>,
 }
 
 #[cfg(feature = "detailed_layout_info")]
@@ -573,7 +574,7 @@ impl<S: CheapCloneStr> GridLineNames<S> {
     pub(crate) fn with_capacity(name_capacity: usize, offset_capacity: usize) -> Self {
         let mut offsets = Vec::with_capacity(offset_capacity);
         offsets.push(0);
-        Self { names: Vec::with_capacity(name_capacity), offsets }
+        Self { names: Vec::with_capacity(name_capacity), offsets, resolver: Map::new() }
     }
 
     /// Start a new (initially empty) line
@@ -590,6 +591,14 @@ impl<S: CheapCloneStr> GridLineNames<S> {
     /// Whether the current (last) line already contains the passed name
     pub(crate) fn current_line_contains(&self, name: &str) -> bool {
         self.line(self.line_count().wrapping_sub(1)).iter().any(|n| n.as_ref() == name)
+    }
+
+    pub(crate) fn resolve_line_names(
+        &self,
+        line: &Line<GridPlacement<S>>,
+        explicit_track_count: u16,
+    ) -> Line<NonNamedGridPlacement> {
+        NamedLineResolverAxis { lines: &self.resolver, explicit_track_count }.resolve_line_names(line)
     }
 
     /// Whether the axis has any named lines at all

--- a/src/compute/grid/types/named.rs
+++ b/src/compute/grid/types/named.rs
@@ -46,10 +46,14 @@ impl<T: CheapCloneStr> Borrow<str> for StrHasher<T> {
     }
 }
 
+/// Map from a grid line name to its one-indexed line positions
 type NamedGridLinesMap<S> = Map<StrHasher<S>, Vec<u32>>;
 
+/// Resolver for named placements in one grid axis
 struct NamedLineResolverAxis<'a, S: CheapCloneStr> {
+    /// Named lines and their one-indexed positions
     lines: &'a NamedGridLinesMap<S>,
+    /// Number of explicit tracks in this axis
     explicit_track_count: u16,
 }
 
@@ -90,6 +94,7 @@ fn upsert_line_name_map<S: CheapCloneStr>(map: &mut Map<StrHasher<S>, Vec<u32>>,
 }
 
 impl<S: CheapCloneStr> NamedLineResolverAxis<'_, S> {
+    /// Resolve named lines and spans into numeric placements
     fn resolve_line_names(&self, line: &Line<GridPlacement<S>>) -> Line<NonNamedGridPlacement> {
         let start_holder;
         let start_line_resolved = if let GridPlacement::NamedLine(name, idx) = &line.start {
@@ -482,6 +487,7 @@ impl<S: CheapCloneStr> NamedLineResolver<S> {
         .resolve_line_names(line)
     }
 
+    /// Move the row and column line-name maps into the detailed grid information
     #[cfg(feature = "detailed_layout_info")]
     pub(crate) fn populate_detailed_line_resolvers(self, rows: &mut GridLineNames<S>, columns: &mut GridLineNames<S>) {
         rows.resolver = self.row_lines;
@@ -565,6 +571,7 @@ pub struct GridLineNames<S: CheapCloneStr = DefaultCheapStr> {
     /// Offsets into `names`: line `i`'s names are `names[offsets[i]..offsets[i + 1]]`.
     /// Either empty (no named lines) or of length `line count + 1`.
     offsets: Vec<u32>,
+    /// Named line lookup used to resolve arbitrary grid placements
     resolver: NamedGridLinesMap<S>,
 }
 
@@ -593,6 +600,7 @@ impl<S: CheapCloneStr> GridLineNames<S> {
         self.line(self.line_count().wrapping_sub(1)).iter().any(|n| n.as_ref() == name)
     }
 
+    /// Resolve named lines and spans using the retained line-name map
     pub(crate) fn resolve_line_names(
         &self,
         line: &Line<GridPlacement<S>>,

--- a/tests/hand_written/detailed_grid_info.rs
+++ b/tests/hand_written/detailed_grid_info.rs
@@ -208,6 +208,97 @@ mod detailed_grid_info {
         assert_eq!(info.item_grid_area(1), Some((Point { x: 5.0, y: 65.0 }, Size { width: 110.0, height: 30.0 })));
         // out of bounds index
         assert_eq!(info.item_grid_area(2), None);
+
+        assert_eq!(
+            info.resolve_absolute_grid_area(
+                Line { start: line(1), end: line(3) },
+                Line { start: line(1), end: line(3) },
+                taffy::style::Direction::Ltr,
+                Rect { left: 0.0, right: 120.0, top: 0.0, bottom: 100.0 },
+            ),
+            Rect { left: 5.0, right: 115.0, top: 5.0, bottom: 95.0 }
+        );
+        assert_eq!(
+            info.resolve_absolute_grid_area(
+                Line::AUTO,
+                Line { start: GridPlacement::Auto, end: line(2) },
+                taffy::style::Direction::Ltr,
+                Rect { left: 0.0, right: 120.0, top: 0.0, bottom: 100.0 },
+            ),
+            Rect { left: 0.0, right: 45.0, top: 0.0, bottom: 100.0 }
+        );
+        assert_eq!(
+            info.resolve_absolute_grid_area(
+                Line::AUTO,
+                Line { start: line(-1), end: GridPlacement::Auto },
+                taffy::style::Direction::Ltr,
+                Rect { left: 0.0, right: 120.0, top: 0.0, bottom: 100.0 },
+            ),
+            Rect { left: 115.0, right: 120.0, top: 0.0, bottom: 100.0 }
+        );
+        assert_eq!(
+            info.resolve_absolute_grid_area(
+                Line::AUTO,
+                Line { start: GridPlacement::NamedLine("missing".into(), 1), end: line(2) },
+                taffy::style::Direction::Ltr,
+                Rect { left: 0.0, right: 120.0, top: 0.0, bottom: 100.0 },
+            ),
+            Rect { left: 0.0, right: 45.0, top: 0.0, bottom: 100.0 }
+        );
+        assert_eq!(
+            info.resolve_absolute_grid_area(
+                Line::AUTO,
+                Line { start: GridPlacement::Span(2), end: GridPlacement::Span(3) },
+                taffy::style::Direction::Ltr,
+                Rect { left: 0.0, right: 120.0, top: 0.0, bottom: 100.0 },
+            ),
+            Rect { left: 0.0, right: 120.0, top: 0.0, bottom: 100.0 }
+        );
+    }
+
+    #[test]
+    fn absolute_grid_area_named_span() {
+        let mut tree = new_test_tree();
+        let child = tree.new_leaf(Style::default()).unwrap();
+        let root = tree
+            .new_with_children(
+                Style {
+                    display: Display::Grid,
+                    size: Size { width: Dimension::from_length(90.0), height: Dimension::from_length(50.0) },
+                    grid_template_columns: vec![length(30.0), length(30.0), length(30.0)],
+                    grid_template_column_names: vec![
+                        vec!["a".into()],
+                        vec!["b".into()],
+                        vec!["b".into()],
+                        vec!["c".into()],
+                    ],
+                    grid_template_rows: vec![length(50.0)],
+                    ..Default::default()
+                },
+                &[child],
+            )
+            .unwrap();
+        tree.compute_layout(root, definite(90.0, 50.0)).unwrap();
+
+        let info = get_detailed_grid_info(&tree, root);
+        assert_eq!(
+            info.resolve_absolute_grid_area(
+                Line::AUTO,
+                Line { start: GridPlacement::NamedLine("a".into(), 1), end: GridPlacement::NamedSpan("b".into(), 2) },
+                taffy::style::Direction::Ltr,
+                Rect { left: 0.0, right: 90.0, top: 0.0, bottom: 50.0 },
+            ),
+            Rect { left: 0.0, right: 60.0, top: 0.0, bottom: 50.0 }
+        );
+        assert_eq!(
+            info.resolve_absolute_grid_area(
+                Line::AUTO,
+                Line { start: GridPlacement::NamedLine("b".into(), 2), end: GridPlacement::NamedLine("c".into(), 1) },
+                taffy::style::Direction::Ltr,
+                Rect { left: 0.0, right: 90.0, top: 0.0, bottom: 50.0 },
+            ),
+            Rect { left: 60.0, right: 90.0, top: 0.0, bottom: 50.0 }
+        );
     }
 
     #[test]
@@ -243,5 +334,32 @@ mod detailed_grid_info {
         assert_eq!(info.columns.positions[1], Line { start: 0.0, end: 60.0 });
         // item_grid_area resolves the physical rectangle of the (auto-placed) item's grid area
         assert_eq!(info.item_grid_area(0), Some((Point { x: 60.0, y: 0.0 }, Size { width: 40.0, height: 50.0 })));
+        assert_eq!(
+            info.resolve_absolute_grid_area(
+                Line::AUTO,
+                Line { start: line(1), end: line(2) },
+                taffy::style::Direction::Rtl,
+                Rect { left: 0.0, right: 100.0, top: 0.0, bottom: 50.0 },
+            ),
+            Rect { left: 60.0, right: 100.0, top: 0.0, bottom: 50.0 }
+        );
+        assert_eq!(
+            info.resolve_absolute_grid_area(
+                Line::AUTO,
+                Line { start: GridPlacement::NamedLine("a".into(), 1), end: GridPlacement::NamedLine("b".into(), 1) },
+                taffy::style::Direction::Rtl,
+                Rect { left: 0.0, right: 100.0, top: 0.0, bottom: 50.0 },
+            ),
+            Rect { left: 60.0, right: 100.0, top: 0.0, bottom: 50.0 }
+        );
+        assert_eq!(
+            info.resolve_absolute_grid_area(
+                Line::AUTO,
+                Line { start: line(1), end: GridPlacement::Auto },
+                taffy::style::Direction::Rtl,
+                Rect { left: 0.0, right: 100.0, top: 0.0, bottom: 50.0 },
+            ),
+            Rect { left: 0.0, right: 100.0, top: 0.0, bottom: 50.0 }
+        );
     }
 }


### PR DESCRIPTION
## Summary
- retain named grid-line lookup maps in detailed grid information
- add `DetailedGridInfo::resolve_absolute_grid_area` for resolving absolute placements to physical coordinates
- cover numeric, named, span, auto, missing-name, and RTL placement cases

#### Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --features detailed_layout_info --test hand_written detailed_grid_info`