### PR TITLE
Fix intrinsic flex sizing with negative margins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@
 
 ### Fixed
 
+- Flexbox: intrinsic main sizing now applies negative main-axis margins as lengths for non-shrinking items, and zero-basis items no longer collapse the intrinsic container size (#1151)
+
 - CSS parser (`parse` feature): `GridTemplateTracks::from_css` (used to parse `grid-template-rows`/`grid-template-columns` values) now emits one line-name group per grid line, pushing an empty group for lines with no `[...]` in the source. Previously groups were only emitted for lines that had names, which is ambiguous (name groups are positional) and caused line names in templates such as `repeat(auto-fill, [col] 40px)` to be silently dropped when the parsed value was applied to a style
 
 - Block/float: the height of overflowing in-flow content of a nested block no longer contributes to the height of the block formatting context root as if it were floated content. Previously an auto-height BFC root containing a block whose in-flow content overflowed it (e.g. a fixed-height block with taller content) was incorrectly extended to contain that overflowing content

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -1465,7 +1465,7 @@ fn determine_container_main_size(
                             if diff > 0.0 {
                                 diff / f32_max(1.0, item.flex_grow)
                             } else if diff < 0.0 {
-                                let scaled_shrink_factor = f32_max(1.0, item.flex_shrink * item.inner_flex_basis);
+                                let scaled_shrink_factor = f32_max(1.0, item.flex_shrink) * item.inner_flex_basis;
                                 diff / scaled_shrink_factor
                             } else {
                                 // We are assuming that diff is 0.0 here and that we haven't accidentally introduced a NaN

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -1502,7 +1502,11 @@ fn determine_container_main_size(
                                 f32_max(1.0, item.flex_grow) * flex_fraction
                             } else if item.content_flex_fraction < 0.0 {
                                 let scaled_shrink_factor = f32_max(1.0, item.flex_shrink) * item.inner_flex_basis;
-                                scaled_shrink_factor * flex_fraction
+                                if scaled_shrink_factor == 0.0 {
+                                    0.0
+                                } else {
+                                    scaled_shrink_factor * flex_fraction
+                                }
                             } else {
                                 0.0
                             };

--- a/test_fixtures/flex/taffy_issue_1151_negative_margin.html
+++ b/test_fixtures/flex/taffy_issue_1151_negative_margin.html
@@ -14,9 +14,12 @@
     <div style="width: 20px; height: 10px; flex-shrink: 0; margin-bottom: -0.5px;"></div>
     <div style="width: 20px; height: 20px; flex-shrink: 0; margin-top: -5px;"></div>
   </div>
-  <div style="width: 100px; flex-direction: row; flex-shrink: 0;">
+  <div style="flex-direction: row; flex-shrink: 0;">
     <div style="width: 10px; height: 20px; flex-shrink: 0; margin-right: -0.5px;"></div>
-    <div style="width: 20px; height: 20px; flex-grow: 1; flex-shrink: 0; margin-left: -5px;"></div>
+    <div style="width: 20px; height: 20px; flex-shrink: 0; margin-left: -5px;"></div>
+  </div>
+  <div style="flex-direction: row; flex-shrink: 0;">
+    <div style="flex-grow: 1; flex-shrink: 0; margin-left: -5px;">XXXX</div>
   </div>
 </div>
 

--- a/test_fixtures/flex/taffy_issue_1151_negative_margin.html
+++ b/test_fixtures/flex/taffy_issue_1151_negative_margin.html
@@ -21,6 +21,10 @@
   <div style="flex-direction: row; flex-shrink: 0;">
     <div style="flex-grow: 1; flex-shrink: 0; margin-left: -5px;">XXXX</div>
   </div>
+  <div style="flex-direction: row; flex-wrap: wrap; width: max-content; flex-shrink: 0;">
+    <div style="width: 100px;"></div>
+    <div style="width: 0px; margin-left: -10px;"></div>
+  </div>
 </div>
 
 </body>

--- a/test_fixtures/flex/taffy_issue_1151_negative_margin.html
+++ b/test_fixtures/flex/taffy_issue_1151_negative_margin.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="flex-direction: column; align-items: flex-start;">
+  <div style="width: 100px; flex-direction: column; flex-shrink: 0;">
+    <div style="width: 20px; height: 10px; flex-shrink: 0; margin-bottom: -0.5px;"></div>
+    <div style="width: 20px; height: 20px; flex-shrink: 0; margin-top: -5px;"></div>
+  </div>
+  <div style="width: 100px; flex-direction: row; flex-shrink: 0;">
+    <div style="width: 10px; height: 20px; flex-shrink: 0; margin-right: -0.5px;"></div>
+    <div style="width: 20px; height: 20px; flex-grow: 1; flex-shrink: 0; margin-left: -5px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/flex/taffy_issue_1151_negative_margin__border_box_ltr.xml
+++ b/tests/xml/flex/taffy_issue_1151_negative_margin__border_box_ltr.xml
@@ -6,21 +6,29 @@
         <div direction="ltr" flex-shrink="0" width="20px" height="10px" margin-bottom="-0.5px"/>
         <div direction="ltr" flex-shrink="0" width="20px" height="20px" margin-top="-5px"/>
       </div>
-      <div direction="ltr" flex-shrink="0" width="100px">
+      <div direction="ltr" flex-shrink="0">
         <div direction="ltr" flex-shrink="0" width="10px" height="20px" margin-right="-0.5px"/>
-        <div direction="ltr" flex-grow="1" flex-shrink="0" width="20px" height="20px" margin-left="-5px"/>
+        <div direction="ltr" flex-shrink="0" width="20px" height="20px" margin-left="-5px"/>
+      </div>
+      <div direction="ltr" flex-shrink="0">
+        <text direction="ltr" flex-grow="1" flex-shrink="0" margin-left="-5px">
+          XXXX
+        </text>
       </div>
     </div>
   </input>
   <expectations>
-    <node x="0" y="0" width="100" height="45">
+    <node x="0" y="0" width="100" height="55">
       <node x="0" y="0" width="100" height="25">
         <node x="0" y="0" width="20" height="10"/>
         <node x="0" y="5" width="20" height="20"/>
       </node>
-      <node x="0" y="25" width="100" height="20">
+      <node x="0" y="25" width="25" height="20">
         <node x="0" y="0" width="10" height="20"/>
-        <node x="5" y="0" width="95" height="20"/>
+        <node x="5" y="0" width="20" height="20"/>
+      </node>
+      <node x="0" y="45" width="35" height="10">
+        <node x="-5" y="0" width="40" height="10"/>
       </node>
     </node>
   </expectations>

--- a/tests/xml/flex/taffy_issue_1151_negative_margin__border_box_ltr.xml
+++ b/tests/xml/flex/taffy_issue_1151_negative_margin__border_box_ltr.xml
@@ -15,6 +15,10 @@
           XXXX
         </text>
       </div>
+      <div direction="ltr" flex-wrap="wrap" flex-shrink="0" width="max-content">
+        <div direction="ltr" width="100px"/>
+        <div direction="ltr" width="0px" margin-left="-10px"/>
+      </div>
     </div>
   </input>
   <expectations>
@@ -29,6 +33,10 @@
       </node>
       <node x="0" y="45" width="35" height="10">
         <node x="-5" y="0" width="40" height="10"/>
+      </node>
+      <node x="0" y="55" width="100" height="0">
+        <node x="0" y="0" width="100" height="0"/>
+        <node x="90" y="0" width="0" height="0"/>
       </node>
     </node>
   </expectations>

--- a/tests/xml/flex/taffy_issue_1151_negative_margin__border_box_ltr.xml
+++ b/tests/xml/flex/taffy_issue_1151_negative_margin__border_box_ltr.xml
@@ -1,0 +1,27 @@
+<test name="taffy_issue_1151_negative_margin__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" flex-direction="column" align-items="flex-start">
+      <div direction="ltr" flex-direction="column" flex-shrink="0" width="100px">
+        <div direction="ltr" flex-shrink="0" width="20px" height="10px" margin-bottom="-0.5px"/>
+        <div direction="ltr" flex-shrink="0" width="20px" height="20px" margin-top="-5px"/>
+      </div>
+      <div direction="ltr" flex-shrink="0" width="100px">
+        <div direction="ltr" flex-shrink="0" width="10px" height="20px" margin-right="-0.5px"/>
+        <div direction="ltr" flex-grow="1" flex-shrink="0" width="20px" height="20px" margin-left="-5px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="45">
+      <node x="0" y="0" width="100" height="25">
+        <node x="0" y="0" width="20" height="10"/>
+        <node x="0" y="5" width="20" height="20"/>
+      </node>
+      <node x="0" y="25" width="100" height="20">
+        <node x="0" y="0" width="10" height="20"/>
+        <node x="5" y="0" width="95" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/taffy_issue_1151_negative_margin__border_box_rtl.xml
+++ b/tests/xml/flex/taffy_issue_1151_negative_margin__border_box_rtl.xml
@@ -15,6 +15,10 @@
           XXXX
         </text>
       </div>
+      <div direction="rtl" flex-wrap="wrap" flex-shrink="0" width="max-content">
+        <div direction="rtl" width="100px"/>
+        <div direction="rtl" width="0px" margin-left="-10px"/>
+      </div>
     </div>
   </input>
   <expectations>
@@ -29,6 +33,10 @@
       </node>
       <node x="65" y="45" width="35" height="10">
         <node x="-5" y="0" width="40" height="10"/>
+      </node>
+      <node x="0" y="55" width="100" height="0">
+        <node x="0" y="0" width="100" height="0"/>
+        <node x="0" y="0" width="0" height="0"/>
       </node>
     </node>
   </expectations>

--- a/tests/xml/flex/taffy_issue_1151_negative_margin__border_box_rtl.xml
+++ b/tests/xml/flex/taffy_issue_1151_negative_margin__border_box_rtl.xml
@@ -1,0 +1,27 @@
+<test name="taffy_issue_1151_negative_margin__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" flex-direction="column" align-items="flex-start">
+      <div direction="rtl" flex-direction="column" flex-shrink="0" width="100px">
+        <div direction="rtl" flex-shrink="0" width="20px" height="10px" margin-bottom="-0.5px"/>
+        <div direction="rtl" flex-shrink="0" width="20px" height="20px" margin-top="-5px"/>
+      </div>
+      <div direction="rtl" flex-shrink="0" width="100px">
+        <div direction="rtl" flex-shrink="0" width="10px" height="20px" margin-right="-0.5px"/>
+        <div direction="rtl" flex-grow="1" flex-shrink="0" width="20px" height="20px" margin-left="-5px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="45">
+      <node x="0" y="0" width="100" height="25">
+        <node x="80" y="0" width="20" height="10"/>
+        <node x="80" y="5" width="20" height="20"/>
+      </node>
+      <node x="0" y="25" width="100" height="20">
+        <node x="91" y="0" width="10" height="20"/>
+        <node x="-5" y="0" width="96" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/taffy_issue_1151_negative_margin__border_box_rtl.xml
+++ b/tests/xml/flex/taffy_issue_1151_negative_margin__border_box_rtl.xml
@@ -6,21 +6,29 @@
         <div direction="rtl" flex-shrink="0" width="20px" height="10px" margin-bottom="-0.5px"/>
         <div direction="rtl" flex-shrink="0" width="20px" height="20px" margin-top="-5px"/>
       </div>
-      <div direction="rtl" flex-shrink="0" width="100px">
+      <div direction="rtl" flex-shrink="0">
         <div direction="rtl" flex-shrink="0" width="10px" height="20px" margin-right="-0.5px"/>
-        <div direction="rtl" flex-grow="1" flex-shrink="0" width="20px" height="20px" margin-left="-5px"/>
+        <div direction="rtl" flex-shrink="0" width="20px" height="20px" margin-left="-5px"/>
+      </div>
+      <div direction="rtl" flex-shrink="0">
+        <text direction="rtl" flex-grow="1" flex-shrink="0" margin-left="-5px">
+          XXXX
+        </text>
       </div>
     </div>
   </input>
   <expectations>
-    <node x="0" y="0" width="100" height="45">
+    <node x="0" y="0" width="100" height="55">
       <node x="0" y="0" width="100" height="25">
         <node x="80" y="0" width="20" height="10"/>
         <node x="80" y="5" width="20" height="20"/>
       </node>
-      <node x="0" y="25" width="100" height="20">
-        <node x="91" y="0" width="10" height="20"/>
-        <node x="-5" y="0" width="96" height="20"/>
+      <node x="76" y="25" width="24" height="20">
+        <node x="15" y="0" width="10" height="20"/>
+        <node x="-5" y="0" width="20" height="20"/>
+      </node>
+      <node x="65" y="45" width="35" height="10">
+        <node x="-5" y="0" width="40" height="10"/>
       </node>
     </node>
   </expectations>

--- a/tests/xml/flex/taffy_issue_1151_negative_margin__content_box_ltr.xml
+++ b/tests/xml/flex/taffy_issue_1151_negative_margin__content_box_ltr.xml
@@ -15,6 +15,10 @@
           XXXX
         </text>
       </div>
+      <div box-sizing="content-box" direction="ltr" flex-wrap="wrap" flex-shrink="0" width="max-content">
+        <div box-sizing="content-box" direction="ltr" width="100px"/>
+        <div box-sizing="content-box" direction="ltr" width="0px" margin-left="-10px"/>
+      </div>
     </div>
   </input>
   <expectations>
@@ -29,6 +33,10 @@
       </node>
       <node x="0" y="45" width="35" height="10">
         <node x="-5" y="0" width="40" height="10"/>
+      </node>
+      <node x="0" y="55" width="100" height="0">
+        <node x="0" y="0" width="100" height="0"/>
+        <node x="90" y="0" width="0" height="0"/>
       </node>
     </node>
   </expectations>

--- a/tests/xml/flex/taffy_issue_1151_negative_margin__content_box_ltr.xml
+++ b/tests/xml/flex/taffy_issue_1151_negative_margin__content_box_ltr.xml
@@ -1,0 +1,27 @@
+<test name="taffy_issue_1151_negative_margin__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" flex-direction="column" align-items="flex-start">
+      <div box-sizing="content-box" direction="ltr" flex-direction="column" flex-shrink="0" width="100px">
+        <div box-sizing="content-box" direction="ltr" flex-shrink="0" width="20px" height="10px" margin-bottom="-0.5px"/>
+        <div box-sizing="content-box" direction="ltr" flex-shrink="0" width="20px" height="20px" margin-top="-5px"/>
+      </div>
+      <div box-sizing="content-box" direction="ltr" flex-shrink="0" width="100px">
+        <div box-sizing="content-box" direction="ltr" flex-shrink="0" width="10px" height="20px" margin-right="-0.5px"/>
+        <div box-sizing="content-box" direction="ltr" flex-grow="1" flex-shrink="0" width="20px" height="20px" margin-left="-5px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="45">
+      <node x="0" y="0" width="100" height="25">
+        <node x="0" y="0" width="20" height="10"/>
+        <node x="0" y="5" width="20" height="20"/>
+      </node>
+      <node x="0" y="25" width="100" height="20">
+        <node x="0" y="0" width="10" height="20"/>
+        <node x="5" y="0" width="95" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/taffy_issue_1151_negative_margin__content_box_ltr.xml
+++ b/tests/xml/flex/taffy_issue_1151_negative_margin__content_box_ltr.xml
@@ -6,21 +6,29 @@
         <div box-sizing="content-box" direction="ltr" flex-shrink="0" width="20px" height="10px" margin-bottom="-0.5px"/>
         <div box-sizing="content-box" direction="ltr" flex-shrink="0" width="20px" height="20px" margin-top="-5px"/>
       </div>
-      <div box-sizing="content-box" direction="ltr" flex-shrink="0" width="100px">
+      <div box-sizing="content-box" direction="ltr" flex-shrink="0">
         <div box-sizing="content-box" direction="ltr" flex-shrink="0" width="10px" height="20px" margin-right="-0.5px"/>
-        <div box-sizing="content-box" direction="ltr" flex-grow="1" flex-shrink="0" width="20px" height="20px" margin-left="-5px"/>
+        <div box-sizing="content-box" direction="ltr" flex-shrink="0" width="20px" height="20px" margin-left="-5px"/>
+      </div>
+      <div box-sizing="content-box" direction="ltr" flex-shrink="0">
+        <text box-sizing="content-box" direction="ltr" flex-grow="1" flex-shrink="0" margin-left="-5px">
+          XXXX
+        </text>
       </div>
     </div>
   </input>
   <expectations>
-    <node x="0" y="0" width="100" height="45">
+    <node x="0" y="0" width="100" height="55">
       <node x="0" y="0" width="100" height="25">
         <node x="0" y="0" width="20" height="10"/>
         <node x="0" y="5" width="20" height="20"/>
       </node>
-      <node x="0" y="25" width="100" height="20">
+      <node x="0" y="25" width="25" height="20">
         <node x="0" y="0" width="10" height="20"/>
-        <node x="5" y="0" width="95" height="20"/>
+        <node x="5" y="0" width="20" height="20"/>
+      </node>
+      <node x="0" y="45" width="35" height="10">
+        <node x="-5" y="0" width="40" height="10"/>
       </node>
     </node>
   </expectations>

--- a/tests/xml/flex/taffy_issue_1151_negative_margin__content_box_rtl.xml
+++ b/tests/xml/flex/taffy_issue_1151_negative_margin__content_box_rtl.xml
@@ -1,0 +1,27 @@
+<test name="taffy_issue_1151_negative_margin__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" flex-direction="column" align-items="flex-start">
+      <div box-sizing="content-box" direction="rtl" flex-direction="column" flex-shrink="0" width="100px">
+        <div box-sizing="content-box" direction="rtl" flex-shrink="0" width="20px" height="10px" margin-bottom="-0.5px"/>
+        <div box-sizing="content-box" direction="rtl" flex-shrink="0" width="20px" height="20px" margin-top="-5px"/>
+      </div>
+      <div box-sizing="content-box" direction="rtl" flex-shrink="0" width="100px">
+        <div box-sizing="content-box" direction="rtl" flex-shrink="0" width="10px" height="20px" margin-right="-0.5px"/>
+        <div box-sizing="content-box" direction="rtl" flex-grow="1" flex-shrink="0" width="20px" height="20px" margin-left="-5px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="45">
+      <node x="0" y="0" width="100" height="25">
+        <node x="80" y="0" width="20" height="10"/>
+        <node x="80" y="5" width="20" height="20"/>
+      </node>
+      <node x="0" y="25" width="100" height="20">
+        <node x="91" y="0" width="10" height="20"/>
+        <node x="-5" y="0" width="96" height="20"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/taffy_issue_1151_negative_margin__content_box_rtl.xml
+++ b/tests/xml/flex/taffy_issue_1151_negative_margin__content_box_rtl.xml
@@ -6,21 +6,29 @@
         <div box-sizing="content-box" direction="rtl" flex-shrink="0" width="20px" height="10px" margin-bottom="-0.5px"/>
         <div box-sizing="content-box" direction="rtl" flex-shrink="0" width="20px" height="20px" margin-top="-5px"/>
       </div>
-      <div box-sizing="content-box" direction="rtl" flex-shrink="0" width="100px">
+      <div box-sizing="content-box" direction="rtl" flex-shrink="0">
         <div box-sizing="content-box" direction="rtl" flex-shrink="0" width="10px" height="20px" margin-right="-0.5px"/>
-        <div box-sizing="content-box" direction="rtl" flex-grow="1" flex-shrink="0" width="20px" height="20px" margin-left="-5px"/>
+        <div box-sizing="content-box" direction="rtl" flex-shrink="0" width="20px" height="20px" margin-left="-5px"/>
+      </div>
+      <div box-sizing="content-box" direction="rtl" flex-shrink="0">
+        <text box-sizing="content-box" direction="rtl" flex-grow="1" flex-shrink="0" margin-left="-5px">
+          XXXX
+        </text>
       </div>
     </div>
   </input>
   <expectations>
-    <node x="0" y="0" width="100" height="45">
+    <node x="0" y="0" width="100" height="55">
       <node x="0" y="0" width="100" height="25">
         <node x="80" y="0" width="20" height="10"/>
         <node x="80" y="5" width="20" height="20"/>
       </node>
-      <node x="0" y="25" width="100" height="20">
-        <node x="91" y="0" width="10" height="20"/>
-        <node x="-5" y="0" width="96" height="20"/>
+      <node x="76" y="25" width="24" height="20">
+        <node x="15" y="0" width="10" height="20"/>
+        <node x="-5" y="0" width="20" height="20"/>
+      </node>
+      <node x="65" y="45" width="35" height="10">
+        <node x="-5" y="0" width="40" height="10"/>
       </node>
     </node>
   </expectations>

--- a/tests/xml/flex/taffy_issue_1151_negative_margin__content_box_rtl.xml
+++ b/tests/xml/flex/taffy_issue_1151_negative_margin__content_box_rtl.xml
@@ -15,6 +15,10 @@
           XXXX
         </text>
       </div>
+      <div box-sizing="content-box" direction="rtl" flex-wrap="wrap" flex-shrink="0" width="max-content">
+        <div box-sizing="content-box" direction="rtl" width="100px"/>
+        <div box-sizing="content-box" direction="rtl" width="0px" margin-left="-10px"/>
+      </div>
     </div>
   </input>
   <expectations>
@@ -29,6 +33,10 @@
       </node>
       <node x="65" y="45" width="35" height="10">
         <node x="-5" y="0" width="40" height="10"/>
+      </node>
+      <node x="0" y="55" width="100" height="0">
+        <node x="0" y="0" width="100" height="0"/>
+        <node x="0" y="0" width="0" height="0"/>
       </node>
     </node>
   </expectations>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -18260,6 +18260,26 @@ mod flex {
     }
 
     #[test]
+    fn taffy_issue_1151_negative_margin__border_box_ltr() {
+        crate::run_xml_test("flex", "taffy_issue_1151_negative_margin__border_box_ltr");
+    }
+
+    #[test]
+    fn taffy_issue_1151_negative_margin__content_box_ltr() {
+        crate::run_xml_test("flex", "taffy_issue_1151_negative_margin__content_box_ltr");
+    }
+
+    #[test]
+    fn taffy_issue_1151_negative_margin__border_box_rtl() {
+        crate::run_xml_test("flex", "taffy_issue_1151_negative_margin__border_box_rtl");
+    }
+
+    #[test]
+    fn taffy_issue_1151_negative_margin__content_box_rtl() {
+        crate::run_xml_test("flex", "taffy_issue_1151_negative_margin__content_box_rtl");
+    }
+
+    #[test]
     fn taffy_issue_696__border_box_ltr() {
         crate::run_xml_test("flex", "taffy_issue_696__border_box_ltr");
     }


### PR DESCRIPTION
# Objective

Fixes #1151.

Floor the flex shrink factor before scaling it by the inner flex basis when calculating negative content flex fractions. This keeps the divisor consistent with reconstruction, so negative margins subtract their resolved length instead of multiplying the item's main size.

Avoid `0 × -∞` during reconstruction for zero-basis items, preserving the intrinsic container size required by `css/css-flexbox/intrinsic-size/row-wrap-002.tentative.html`.

Add browser-generated regression coverage for auto-sized row and column containers, fractional negative margins, non-shrinking and growing items, and the zero-basis wrapping case.

## Context

The previous divisor used `max(1, flex_shrink * inner_flex_basis)`, while the matching multiplier used `max(1, flex_shrink) * inner_flex_basis`. For `flex-shrink: 0`, that mismatch turned a negative margin into a size-proportional flex contribution.

With a zero inner flex basis, the corrected divisor produces the spec-defined negative-infinite desired flex fraction. Treating its zero scaled shrink contribution as zero prevents that boundary case from becoming `NaN`.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/1c82fa79d1824e7f83b83bebcdfb778a
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/1c82fa79d1824e7f83b83bebcdfb778a?variant=devin-insiders
Requested by: @nicoburns