### PR TITLE
Flexbox: always use `ContentSize` when measuring children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@
 
 - Flexbox: intrinsic main sizing now applies negative main-axis margins as lengths for non-shrinking items, and zero-basis items no longer collapse the intrinsic container size (#1151)
 
+- Flexbox: the algorithm no longer measures children with `SizingMode::InherentSize`, instead applying the item's own style sizes on top of `SizingMode::ContentSize` measures. This prevents `ComputeSize` cache entries computed under `ContentSize` (which ignore the node's own size styles) from being served for inherent-size measures, which could ignore an item's specified size (#1149)
+
 - CSS parser (`parse` feature): `GridTemplateTracks::from_css` (used to parse `grid-template-rows`/`grid-template-columns` values) now emits one line-name group per grid line, pushing an empty group for lines with no `[...]` in the source. Previously groups were only emitted for lines that had names, which is ambiguous (name groups are positional) and caused line names in templates such as `repeat(auto-fill, [col] 40px)` to be silently dropped when the parsed value was applied to a style
 
 - Block/float: the height of overflowing in-flow content of a nested block no longer contributes to the height of the block formatting context root as if it were floated content. Previously an auto-height BFC root containing a block whose in-flow content overflowed it (e.g. a fixed-height block with taller content) was incorrectly extended to contain that overflowing content

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@
 
 - Flexbox: the algorithm no longer measures children with `SizingMode::InherentSize`, instead applying the item's own style sizes on top of `SizingMode::ContentSize` measures. This prevents `ComputeSize` cache entries computed under `ContentSize` (which ignore the node's own size styles) from being served for inherent-size measures, which could ignore an item's specified size (#1149)
 
+- Flexbox: a flex item with an aspect ratio, a content flex basis, and a definite cross size derived from stretching now has its flex base size (and its intrinsic main-size contribution) calculated by transferring the stretched cross size through the aspect ratio, per case B of the flex base size determination algorithm. Previously the transferred size was ignored and such items were sized as if they had no aspect ratio
+
 - CSS parser (`parse` feature): `GridTemplateTracks::from_css` (used to parse `grid-template-rows`/`grid-template-columns` values) now emits one line-name group per grid line, pushing an empty group for lines with no `[...]` in the source. Previously groups were only emitted for lines that had names, which is ambiguous (name groups are positional) and caused line names in templates such as `repeat(auto-fill, [col] 40px)` to be silently dropped when the parsed value was applied to a style
 
 - Block/float: the height of overflowing in-flow content of a nested block no longer contributes to the height of the block formatting context root as if it were floated content. Previously an auto-height BFC root containing a block whose in-flow content overflowed it (e.g. a fixed-height block with taller content) was incorrectly extended to contain that overflowing content

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -1397,6 +1397,23 @@ fn determine_container_main_size(
                             _ if item.is_scroll_container() => {
                                 item.flex_basis + item.margin.main_axis_sum(constants.dir)
                             }
+
+                            // If the item has a definite preferred main size then that is its content
+                            // contribution (an inherent-size measure of the item would return it), floored
+                            // by the item's main-axis padding+border, so measuring the item can be skipped.
+                            // Min/max clamping is applied in the same way as for measured contributions.
+                            (_, Some(pref), _) => {
+                                let item_pb_main = item.padding.main_axis_sum(constants.dir)
+                                    + item.border.main_axis_sum(constants.dir);
+                                let content_main_size =
+                                    pref.max(item_pb_main) + item.margin.main_axis_sum(constants.dir);
+                                if constants.is_row {
+                                    content_main_size.maybe_clamp(style_min, style_max)
+                                } else {
+                                    content_main_size.max(item.flex_basis).maybe_clamp(style_min, style_max)
+                                }
+                            }
+
                             _ => {
                                 // Parent size for child sizing
                                 let cross_axis_parent_size = constants.node_inner_size.cross(dir);
@@ -1431,7 +1448,7 @@ fn determine_container_main_size(
                                 // Either the min- or max- content size depending on which constraint we are sizing under.
                                 // TODO: Optimise by using already computed values where available
                                 debug_log!("COMPUTE CHILD BASE SIZE (for intrinsic main size):");
-                                let measured_main_size = tree.measure_child_size(
+                                let content_main_size = tree.measure_child_size(
                                     item.node,
                                     child_known_dimensions,
                                     constants.node_inner_size,
@@ -1439,16 +1456,7 @@ fn determine_container_main_size(
                                     SizingMode::ContentSize,
                                     dir.main_axis(),
                                     Line::FALSE,
-                                );
-                                // The item's own preferred main size (if definite) is used in place
-                                // of the measured content size (it would otherwise be applied by an
-                                // inherent-size measure of the item itself), floored by the item's
-                                // main-axis padding+border.
-                                let item_pb_main = item.padding.main_axis_sum(constants.dir)
-                                    + item.border.main_axis_sum(constants.dir);
-                                let content_main_size =
-                                    style_preferred.map(|pref| pref.max(item_pb_main)).unwrap_or(measured_main_size)
-                                        + item.margin.main_axis_sum(constants.dir);
+                                ) + item.margin.main_axis_sum(constants.dir);
 
                                 // This is somewhat bizarre in that it's asymmetrical depending whether the flex container is a column or a row.
                                 //

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -496,7 +496,7 @@ fn compute_preliminary(tree: &mut impl LayoutFlexboxContainer, node: NodeId, inp
                 Size::NONE,
                 Size::NONE,
                 Size::MAX_CONTENT,
-                SizingMode::InherentSize,
+                SizingMode::ContentSize,
                 Line::FALSE,
             );
         }
@@ -1431,15 +1431,24 @@ fn determine_container_main_size(
                                 // Either the min- or max- content size depending on which constraint we are sizing under.
                                 // TODO: Optimise by using already computed values where available
                                 debug_log!("COMPUTE CHILD BASE SIZE (for intrinsic main size):");
-                                let content_main_size = tree.measure_child_size(
+                                let measured_main_size = tree.measure_child_size(
                                     item.node,
                                     child_known_dimensions,
                                     constants.node_inner_size,
                                     child_available_space,
-                                    SizingMode::InherentSize,
+                                    SizingMode::ContentSize,
                                     dir.main_axis(),
                                     Line::FALSE,
-                                ) + item.margin.main_axis_sum(constants.dir);
+                                );
+                                // The item's own preferred main size (if definite) is used in place
+                                // of the measured content size (it would otherwise be applied by an
+                                // inherent-size measure of the item itself), floored by the item's
+                                // main-axis padding+border.
+                                let item_pb_main = item.padding.main_axis_sum(constants.dir)
+                                    + item.border.main_axis_sum(constants.dir);
+                                let content_main_size =
+                                    style_preferred.map(|pref| pref.max(item_pb_main)).unwrap_or(measured_main_size)
+                                        + item.margin.main_axis_sum(constants.dir);
 
                                 // This is somewhat bizarre in that it's asymmetrical depending whether the flex container is a column or a row.
                                 //
@@ -2691,7 +2700,7 @@ fn perform_absolute_layout_on_absolute_children(
                 inset_relative_size,
                 Rect { left, right, top, bottom },
                 margin,
-                SizingMode::InherentSize,
+                SizingMode::ContentSize,
             );
             known_dimensions = known_dimensions.maybe_apply_aspect_ratio(aspect_ratio).maybe_clamp(min_size, max_size);
         }
@@ -2727,7 +2736,7 @@ fn perform_absolute_layout_on_absolute_children(
                             container_height.maybe_clamp(min_size.height, max_size.height),
                         ),
                     },
-                    SizingMode::InherentSize,
+                    SizingMode::ContentSize,
                     Line::FALSE,
                 );
                 known_dimensions.unwrap_or(measured_size)
@@ -2743,7 +2752,7 @@ fn perform_absolute_layout_on_absolute_children(
                 width: AvailableSpace::Definite(container_width.maybe_clamp(min_size.width, max_size.width)),
                 height: AvailableSpace::Definite(container_height.maybe_clamp(min_size.height, max_size.height)),
             },
-            SizingMode::InherentSize,
+            SizingMode::ContentSize,
             Line::FALSE,
         );
 

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -965,13 +965,13 @@ fn determine_flex_base_size(
             // TODO if/when vertical writing modes are supported
 
             // If the item has an aspect ratio and a definite cross size then the flex base size
-            // is derived from that cross size via the aspect ratio (case B above, as applied by
-            // the child's own layout below), and is therefore definite.
-            if child.aspect_ratio.is_some()
-                && child_cross_size_is_definite
-                && child_known_dimensions.cross(dir).is_some()
-            {
-                child.flex_basis_is_definite = true;
+            // is calculated by transferring that cross size through the aspect ratio (case B
+            // above), and is therefore definite.
+            if child_cross_size_is_definite {
+                if let (Some(ratio), Some(cross)) = (child.aspect_ratio, child_known_dimensions.cross(dir)) {
+                    child.flex_basis_is_definite = true;
+                    break 'flex_basis if dir.is_row() { cross * ratio } else { cross / ratio };
+                }
             }
 
             // E. Otherwise, size the item into the available space using its used flex basis
@@ -1448,7 +1448,7 @@ fn determine_container_main_size(
                                 // Either the min- or max- content size depending on which constraint we are sizing under.
                                 // TODO: Optimise by using already computed values where available
                                 debug_log!("COMPUTE CHILD BASE SIZE (for intrinsic main size):");
-                                let content_main_size = tree.measure_child_size(
+                                let measured_main_size = tree.measure_child_size(
                                     item.node,
                                     child_known_dimensions,
                                     constants.node_inner_size,
@@ -1456,7 +1456,17 @@ fn determine_container_main_size(
                                     SizingMode::ContentSize,
                                     dir.main_axis(),
                                     Line::FALSE,
-                                ) + item.margin.main_axis_sum(constants.dir);
+                                );
+
+                                // A known cross size is transferred through the item's aspect-ratio
+                                // and floors the measured content size
+                                let transferred_main_size = item
+                                    .aspect_ratio
+                                    .zip(child_known_dimensions.cross(dir))
+                                    .map(|(ratio, cross)| if constants.is_row { cross * ratio } else { cross / ratio });
+
+                                let content_main_size = measured_main_size.maybe_max(transferred_main_size)
+                                    + item.margin.main_axis_sum(constants.dir);
 
                                 // This is somewhat bizarre in that it's asymmetrical depending whether the flex container is a column or a row.
                                 //

--- a/test_fixtures/flex/intrinsic_sizing_main_size_aspect_ratio_stretched_column.html
+++ b/test_fixtures/flex/intrinsic_sizing_main_size_aspect_ratio_stretched_column.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="flex-direction: column; width: 100px;">
+  <div style="aspect-ratio: 0.5;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/intrinsic_sizing_main_size_aspect_ratio_stretched_row.html
+++ b/test_fixtures/flex/intrinsic_sizing_main_size_aspect_ratio_stretched_row.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="height: 100px;">
+  <div style="aspect-ratio: 2;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/flex/intrinsic_sizing_main_size_aspect_ratio_stretched_column__border_box_ltr.xml
+++ b/tests/xml/flex/intrinsic_sizing_main_size_aspect_ratio_stretched_column__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="intrinsic_sizing_main_size_aspect_ratio_stretched_column__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" flex-direction="column" width="100px">
+      <div direction="ltr" aspect-ratio="0.5"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="200">
+      <node x="0" y="0" width="100" height="200"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/intrinsic_sizing_main_size_aspect_ratio_stretched_column__border_box_rtl.xml
+++ b/tests/xml/flex/intrinsic_sizing_main_size_aspect_ratio_stretched_column__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="intrinsic_sizing_main_size_aspect_ratio_stretched_column__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" flex-direction="column" width="100px">
+      <div direction="rtl" aspect-ratio="0.5"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="200">
+      <node x="0" y="0" width="100" height="200"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/intrinsic_sizing_main_size_aspect_ratio_stretched_column__content_box_ltr.xml
+++ b/tests/xml/flex/intrinsic_sizing_main_size_aspect_ratio_stretched_column__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="intrinsic_sizing_main_size_aspect_ratio_stretched_column__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" flex-direction="column" width="100px">
+      <div box-sizing="content-box" direction="ltr" aspect-ratio="0.5"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="200">
+      <node x="0" y="0" width="100" height="200"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/intrinsic_sizing_main_size_aspect_ratio_stretched_column__content_box_rtl.xml
+++ b/tests/xml/flex/intrinsic_sizing_main_size_aspect_ratio_stretched_column__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="intrinsic_sizing_main_size_aspect_ratio_stretched_column__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" flex-direction="column" width="100px">
+      <div box-sizing="content-box" direction="rtl" aspect-ratio="0.5"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="200">
+      <node x="0" y="0" width="100" height="200"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/intrinsic_sizing_main_size_aspect_ratio_stretched_row__border_box_ltr.xml
+++ b/tests/xml/flex/intrinsic_sizing_main_size_aspect_ratio_stretched_row__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="intrinsic_sizing_main_size_aspect_ratio_stretched_row__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="ltr" height="100px">
+      <div direction="ltr" aspect-ratio="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="0" y="0" width="200" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/intrinsic_sizing_main_size_aspect_ratio_stretched_row__border_box_rtl.xml
+++ b/tests/xml/flex/intrinsic_sizing_main_size_aspect_ratio_stretched_row__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="intrinsic_sizing_main_size_aspect_ratio_stretched_row__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div direction="rtl" height="100px">
+      <div direction="rtl" aspect-ratio="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="0" y="0" width="200" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/intrinsic_sizing_main_size_aspect_ratio_stretched_row__content_box_ltr.xml
+++ b/tests/xml/flex/intrinsic_sizing_main_size_aspect_ratio_stretched_row__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="intrinsic_sizing_main_size_aspect_ratio_stretched_row__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="ltr" height="100px">
+      <div box-sizing="content-box" direction="ltr" aspect-ratio="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="0" y="0" width="200" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/intrinsic_sizing_main_size_aspect_ratio_stretched_row__content_box_rtl.xml
+++ b/tests/xml/flex/intrinsic_sizing_main_size_aspect_ratio_stretched_row__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="intrinsic_sizing_main_size_aspect_ratio_stretched_row__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div box-sizing="content-box" direction="rtl" height="100px">
+      <div box-sizing="content-box" direction="rtl" aspect-ratio="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="100">
+      <node x="0" y="0" width="200" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -14104,6 +14104,46 @@ mod flex {
     }
 
     #[test]
+    fn intrinsic_sizing_main_size_aspect_ratio_stretched_column__border_box_ltr() {
+        crate::run_xml_test("flex", "intrinsic_sizing_main_size_aspect_ratio_stretched_column__border_box_ltr");
+    }
+
+    #[test]
+    fn intrinsic_sizing_main_size_aspect_ratio_stretched_column__content_box_ltr() {
+        crate::run_xml_test("flex", "intrinsic_sizing_main_size_aspect_ratio_stretched_column__content_box_ltr");
+    }
+
+    #[test]
+    fn intrinsic_sizing_main_size_aspect_ratio_stretched_column__border_box_rtl() {
+        crate::run_xml_test("flex", "intrinsic_sizing_main_size_aspect_ratio_stretched_column__border_box_rtl");
+    }
+
+    #[test]
+    fn intrinsic_sizing_main_size_aspect_ratio_stretched_column__content_box_rtl() {
+        crate::run_xml_test("flex", "intrinsic_sizing_main_size_aspect_ratio_stretched_column__content_box_rtl");
+    }
+
+    #[test]
+    fn intrinsic_sizing_main_size_aspect_ratio_stretched_row__border_box_ltr() {
+        crate::run_xml_test("flex", "intrinsic_sizing_main_size_aspect_ratio_stretched_row__border_box_ltr");
+    }
+
+    #[test]
+    fn intrinsic_sizing_main_size_aspect_ratio_stretched_row__content_box_ltr() {
+        crate::run_xml_test("flex", "intrinsic_sizing_main_size_aspect_ratio_stretched_row__content_box_ltr");
+    }
+
+    #[test]
+    fn intrinsic_sizing_main_size_aspect_ratio_stretched_row__border_box_rtl() {
+        crate::run_xml_test("flex", "intrinsic_sizing_main_size_aspect_ratio_stretched_row__border_box_rtl");
+    }
+
+    #[test]
+    fn intrinsic_sizing_main_size_aspect_ratio_stretched_row__content_box_rtl() {
+        crate::run_xml_test("flex", "intrinsic_sizing_main_size_aspect_ratio_stretched_row__content_box_rtl");
+    }
+
+    #[test]
     fn intrinsic_sizing_main_size_column__border_box_ltr() {
         crate::run_xml_test("flex", "intrinsic_sizing_main_size_column__border_box_ltr");
     }


### PR DESCRIPTION
# Objective

Fixes #1149.

Taffy's `CacheKey` (`src/tree/cache.rs`) does not include `LayoutInput::sizing_mode`, so `ComputeSize` cache entries are shared between `SizingMode::ContentSize` (which ignores the node's own size/min/max/aspect-ratio styles, see `src/compute/leaf.rs`) and `SizingMode::InherentSize`. In the #1149 repro, a leaf's content contribution measured under `ContentSize` was later served from cache for an `InherentSize` measure, so the leaf's `width: 86` style was ignored and it collapsed to the container's `max-width: 8`.

This PR removes all use of `SizingMode::InherentSize` from the flexbox algorithm, so flexbox only ever measures children with `SizingMode::ContentSize` and applies the item's own inherent style sizes itself on top of the returned content sizes.

## Context

All 5 flexbox `InherentSize` call sites are converted to `ContentSize`:

- **Intrinsic main-size content contribution** (`determine_container_main_size`): the only site that needed compensation. If the item's resolved preferred main size (`style_preferred`, already aspect-ratio-applied and box-sizing-adjusted) is definite, it is used directly — floored by main-axis padding+border — and the measure call is skipped entirely. Otherwise the child is measured with `ContentSize`; a known cross size is additionally transferred through the item's aspect ratio and floors the measured size (replicating the leaf-side `height = max(height, width / ratio)` behavior dropped by the conversion). Min/max clamping was already applied externally at this call site.
- **Hidden layout**: `PerformHiddenLayout` never reads `sizing_mode`, so no compensation needed.
- **Absolutely-positioned children (3 sites)**: size/min/max/aspect-ratio (with box-sizing adjustment) were already resolved externally and passed as `known_dimensions`, which `ContentSize` measures still honor; the fallback measured size is clamped at the call site.

Additionally, flex base size determination now implements case B of the spec: an item with an aspect ratio, a content flex basis, and a definite cross size (including one derived from `align-self: stretch`) gets its flex base size by transferring the cross size through the aspect ratio. New generated tests (`intrinsic_sizing_main_size_aspect_ratio_stretched_{row,column}`) verify this matches Chrome (e.g. an empty `aspect-ratio: 2` item in a `height: 100px` row container lays out at 200x100).

Validation:
- Full workspace test suite passes (6021 generated + hand-written), fmt/clippy clean.
- #1149 repro yields leaf width 86 (was 8).
- Blitz WPT (default suite + `css/CSS2/margin-padding-clear`) with this revision is identical to the baseline: 1584/1687 tests passed/failed, 5112/8804 subtests passed; mpc 648/34; per-test diff shows 0 tests changed.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/d4ac61d19dd44d4a89dae618503bde4f
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/d4ac61d19dd44d4a89dae618503bde4f?variant=devin-insiders
Requested by: @nicoburns