### PR TITLE
Fix intrinsic width contribution of floats with clear

### DIFF
--- a/src/compute/float.rs
+++ b/src/compute/float.rs
@@ -740,6 +740,8 @@ impl FloatContext {
 pub struct FloatIntrinsicWidthCalculator {
     /// The available width of the container
     available_width: AvailableSpace,
+    /// The running sums of the widths of adjacent uncleared floats on each side (left, right)
+    side_sums: [f32; 2],
     /// The running total intrinsic width contribution
     contribution: f32,
     /// The widest single float (the floats' min-content contribution)
@@ -749,16 +751,27 @@ pub struct FloatIntrinsicWidthCalculator {
 impl FloatIntrinsicWidthCalculator {
     /// Create a new `FloatIntrinsicWidthCalculator`
     pub fn new(available_width: AvailableSpace) -> Self {
-        Self { available_width, contribution: 0.0, widest: 0.0 }
+        Self { available_width, side_sums: [0.0; 2], contribution: 0.0, widest: 0.0 }
     }
 
     /// Add a float to the computation
-    pub fn add_float(&mut self, width: f32, _direction: FloatDirection, _clear: Clear) {
+    pub fn add_float(&mut self, width: f32, direction: FloatDirection, clear: Clear) {
         match self.available_width {
             // Definite available width means the container is being fit-content sized
             // (e.g. it is itself a float being shrink-to-fit sized). The floats' max-content
             // contribution (widths summed) is clamped by the available width in `result`.
-            AvailableSpace::Definite(_) | AvailableSpace::MaxContent => self.contribution += width,
+            AvailableSpace::Definite(_) | AvailableSpace::MaxContent => {
+                // A float that clears a side is placed below the floats on that side, so its
+                // width does not accumulate with theirs.
+                if matches!(clear, Clear::Left | Clear::Both) {
+                    self.side_sums[0] = 0.0;
+                }
+                if matches!(clear, Clear::Right | Clear::Both) {
+                    self.side_sums[1] = 0.0;
+                }
+                self.side_sums[direction as usize] += width;
+                self.contribution = self.contribution.max(self.side_sums[0] + self.side_sums[1]);
+            }
             AvailableSpace::MinContent => self.contribution = self.contribution.max(width),
         };
         self.widest = self.widest.max(width);

--- a/test_fixtures/float/float_shrink_to_fit_cleared_floats.html
+++ b/test_fixtures/float/float_shrink_to_fit_cleared_floats.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 400px; height: 200px;">
+  <div style="display: block; float: right;">
+    <div style="display: block; float: right; width: 100px; height: 20px;"></div>
+    <div style="display: block; float: right; clear: right; width: 120px; height: 20px;"></div>
+  </div>
+  <div style="display: block; float: left;">
+    <div style="display: block; float: left; width: 50px; height: 20px;"></div>
+    <div style="display: block; float: left; clear: left; width: 60px; height: 20px;"></div>
+    <div style="display: block; float: left; width: 30px; height: 20px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/float/float_shrink_to_fit_cleared_floats__border_box_ltr.xml
+++ b/tests/xml/float/float_shrink_to_fit_cleared_floats__border_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="float_shrink_to_fit_cleared_floats__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="400px" height="200px">
+      <div display="block" direction="ltr" float="right">
+        <div display="block" direction="ltr" float="right" width="100px" height="20px"/>
+        <div display="block" direction="ltr" float="right" clear="right" width="120px" height="20px"/>
+      </div>
+      <div display="block" direction="ltr" float="left">
+        <div display="block" direction="ltr" float="left" width="50px" height="20px"/>
+        <div display="block" direction="ltr" float="left" clear="left" width="60px" height="20px"/>
+        <div display="block" direction="ltr" float="left" width="30px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="200">
+      <node x="280" y="0" width="120" height="40">
+        <node x="20" y="0" width="100" height="20"/>
+        <node x="0" y="20" width="120" height="20"/>
+      </node>
+      <node x="0" y="0" width="90" height="40">
+        <node x="0" y="0" width="50" height="20"/>
+        <node x="0" y="20" width="60" height="20"/>
+        <node x="60" y="20" width="30" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_shrink_to_fit_cleared_floats__border_box_rtl.xml
+++ b/tests/xml/float/float_shrink_to_fit_cleared_floats__border_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="float_shrink_to_fit_cleared_floats__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="400px" height="200px">
+      <div display="block" direction="rtl" float="right">
+        <div display="block" direction="rtl" float="right" width="100px" height="20px"/>
+        <div display="block" direction="rtl" float="right" clear="right" width="120px" height="20px"/>
+      </div>
+      <div display="block" direction="rtl" float="left">
+        <div display="block" direction="rtl" float="left" width="50px" height="20px"/>
+        <div display="block" direction="rtl" float="left" clear="left" width="60px" height="20px"/>
+        <div display="block" direction="rtl" float="left" width="30px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="200">
+      <node x="280" y="0" width="120" height="40">
+        <node x="20" y="0" width="100" height="20"/>
+        <node x="0" y="20" width="120" height="20"/>
+      </node>
+      <node x="0" y="0" width="90" height="40">
+        <node x="0" y="0" width="50" height="20"/>
+        <node x="0" y="20" width="60" height="20"/>
+        <node x="60" y="20" width="30" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_shrink_to_fit_cleared_floats__content_box_ltr.xml
+++ b/tests/xml/float/float_shrink_to_fit_cleared_floats__content_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="float_shrink_to_fit_cleared_floats__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="400px" height="200px">
+      <div display="block" box-sizing="content-box" direction="ltr" float="right">
+        <div display="block" box-sizing="content-box" direction="ltr" float="right" width="100px" height="20px"/>
+        <div display="block" box-sizing="content-box" direction="ltr" float="right" clear="right" width="120px" height="20px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="ltr" float="left">
+        <div display="block" box-sizing="content-box" direction="ltr" float="left" width="50px" height="20px"/>
+        <div display="block" box-sizing="content-box" direction="ltr" float="left" clear="left" width="60px" height="20px"/>
+        <div display="block" box-sizing="content-box" direction="ltr" float="left" width="30px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="200">
+      <node x="280" y="0" width="120" height="40">
+        <node x="20" y="0" width="100" height="20"/>
+        <node x="0" y="20" width="120" height="20"/>
+      </node>
+      <node x="0" y="0" width="90" height="40">
+        <node x="0" y="0" width="50" height="20"/>
+        <node x="0" y="20" width="60" height="20"/>
+        <node x="60" y="20" width="30" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_shrink_to_fit_cleared_floats__content_box_rtl.xml
+++ b/tests/xml/float/float_shrink_to_fit_cleared_floats__content_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="float_shrink_to_fit_cleared_floats__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="400px" height="200px">
+      <div display="block" box-sizing="content-box" direction="rtl" float="right">
+        <div display="block" box-sizing="content-box" direction="rtl" float="right" width="100px" height="20px"/>
+        <div display="block" box-sizing="content-box" direction="rtl" float="right" clear="right" width="120px" height="20px"/>
+      </div>
+      <div display="block" box-sizing="content-box" direction="rtl" float="left">
+        <div display="block" box-sizing="content-box" direction="rtl" float="left" width="50px" height="20px"/>
+        <div display="block" box-sizing="content-box" direction="rtl" float="left" clear="left" width="60px" height="20px"/>
+        <div display="block" box-sizing="content-box" direction="rtl" float="left" width="30px" height="20px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="200">
+      <node x="280" y="0" width="120" height="40">
+        <node x="20" y="0" width="100" height="20"/>
+        <node x="0" y="20" width="120" height="20"/>
+      </node>
+      <node x="0" y="0" width="90" height="40">
+        <node x="0" y="0" width="50" height="20"/>
+        <node x="0" y="20" width="60" height="20"/>
+        <node x="60" y="20" width="30" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -19482,6 +19482,26 @@ mod float {
     }
 
     #[test]
+    fn float_shrink_to_fit_cleared_floats__border_box_ltr() {
+        crate::run_xml_test("float", "float_shrink_to_fit_cleared_floats__border_box_ltr");
+    }
+
+    #[test]
+    fn float_shrink_to_fit_cleared_floats__content_box_ltr() {
+        crate::run_xml_test("float", "float_shrink_to_fit_cleared_floats__content_box_ltr");
+    }
+
+    #[test]
+    fn float_shrink_to_fit_cleared_floats__border_box_rtl() {
+        crate::run_xml_test("float", "float_shrink_to_fit_cleared_floats__border_box_rtl");
+    }
+
+    #[test]
+    fn float_shrink_to_fit_cleared_floats__content_box_rtl() {
+        crate::run_xml_test("float", "float_shrink_to_fit_cleared_floats__content_box_rtl");
+    }
+
+    #[test]
     fn float_shrink_to_fit_contains_floats__border_box_ltr() {
         crate::run_xml_test("float", "float_shrink_to_fit_contains_floats__border_box_ltr");
     }


### PR DESCRIPTION
# Objective

Fix the squeezed body text on https://en.wikipedia.org/wiki/Barack_Obama in Blitz: the intro paragraph got roughly half the width it should because the right-floated `.stack` wrapper (containing the infobox *and* a `clear: right` sidebar) was shrink-to-fit sized to ~2x the correct width, so the text avoided a float twice as wide as what was painted.

## Context

`FloatIntrinsicWidthCalculator::add_float` ignored `clear` and unconditionally summed float widths for the max-content contribution:

```rust
AvailableSpace::Definite(_) | AvailableSpace::MaxContent => self.contribution += width,
```

But a float that clears a side is placed *below* the floats on that side, so its width does not accumulate with theirs. The Wikipedia stack contains two 22em right floats where the second has `clear: right`; they stack vertically, so the container's fit-content width should be `max(w1, w2)`, not `w1 + w2`.

The fix tracks per-side running sums of adjacent uncleared float widths; a float's `clear` resets the cleared side's sum before its own width is added, and the contribution is the running max of `left_sum + right_sum`:

```rust
if clear ∈ {Left, Both} { side_sums[0] = 0.0 }
if clear ∈ {Right, Both} { side_sums[1] = 0.0 }
side_sums[direction] += width;
contribution = contribution.max(side_sums[0] + side_sums[1]);
```

This matches Chrome's behavior, verified by the new generated test fixture `float_shrink_to_fit_cleared_floats` (shrink-to-fit float containers with cleared right floats and a left-float mix).

Before/after rendering the reduced Wikipedia repro in Blitz (paragraph next to a float wrapper containing an infobox plus a cleared sidebar):

| Before | After |
|---|---|
| text squeezed to ~half width | text fills up to the float edge |

Full `cargo test --workspace` passes (6009 tests, including the 4 new generated cases).


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/93f5f27500934387ae3e7ca3bbfc9f43
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/93f5f27500934387ae3e7ca3bbfc9f43?variant=devin-insiders
Requested by: @nicoburns