### PR TITLE
Use SmallVec<[u32; 4]> for named grid line positions

### DIFF
--- a/src/compute/grid/types/named.rs
+++ b/src/compute/grid/types/named.rs
@@ -12,7 +12,8 @@ use crate::geometry::AbsoluteAxis;
 #[cfg(feature = "detailed_layout_info")]
 use crate::sys::DefaultCheapStr;
 // use alloc::fmt::format;
-use crate::sys::{format, single_value_vec, Map, Vec};
+use crate::sys::{format, Map, Vec};
+use smallvec::{smallvec, SmallVec};
 
 /// Wrap an `AsRef<str>` type with a type which implements Hash by first
 /// deferring to the underlying `&str`'s implementation of Hash.
@@ -46,8 +47,13 @@ impl<T: CheapCloneStr> Borrow<str> for StrHasher<T> {
     }
 }
 
+/// The one-indexed line positions of a single grid line name. Inline capacity of 4 keeps the
+/// type the same size as `Vec<u32>` (24 bytes) while avoiding a heap allocation for names
+/// mapping to at most 4 lines (the common case)
+pub(crate) type LinePositions = SmallVec<[u32; 4]>;
+
 /// Map from a grid line name to its one-indexed line positions
-type NamedGridLinesMap<S> = Map<StrHasher<S>, Vec<u32>>;
+type NamedGridLinesMap<S> = Map<StrHasher<S>, LinePositions>;
 
 /// Resolver for named placements in one grid axis
 struct NamedLineResolverAxis<'a, S: CheapCloneStr> {
@@ -61,11 +67,11 @@ struct NamedLineResolverAxis<'a, S: CheapCloneStr> {
 /// resolve line names of grid placement properties into line numbers.
 pub(crate) struct NamedLineResolver<S: CheapCloneStr> {
     /// Map of row line names to line numbers. Each line name may correspond to multiple lines
-    /// so we store a `Vec`
-    row_lines: Map<StrHasher<S>, Vec<u32>>,
+    /// so we store a `SmallVec`
+    row_lines: NamedGridLinesMap<S>,
     /// Map of column line names to line numbers. Each line name may correspond to multiple lines
-    /// so we store a `Vec`
-    column_lines: Map<StrHasher<S>, Vec<u32>>,
+    /// so we store a `SmallVec`
+    column_lines: NamedGridLinesMap<S>,
     /// Map of area names to area definitions (start and end lines numbers in each axis)
     areas: Map<StrHasher<S>, GridTemplateArea<S>>,
     /// Number of columns implied by grid area definitions
@@ -89,8 +95,8 @@ pub(crate) struct NamedLineResolver<S: CheapCloneStr> {
 }
 
 /// Utility function to create or update an entry in a line name map
-fn upsert_line_name_map<S: CheapCloneStr>(map: &mut Map<StrHasher<S>, Vec<u32>>, key: S, value: u32) {
-    map.entry(StrHasher(key)).and_modify(|lines| lines.push(value)).or_insert_with(|| single_value_vec(value));
+fn upsert_line_name_map<S: CheapCloneStr>(map: &mut NamedGridLinesMap<S>, key: S, value: u32) {
+    map.entry(StrHasher(key)).and_modify(|lines| lines.push(value)).or_insert_with(|| smallvec![value]);
 }
 
 impl<S: CheapCloneStr> NamedLineResolverAxis<'_, S> {
@@ -238,8 +244,8 @@ impl<S: CheapCloneStr> NamedLineResolver<S> {
         row_auto_repetitions: u16,
     ) -> Self {
         let mut areas: Map<StrHasher<S>, GridTemplateArea<_>> = Map::new();
-        let mut column_lines: Map<StrHasher<S>, Vec<u32>> = Map::new();
-        let mut row_lines: Map<StrHasher<S>, Vec<u32>> = Map::new();
+        let mut column_lines: NamedGridLinesMap<S> = Map::new();
+        let mut row_lines: NamedGridLinesMap<S> = Map::new();
 
         #[cfg(feature = "detailed_layout_info")]
         let mut column_line_name_pairs: Vec<(u32, S)> = Vec::new();
@@ -254,10 +260,7 @@ impl<S: CheapCloneStr> NamedLineResolver<S> {
                     for line_name in line_names.into_iter() {
                         #[cfg(feature = "detailed_layout_info")]
                         column_line_name_pairs.push((current_line, line_name.clone()));
-                        column_lines
-                            .entry(StrHasher(line_name.clone()))
-                            .and_modify(|lines: &mut Vec<u32>| lines.push(current_line))
-                            .or_insert_with(|| single_value_vec(current_line));
+                        upsert_line_name_map(&mut column_lines, line_name.clone(), current_line);
                     }
 
                     if let Some(GenericGridTemplateComponent::Repeat(repeat)) = column_tracks.next() {
@@ -313,10 +316,7 @@ impl<S: CheapCloneStr> NamedLineResolver<S> {
                     for line_name in line_names.into_iter() {
                         #[cfg(feature = "detailed_layout_info")]
                         row_line_name_pairs.push((current_line, line_name.clone()));
-                        row_lines
-                            .entry(StrHasher(line_name.clone()))
-                            .and_modify(|lines: &mut Vec<u32>| lines.push(current_line))
-                            .or_insert_with(|| single_value_vec(current_line));
+                        upsert_line_name_map(&mut row_lines, line_name.clone(), current_line);
                     }
 
                     if let Some(GenericGridTemplateComponent::Repeat(repeat)) = row_tracks.next() {

--- a/src/util/sys.rs
+++ b/src/util/sys.rs
@@ -47,12 +47,6 @@ mod std {
         Vec::with_capacity(capacity)
     }
 
-    /// Creates a new vector with the capacity for the specified number of items before it must be resized
-    #[must_use]
-    pub(crate) fn single_value_vec<A>(value: A) -> Vec<A> {
-        vec![value]
-    }
-
     /// Rounds to the nearest whole number
     #[must_use]
     #[inline(always)]
@@ -133,14 +127,6 @@ mod alloc {
         Vec::with_capacity(capacity)
     }
 
-    /// Creates a new vector with the capacity for the specified number of items before it must be resized
-    #[must_use]
-    pub(crate) fn single_value_vec<A>(value: A) -> Vec<A> {
-        let mut vec = Vec::with_capacity(1);
-        vec.push(value);
-        vec
-    }
-
     /// Rounds to the nearest whole number
     pub(crate) use super::polyfill::round;
 
@@ -198,14 +184,6 @@ mod core {
     #[must_use]
     pub(crate) fn new_vec_with_capacity<A, const CAP: usize>(_capacity: usize) -> arrayvec::ArrayVec<A, CAP> {
         arrayvec::ArrayVec::new()
-    }
-
-    /// Creates a new vector with the capacity for the specified number of items before it must be resized
-    #[must_use]
-    pub(crate) fn single_value_vec<A, const CAP: usize>(value: A) -> arrayvec::ArrayVec<A, CAP> {
-        let mut vec = new_vec_with_capacity(1);
-        vec.push(value);
-        vec
     }
 
     /// Rounds to the nearest whole number


### PR DESCRIPTION
# Objective

Avoid a heap allocation per named grid line by storing line positions in the `NamedLineResolver` line-name maps as `SmallVec<[u32; 4]>` instead of `Vec<u32>`.

`[u32; 4]` is the largest inline capacity that keeps the type the same size as `Vec<u32>` (24 bytes: one usize len/tag + a 16-byte union of `(ptr, cap)` vs the inline array), and it covers the common case — most names map to 1–2 lines (explicit names, area `-start`/`-end` names). Names appearing on more than 4 lines (e.g. via `repeat()`) spill to the heap as before.

## Context

```rust
pub(crate) type LinePositions = SmallVec<[u32; 4]>;
type NamedGridLinesMap<S> = Map<StrHasher<S>, LinePositions>;
```

- `smallvec` was already a dependency of the `grid` feature (used in `cell_occupancy.rs`), so no new dependency.
- The inline map-upsert code paths now reuse `upsert_line_name_map`, and the now-unused `sys::single_value_vec` helpers are removed.
- No public API change: the map is internal (`GridLineNames.resolver` included), and consumers only ever see `&[u32]` slices.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/34708722c11c4b49b98a74334cda671e
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/34708722c11c4b49b98a74334cda671e?variant=devin-insiders
Requested by: @nicoburns