### PR TITLE
Replace `Option<f32>` with NaN-boxed `OptF32` for ~20% speedup

### DIFF
--- a/benches/benches/mixed.rs
+++ b/benches/benches/mixed.rs
@@ -47,10 +47,11 @@ impl ParleyTextContext {
 }
 
 fn measure_function(
-    known_dimensions: taffy::Size<Option<f32>>,
+    known_dimensions: taffy::Size<taffy::OptFloat>,
     available_space: taffy::Size<taffy::AvailableSpace>,
     node_context: Option<&mut ParleyTextContext>,
 ) -> Size<f32> {
+    let known_dimensions = known_dimensions.into_options();
     if let Size { width: Some(width), height: Some(height) } = known_dimensions {
         return Size { width, height };
     }

--- a/benches/benches/mixed.rs
+++ b/benches/benches/mixed.rs
@@ -47,7 +47,7 @@ impl ParleyTextContext {
 }
 
 fn measure_function(
-    known_dimensions: taffy::Size<taffy::OptFloat>,
+    known_dimensions: taffy::Size<taffy::OptF32>,
     available_space: taffy::Size<taffy::AvailableSpace>,
     node_context: Option<&mut ParleyTextContext>,
 ) -> Size<f32> {

--- a/examples/common/image.rs
+++ b/examples/common/image.rs
@@ -6,7 +6,7 @@ pub struct ImageContext {
 }
 
 pub fn image_measure_function(
-    known_dimensions: taffy::geometry::Size<taffy::OptFloat>,
+    known_dimensions: taffy::geometry::Size<taffy::OptF32>,
     image_context: &ImageContext,
 ) -> taffy::geometry::Size<f32> {
     match (known_dimensions.width.into_option(), known_dimensions.height.into_option()) {

--- a/examples/common/image.rs
+++ b/examples/common/image.rs
@@ -6,10 +6,10 @@ pub struct ImageContext {
 }
 
 pub fn image_measure_function(
-    known_dimensions: taffy::geometry::Size<Option<f32>>,
+    known_dimensions: taffy::geometry::Size<taffy::OptFloat>,
     image_context: &ImageContext,
 ) -> taffy::geometry::Size<f32> {
-    match (known_dimensions.width, known_dimensions.height) {
+    match (known_dimensions.width.into_option(), known_dimensions.height.into_option()) {
         (Some(width), Some(height)) => Size { width, height },
         (Some(width), None) => Size { width, height: (width / image_context.width) * image_context.height },
         (None, Some(height)) => Size { width: (height / image_context.height) * image_context.width, height },

--- a/examples/common/text.rs
+++ b/examples/common/text.rs
@@ -17,7 +17,7 @@ pub struct TextContext {
 }
 
 pub fn text_measure_function(
-    known_dimensions: taffy::geometry::Size<taffy::OptFloat>,
+    known_dimensions: taffy::geometry::Size<taffy::OptF32>,
     available_space: taffy::geometry::Size<taffy::style::AvailableSpace>,
     text_context: &TextContext,
     font_metrics: &FontMetrics,

--- a/examples/common/text.rs
+++ b/examples/common/text.rs
@@ -17,13 +17,15 @@ pub struct TextContext {
 }
 
 pub fn text_measure_function(
-    known_dimensions: taffy::geometry::Size<Option<f32>>,
+    known_dimensions: taffy::geometry::Size<taffy::OptFloat>,
     available_space: taffy::geometry::Size<taffy::style::AvailableSpace>,
     text_context: &TextContext,
     font_metrics: &FontMetrics,
 ) -> taffy::geometry::Size<f32> {
     use taffy::geometry::AbsoluteAxis;
     use taffy::prelude::*;
+
+    let known_dimensions = known_dimensions.into_options();
 
     let inline_axis = match text_context.writing_mode {
         WritingMode::Horizontal => AbsoluteAxis::Horizontal,

--- a/examples/measure.rs
+++ b/examples/measure.rs
@@ -12,7 +12,7 @@ enum NodeContext {
 }
 
 fn measure_function(
-    known_dimensions: taffy::geometry::Size<taffy::OptFloat>,
+    known_dimensions: taffy::geometry::Size<taffy::OptF32>,
     available_space: taffy::geometry::Size<taffy::style::AvailableSpace>,
     node_context: Option<&mut NodeContext>,
     font_metrics: &FontMetrics,

--- a/examples/measure.rs
+++ b/examples/measure.rs
@@ -12,12 +12,12 @@ enum NodeContext {
 }
 
 fn measure_function(
-    known_dimensions: taffy::geometry::Size<Option<f32>>,
+    known_dimensions: taffy::geometry::Size<taffy::OptFloat>,
     available_space: taffy::geometry::Size<taffy::style::AvailableSpace>,
     node_context: Option<&mut NodeContext>,
     font_metrics: &FontMetrics,
 ) -> Size<f32> {
-    if let Size { width: Some(width), height: Some(height) } = known_dimensions {
+    if let Size { width: Some(width), height: Some(height) } = known_dimensions.into_options() {
         return Size { width, height };
     }
 

--- a/examples/parley/src/main.rs
+++ b/examples/parley/src/main.rs
@@ -71,7 +71,7 @@ impl NodeContext {
 }
 
 fn measure_function(
-    known_dimensions: taffy::Size<taffy::OptFloat>,
+    known_dimensions: taffy::Size<taffy::OptF32>,
     available_space: taffy::Size<taffy::AvailableSpace>,
     node_context: Option<&mut NodeContext>,
 ) -> Size<f32> {

--- a/examples/parley/src/main.rs
+++ b/examples/parley/src/main.rs
@@ -71,10 +71,11 @@ impl NodeContext {
 }
 
 fn measure_function(
-    known_dimensions: taffy::Size<Option<f32>>,
+    known_dimensions: taffy::Size<taffy::OptFloat>,
     available_space: taffy::Size<taffy::AvailableSpace>,
     node_context: Option<&mut NodeContext>,
 ) -> Size<f32> {
+    let known_dimensions = known_dimensions.into_options();
     if let Size { width: Some(width), height: Some(height) } = known_dimensions {
         return Size { width, height };
     }

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -8,6 +8,7 @@ use crate::util::debug::debug_log;
 use crate::util::sys::f32_max;
 use crate::util::sys::Vec;
 use crate::util::MaybeMath;
+use crate::util::OptFloat;
 use crate::util::{MaybeResolve, ResolveOrZero};
 use crate::{
     BlockContainerStyle, BlockItemStyle, BoxGenerationMode, BoxSizing, Contain, Dimension, Direction,
@@ -205,7 +206,7 @@ impl BlockContext<'_> {
     }
 
     /// Get the bottom of lowest relevant float for the specific clear property
-    pub fn cleared_threshold(&self, clear: Clear) -> Option<f32> {
+    pub fn cleared_threshold(&self, clear: Clear) -> OptFloat {
         self.bfc.float_context.cleared_threshold(clear).map(|threshold| threshold - self.y_offset)
     }
 
@@ -305,11 +306,11 @@ struct BlockItem {
     size_style: Size<Dimension>,
 
     /// The base size of this item
-    size: Size<Option<f32>>,
+    size: Size<OptFloat>,
     /// The minimum allowable size of this item
-    min_size: Size<Option<f32>>,
+    min_size: Size<OptFloat>,
     /// The maximum allowable size of this item
-    max_size: Size<Option<f32>>,
+    max_size: Size<OptFloat>,
 
     /// The overflow style of the item
     overflow: Point<Overflow>,
@@ -395,9 +396,9 @@ pub fn compute_block_layout(
     drop(style);
 
     // If both min and max in a given axis are set and max <= min then this determines the size in that axis
-    let min_max_definite_size = min_size.zip_map(max_size, |min, max| match (min, max) {
-        (Some(min), Some(max)) if max <= min => Some(min),
-        _ => None,
+    let min_max_definite_size = min_size.zip_map(max_size, |min, max| match (min.into_option(), max.into_option()) {
+        (Some(min), Some(max)) if max <= min => OptFloat::some(min),
+        _ => OptFloat::NONE,
     });
 
     let styled_based_known_dimensions =
@@ -406,13 +407,13 @@ pub fn compute_block_layout(
     // Short-circuit layout if the container's size is fully determined by the container's size and the run mode
     // is ComputeSize (and thus the container's size is all that we're interested in)
     if run_mode == RunMode::ComputeSize {
-        if let Size { width: Some(width), height: Some(height) } = styled_based_known_dimensions {
+        if let Size { width: Some(width), height: Some(height) } = styled_based_known_dimensions.into_options() {
             return LayoutOutput::from_outer_size(Size { width, height });
         }
 
         // We can also short-circuit if the width is known and only the width has been requested.
         if inputs.axis == RequestedAxis::Horizontal {
-            if let Some(width) = styled_based_known_dimensions.width {
+            if let Some(width) = styled_based_known_dimensions.width.into_option() {
                 return LayoutOutput::from_outer_size(Size { width, height: 0.0 });
             }
         }
@@ -551,8 +552,8 @@ fn compute_inner(
         || padding.bottom > 0.0
         || border.top > 0.0
         || border.bottom > 0.0
-        || matches!(size.height, Some(h) if h > 0.0)
-        || matches!(min_size.height, Some(h) if h > 0.0);
+        || matches!(size.height.into_option(), Some(h) if h > 0.0)
+        || matches!(min_size.height.into_option(), Some(h) if h > 0.0);
 
     let text_align = style.text_align();
     let align_content = style.align_content();
@@ -566,11 +567,11 @@ fn compute_inner(
         let available_width = available_space.width.maybe_sub(content_box_inset.horizontal_axis_sum());
         let intrinsic_width = determine_content_based_container_width(tree, &items, available_width)
             + content_box_inset.horizontal_axis_sum();
-        intrinsic_width.maybe_clamp(min_size.width, max_size.width).maybe_max(Some(padding_border_size.width))
+        intrinsic_width.maybe_clamp(min_size.width, max_size.width).maybe_max(OptFloat::some(padding_border_size.width))
     });
 
     // Short-circuit if computing size and both dimensions known
-    if let (RunMode::ComputeSize, Some(container_outer_height)) = (run_mode, known_dimensions.height) {
+    if let (RunMode::ComputeSize, Some(container_outer_height)) = (run_mode, known_dimensions.height.into_option()) {
         return LayoutOutput::from_outer_size(Size { width: container_outer_width, height: container_outer_height });
     }
 
@@ -590,9 +591,9 @@ fn compute_inner(
     // unknown (e.g. at the root of the layout tree).
     let percentage_resolution_width = parent_size.width.unwrap_or(container_outer_width);
     let resolved_padding =
-        raw_padding.resolve_or_zero(Some(percentage_resolution_width), |val, basis| tree.calc(val, basis));
+        raw_padding.resolve_or_zero(OptFloat::some(percentage_resolution_width), |val, basis| tree.calc(val, basis));
     let resolved_border =
-        raw_border.resolve_or_zero(Some(percentage_resolution_width), |val, basis| tree.calc(val, basis));
+        raw_border.resolve_or_zero(OptFloat::some(percentage_resolution_width), |val, basis| tree.calc(val, basis));
     let resolved_content_box_inset = resolved_padding + resolved_border + scrollbar_gutter;
     #[cfg_attr(not(feature = "content_size"), allow(unused_mut))]
     let (
@@ -627,7 +628,7 @@ fn compute_inner(
     let container_outer_height = known_dimensions
         .height
         .unwrap_or(intrinsic_outer_height.maybe_clamp(min_size.height, max_size.height))
-        .maybe_max(Some(padding_border_size.height));
+        .maybe_max(OptFloat::some(padding_border_size.height));
     let final_outer_size = Size { width: container_outer_width, height: container_outer_height };
 
     // CSS2 §8.3.1: the bottom margin of a block with `height: auto` collapses with its last
@@ -635,7 +636,8 @@ fn compute_inner(
     // used height. When `min-height` determines the used height, the last child's bottom
     // margin no longer adjoins the box's bottom edge, so it stays inside the box instead of
     // collapsing with the box's own bottom margin. (`max-height` has no such effect.)
-    let height_constrained_by_min_height = matches!(min_size.height, Some(h) if h > 0.0 && h >= container_outer_height);
+    let height_constrained_by_min_height =
+        matches!(min_size.height.into_option(), Some(h) if h > 0.0 && h >= container_outer_height);
     let own_bottom_margin_collapses_with_children =
         own_margins_collapse_with_children.end && !height_constrained_by_min_height;
 
@@ -795,7 +797,7 @@ fn compute_inner(
 fn generate_item_list(
     tree: &impl LayoutBlockContainer,
     node: NodeId,
-    node_inner_size: Size<Option<f32>>,
+    node_inner_size: Size<OptFloat>,
 ) -> Vec<BlockItem> {
     tree.child_ids(node)
         .map(|child_node_id| (child_node_id, tree.get_block_child_style(child_node_id)))
@@ -886,16 +888,16 @@ fn generate_item_list(
 #[inline]
 fn resolve_stretch_height(
     height_style: Dimension,
-    container_inner_height: Option<f32>,
+    container_inner_height: OptFloat,
     item_y_margin_sum: f32,
-) -> Option<f32> {
+) -> OptFloat {
     match resolve_sizing_keyword(
         height_style,
         container_inner_height.maybe_sub(item_y_margin_sum),
         container_inner_height,
     ) {
-        Some(SizingKeywordResolution::Exact(height)) => Some(height),
-        _ => None,
+        Some(SizingKeywordResolution::Exact(height)) => OptFloat::some(height),
+        _ => OptFloat::NONE,
     }
 }
 
@@ -919,11 +921,12 @@ fn determine_content_based_container_width(
             .resolve_or_zero(available_space.width.into_option(), |val, basis| tree.calc(val, basis))
             .horizontal_axis_sum();
         let width = known_dimensions.width.unwrap_or_else(|| {
-            let item_available_width = match resolve_sizing_keyword(item.size_style.width, None, None) {
-                Some(SizingKeywordResolution::Measure(available_width)) => available_width,
-                Some(SizingKeywordResolution::Exact(width)) => AvailableSpace::Definite(width),
-                None => available_space.width.maybe_sub(item_x_margin_sum),
-            };
+            let item_available_width =
+                match resolve_sizing_keyword(item.size_style.width, OptFloat::NONE, OptFloat::NONE) {
+                    Some(SizingKeywordResolution::Measure(available_width)) => available_width,
+                    Some(SizingKeywordResolution::Exact(width)) => AvailableSpace::Definite(width),
+                    None => available_space.width.maybe_sub(item_x_margin_sum),
+                };
             tree.measure_child_size(
                 item.node_id,
                 known_dimensions,
@@ -962,7 +965,7 @@ fn perform_final_layout_on_in_flow_children(
     run_mode: RunMode,
     items: &mut [BlockItem],
     container_outer_width: f32,
-    container_percentage_resolution_height: Option<f32>,
+    container_percentage_resolution_height: OptFloat,
     content_box_inset: Rect<f32>,
     resolved_content_box_inset: Rect<f32>,
     resolved_border: Rect<f32>,
@@ -971,12 +974,13 @@ fn perform_final_layout_on_in_flow_children(
     own_margins_collapse_with_children: Line<bool>,
     #[cfg(feature = "content_size")] is_scroll_container: bool,
     block_ctx: &mut BlockContext<'_>,
-) -> (Rect<f32>, f32, CollapsibleMarginSet, CollapsibleMarginSet, Option<f32>) {
+) -> (Rect<f32>, f32, CollapsibleMarginSet, CollapsibleMarginSet, OptFloat) {
     // Resolve container_inner_width for sizing child nodes using initial content_box_inset
     let container_inner_width = container_outer_width - resolved_content_box_inset.horizontal_axis_sum();
     let container_percentage_resolution_height =
         container_percentage_resolution_height.maybe_sub(resolved_content_box_inset.vertical_axis_sum());
-    let parent_size = Size { width: Some(container_inner_width), height: container_percentage_resolution_height };
+    let parent_size =
+        Size { width: Some(container_inner_width), height: container_percentage_resolution_height.into() };
     // Vertical available space in block flow is indefinite, NOT a min-content
     // constraint: MaxContent is taffy's representation of "indefinite".
     // Passing MinContent here made every descendant grid believe it was being
@@ -1009,7 +1013,7 @@ fn perform_final_layout_on_in_flow_children(
     let mut first_child_top_margin_set = CollapsibleMarginSet::ZERO;
     let mut active_collapsible_margin_set = CollapsibleMarginSet::ZERO;
     let mut is_collapsing_with_first_margin_set = true;
-    let mut first_baseline: Option<f32> = None;
+    let mut first_baseline: OptFloat = OptFloat::NONE;
     // Whether the active margin set contains the margins of a self-collapsing element with
     // clearance. Such margins collapse with the margins of following siblings but the resulting
     // margin does not collapse with the bottom margin of the parent block.
@@ -1049,8 +1053,8 @@ fn perform_final_layout_on_in_flow_children(
                 let available_width = container_inner_width - item_non_auto_x_margin_sum;
                 let (item_known_width, item_available_width) = match resolve_sizing_keyword(
                     item.size_style.width,
-                    Some(available_width),
-                    Some(container_inner_width),
+                    OptFloat::some(available_width),
+                    OptFloat::some(container_inner_width),
                 ) {
                     Some(SizingKeywordResolution::Measure(available)) => (None, available),
                     Some(SizingKeywordResolution::Exact(width)) => (Some(width), AvailableSpace::Definite(width)),
@@ -1063,8 +1067,8 @@ fn perform_final_layout_on_in_flow_children(
                 );
                 let item_layout = tree.perform_child_layout(
                     item.node_id,
-                    Size { width: item_known_width, height: item_known_height },
-                    parent_size,
+                    Size { width: item_known_width.into(), height: item_known_height },
+                    parent_size.into(),
                     Size { width: item_available_width, height: AvailableSpace::MaxContent },
                     SizingMode::InherentSize,
                     // A float establishes a new block formatting context: its margins do not
@@ -1236,20 +1240,23 @@ fn perform_final_layout_on_in_flow_children(
                 // Items with a sizing keyword width (min-content, max-content, fit-content,
                 // fit-content(...), stretch) resolve their width either directly or by measuring
                 // the item under the corresponding available space constraint
-                let keyword_width =
-                    resolve_sizing_keyword(item.size_style.width, Some(stretch_width), Some(container_inner_width))
-                        .map(|resolution| match resolution {
-                            SizingKeywordResolution::Exact(width) => width,
-                            SizingKeywordResolution::Measure(item_available_width) => tree.measure_child_size(
-                                item.node_id,
-                                Size::NONE,
-                                parent_size,
-                                Size { width: item_available_width, height: AvailableSpace::MaxContent },
-                                SizingMode::InherentSize,
-                                crate::AbsoluteAxis::Horizontal,
-                                Line::TRUE,
-                            ),
-                        });
+                let keyword_width = resolve_sizing_keyword(
+                    item.size_style.width,
+                    OptFloat::some(stretch_width),
+                    OptFloat::some(container_inner_width),
+                )
+                .map(|resolution| match resolution {
+                    SizingKeywordResolution::Exact(width) => width,
+                    SizingKeywordResolution::Measure(item_available_width) => tree.measure_child_size(
+                        item.node_id,
+                        Size::NONE,
+                        parent_size.into(),
+                        Size { width: item_available_width, height: AvailableSpace::MaxContent },
+                        SizingMode::InherentSize,
+                        crate::AbsoluteAxis::Horizontal,
+                        Line::TRUE,
+                    ),
+                });
 
                 let keyword_height = resolve_stretch_height(
                     item.size_style.height,
@@ -1259,9 +1266,9 @@ fn perform_final_layout_on_in_flow_children(
 
                 item.size
                     .map_width(|width| {
-                        Some(
+                        OptFloat::some(
                             width
-                                .or(keyword_width)
+                                .or(keyword_width.into())
                                 .unwrap_or(stretch_width)
                                 .maybe_clamp(item.min_size.width, item.max_size.width),
                         )
@@ -1278,7 +1285,7 @@ fn perform_final_layout_on_in_flow_children(
                 axis: RequestedAxis::Both,
                 known_dimensions,
                 known_dimensions_are_definite: Size { width: true, height: true },
-                parent_size,
+                parent_size: parent_size.into(),
                 available_space: available_space.map_width(|_| AvailableSpace::Definite(stretch_width)),
                 vertical_margins_are_collapsible: if item.is_in_same_bfc { Line::TRUE } else { Line::FALSE },
             };
@@ -1345,8 +1352,10 @@ fn perform_final_layout_on_in_flow_children(
             };
 
             // Resolve item inset
-            let inset_percentage_basis =
-                Size { width: Some(container_inner_width), height: container_percentage_resolution_height };
+            let inset_percentage_basis = Size {
+                width: OptFloat::some(container_inner_width),
+                height: container_percentage_resolution_height.into(),
+            };
             let inset = item
                 .inset
                 .zip_size(inset_percentage_basis, |p, s| p.maybe_resolve(s, |val, basis| tree.calc(val, basis)));
@@ -1376,7 +1385,7 @@ fn perform_final_layout_on_in_flow_children(
             let has_clearance = false;
             #[cfg(feature = "float_layout")]
             if item.is_in_same_bfc {
-                if let Some(threshold) = clear_threshold {
+                if let Some(threshold) = clear_threshold.into_option() {
                     // The hypothetical position always includes the item's collapsed top margin set, even
                     // when those margins collapse with the container's own top margin (and are thus applied
                     // outside the container): in that case they still move the container (and hence the item)
@@ -1499,7 +1508,7 @@ fn perform_final_layout_on_in_flow_children(
             // See https://github.com/w3c/csswg-drafts/issues/7660
             if first_baseline.is_none() {
                 let child_baseline = if item.overflow.y.is_scroll_container() {
-                    Some(
+                    OptFloat::some(
                         item_layout
                             .baselines
                             .first
@@ -1646,8 +1655,10 @@ fn perform_absolute_layout_on_absolute_children(
         let aspect_ratio = child_style.aspect_ratio();
         let margin =
             child_style.margin().map(|margin| margin.resolve_to_option(area_width, |val, basis| tree.calc(val, basis)));
-        let padding = child_style.padding().resolve_or_zero(Some(area_width), |val, basis| tree.calc(val, basis));
-        let border = child_style.border().resolve_or_zero(Some(area_width), |val, basis| tree.calc(val, basis));
+        let padding =
+            child_style.padding().resolve_or_zero(OptFloat::some(area_width), |val, basis| tree.calc(val, basis));
+        let border =
+            child_style.border().resolve_or_zero(OptFloat::some(area_width), |val, basis| tree.calc(val, basis));
         let padding_border_sum = (padding + border).sum_axes();
         let box_sizing_adjustment =
             if child_style.box_sizing() == BoxSizing::ContentBox { padding_border_sum } else { Size::ZERO };
@@ -1669,7 +1680,7 @@ fn perform_absolute_layout_on_absolute_children(
             .maybe_resolve(area_size, |val, basis| tree.calc(val, basis))
             .maybe_apply_aspect_ratio(aspect_ratio)
             .maybe_add(box_sizing_adjustment)
-            .or(padding_border_sum.map(Some))
+            .or(padding_border_sum.map(OptFloat::some))
             .maybe_max(padding_border_sum);
         let max_size = child_style
             .max_size()
@@ -1700,28 +1711,32 @@ fn perform_absolute_layout_on_absolute_children(
         // Fill in width from left/right and reapply aspect ratio if:
         //   - Width is not already known
         //   - Item has both left and right inset properties set
-        if let (None, Some(left), Some(right)) = (known_dimensions.width, left, right) {
+        if let (None, Some(left), Some(right)) =
+            (known_dimensions.width.into_option(), left.into_option(), right.into_option())
+        {
             let new_width_raw = area_width.maybe_sub(margin.left).maybe_sub(margin.right) - left - right;
-            known_dimensions.width = Some(f32_max(new_width_raw, 0.0));
+            known_dimensions.width = OptFloat::some(f32_max(new_width_raw, 0.0));
             known_dimensions = known_dimensions.maybe_apply_aspect_ratio(aspect_ratio).maybe_clamp(min_size, max_size);
         }
 
         // Fill in height from top/bottom and reapply aspect ratio if:
         //   - Height is not already known
         //   - Item has both top and bottom inset properties set
-        if let (None, Some(top), Some(bottom)) = (known_dimensions.height, top, bottom) {
+        if let (None, Some(top), Some(bottom)) =
+            (known_dimensions.height.into_option(), top.into_option(), bottom.into_option())
+        {
             let new_height_raw = area_height.maybe_sub(margin.top).maybe_sub(margin.bottom) - top - bottom;
-            known_dimensions.height = Some(f32_max(new_height_raw, 0.0));
+            known_dimensions.height = OptFloat::some(f32_max(new_height_raw, 0.0));
             known_dimensions = known_dimensions.maybe_apply_aspect_ratio(aspect_ratio).maybe_clamp(min_size, max_size);
         }
 
-        let final_size = match (known_dimensions.width, known_dimensions.height) {
+        let final_size = match (known_dimensions.width.into_option(), known_dimensions.height.into_option()) {
             (Some(width), Some(height)) => Size { width, height },
             _ => {
                 let measured_size = tree.measure_child_size_both(
                     item.node_id,
                     known_dimensions,
-                    area_size.map(Some),
+                    area_size.map(OptFloat::some),
                     Size {
                         width: AvailableSpace::Definite(area_width.maybe_clamp(min_size.width, max_size.width)),
                         height: AvailableSpace::Definite(area_height.maybe_clamp(min_size.height, max_size.height)),
@@ -1736,8 +1751,8 @@ fn perform_absolute_layout_on_absolute_children(
 
         let layout_output = tree.perform_child_layout(
             item.node_id,
-            final_size.map(Some),
-            area_size.map(Some),
+            final_size.map(OptFloat::some),
+            area_size.map(OptFloat::some),
             Size {
                 width: AvailableSpace::Definite(area_width.maybe_clamp(min_size.width, max_size.width)),
                 height: AvailableSpace::Definite(area_height.maybe_clamp(min_size.height, max_size.height)),
@@ -1814,7 +1829,7 @@ fn perform_absolute_layout_on_absolute_children(
             bottom: margin.bottom.unwrap_or(auto_margin.bottom),
         };
 
-        let x_offset = match (left, right) {
+        let x_offset = match (left.into_option(), right.into_option()) {
             (Some(left), Some(right)) => {
                 if direction.is_rtl() {
                     area_size.width - final_size.width - right - resolved_margin.right

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -8,7 +8,7 @@ use crate::util::debug::debug_log;
 use crate::util::sys::f32_max;
 use crate::util::sys::Vec;
 use crate::util::MaybeMath;
-use crate::util::OptFloat;
+use crate::util::OptF32;
 use crate::util::{MaybeResolve, ResolveOrZero};
 use crate::{
     BlockContainerStyle, BlockItemStyle, BoxGenerationMode, BoxSizing, Contain, Dimension, Direction,
@@ -206,7 +206,7 @@ impl BlockContext<'_> {
     }
 
     /// Get the bottom of lowest relevant float for the specific clear property
-    pub fn cleared_threshold(&self, clear: Clear) -> OptFloat {
+    pub fn cleared_threshold(&self, clear: Clear) -> OptF32 {
         self.bfc.float_context.cleared_threshold(clear).map(|threshold| threshold - self.y_offset)
     }
 
@@ -306,11 +306,11 @@ struct BlockItem {
     size_style: Size<Dimension>,
 
     /// The base size of this item
-    size: Size<OptFloat>,
+    size: Size<OptF32>,
     /// The minimum allowable size of this item
-    min_size: Size<OptFloat>,
+    min_size: Size<OptF32>,
     /// The maximum allowable size of this item
-    max_size: Size<OptFloat>,
+    max_size: Size<OptF32>,
 
     /// The overflow style of the item
     overflow: Point<Overflow>,
@@ -397,8 +397,8 @@ pub fn compute_block_layout(
 
     // If both min and max in a given axis are set and max <= min then this determines the size in that axis
     let min_max_definite_size = min_size.zip_map(max_size, |min, max| match (min.into_option(), max.into_option()) {
-        (Some(min), Some(max)) if max <= min => OptFloat::some(min),
-        _ => OptFloat::NONE,
+        (Some(min), Some(max)) if max <= min => OptF32::some(min),
+        _ => OptF32::NONE,
     });
 
     let styled_based_known_dimensions =
@@ -567,7 +567,7 @@ fn compute_inner(
         let available_width = available_space.width.maybe_sub(content_box_inset.horizontal_axis_sum());
         let intrinsic_width = determine_content_based_container_width(tree, &items, available_width)
             + content_box_inset.horizontal_axis_sum();
-        intrinsic_width.maybe_clamp(min_size.width, max_size.width).maybe_max(OptFloat::some(padding_border_size.width))
+        intrinsic_width.maybe_clamp(min_size.width, max_size.width).maybe_max(OptF32::some(padding_border_size.width))
     });
 
     // Short-circuit if computing size and both dimensions known
@@ -591,9 +591,9 @@ fn compute_inner(
     // unknown (e.g. at the root of the layout tree).
     let percentage_resolution_width = parent_size.width.unwrap_or(container_outer_width);
     let resolved_padding =
-        raw_padding.resolve_or_zero(OptFloat::some(percentage_resolution_width), |val, basis| tree.calc(val, basis));
+        raw_padding.resolve_or_zero(OptF32::some(percentage_resolution_width), |val, basis| tree.calc(val, basis));
     let resolved_border =
-        raw_border.resolve_or_zero(OptFloat::some(percentage_resolution_width), |val, basis| tree.calc(val, basis));
+        raw_border.resolve_or_zero(OptF32::some(percentage_resolution_width), |val, basis| tree.calc(val, basis));
     let resolved_content_box_inset = resolved_padding + resolved_border + scrollbar_gutter;
     #[cfg_attr(not(feature = "content_size"), allow(unused_mut))]
     let (
@@ -628,7 +628,7 @@ fn compute_inner(
     let container_outer_height = known_dimensions
         .height
         .unwrap_or(intrinsic_outer_height.maybe_clamp(min_size.height, max_size.height))
-        .maybe_max(OptFloat::some(padding_border_size.height));
+        .maybe_max(OptF32::some(padding_border_size.height));
     let final_outer_size = Size { width: container_outer_width, height: container_outer_height };
 
     // CSS2 §8.3.1: the bottom margin of a block with `height: auto` collapses with its last
@@ -794,11 +794,7 @@ fn compute_inner(
 
 /// Create a `Vec` of `BlockItem` structs where each item in the `Vec` represents a child of the current node
 #[inline]
-fn generate_item_list(
-    tree: &impl LayoutBlockContainer,
-    node: NodeId,
-    node_inner_size: Size<OptFloat>,
-) -> Vec<BlockItem> {
+fn generate_item_list(tree: &impl LayoutBlockContainer, node: NodeId, node_inner_size: Size<OptF32>) -> Vec<BlockItem> {
     tree.child_ids(node)
         .map(|child_node_id| (child_node_id, tree.get_block_child_style(child_node_id)))
         .filter(|(_, style)| style.box_generation_mode() != BoxGenerationMode::None)
@@ -886,18 +882,14 @@ fn generate_item_list(
 /// are all equal to the content size, which is what an auto height already resolves to, so
 /// only `stretch` requires explicit resolution.
 #[inline]
-fn resolve_stretch_height(
-    height_style: Dimension,
-    container_inner_height: OptFloat,
-    item_y_margin_sum: f32,
-) -> OptFloat {
+fn resolve_stretch_height(height_style: Dimension, container_inner_height: OptF32, item_y_margin_sum: f32) -> OptF32 {
     match resolve_sizing_keyword(
         height_style,
         container_inner_height.maybe_sub(item_y_margin_sum),
         container_inner_height,
     ) {
-        Some(SizingKeywordResolution::Exact(height)) => OptFloat::some(height),
-        _ => OptFloat::NONE,
+        Some(SizingKeywordResolution::Exact(height)) => OptF32::some(height),
+        _ => OptF32::NONE,
     }
 }
 
@@ -921,12 +913,11 @@ fn determine_content_based_container_width(
             .resolve_or_zero(available_space.width.into_option(), |val, basis| tree.calc(val, basis))
             .horizontal_axis_sum();
         let width = known_dimensions.width.unwrap_or_else(|| {
-            let item_available_width =
-                match resolve_sizing_keyword(item.size_style.width, OptFloat::NONE, OptFloat::NONE) {
-                    Some(SizingKeywordResolution::Measure(available_width)) => available_width,
-                    Some(SizingKeywordResolution::Exact(width)) => AvailableSpace::Definite(width),
-                    None => available_space.width.maybe_sub(item_x_margin_sum),
-                };
+            let item_available_width = match resolve_sizing_keyword(item.size_style.width, OptF32::NONE, OptF32::NONE) {
+                Some(SizingKeywordResolution::Measure(available_width)) => available_width,
+                Some(SizingKeywordResolution::Exact(width)) => AvailableSpace::Definite(width),
+                None => available_space.width.maybe_sub(item_x_margin_sum),
+            };
             tree.measure_child_size(
                 item.node_id,
                 known_dimensions,
@@ -965,7 +956,7 @@ fn perform_final_layout_on_in_flow_children(
     run_mode: RunMode,
     items: &mut [BlockItem],
     container_outer_width: f32,
-    container_percentage_resolution_height: OptFloat,
+    container_percentage_resolution_height: OptF32,
     content_box_inset: Rect<f32>,
     resolved_content_box_inset: Rect<f32>,
     resolved_border: Rect<f32>,
@@ -974,7 +965,7 @@ fn perform_final_layout_on_in_flow_children(
     own_margins_collapse_with_children: Line<bool>,
     #[cfg(feature = "content_size")] is_scroll_container: bool,
     block_ctx: &mut BlockContext<'_>,
-) -> (Rect<f32>, f32, CollapsibleMarginSet, CollapsibleMarginSet, OptFloat) {
+) -> (Rect<f32>, f32, CollapsibleMarginSet, CollapsibleMarginSet, OptF32) {
     // Resolve container_inner_width for sizing child nodes using initial content_box_inset
     let container_inner_width = container_outer_width - resolved_content_box_inset.horizontal_axis_sum();
     let container_percentage_resolution_height =
@@ -1013,7 +1004,7 @@ fn perform_final_layout_on_in_flow_children(
     let mut first_child_top_margin_set = CollapsibleMarginSet::ZERO;
     let mut active_collapsible_margin_set = CollapsibleMarginSet::ZERO;
     let mut is_collapsing_with_first_margin_set = true;
-    let mut first_baseline: OptFloat = OptFloat::NONE;
+    let mut first_baseline: OptF32 = OptF32::NONE;
     // Whether the active margin set contains the margins of a self-collapsing element with
     // clearance. Such margins collapse with the margins of following siblings but the resulting
     // margin does not collapse with the bottom margin of the parent block.
@@ -1053,8 +1044,8 @@ fn perform_final_layout_on_in_flow_children(
                 let available_width = container_inner_width - item_non_auto_x_margin_sum;
                 let (item_known_width, item_available_width) = match resolve_sizing_keyword(
                     item.size_style.width,
-                    OptFloat::some(available_width),
-                    OptFloat::some(container_inner_width),
+                    OptF32::some(available_width),
+                    OptF32::some(container_inner_width),
                 ) {
                     Some(SizingKeywordResolution::Measure(available)) => (None, available),
                     Some(SizingKeywordResolution::Exact(width)) => (Some(width), AvailableSpace::Definite(width)),
@@ -1242,8 +1233,8 @@ fn perform_final_layout_on_in_flow_children(
                 // the item under the corresponding available space constraint
                 let keyword_width = resolve_sizing_keyword(
                     item.size_style.width,
-                    OptFloat::some(stretch_width),
-                    OptFloat::some(container_inner_width),
+                    OptF32::some(stretch_width),
+                    OptF32::some(container_inner_width),
                 )
                 .map(|resolution| match resolution {
                     SizingKeywordResolution::Exact(width) => width,
@@ -1266,7 +1257,7 @@ fn perform_final_layout_on_in_flow_children(
 
                 item.size
                     .map_width(|width| {
-                        OptFloat::some(
+                        OptF32::some(
                             width
                                 .or(keyword_width.into())
                                 .unwrap_or(stretch_width)
@@ -1353,7 +1344,7 @@ fn perform_final_layout_on_in_flow_children(
 
             // Resolve item inset
             let inset_percentage_basis =
-                Size { width: OptFloat::some(container_inner_width), height: container_percentage_resolution_height };
+                Size { width: OptF32::some(container_inner_width), height: container_percentage_resolution_height };
             let inset = item
                 .inset
                 .zip_size(inset_percentage_basis, |p, s| p.maybe_resolve(s, |val, basis| tree.calc(val, basis)));
@@ -1506,7 +1497,7 @@ fn perform_final_layout_on_in_flow_children(
             // See https://github.com/w3c/csswg-drafts/issues/7660
             if first_baseline.is_none() {
                 let child_baseline = if item.overflow.y.is_scroll_container() {
-                    OptFloat::some(
+                    OptF32::some(
                         item_layout
                             .baselines
                             .first
@@ -1654,9 +1645,8 @@ fn perform_absolute_layout_on_absolute_children(
         let margin =
             child_style.margin().map(|margin| margin.resolve_to_option(area_width, |val, basis| tree.calc(val, basis)));
         let padding =
-            child_style.padding().resolve_or_zero(OptFloat::some(area_width), |val, basis| tree.calc(val, basis));
-        let border =
-            child_style.border().resolve_or_zero(OptFloat::some(area_width), |val, basis| tree.calc(val, basis));
+            child_style.padding().resolve_or_zero(OptF32::some(area_width), |val, basis| tree.calc(val, basis));
+        let border = child_style.border().resolve_or_zero(OptF32::some(area_width), |val, basis| tree.calc(val, basis));
         let padding_border_sum = (padding + border).sum_axes();
         let box_sizing_adjustment =
             if child_style.box_sizing() == BoxSizing::ContentBox { padding_border_sum } else { Size::ZERO };
@@ -1678,7 +1668,7 @@ fn perform_absolute_layout_on_absolute_children(
             .maybe_resolve(area_size, |val, basis| tree.calc(val, basis))
             .maybe_apply_aspect_ratio(aspect_ratio)
             .maybe_add(box_sizing_adjustment)
-            .or(padding_border_sum.map(OptFloat::some))
+            .or(padding_border_sum.map(OptF32::some))
             .maybe_max(padding_border_sum);
         let max_size = child_style
             .max_size()
@@ -1713,7 +1703,7 @@ fn perform_absolute_layout_on_absolute_children(
             (known_dimensions.width.into_option(), left.into_option(), right.into_option())
         {
             let new_width_raw = area_width.maybe_sub(margin.left).maybe_sub(margin.right) - left - right;
-            known_dimensions.width = OptFloat::some(f32_max(new_width_raw, 0.0));
+            known_dimensions.width = OptF32::some(f32_max(new_width_raw, 0.0));
             known_dimensions = known_dimensions.maybe_apply_aspect_ratio(aspect_ratio).maybe_clamp(min_size, max_size);
         }
 
@@ -1724,7 +1714,7 @@ fn perform_absolute_layout_on_absolute_children(
             (known_dimensions.height.into_option(), top.into_option(), bottom.into_option())
         {
             let new_height_raw = area_height.maybe_sub(margin.top).maybe_sub(margin.bottom) - top - bottom;
-            known_dimensions.height = OptFloat::some(f32_max(new_height_raw, 0.0));
+            known_dimensions.height = OptF32::some(f32_max(new_height_raw, 0.0));
             known_dimensions = known_dimensions.maybe_apply_aspect_ratio(aspect_ratio).maybe_clamp(min_size, max_size);
         }
 
@@ -1734,7 +1724,7 @@ fn perform_absolute_layout_on_absolute_children(
                 let measured_size = tree.measure_child_size_both(
                     item.node_id,
                     known_dimensions,
-                    area_size.map(OptFloat::some),
+                    area_size.map(OptF32::some),
                     Size {
                         width: AvailableSpace::Definite(area_width.maybe_clamp(min_size.width, max_size.width)),
                         height: AvailableSpace::Definite(area_height.maybe_clamp(min_size.height, max_size.height)),
@@ -1749,8 +1739,8 @@ fn perform_absolute_layout_on_absolute_children(
 
         let layout_output = tree.perform_child_layout(
             item.node_id,
-            final_size.map(OptFloat::some),
-            area_size.map(OptFloat::some),
+            final_size.map(OptF32::some),
+            area_size.map(OptF32::some),
             Size {
                 width: AvailableSpace::Definite(area_width.maybe_clamp(min_size.width, max_size.width)),
                 height: AvailableSpace::Definite(area_height.maybe_clamp(min_size.height, max_size.height)),

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -1352,10 +1352,8 @@ fn perform_final_layout_on_in_flow_children(
             };
 
             // Resolve item inset
-            let inset_percentage_basis = Size {
-                width: OptFloat::some(container_inner_width),
-                height: container_percentage_resolution_height.into(),
-            };
+            let inset_percentage_basis =
+                Size { width: OptFloat::some(container_inner_width), height: container_percentage_resolution_height };
             let inset = item
                 .inset
                 .zip_size(inset_percentage_basis, |p, s| p.maybe_resolve(s, |val, basis| tree.calc(val, basis)));

--- a/src/compute/common/sizing_keyword.rs
+++ b/src/compute/common/sizing_keyword.rs
@@ -3,7 +3,7 @@
 use crate::geometry::{AbsoluteAxis, Line, Rect, Size};
 use crate::tree::{LayoutPartialTree, LayoutPartialTreeExt, NodeId, SizingMode};
 use crate::util::sys::f32_max;
-use crate::util::OptFloat;
+use crate::util::OptF32;
 use crate::AvailableSpace;
 use crate::{CompactLength, Dimension};
 
@@ -28,8 +28,8 @@ pub(crate) enum SizingKeywordResolution {
 #[inline]
 pub(crate) fn resolve_sizing_keyword(
     style: Dimension,
-    stretch_size: OptFloat,
-    percent_resolution_basis: OptFloat,
+    stretch_size: OptF32,
+    percent_resolution_basis: OptF32,
 ) -> Option<SizingKeywordResolution> {
     match style.tag() {
         CompactLength::MIN_CONTENT_TAG => Some(SizingKeywordResolution::Measure(AvailableSpace::MinContent)),
@@ -60,11 +60,11 @@ pub(crate) fn resolve_sizing_keyword(
 pub(crate) fn resolve_absolute_sizing_keywords(
     tree: &mut impl LayoutPartialTree,
     node: NodeId,
-    known_dimensions: &mut Size<OptFloat>,
+    known_dimensions: &mut Size<OptF32>,
     size_style: Size<Dimension>,
     area_size: Size<f32>,
-    inset: Rect<OptFloat>,
-    margin: Rect<OptFloat>,
+    inset: Rect<OptF32>,
+    margin: Rect<OptF32>,
     sizing_mode: SizingMode,
 ) {
     let stretch_size = Size {
@@ -87,12 +87,12 @@ pub(crate) fn resolve_absolute_sizing_keywords(
     };
 
     let keyword_width = if known_dimensions.width.is_none() {
-        resolve_sizing_keyword(size_style.width, OptFloat::some(stretch_size.width), OptFloat::some(area_size.width))
+        resolve_sizing_keyword(size_style.width, OptF32::some(stretch_size.width), OptF32::some(area_size.width))
     } else {
         None
     };
     let keyword_height = if known_dimensions.height.is_none() {
-        resolve_sizing_keyword(size_style.height, OptFloat::some(stretch_size.height), OptFloat::some(area_size.height))
+        resolve_sizing_keyword(size_style.height, OptF32::some(stretch_size.height), OptF32::some(area_size.height))
     } else {
         None
     };
@@ -106,21 +106,21 @@ pub(crate) fn resolve_absolute_sizing_keywords(
             let measured_size = tree.measure_child_size_both(
                 node,
                 Size::NONE,
-                area_size.map(OptFloat::some),
+                area_size.map(OptF32::some),
                 Size { width: available_width, height: available_height },
                 sizing_mode,
                 Line::FALSE,
             );
-            *known_dimensions = measured_size.map(OptFloat::some);
+            *known_dimensions = measured_size.map(OptF32::some);
         }
         (keyword_width, keyword_height) => {
             if let Some(resolution) = keyword_width {
-                known_dimensions.width = OptFloat::some(match resolution {
+                known_dimensions.width = OptF32::some(match resolution {
                     SizingKeywordResolution::Exact(width) => width,
                     SizingKeywordResolution::Measure(available_width) => tree.measure_child_size(
                         node,
                         *known_dimensions,
-                        area_size.map(OptFloat::some),
+                        area_size.map(OptF32::some),
                         Size { width: available_width, height: AvailableSpace::Definite(stretch_size.height) },
                         sizing_mode,
                         AbsoluteAxis::Horizontal,
@@ -129,12 +129,12 @@ pub(crate) fn resolve_absolute_sizing_keywords(
                 });
             }
             if let Some(resolution) = keyword_height {
-                known_dimensions.height = OptFloat::some(match resolution {
+                known_dimensions.height = OptF32::some(match resolution {
                     SizingKeywordResolution::Exact(height) => height,
                     SizingKeywordResolution::Measure(available_height) => tree.measure_child_size(
                         node,
                         *known_dimensions,
-                        area_size.map(OptFloat::some),
+                        area_size.map(OptF32::some),
                         Size {
                             width: AvailableSpace::Definite(known_dimensions.width.unwrap_or(stretch_size.width)),
                             height: available_height,

--- a/src/compute/common/sizing_keyword.rs
+++ b/src/compute/common/sizing_keyword.rs
@@ -1,9 +1,10 @@
 //! Shared resolution logic for sizing keywords (`min-content`, `max-content`, `fit-content`,
 //! `fit-content(...)`, and `stretch`) on the `width`/`height` style properties
 use crate::geometry::{AbsoluteAxis, Line, Rect, Size};
-use crate::style::AvailableSpace;
 use crate::tree::{LayoutPartialTree, LayoutPartialTreeExt, NodeId, SizingMode};
 use crate::util::sys::f32_max;
+use crate::util::OptFloat;
+use crate::AvailableSpace;
 use crate::{CompactLength, Dimension};
 
 /// How a sizing keyword resolves to a used size
@@ -27,8 +28,8 @@ pub(crate) enum SizingKeywordResolution {
 #[inline]
 pub(crate) fn resolve_sizing_keyword(
     style: Dimension,
-    stretch_size: Option<f32>,
-    percent_resolution_basis: Option<f32>,
+    stretch_size: OptFloat,
+    percent_resolution_basis: OptFloat,
 ) -> Option<SizingKeywordResolution> {
     match style.tag() {
         CompactLength::MIN_CONTENT_TAG => Some(SizingKeywordResolution::Measure(AvailableSpace::MinContent)),
@@ -37,11 +38,12 @@ pub(crate) fn resolve_sizing_keyword(
             Some(SizingKeywordResolution::Measure(AvailableSpace::Definite(style.value())))
         }
         CompactLength::FIT_CONTENT_PERCENT_TAG => percent_resolution_basis
+            .into_option()
             .map(|basis| SizingKeywordResolution::Measure(AvailableSpace::Definite(basis * style.value()))),
         CompactLength::FIT_CONTENT_KEYWORD_TAG => {
-            stretch_size.map(|size| SizingKeywordResolution::Measure(AvailableSpace::Definite(size)))
+            stretch_size.into_option().map(|size| SizingKeywordResolution::Measure(AvailableSpace::Definite(size)))
         }
-        CompactLength::STRETCH_TAG => stretch_size.map(SizingKeywordResolution::Exact),
+        CompactLength::STRETCH_TAG => stretch_size.into_option().map(SizingKeywordResolution::Exact),
         _ => None,
     }
 }
@@ -58,11 +60,11 @@ pub(crate) fn resolve_sizing_keyword(
 pub(crate) fn resolve_absolute_sizing_keywords(
     tree: &mut impl LayoutPartialTree,
     node: NodeId,
-    known_dimensions: &mut Size<Option<f32>>,
+    known_dimensions: &mut Size<OptFloat>,
     size_style: Size<Dimension>,
     area_size: Size<f32>,
-    inset: Rect<Option<f32>>,
-    margin: Rect<Option<f32>>,
+    inset: Rect<OptFloat>,
+    margin: Rect<OptFloat>,
     sizing_mode: SizingMode,
 ) {
     let stretch_size = Size {
@@ -85,12 +87,12 @@ pub(crate) fn resolve_absolute_sizing_keywords(
     };
 
     let keyword_width = if known_dimensions.width.is_none() {
-        resolve_sizing_keyword(size_style.width, Some(stretch_size.width), Some(area_size.width))
+        resolve_sizing_keyword(size_style.width, OptFloat::some(stretch_size.width), OptFloat::some(area_size.width))
     } else {
         None
     };
     let keyword_height = if known_dimensions.height.is_none() {
-        resolve_sizing_keyword(size_style.height, Some(stretch_size.height), Some(area_size.height))
+        resolve_sizing_keyword(size_style.height, OptFloat::some(stretch_size.height), OptFloat::some(area_size.height))
     } else {
         None
     };
@@ -104,21 +106,21 @@ pub(crate) fn resolve_absolute_sizing_keywords(
             let measured_size = tree.measure_child_size_both(
                 node,
                 Size::NONE,
-                area_size.map(Some),
+                area_size.map(OptFloat::some),
                 Size { width: available_width, height: available_height },
                 sizing_mode,
                 Line::FALSE,
             );
-            *known_dimensions = measured_size.map(Some);
+            *known_dimensions = measured_size.map(OptFloat::some);
         }
         (keyword_width, keyword_height) => {
             if let Some(resolution) = keyword_width {
-                known_dimensions.width = Some(match resolution {
+                known_dimensions.width = OptFloat::some(match resolution {
                     SizingKeywordResolution::Exact(width) => width,
                     SizingKeywordResolution::Measure(available_width) => tree.measure_child_size(
                         node,
                         *known_dimensions,
-                        area_size.map(Some),
+                        area_size.map(OptFloat::some),
                         Size { width: available_width, height: AvailableSpace::Definite(stretch_size.height) },
                         sizing_mode,
                         AbsoluteAxis::Horizontal,
@@ -127,17 +129,14 @@ pub(crate) fn resolve_absolute_sizing_keywords(
                 });
             }
             if let Some(resolution) = keyword_height {
-                known_dimensions.height = Some(match resolution {
+                known_dimensions.height = OptFloat::some(match resolution {
                     SizingKeywordResolution::Exact(height) => height,
                     SizingKeywordResolution::Measure(available_height) => tree.measure_child_size(
                         node,
                         *known_dimensions,
-                        area_size.map(Some),
+                        area_size.map(OptFloat::some),
                         Size {
-                            width: known_dimensions
-                                .width
-                                .map(AvailableSpace::Definite)
-                                .unwrap_or(AvailableSpace::Definite(stretch_size.width)),
+                            width: AvailableSpace::Definite(known_dimensions.width.unwrap_or(stretch_size.width)),
                             height: available_height,
                         },
                         sizing_mode,

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -12,7 +12,7 @@ use crate::tree::{LayoutFlexboxContainer, LayoutPartialTreeExt, NodeId};
 use crate::util::debug::debug_log;
 use crate::util::sys::{f32_max, f32_min, new_vec_with_capacity, Vec};
 use crate::util::MaybeMath;
-use crate::util::OptFloat;
+use crate::util::OptF32;
 use crate::util::{MaybeResolve, ResolveOrZero};
 use crate::{BoxGenerationMode, BoxSizing, Dimension, Direction, RequestedAxis};
 
@@ -32,14 +32,14 @@ struct FlexItem {
     order: u32,
 
     /// The base size of this item
-    size: Size<OptFloat>,
+    size: Size<OptF32>,
     /// The raw size style of this item. Used to detect and resolve sizing
     /// keywords (`min-content`, `max-content`, `fit-content`, `fit-content(...)`, and `stretch`)
     size_style: Size<Dimension>,
     /// The minimum allowable size of this item
-    min_size: Size<OptFloat>,
+    min_size: Size<OptF32>,
     /// The maximum allowable size of this item
-    max_size: Size<OptFloat>,
+    max_size: Size<OptF32>,
     /// The aspect ratio of this item
     aspect_ratio: Option<f32>,
     /// The cross-alignment of this item
@@ -63,7 +63,7 @@ struct FlexItem {
     resolved_minimum_main_size: f32,
 
     /// The final offset of this item
-    inset: Rect<OptFloat>,
+    inset: Rect<OptF32>,
     /// The margin of this item
     margin: Rect<f32>,
     /// Whether each margin is an auto margin or not
@@ -159,9 +159,9 @@ struct AlgoConstants {
     line_count: Option<u16>,
 
     /// The item's min_size style
-    min_size: Size<OptFloat>,
+    min_size: Size<OptF32>,
     /// The item's max_size style
-    max_size: Size<OptFloat>,
+    max_size: Size<OptF32>,
     /// The margin of this section
     margin: Rect<f32>,
     /// The border of this section
@@ -184,9 +184,9 @@ struct AlgoConstants {
     justify_content: Option<JustifyContent>,
 
     /// The border-box size of the node being laid out (if known)
-    node_outer_size: Size<OptFloat>,
+    node_outer_size: Size<OptF32>,
     /// The content-box size of the node being laid out (if known)
-    node_inner_size: Size<OptFloat>,
+    node_inner_size: Size<OptF32>,
     /// Whether the known main size of the node (if any) is definite. This is `false` when a parent
     /// imposes a main size on this node that is derived from the node's own content, in which case
     /// it is indefinite for the purposes of resolving percentage sizes of items and collecting items
@@ -268,8 +268,8 @@ pub fn compute_flexbox_layout(
 
     // If both min and max in a given axis are set and max <= min then this determines the size in that axis
     let min_max_definite_size = min_size.zip_map(max_size, |min, max| match (min.into_option(), max.into_option()) {
-        (Some(min), Some(max)) if max <= min => OptFloat::some(min),
-        _ => OptFloat::NONE,
+        (Some(min), Some(max)) if max <= min => OptF32::some(min),
+        _ => OptF32::NONE,
     });
 
     // The size of the container should be floored by the padding and border
@@ -391,8 +391,8 @@ fn compute_preliminary(tree: &mut impl LayoutFlexboxContainer, node: NodeId, inp
         determine_container_main_size(tree, available_space, &mut flex_lines, &mut constants);
         constants
             .node_inner_size
-            .set_main(constants.dir, OptFloat::some(constants.inner_container_size.main(constants.dir)));
-        constants.node_outer_size.set_main(constants.dir, OptFloat::some(constants.container_size.main(constants.dir)));
+            .set_main(constants.dir, OptF32::some(constants.inner_container_size.main(constants.dir)));
+        constants.node_outer_size.set_main(constants.dir, OptF32::some(constants.container_size.main(constants.dir)));
 
         debug_log!("constants.node_outer_size", dbg:constants.node_outer_size);
         debug_log!("constants.node_inner_size", dbg:constants.node_inner_size);
@@ -538,9 +538,9 @@ fn compute_preliminary(tree: &mut impl LayoutFlexboxContainer, node: NodeId, inp
 fn compute_constants(
     tree: &impl LayoutFlexboxContainer,
     style: impl FlexboxContainerStyle,
-    known_dimensions: Size<OptFloat>,
+    known_dimensions: Size<OptF32>,
     known_dimensions_are_definite: Size<bool>,
-    parent_size: Size<OptFloat>,
+    parent_size: Size<OptF32>,
     available_space: Size<AvailableSpace>,
 ) -> AlgoConstants {
     let dir = style.flex_direction();
@@ -658,7 +658,7 @@ fn generate_anonymous_flex_items(
     let percent_resolution_size = if constants.known_main_size_is_definite {
         constants.node_inner_size
     } else {
-        constants.node_inner_size.with_main(constants.dir, OptFloat::NONE)
+        constants.node_inner_size.with_main(constants.dir, OptF32::NONE)
     };
 
     tree.child_ids(node)
@@ -754,7 +754,7 @@ fn generate_anonymous_flex_items(
 #[inline]
 #[must_use]
 fn determine_available_space(
-    known_dimensions: Size<OptFloat>,
+    known_dimensions: Size<OptF32>,
     outer_available_space: Size<AvailableSpace>,
     constants: &AlgoConstants,
 ) -> Size<AvailableSpace> {
@@ -850,7 +850,7 @@ fn determine_flex_base_size(
         // Known dimensions for child sizing
         let mut child_cross_size_is_definite = child.size.cross(dir).is_some();
         let child_known_dimensions = {
-            let mut ckd = child.size.with_main(dir, OptFloat::NONE);
+            let mut ckd = child.size.with_main(dir, OptF32::NONE);
             // Clamp the definite cross size by the cross min/max sizes so that sizes
             // transferred through an intrinsic aspect ratio (e.g. for replaced elements)
             // are based on the used cross size.
@@ -888,7 +888,7 @@ fn determine_flex_base_size(
         // if that size is definite. A known main size which is derived from the container's own
         // content is treated as indefinite here.
         let percent_resolution_main_size =
-            if constants.known_main_size_is_definite { constants.node_inner_size.main(dir) } else { OptFloat::NONE };
+            if constants.known_main_size_is_definite { constants.node_inner_size.main(dir) } else { OptF32::NONE };
         let flex_basis_style = child_style.flex_basis();
         let flex_basis = flex_basis_style
             .maybe_resolve(percent_resolution_main_size, |val, basis| tree.calc(val, basis))
@@ -1028,7 +1028,7 @@ fn determine_flex_base_size(
         child.inner_flex_basis =
             child.flex_basis - child.padding.main_axis_sum(constants.dir) - child.border.main_axis_sum(constants.dir);
 
-        let padding_border_axes_sums = (child.padding + child.border).sum_axes().map(OptFloat::some);
+        let padding_border_axes_sums = (child.padding + child.border).sum_axes().map(OptF32::some);
 
         // Note that it is important that the `parent_size` parameter in the main axis is not set for this
         // function call as it used for resolving percentages, and percentage size in an axis should not contribute
@@ -1071,7 +1071,7 @@ fn determine_flex_base_size(
             .maybe_max(padding_border_axes_sums.main(constants.dir));
         let hypothetical_inner_size = child
             .flex_basis
-            .maybe_clamp(OptFloat::some(hypothetical_inner_min_main), transferred_max_size.main(constants.dir));
+            .maybe_clamp(OptF32::some(hypothetical_inner_min_main), transferred_max_size.main(constants.dir));
         let hypothetical_outer_size = hypothetical_inner_size + child.margin.main_axis_sum(constants.dir);
 
         child.hypothetical_inner_size.set_main(constants.dir, hypothetical_inner_size);
@@ -1378,7 +1378,7 @@ fn determine_container_main_size(
                         // Spec modification: https://www.w3.org/TR/css-flexbox-1/#change-2016-max-contribution
                         // Issue: https://github.com/w3c/csswg-drafts/issues/1435
                         // Gentest: padding_border_overrides_size_flex_basis_0.html
-                        let clamping_basis = OptFloat::some(item.flex_basis).maybe_max(style_preferred);
+                        let clamping_basis = OptF32::some(item.flex_basis).maybe_max(style_preferred);
                         let flex_basis_min = clamping_basis.filter(|_| item.flex_shrink == 0.0);
                         let flex_basis_max = clamping_basis.filter(|_| item.flex_grow == 0.0);
 
@@ -1439,7 +1439,7 @@ fn determine_container_main_size(
 
                                 // Known dimensions for child sizing
                                 let child_known_dimensions = {
-                                    let mut ckd = item.size.with_main(dir, OptFloat::NONE);
+                                    let mut ckd = item.size.with_main(dir, OptF32::NONE);
                                     if item.align_self == AlignSelf::STRETCH && ckd.cross(dir).is_none() {
                                         ckd.set_cross(
                                             dir,
@@ -1466,7 +1466,7 @@ fn determine_container_main_size(
 
                                 // A known cross size is transferred through the item's aspect-ratio
                                 // and floors the measured content size
-                                let transferred_main_size: OptFloat = item
+                                let transferred_main_size: OptF32 = item
                                     .aspect_ratio
                                     .zip(child_known_dimensions.cross(dir).into_option())
                                     .map(|(ratio, cross)| if constants.is_row { cross * ratio } else { cross / ratio })
@@ -1568,7 +1568,7 @@ fn determine_container_main_size(
     let inner_main_size = f32_max(outer_main_size - main_content_box_inset, 0.0);
     constants.container_size.set_main(constants.dir, outer_main_size);
     constants.inner_container_size.set_main(constants.dir, inner_main_size);
-    constants.node_inner_size.set_main(constants.dir, OptFloat::some(inner_main_size));
+    constants.node_inner_size.set_main(constants.dir, OptF32::some(inner_main_size));
 }
 
 /// Resolve the flexible lengths of the items within a flex line.
@@ -1731,7 +1731,7 @@ fn resolve_flexible_lengths(line: &mut FlexLine, constants: &AlgoConstants) {
         //    If the item’s target main size was made larger by this, it’s a min violation.
 
         let total_violation = unfrozen.iter_mut().fold(0.0, |acc, child| -> f32 {
-            let resolved_min_main: OptFloat = child.resolved_minimum_main_size.into();
+            let resolved_min_main: OptF32 = child.resolved_minimum_main_size.into();
             let max_main = child.max_size.main(constants.dir);
             let clamped = child.target_size.main(constants.dir).maybe_clamp(resolved_min_main, max_main).max(0.0);
             child.violation = clamped - child.target_size.main(constants.dir);
@@ -1854,7 +1854,7 @@ fn determine_hypothetical_cross_size(
 #[inline]
 fn calculate_children_base_lines(
     tree: &mut impl LayoutFlexboxContainer,
-    node_size: Size<OptFloat>,
+    node_size: Size<OptF32>,
     available_space: Size<AvailableSpace>,
     flex_lines: &mut [FlexLine],
     constants: &AlgoConstants,
@@ -1939,7 +1939,7 @@ fn calculate_children_base_lines(
 ///
 /// - [**Calculate the cross size of each flex line**](https://www.w3.org/TR/css-flexbox-1/#algo-cross-line).
 #[inline]
-fn calculate_cross_size(flex_lines: &mut [FlexLine], node_size: Size<OptFloat>, constants: &AlgoConstants) {
+fn calculate_cross_size(flex_lines: &mut [FlexLine], node_size: Size<OptF32>, constants: &AlgoConstants) {
     // If the flex container is single-line and has a definite cross size,
     // the cross size of the flex line is the flex container’s inner cross size.
     if !constants.is_wrap && node_size.cross(constants.dir).is_some() {
@@ -2003,7 +2003,7 @@ fn calculate_cross_size(flex_lines: &mut [FlexLine], node_size: Size<OptFloat>, 
 ///   and the sum of the flex lines' cross sizes is less than the flex container’s inner cross size,
 ///   increase the cross size of each flex line by equal amounts such that the sum of their cross sizes exactly equals the flex container’s inner cross size.
 #[inline]
-fn handle_align_content_stretch(flex_lines: &mut [FlexLine], node_size: Size<OptFloat>, constants: &AlgoConstants) {
+fn handle_align_content_stretch(flex_lines: &mut [FlexLine], node_size: Size<OptF32>, constants: &AlgoConstants) {
     if constants.align_content == AlignContent::STRETCH {
         let cross_axis_padding_border = constants.content_box_inset.cross_axis_sum(constants.dir);
         let cross_min_size = constants.min_size.cross(constants.dir);
@@ -2330,7 +2330,7 @@ fn align_flex_items_along_cross_axis(
 #[must_use]
 fn determine_container_cross_size(
     flex_lines: &[FlexLine],
-    node_size: Size<OptFloat>,
+    node_size: Size<OptF32>,
     constants: &mut AlgoConstants,
 ) -> f32 {
     let total_cross_axis_gap = sum_axis_gaps(constants.gap.cross(constants.dir), flex_lines.len());
@@ -2675,10 +2675,10 @@ fn perform_absolute_layout_on_absolute_children(
             .map(|margin| margin.resolve_to_option(inset_relative_size.width, |val, basis| tree.calc(val, basis)));
         let padding = child_style
             .padding()
-            .resolve_or_zero(OptFloat::some(inset_relative_size.width), |val, basis| tree.calc(val, basis));
+            .resolve_or_zero(OptF32::some(inset_relative_size.width), |val, basis| tree.calc(val, basis));
         let border = child_style
             .border()
-            .resolve_or_zero(OptFloat::some(inset_relative_size.width), |val, basis| tree.calc(val, basis));
+            .resolve_or_zero(OptF32::some(inset_relative_size.width), |val, basis| tree.calc(val, basis));
         let padding_border_sum = (padding + border).sum_axes();
         let box_sizing_adjustment =
             if child_style.box_sizing() == BoxSizing::ContentBox { padding_border_sum } else { Size::ZERO };
@@ -2704,7 +2704,7 @@ fn perform_absolute_layout_on_absolute_children(
             .maybe_resolve(inset_relative_size, |val, basis| tree.calc(val, basis))
             .maybe_apply_aspect_ratio(aspect_ratio)
             .maybe_add(box_sizing_adjustment)
-            .or(padding_border_sum.map(OptFloat::some))
+            .or(padding_border_sum.map(OptF32::some))
             .maybe_max(padding_border_sum);
         let max_size = child_style
             .max_size()
@@ -2739,7 +2739,7 @@ fn perform_absolute_layout_on_absolute_children(
             (known_dimensions.width.into_option(), left.into_option(), right.into_option())
         {
             let new_width_raw = inset_relative_size.width.maybe_sub(margin.left).maybe_sub(margin.right) - left - right;
-            known_dimensions.width = OptFloat::some(f32_max(new_width_raw, 0.0));
+            known_dimensions.width = OptF32::some(f32_max(new_width_raw, 0.0));
             known_dimensions = known_dimensions.maybe_apply_aspect_ratio(aspect_ratio).maybe_clamp(min_size, max_size);
         }
 
@@ -2751,7 +2751,7 @@ fn perform_absolute_layout_on_absolute_children(
         {
             let new_height_raw =
                 inset_relative_size.height.maybe_sub(margin.top).maybe_sub(margin.bottom) - top - bottom;
-            known_dimensions.height = OptFloat::some(f32_max(new_height_raw, 0.0));
+            known_dimensions.height = OptF32::some(f32_max(new_height_raw, 0.0));
             known_dimensions = known_dimensions.maybe_apply_aspect_ratio(aspect_ratio).maybe_clamp(min_size, max_size);
         }
         let final_size = match (known_dimensions.width.into_option(), known_dimensions.height.into_option()) {
@@ -2777,7 +2777,7 @@ fn perform_absolute_layout_on_absolute_children(
 
         let layout_output = tree.perform_child_layout(
             child,
-            final_size.map(OptFloat::some),
+            final_size.map(OptF32::some),
             constants.node_inner_size,
             Size {
                 width: AvailableSpace::Definite(container_width.maybe_clamp(min_size.width, max_size.width)),

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -1059,7 +1059,7 @@ fn determine_flex_base_size(
             // https://www.w3.org/TR/css-flexbox-1/#min-size-auto
             let clamped_min_content_size =
                 min_content_main_size.maybe_min(child.size.main(dir)).maybe_min(transferred_max_size.main(dir));
-            clamped_min_content_size.maybe_max(padding_border_axes_sums.main(dir).into())
+            clamped_min_content_size.maybe_max(padding_border_axes_sums.main(dir))
         });
 
         // Sizes transferred through the aspect ratio clamp the hypothetical main size,
@@ -1068,7 +1068,7 @@ fn determine_flex_base_size(
         let hypothetical_inner_min_main = child
             .resolved_minimum_main_size
             .maybe_max(transferred_min_size.main(constants.dir))
-            .maybe_max(padding_border_axes_sums.main(constants.dir).into());
+            .maybe_max(padding_border_axes_sums.main(constants.dir));
         let hypothetical_inner_size = child
             .flex_basis
             .maybe_clamp(OptFloat::some(hypothetical_inner_min_main), transferred_max_size.main(constants.dir));

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -12,6 +12,7 @@ use crate::tree::{LayoutFlexboxContainer, LayoutPartialTreeExt, NodeId};
 use crate::util::debug::debug_log;
 use crate::util::sys::{f32_max, f32_min, new_vec_with_capacity, Vec};
 use crate::util::MaybeMath;
+use crate::util::OptFloat;
 use crate::util::{MaybeResolve, ResolveOrZero};
 use crate::{BoxGenerationMode, BoxSizing, Dimension, Direction, RequestedAxis};
 
@@ -31,14 +32,14 @@ struct FlexItem {
     order: u32,
 
     /// The base size of this item
-    size: Size<Option<f32>>,
+    size: Size<OptFloat>,
     /// The raw size style of this item. Used to detect and resolve sizing
     /// keywords (`min-content`, `max-content`, `fit-content`, `fit-content(...)`, and `stretch`)
     size_style: Size<Dimension>,
     /// The minimum allowable size of this item
-    min_size: Size<Option<f32>>,
+    min_size: Size<OptFloat>,
     /// The maximum allowable size of this item
-    max_size: Size<Option<f32>>,
+    max_size: Size<OptFloat>,
     /// The aspect ratio of this item
     aspect_ratio: Option<f32>,
     /// The cross-alignment of this item
@@ -62,7 +63,7 @@ struct FlexItem {
     resolved_minimum_main_size: f32,
 
     /// The final offset of this item
-    inset: Rect<Option<f32>>,
+    inset: Rect<OptFloat>,
     /// The margin of this item
     margin: Rect<f32>,
     /// Whether each margin is an auto margin or not
@@ -158,9 +159,9 @@ struct AlgoConstants {
     line_count: Option<u16>,
 
     /// The item's min_size style
-    min_size: Size<Option<f32>>,
+    min_size: Size<OptFloat>,
     /// The item's max_size style
-    max_size: Size<Option<f32>>,
+    max_size: Size<OptFloat>,
     /// The margin of this section
     margin: Rect<f32>,
     /// The border of this section
@@ -183,9 +184,9 @@ struct AlgoConstants {
     justify_content: Option<JustifyContent>,
 
     /// The border-box size of the node being laid out (if known)
-    node_outer_size: Size<Option<f32>>,
+    node_outer_size: Size<OptFloat>,
     /// The content-box size of the node being laid out (if known)
-    node_inner_size: Size<Option<f32>>,
+    node_inner_size: Size<OptFloat>,
     /// Whether the known main size of the node (if any) is definite. This is `false` when a parent
     /// imposes a main size on this node that is derived from the node's own content, in which case
     /// it is indefinite for the purposes of resolving percentage sizes of items and collecting items
@@ -266,9 +267,9 @@ pub fn compute_flexbox_layout(
     };
 
     // If both min and max in a given axis are set and max <= min then this determines the size in that axis
-    let min_max_definite_size = min_size.zip_map(max_size, |min, max| match (min, max) {
-        (Some(min), Some(max)) if max <= min => Some(min),
-        _ => None,
+    let min_max_definite_size = min_size.zip_map(max_size, |min, max| match (min.into_option(), max.into_option()) {
+        (Some(min), Some(max)) if max <= min => OptFloat::some(min),
+        _ => OptFloat::NONE,
     });
 
     // The size of the container should be floored by the padding and border
@@ -278,13 +279,13 @@ pub fn compute_flexbox_layout(
     // Short-circuit layout if the container's size is fully determined by the container's size and the run mode
     // is ComputeSize (and thus the container's size is all that we're interested in)
     if run_mode == RunMode::ComputeSize {
-        if let Size { width: Some(width), height: Some(height) } = styled_based_known_dimensions {
+        if let Size { width: Some(width), height: Some(height) } = styled_based_known_dimensions.into_options() {
             return LayoutOutput::from_outer_size(Size { width, height });
         }
 
         // We can also short-circuit if the width is known and only the width has been requested.
         if inputs.axis == RequestedAxis::Horizontal {
-            if let Some(width) = styled_based_known_dimensions.width {
+            if let Some(width) = styled_based_known_dimensions.width.into_option() {
                 return LayoutOutput::from_outer_size(Size { width, height: 0.0 });
             }
         }
@@ -293,7 +294,7 @@ pub fn compute_flexbox_layout(
     // Short-circuit layout if the container's size is fully determined by the container's size and the run mode
     // is ComputeSize (and thus the container's size is all that we're interested in)
     if run_mode == RunMode::ComputeSize {
-        if let Size { width: Some(width), height: Some(height) } = styled_based_known_dimensions {
+        if let Size { width: Some(width), height: Some(height) } = styled_based_known_dimensions.into_options() {
             return LayoutOutput::from_outer_size(Size { width, height });
         }
     }
@@ -381,15 +382,17 @@ fn compute_preliminary(tree: &mut impl LayoutFlexboxContainer, node: NodeId, inp
     // If container size is undefined, determine the container's main size
     // and then re-resolve gaps based on newly determined size
     debug_log!("determine_container_main_size");
-    if let Some(inner_main_size) = constants.node_inner_size.main(constants.dir) {
+    if let Some(inner_main_size) = constants.node_inner_size.main(constants.dir).into_option() {
         let outer_main_size = inner_main_size + constants.content_box_inset.main_axis_sum(constants.dir);
         constants.inner_container_size.set_main(constants.dir, inner_main_size);
         constants.container_size.set_main(constants.dir, outer_main_size);
     } else {
         // Sets constants.container_size and constants.outer_container_size
         determine_container_main_size(tree, available_space, &mut flex_lines, &mut constants);
-        constants.node_inner_size.set_main(constants.dir, Some(constants.inner_container_size.main(constants.dir)));
-        constants.node_outer_size.set_main(constants.dir, Some(constants.container_size.main(constants.dir)));
+        constants
+            .node_inner_size
+            .set_main(constants.dir, OptFloat::some(constants.inner_container_size.main(constants.dir)));
+        constants.node_outer_size.set_main(constants.dir, OptFloat::some(constants.container_size.main(constants.dir)));
 
         debug_log!("constants.node_outer_size", dbg:constants.node_outer_size);
         debug_log!("constants.node_inner_size", dbg:constants.node_inner_size);
@@ -526,7 +529,7 @@ fn compute_preliminary(tree: &mut impl LayoutFlexboxContainer, node: NodeId, inp
     LayoutOutput::from_sizes_and_baselines(
         constants.container_size,
         inflow_overflow_rect.union(absolute_overflow_rect),
-        Baselines::from_first(first_vertical_baseline),
+        Baselines::from_first(first_vertical_baseline.into()),
     )
 }
 
@@ -535,9 +538,9 @@ fn compute_preliminary(tree: &mut impl LayoutFlexboxContainer, node: NodeId, inp
 fn compute_constants(
     tree: &impl LayoutFlexboxContainer,
     style: impl FlexboxContainerStyle,
-    known_dimensions: Size<Option<f32>>,
+    known_dimensions: Size<OptFloat>,
     known_dimensions_are_definite: Size<bool>,
-    parent_size: Size<Option<f32>>,
+    parent_size: Size<OptFloat>,
     available_space: Size<AvailableSpace>,
 ) -> AlgoConstants {
     let dir = style.flex_direction();
@@ -655,7 +658,7 @@ fn generate_anonymous_flex_items(
     let percent_resolution_size = if constants.known_main_size_is_definite {
         constants.node_inner_size
     } else {
-        constants.node_inner_size.with_main(constants.dir, None)
+        constants.node_inner_size.with_main(constants.dir, OptFloat::NONE)
     };
 
     tree.child_ids(node)
@@ -751,12 +754,12 @@ fn generate_anonymous_flex_items(
 #[inline]
 #[must_use]
 fn determine_available_space(
-    known_dimensions: Size<Option<f32>>,
+    known_dimensions: Size<OptFloat>,
     outer_available_space: Size<AvailableSpace>,
     constants: &AlgoConstants,
 ) -> Size<AvailableSpace> {
     // Note: min/max/preferred size styles have already been applied to known_dimensions in the `compute` function above
-    let width = match known_dimensions.width {
+    let width = match known_dimensions.width.into_option() {
         Some(node_width) => AvailableSpace::Definite(node_width - constants.content_box_inset.horizontal_axis_sum()),
         None => outer_available_space
             .width
@@ -764,7 +767,7 @@ fn determine_available_space(
             .maybe_sub(constants.content_box_inset.horizontal_axis_sum()),
     };
 
-    let height = match known_dimensions.height {
+    let height = match known_dimensions.height.into_option() {
         Some(node_height) => AvailableSpace::Definite(node_height - constants.content_box_inset.vertical_axis_sum()),
         None => outer_available_space
             .height
@@ -834,11 +837,11 @@ fn determine_flex_base_size(
                     .divided_cross_space(cross_axis_parent_size.unwrap_or(val))
                     .maybe_clamp(child_min_cross, child_max_cross),
             ),
-            AvailableSpace::MinContent => match child_min_cross {
+            AvailableSpace::MinContent => match child_min_cross.into_option() {
                 Some(min) => AvailableSpace::Definite(min),
                 None => AvailableSpace::MinContent,
             },
-            AvailableSpace::MaxContent => match child_max_cross {
+            AvailableSpace::MaxContent => match child_max_cross.into_option() {
                 Some(max) => AvailableSpace::Definite(max),
                 None => AvailableSpace::MaxContent,
             },
@@ -847,7 +850,7 @@ fn determine_flex_base_size(
         // Known dimensions for child sizing
         let mut child_cross_size_is_definite = child.size.cross(dir).is_some();
         let child_known_dimensions = {
-            let mut ckd = child.size.with_main(dir, None);
+            let mut ckd = child.size.with_main(dir, OptFloat::NONE);
             // Clamp the definite cross size by the cross min/max sizes so that sizes
             // transferred through an intrinsic aspect ratio (e.g. for replaced elements)
             // are based on the used cross size.
@@ -885,7 +888,7 @@ fn determine_flex_base_size(
         // if that size is definite. A known main size which is derived from the container's own
         // content is treated as indefinite here.
         let percent_resolution_main_size =
-            if constants.known_main_size_is_definite { constants.node_inner_size.main(dir) } else { None };
+            if constants.known_main_size_is_definite { constants.node_inner_size.main(dir) } else { OptFloat::NONE };
         let flex_basis_style = child_style.flex_basis();
         let flex_basis = flex_basis_style
             .maybe_resolve(percent_resolution_main_size, |val, basis| tree.calc(val, basis))
@@ -926,7 +929,7 @@ fn determine_flex_base_size(
                     None => None,
                 }
             } else {
-                if let Some(flex_basis) = flex_basis.or(main_size) {
+                if let Some(flex_basis) = flex_basis.or(main_size).into_option() {
                     child.flex_basis_is_definite = true;
                     break 'flex_basis flex_basis;
                 };
@@ -968,7 +971,9 @@ fn determine_flex_base_size(
             // is calculated by transferring that cross size through the aspect ratio (case B
             // above), and is therefore definite.
             if child_cross_size_is_definite {
-                if let (Some(ratio), Some(cross)) = (child.aspect_ratio, child_known_dimensions.cross(dir)) {
+                if let (Some(ratio), Some(cross)) =
+                    (child.aspect_ratio, child_known_dimensions.cross(dir).into_option())
+                {
                     child.flex_basis_is_definite = true;
                     break 'flex_basis if dir.is_row() { cross * ratio } else { cross / ratio };
                 }
@@ -1023,7 +1028,7 @@ fn determine_flex_base_size(
         child.inner_flex_basis =
             child.flex_basis - child.padding.main_axis_sum(constants.dir) - child.border.main_axis_sum(constants.dir);
 
-        let padding_border_axes_sums = (child.padding + child.border).sum_axes().map(Some);
+        let padding_border_axes_sums = (child.padding + child.border).sum_axes().map(OptFloat::some);
 
         // Note that it is important that the `parent_size` parameter in the main axis is not set for this
         // function call as it used for resolving percentages, and percentage size in an axis should not contribute
@@ -1054,7 +1059,7 @@ fn determine_flex_base_size(
             // https://www.w3.org/TR/css-flexbox-1/#min-size-auto
             let clamped_min_content_size =
                 min_content_main_size.maybe_min(child.size.main(dir)).maybe_min(transferred_max_size.main(dir));
-            clamped_min_content_size.maybe_max(padding_border_axes_sums.main(dir))
+            clamped_min_content_size.maybe_max(padding_border_axes_sums.main(dir).into())
         });
 
         // Sizes transferred through the aspect ratio clamp the hypothetical main size,
@@ -1063,9 +1068,10 @@ fn determine_flex_base_size(
         let hypothetical_inner_min_main = child
             .resolved_minimum_main_size
             .maybe_max(transferred_min_size.main(constants.dir))
-            .maybe_max(padding_border_axes_sums.main(constants.dir));
-        let hypothetical_inner_size =
-            child.flex_basis.maybe_clamp(Some(hypothetical_inner_min_main), transferred_max_size.main(constants.dir));
+            .maybe_max(padding_border_axes_sums.main(constants.dir).into());
+        let hypothetical_inner_size = child
+            .flex_basis
+            .maybe_clamp(OptFloat::some(hypothetical_inner_min_main), transferred_max_size.main(constants.dir));
         let hypothetical_outer_size = hypothetical_inner_size + child.margin.main_axis_sum(constants.dir);
 
         child.hypothetical_inner_size.set_main(constants.dir, hypothetical_inner_size);
@@ -1104,7 +1110,7 @@ fn collect_flex_lines<'a>(
         lines.push(FlexLine { items: flex_items.as_mut_slice(), cross_size: 0.0, offset_cross: 0.0 });
         lines
     } else {
-        let main_axis_available_space = match constants.max_size.main(constants.dir) {
+        let main_axis_available_space = match constants.max_size.main(constants.dir).into_option() {
             Some(max_size) => AvailableSpace::Definite({
                 let available = available_space.main(constants.dir).into_option().unwrap_or(max_size);
                 // If the container's main size is not definite then it is at most the max main size,
@@ -1185,7 +1191,7 @@ fn collect_balanced_flex_lines<'a>(
     // then items are balanced without a size limit, matching how the container was sized under a
     // min/max-content constraint.
     let main_axis_available_space = if constants.known_main_size_is_definite {
-        match constants.max_size.main(constants.dir) {
+        match constants.max_size.main(constants.dir).into_option() {
             Some(max_size) => AvailableSpace::Definite({
                 let available = available_space.main(constants.dir).into_option().unwrap_or(max_size);
                 // If the container's main size is not definite then it is at most the max main size,
@@ -1372,7 +1378,7 @@ fn determine_container_main_size(
                         // Spec modification: https://www.w3.org/TR/css-flexbox-1/#change-2016-max-contribution
                         // Issue: https://github.com/w3c/csswg-drafts/issues/1435
                         // Gentest: padding_border_overrides_size_flex_basis_0.html
-                        let clamping_basis = Some(item.flex_basis).maybe_max(style_preferred);
+                        let clamping_basis = OptFloat::some(item.flex_basis).maybe_max(style_preferred);
                         let flex_basis_min = clamping_basis.filter(|_| item.flex_shrink == 0.0);
                         let flex_basis_max = clamping_basis.filter(|_| item.flex_grow == 0.0);
 
@@ -1384,7 +1390,7 @@ fn determine_container_main_size(
                         let max_main_size =
                             style_max.maybe_min(flex_basis_max).or(flex_basis_max).unwrap_or(f32::INFINITY);
 
-                        let content_contribution = match (min_main_size, style_preferred, max_main_size) {
+                        let content_contribution = match (min_main_size, style_preferred.into_option(), max_main_size) {
                             // If the clamping values are such that max <= min, then we can avoid the expensive step of computing the content size
                             // as we know that the clamping values will override it anyway
                             (min, Some(pref), max) if max <= min || max <= pref => {
@@ -1433,7 +1439,7 @@ fn determine_container_main_size(
 
                                 // Known dimensions for child sizing
                                 let child_known_dimensions = {
-                                    let mut ckd = item.size.with_main(dir, None);
+                                    let mut ckd = item.size.with_main(dir, OptFloat::NONE);
                                     if item.align_self == AlignSelf::STRETCH && ckd.cross(dir).is_none() {
                                         ckd.set_cross(
                                             dir,
@@ -1460,10 +1466,11 @@ fn determine_container_main_size(
 
                                 // A known cross size is transferred through the item's aspect-ratio
                                 // and floors the measured content size
-                                let transferred_main_size = item
+                                let transferred_main_size: OptFloat = item
                                     .aspect_ratio
-                                    .zip(child_known_dimensions.cross(dir))
-                                    .map(|(ratio, cross)| if constants.is_row { cross * ratio } else { cross / ratio });
+                                    .zip(child_known_dimensions.cross(dir).into_option())
+                                    .map(|(ratio, cross)| if constants.is_row { cross * ratio } else { cross / ratio })
+                                    .into();
 
                                 let content_main_size = measured_main_size.maybe_max(transferred_main_size)
                                     + item.margin.main_axis_sum(constants.dir);
@@ -1561,7 +1568,7 @@ fn determine_container_main_size(
     let inner_main_size = f32_max(outer_main_size - main_content_box_inset, 0.0);
     constants.container_size.set_main(constants.dir, outer_main_size);
     constants.inner_container_size.set_main(constants.dir, inner_main_size);
-    constants.node_inner_size.set_main(constants.dir, Some(inner_main_size));
+    constants.node_inner_size.set_main(constants.dir, OptFloat::some(inner_main_size));
 }
 
 /// Resolve the flexible lengths of the items within a flex line.
@@ -1724,7 +1731,7 @@ fn resolve_flexible_lengths(line: &mut FlexLine, constants: &AlgoConstants) {
         //    If the item’s target main size was made larger by this, it’s a min violation.
 
         let total_violation = unfrozen.iter_mut().fold(0.0, |acc, child| -> f32 {
-            let resolved_min_main: Option<f32> = child.resolved_minimum_main_size.into();
+            let resolved_min_main: OptFloat = child.resolved_minimum_main_size.into();
             let max_main = child.max_size.main(constants.dir);
             let clamped = child.target_size.main(constants.dir).maybe_clamp(resolved_min_main, max_main).max(0.0);
             child.violation = clamped - child.target_size.main(constants.dir);
@@ -1847,7 +1854,7 @@ fn determine_hypothetical_cross_size(
 #[inline]
 fn calculate_children_base_lines(
     tree: &mut impl LayoutFlexboxContainer,
-    node_size: Size<Option<f32>>,
+    node_size: Size<OptFloat>,
     available_space: Size<AvailableSpace>,
     flex_lines: &mut [FlexLine],
     constants: &AlgoConstants,
@@ -1932,7 +1939,7 @@ fn calculate_children_base_lines(
 ///
 /// - [**Calculate the cross size of each flex line**](https://www.w3.org/TR/css-flexbox-1/#algo-cross-line).
 #[inline]
-fn calculate_cross_size(flex_lines: &mut [FlexLine], node_size: Size<Option<f32>>, constants: &AlgoConstants) {
+fn calculate_cross_size(flex_lines: &mut [FlexLine], node_size: Size<OptFloat>, constants: &AlgoConstants) {
     // If the flex container is single-line and has a definite cross size,
     // the cross size of the flex line is the flex container’s inner cross size.
     if !constants.is_wrap && node_size.cross(constants.dir).is_some() {
@@ -1996,7 +2003,7 @@ fn calculate_cross_size(flex_lines: &mut [FlexLine], node_size: Size<Option<f32>
 ///   and the sum of the flex lines' cross sizes is less than the flex container’s inner cross size,
 ///   increase the cross size of each flex line by equal amounts such that the sum of their cross sizes exactly equals the flex container’s inner cross size.
 #[inline]
-fn handle_align_content_stretch(flex_lines: &mut [FlexLine], node_size: Size<Option<f32>>, constants: &AlgoConstants) {
+fn handle_align_content_stretch(flex_lines: &mut [FlexLine], node_size: Size<OptFloat>, constants: &AlgoConstants) {
     if constants.align_content == AlignContent::STRETCH {
         let cross_axis_padding_border = constants.content_box_inset.cross_axis_sum(constants.dir);
         let cross_min_size = constants.min_size.cross(constants.dir);
@@ -2323,7 +2330,7 @@ fn align_flex_items_along_cross_axis(
 #[must_use]
 fn determine_container_cross_size(
     flex_lines: &[FlexLine],
-    node_size: Size<Option<f32>>,
+    node_size: Size<OptFloat>,
     constants: &mut AlgoConstants,
 ) -> f32 {
     let total_cross_axis_gap = sum_axis_gaps(constants.gap.cross(constants.dir), flex_lines.len());
@@ -2666,10 +2673,12 @@ fn perform_absolute_layout_on_absolute_children(
         let margin = child_style
             .margin()
             .map(|margin| margin.resolve_to_option(inset_relative_size.width, |val, basis| tree.calc(val, basis)));
-        let padding =
-            child_style.padding().resolve_or_zero(Some(inset_relative_size.width), |val, basis| tree.calc(val, basis));
-        let border =
-            child_style.border().resolve_or_zero(Some(inset_relative_size.width), |val, basis| tree.calc(val, basis));
+        let padding = child_style
+            .padding()
+            .resolve_or_zero(OptFloat::some(inset_relative_size.width), |val, basis| tree.calc(val, basis));
+        let border = child_style
+            .border()
+            .resolve_or_zero(OptFloat::some(inset_relative_size.width), |val, basis| tree.calc(val, basis));
         let padding_border_sum = (padding + border).sum_axes();
         let box_sizing_adjustment =
             if child_style.box_sizing() == BoxSizing::ContentBox { padding_border_sum } else { Size::ZERO };
@@ -2695,7 +2704,7 @@ fn perform_absolute_layout_on_absolute_children(
             .maybe_resolve(inset_relative_size, |val, basis| tree.calc(val, basis))
             .maybe_apply_aspect_ratio(aspect_ratio)
             .maybe_add(box_sizing_adjustment)
-            .or(padding_border_sum.map(Some))
+            .or(padding_border_sum.map(OptFloat::some))
             .maybe_max(padding_border_sum);
         let max_size = child_style
             .max_size()
@@ -2726,22 +2735,26 @@ fn perform_absolute_layout_on_absolute_children(
         // Fill in width from left/right and reapply aspect ratio if:
         //   - Width is not already known
         //   - Item has both left and right inset properties set
-        if let (None, Some(left), Some(right)) = (known_dimensions.width, left, right) {
+        if let (None, Some(left), Some(right)) =
+            (known_dimensions.width.into_option(), left.into_option(), right.into_option())
+        {
             let new_width_raw = inset_relative_size.width.maybe_sub(margin.left).maybe_sub(margin.right) - left - right;
-            known_dimensions.width = Some(f32_max(new_width_raw, 0.0));
+            known_dimensions.width = OptFloat::some(f32_max(new_width_raw, 0.0));
             known_dimensions = known_dimensions.maybe_apply_aspect_ratio(aspect_ratio).maybe_clamp(min_size, max_size);
         }
 
         // Fill in height from top/bottom and reapply aspect ratio if:
         //   - Height is not already known
         //   - Item has both top and bottom inset properties set
-        if let (None, Some(top), Some(bottom)) = (known_dimensions.height, top, bottom) {
+        if let (None, Some(top), Some(bottom)) =
+            (known_dimensions.height.into_option(), top.into_option(), bottom.into_option())
+        {
             let new_height_raw =
                 inset_relative_size.height.maybe_sub(margin.top).maybe_sub(margin.bottom) - top - bottom;
-            known_dimensions.height = Some(f32_max(new_height_raw, 0.0));
+            known_dimensions.height = OptFloat::some(f32_max(new_height_raw, 0.0));
             known_dimensions = known_dimensions.maybe_apply_aspect_ratio(aspect_ratio).maybe_clamp(min_size, max_size);
         }
-        let final_size = match (known_dimensions.width, known_dimensions.height) {
+        let final_size = match (known_dimensions.width.into_option(), known_dimensions.height.into_option()) {
             (Some(width), Some(height)) => Size { width, height },
             _ => {
                 let measured_size = tree.measure_child_size_both(
@@ -2764,7 +2777,7 @@ fn perform_absolute_layout_on_absolute_children(
 
         let layout_output = tree.perform_child_layout(
             child,
-            final_size.map(Some),
+            final_size.map(OptFloat::some),
             constants.node_inner_size,
             Size {
                 width: AvailableSpace::Definite(container_width.maybe_clamp(min_size.width, max_size.width)),
@@ -2840,7 +2853,7 @@ fn perform_absolute_layout_on_absolute_children(
                     - final_size.main(constants.dir)
                     - end_main.unwrap_or(0.0)
                     - resolved_margin.main_end(constants.dir)
-            } else if let Some(start) = start_main {
+            } else if let Some(start) = start_main.into_option() {
                 start
                     + constants.border.main_start(constants.dir)
                     + main_start_scrollbar_offset
@@ -2924,7 +2937,7 @@ fn perform_absolute_layout_on_absolute_children(
                     - final_size.cross(constants.dir)
                     - end_cross.unwrap_or(0.0)
                     - resolved_margin.cross_end(constants.dir)
-            } else if let Some(start) = start_cross {
+            } else if let Some(start) = start_cross.into_option() {
                 start
                     + constants.border.cross_start(constants.dir)
                     + cross_start_scrollbar_offset

--- a/src/compute/float.rs
+++ b/src/compute/float.rs
@@ -26,6 +26,7 @@
 //!
 //! <https://www.w3.org/TR/CSS22/visuren.html#floats>
 
+use crate::util::OptFloat;
 use core::ops::Range;
 
 use crate::{debug::debug_log, sys::Vec, AvailableSpace, Clear, Direction, FloatDirection, Point, Size};
@@ -219,10 +220,10 @@ pub struct FloatContext {
     last_placed_floats: [Range<usize>; 2],
     /// The bottom (y + height) of the lowest float placed on each side, including
     /// zero-sized floats (which occupy no segment). Left in slot 0, right in slot 1.
-    clear_bottoms: [Option<f32>; 2],
+    clear_bottoms: [OptFloat; 2],
     /// The topmost y position allowed for a new float (CSS2 float rule 5), including
     /// the tops of zero-sized floats (which occupy no segment)
-    float_ceiling: Option<f32>,
+    float_ceiling: OptFloat,
     // Left hwm in slot 0. Right hwm in slot 1.
     // high_water_marks: [usize; 2],
     // left_float_high_water_mark: usize,
@@ -238,8 +239,8 @@ impl Default for FloatContext {
             right_floats: Vec::new(),
             segments: Vec::new(),
             last_placed_floats: [0..0, 0..0], // high_water_marks: [0, 0],
-            clear_bottoms: [None, None],
-            float_ceiling: None,
+            clear_bottoms: [OptFloat::NONE, OptFloat::NONE],
+            float_ceiling: OptFloat::NONE,
         }
     }
 }
@@ -316,9 +317,9 @@ impl FloatContext {
 
         let slot = direction as usize;
         let bottom = placed_floated_box.y + placed_floated_box.height;
-        self.clear_bottoms[slot] = Some(self.clear_bottoms[slot].map_or(bottom, |b| b.max(bottom)));
+        self.clear_bottoms[slot] = OptFloat::some(self.clear_bottoms[slot].map_or(bottom, |b| b.max(bottom)));
         let y = placed_floated_box.y;
-        self.float_ceiling = Some(self.float_ceiling.map_or(y, |ceiling| ceiling.max(y)));
+        self.float_ceiling = OptFloat::some(self.float_ceiling.map_or(y, |ceiling| ceiling.max(y)));
 
         let x_inset = placed_floated_box.x_inset;
         let y = placed_floated_box.y;
@@ -571,15 +572,18 @@ impl FloatContext {
     }
 
     /// Get the bottom of lowest relevant float for the specific clear property
-    pub fn cleared_threshold(&self, clear: Clear) -> Option<f32> {
+    pub fn cleared_threshold(&self, clear: Clear) -> OptFloat {
         match clear {
             Clear::Left => self.clear_bottoms[0],
             Clear::Right => self.clear_bottoms[1],
-            Clear::Both => match self.clear_bottoms {
-                [Some(l), Some(r)] => Some(l.max(r)),
-                [l, r] => l.or(r),
-            },
-            Clear::None => None,
+            Clear::Both => {
+                let [l, r] = self.clear_bottoms;
+                match (l.into_option(), r.into_option()) {
+                    (Some(l), Some(r)) => OptFloat::some(l.max(r)),
+                    _ => l.or(r),
+                }
+            }
+            Clear::None => OptFloat::NONE,
         }
     }
 

--- a/src/compute/float.rs
+++ b/src/compute/float.rs
@@ -26,7 +26,7 @@
 //!
 //! <https://www.w3.org/TR/CSS22/visuren.html#floats>
 
-use crate::util::OptFloat;
+use crate::util::OptF32;
 use core::ops::Range;
 
 use crate::{debug::debug_log, sys::Vec, AvailableSpace, Clear, Direction, FloatDirection, Point, Size};
@@ -220,10 +220,10 @@ pub struct FloatContext {
     last_placed_floats: [Range<usize>; 2],
     /// The bottom (y + height) of the lowest float placed on each side, including
     /// zero-sized floats (which occupy no segment). Left in slot 0, right in slot 1.
-    clear_bottoms: [OptFloat; 2],
+    clear_bottoms: [OptF32; 2],
     /// The topmost y position allowed for a new float (CSS2 float rule 5), including
     /// the tops of zero-sized floats (which occupy no segment)
-    float_ceiling: OptFloat,
+    float_ceiling: OptF32,
     // Left hwm in slot 0. Right hwm in slot 1.
     // high_water_marks: [usize; 2],
     // left_float_high_water_mark: usize,
@@ -239,8 +239,8 @@ impl Default for FloatContext {
             right_floats: Vec::new(),
             segments: Vec::new(),
             last_placed_floats: [0..0, 0..0], // high_water_marks: [0, 0],
-            clear_bottoms: [OptFloat::NONE, OptFloat::NONE],
-            float_ceiling: OptFloat::NONE,
+            clear_bottoms: [OptF32::NONE, OptF32::NONE],
+            float_ceiling: OptF32::NONE,
         }
     }
 }
@@ -317,9 +317,9 @@ impl FloatContext {
 
         let slot = direction as usize;
         let bottom = placed_floated_box.y + placed_floated_box.height;
-        self.clear_bottoms[slot] = OptFloat::some(self.clear_bottoms[slot].map_or(bottom, |b| b.max(bottom)));
+        self.clear_bottoms[slot] = OptF32::some(self.clear_bottoms[slot].map_or(bottom, |b| b.max(bottom)));
         let y = placed_floated_box.y;
-        self.float_ceiling = OptFloat::some(self.float_ceiling.map_or(y, |ceiling| ceiling.max(y)));
+        self.float_ceiling = OptF32::some(self.float_ceiling.map_or(y, |ceiling| ceiling.max(y)));
 
         let x_inset = placed_floated_box.x_inset;
         let y = placed_floated_box.y;
@@ -572,18 +572,18 @@ impl FloatContext {
     }
 
     /// Get the bottom of lowest relevant float for the specific clear property
-    pub fn cleared_threshold(&self, clear: Clear) -> OptFloat {
+    pub fn cleared_threshold(&self, clear: Clear) -> OptF32 {
         match clear {
             Clear::Left => self.clear_bottoms[0],
             Clear::Right => self.clear_bottoms[1],
             Clear::Both => {
                 let [l, r] = self.clear_bottoms;
                 match (l.into_option(), r.into_option()) {
-                    (Some(l), Some(r)) => OptFloat::some(l.max(r)),
+                    (Some(l), Some(r)) => OptF32::some(l.max(r)),
                     _ => l.or(r),
                 }
             }
-            Clear::None => OptFloat::NONE,
+            Clear::None => OptF32::NONE,
         }
     }
 

--- a/src/compute/grid/alignment.rs
+++ b/src/compute/grid/alignment.rs
@@ -5,12 +5,13 @@ use crate::compute::common::alignment::{
 };
 use crate::geometry::{InBothAbsAxis, Line, Point, Rect, Size};
 use crate::style::{
-    AlignContent, AlignItems, AlignItemsKeyword, AlignSelf, AvailableSpace, CoreStyle, GridItemStyle, Overflow,
-    Position,
+    AlignContent, AlignItems, AlignItemsKeyword, AlignSelf, CoreStyle, GridItemStyle, Overflow, Position,
 };
 use crate::tree::{Layout, LayoutPartialTreeExt, NodeId, SizingMode};
 use crate::util::sys::f32_max;
+use crate::util::OptFloat;
 use crate::util::{MaybeMath, MaybeResolve, ResolveOrZero};
+use crate::AvailableSpace;
 
 #[cfg(feature = "content_size")]
 use crate::compute::common::scrollable_overflow::compute_scrollable_overflow_contribution;
@@ -129,10 +130,12 @@ pub(super) fn align_and_position_item(
         .inset()
         .vertical_components()
         .map(|size| size.resolve_to_option(grid_area_size.height, |val, basis| tree.calc(val, basis)));
-    let padding =
-        style.padding().map(|p| p.resolve_or_zero(Some(grid_area_size.width), |val, basis| tree.calc(val, basis)));
-    let border =
-        style.border().map(|p| p.resolve_or_zero(Some(grid_area_size.width), |val, basis| tree.calc(val, basis)));
+    let padding = style
+        .padding()
+        .map(|p| p.resolve_or_zero(OptFloat::some(grid_area_size.width), |val, basis| tree.calc(val, basis)));
+    let border = style
+        .border()
+        .map(|p| p.resolve_or_zero(OptFloat::some(grid_area_size.width), |val, basis| tree.calc(val, basis)));
     let padding_border_size = (padding + border).sum_axes();
 
     let box_sizing_adjustment =
@@ -147,7 +150,7 @@ pub(super) fn align_and_position_item(
         .min_size()
         .maybe_resolve(grid_area_size, |val, basis| tree.calc(val, basis))
         .maybe_add(box_sizing_adjustment)
-        .or(padding_border_size.map(Some))
+        .or(padding_border_size.map(OptFloat::some))
         .maybe_max(padding_border_size)
         .maybe_apply_aspect_ratio(aspect_ratio);
     let max_size = style
@@ -195,20 +198,20 @@ pub(super) fn align_and_position_item(
     let keyword_width = inherent_size.width.is_none().then(|| {
         resolve_sizing_keyword(
             size_style.width,
-            Some(grid_area_minus_item_margins_size.width),
-            Some(grid_area_size.width),
+            OptFloat::some(grid_area_minus_item_margins_size.width),
+            OptFloat::some(grid_area_size.width),
         )
     });
     let keyword_height = inherent_size.height.is_none().then(|| {
         resolve_sizing_keyword(
             size_style.height,
-            Some(grid_area_minus_item_margins_size.height),
-            Some(grid_area_size.height),
+            OptFloat::some(grid_area_minus_item_margins_size.height),
+            OptFloat::some(grid_area_size.height),
         )
     });
 
     // If both axes need to be measured then resolve them with a single measure call
-    let keyword_measured_size: Size<Option<f32>> = match (&keyword_width, &keyword_height) {
+    let keyword_measured_size: Size<OptFloat> = match (&keyword_width, &keyword_height) {
         (
             Some(Some(SizingKeywordResolution::Measure(available_width))),
             Some(Some(SizingKeywordResolution::Measure(available_height))),
@@ -216,12 +219,12 @@ pub(super) fn align_and_position_item(
             .measure_child_size_both(
                 node,
                 Size::NONE,
-                grid_area_size.map(Option::Some),
+                grid_area_size.map(OptFloat::some),
                 Size { width: *available_width, height: *available_height },
                 SizingMode::InherentSize,
                 Line::FALSE,
             )
-            .map(Option::Some),
+            .map(OptFloat::some),
         _ => Size::NONE,
     };
 
@@ -231,19 +234,21 @@ pub(super) fn align_and_position_item(
         // Apply width derived from both the left and right properties of an absolutely
         // positioned element being set
         if position == Position::Absolute {
-            if let (Some(left), Some(right)) = (inset_horizontal.start, inset_horizontal.end) {
-                return Some(f32_max(grid_area_minus_item_margins_size.width - left - right, 0.0));
+            if let (Some(left), Some(right)) =
+                (inset_horizontal.start.into_option(), inset_horizontal.end.into_option())
+            {
+                return OptFloat::some(f32_max(grid_area_minus_item_margins_size.width - left - right, 0.0));
             }
         }
 
         if let Some(Some(resolution)) = keyword_width {
-            return Some(match resolution {
+            return OptFloat::some(match resolution {
                 SizingKeywordResolution::Exact(width) => width,
                 SizingKeywordResolution::Measure(available_width) => keyword_measured_size.width.unwrap_or_else(|| {
                     tree.measure_child_size(
                         node,
                         Size::NONE,
-                        grid_area_size.map(Option::Some),
+                        grid_area_size.map(OptFloat::some),
                         Size {
                             width: available_width,
                             height: AvailableSpace::Definite(grid_area_minus_item_margins_size.height),
@@ -265,10 +270,10 @@ pub(super) fn align_and_position_item(
             && alignment_styles.horizontal == AlignSelf::STRETCH
             && position != Position::Absolute
         {
-            return Some(grid_area_minus_item_margins_size.width);
+            return OptFloat::some(grid_area_minus_item_margins_size.width);
         }
 
-        None
+        OptFloat::NONE
     });
 
     // Reapply aspect ratio after stretch and absolute position width adjustments
@@ -276,24 +281,25 @@ pub(super) fn align_and_position_item(
 
     let height = height.or_else(|| {
         if position == Position::Absolute {
-            if let (Some(top), Some(bottom)) = (inset_vertical.start, inset_vertical.end) {
-                return Some(f32_max(grid_area_minus_item_margins_size.height - top - bottom, 0.0));
+            if let (Some(top), Some(bottom)) = (inset_vertical.start.into_option(), inset_vertical.end.into_option()) {
+                return OptFloat::some(f32_max(grid_area_minus_item_margins_size.height - top - bottom, 0.0));
             }
         }
 
         if let Some(Some(resolution)) = keyword_height {
-            return Some(match resolution {
+            return OptFloat::some(match resolution {
                 SizingKeywordResolution::Exact(height) => height,
                 SizingKeywordResolution::Measure(available_height) => {
                     keyword_measured_size.height.unwrap_or_else(|| {
                         tree.measure_child_size(
                             node,
-                            Size { width, height: None },
-                            grid_area_size.map(Option::Some),
+                            Size { width, height: OptFloat::NONE },
+                            grid_area_size.map(OptFloat::some),
                             Size {
-                                width: width
-                                    .map(AvailableSpace::Definite)
-                                    .unwrap_or(AvailableSpace::Definite(grid_area_minus_item_margins_size.width)),
+                                width: width.map_or(
+                                    AvailableSpace::Definite(grid_area_minus_item_margins_size.width),
+                                    AvailableSpace::Definite,
+                                ),
                                 height: available_height,
                             },
                             SizingMode::InherentSize,
@@ -314,10 +320,10 @@ pub(super) fn align_and_position_item(
             && alignment_styles.vertical == AlignSelf::STRETCH
             && position != Position::Absolute
         {
-            return Some(grid_area_minus_item_margins_size.height);
+            return OptFloat::some(grid_area_minus_item_margins_size.height);
         }
 
-        None
+        OptFloat::NONE
     });
     // Reapply aspect ratio after stretch and absolute position height adjustments
     let Size { width, height } = Size { width, height }.maybe_apply_aspect_ratio(aspect_ratio);
@@ -330,12 +336,12 @@ pub(super) fn align_and_position_item(
         tree.measure_child_size_both(
             node,
             Size { width, height },
-            grid_area_size.map(Option::Some),
+            grid_area_size.map(OptFloat::some),
             grid_area_minus_item_margins_size.map(AvailableSpace::Definite),
             SizingMode::InherentSize,
             Line::FALSE,
         )
-        .map(Some)
+        .map(OptFloat::some)
     } else {
         Size { width, height }
     };
@@ -343,7 +349,7 @@ pub(super) fn align_and_position_item(
     let layout_output = tree.perform_child_layout(
         node,
         size,
-        grid_area_size.map(Option::Some),
+        grid_area_size.map(Option::Some).into(),
         grid_area_minus_item_margins_size.map(AvailableSpace::Definite),
         SizingMode::InherentSize,
         Line::FALSE,
@@ -426,8 +432,8 @@ pub(super) fn align_item_within_area(
     alignment_style: AlignSelf,
     resolved_size: f32,
     position: Position,
-    inset: Line<Option<f32>>,
-    margin: Line<Option<f32>>,
+    inset: Line<OptFloat>,
+    margin: Line<OptFloat>,
     baseline_shim: f32,
     direction: Direction,
 ) -> (f32, Line<f32>) {
@@ -476,7 +482,7 @@ pub(super) fn align_item_within_area(
     };
 
     let offset_within_area = if position == Position::Absolute {
-        match (inset.start, inset.end) {
+        match (inset.start.into_option(), inset.end.into_option()) {
             (Some(start), Some(end)) => {
                 if direction.is_rtl() {
                     grid_area_size - end - resolved_size - non_auto_margin.end

--- a/src/compute/grid/alignment.rs
+++ b/src/compute/grid/alignment.rs
@@ -9,7 +9,7 @@ use crate::style::{
 };
 use crate::tree::{Layout, LayoutPartialTreeExt, NodeId, SizingMode};
 use crate::util::sys::f32_max;
-use crate::util::OptFloat;
+use crate::util::OptF32;
 use crate::util::{MaybeMath, MaybeResolve, ResolveOrZero};
 use crate::AvailableSpace;
 
@@ -132,10 +132,10 @@ pub(super) fn align_and_position_item(
         .map(|size| size.resolve_to_option(grid_area_size.height, |val, basis| tree.calc(val, basis)));
     let padding = style
         .padding()
-        .map(|p| p.resolve_or_zero(OptFloat::some(grid_area_size.width), |val, basis| tree.calc(val, basis)));
+        .map(|p| p.resolve_or_zero(OptF32::some(grid_area_size.width), |val, basis| tree.calc(val, basis)));
     let border = style
         .border()
-        .map(|p| p.resolve_or_zero(OptFloat::some(grid_area_size.width), |val, basis| tree.calc(val, basis)));
+        .map(|p| p.resolve_or_zero(OptF32::some(grid_area_size.width), |val, basis| tree.calc(val, basis)));
     let padding_border_size = (padding + border).sum_axes();
 
     let box_sizing_adjustment =
@@ -150,7 +150,7 @@ pub(super) fn align_and_position_item(
         .min_size()
         .maybe_resolve(grid_area_size, |val, basis| tree.calc(val, basis))
         .maybe_add(box_sizing_adjustment)
-        .or(padding_border_size.map(OptFloat::some))
+        .or(padding_border_size.map(OptF32::some))
         .maybe_max(padding_border_size)
         .maybe_apply_aspect_ratio(aspect_ratio);
     let max_size = style
@@ -198,20 +198,20 @@ pub(super) fn align_and_position_item(
     let keyword_width = inherent_size.width.is_none().then(|| {
         resolve_sizing_keyword(
             size_style.width,
-            OptFloat::some(grid_area_minus_item_margins_size.width),
-            OptFloat::some(grid_area_size.width),
+            OptF32::some(grid_area_minus_item_margins_size.width),
+            OptF32::some(grid_area_size.width),
         )
     });
     let keyword_height = inherent_size.height.is_none().then(|| {
         resolve_sizing_keyword(
             size_style.height,
-            OptFloat::some(grid_area_minus_item_margins_size.height),
-            OptFloat::some(grid_area_size.height),
+            OptF32::some(grid_area_minus_item_margins_size.height),
+            OptF32::some(grid_area_size.height),
         )
     });
 
     // If both axes need to be measured then resolve them with a single measure call
-    let keyword_measured_size: Size<OptFloat> = match (&keyword_width, &keyword_height) {
+    let keyword_measured_size: Size<OptF32> = match (&keyword_width, &keyword_height) {
         (
             Some(Some(SizingKeywordResolution::Measure(available_width))),
             Some(Some(SizingKeywordResolution::Measure(available_height))),
@@ -219,12 +219,12 @@ pub(super) fn align_and_position_item(
             .measure_child_size_both(
                 node,
                 Size::NONE,
-                grid_area_size.map(OptFloat::some),
+                grid_area_size.map(OptF32::some),
                 Size { width: *available_width, height: *available_height },
                 SizingMode::InherentSize,
                 Line::FALSE,
             )
-            .map(OptFloat::some),
+            .map(OptF32::some),
         _ => Size::NONE,
     };
 
@@ -237,18 +237,18 @@ pub(super) fn align_and_position_item(
             if let (Some(left), Some(right)) =
                 (inset_horizontal.start.into_option(), inset_horizontal.end.into_option())
             {
-                return OptFloat::some(f32_max(grid_area_minus_item_margins_size.width - left - right, 0.0));
+                return OptF32::some(f32_max(grid_area_minus_item_margins_size.width - left - right, 0.0));
             }
         }
 
         if let Some(Some(resolution)) = keyword_width {
-            return OptFloat::some(match resolution {
+            return OptF32::some(match resolution {
                 SizingKeywordResolution::Exact(width) => width,
                 SizingKeywordResolution::Measure(available_width) => keyword_measured_size.width.unwrap_or_else(|| {
                     tree.measure_child_size(
                         node,
                         Size::NONE,
-                        grid_area_size.map(OptFloat::some),
+                        grid_area_size.map(OptF32::some),
                         Size {
                             width: available_width,
                             height: AvailableSpace::Definite(grid_area_minus_item_margins_size.height),
@@ -270,10 +270,10 @@ pub(super) fn align_and_position_item(
             && alignment_styles.horizontal == AlignSelf::STRETCH
             && position != Position::Absolute
         {
-            return OptFloat::some(grid_area_minus_item_margins_size.width);
+            return OptF32::some(grid_area_minus_item_margins_size.width);
         }
 
-        OptFloat::NONE
+        OptF32::NONE
     });
 
     // Reapply aspect ratio after stretch and absolute position width adjustments
@@ -282,19 +282,19 @@ pub(super) fn align_and_position_item(
     let height = height.or_else(|| {
         if position == Position::Absolute {
             if let (Some(top), Some(bottom)) = (inset_vertical.start.into_option(), inset_vertical.end.into_option()) {
-                return OptFloat::some(f32_max(grid_area_minus_item_margins_size.height - top - bottom, 0.0));
+                return OptF32::some(f32_max(grid_area_minus_item_margins_size.height - top - bottom, 0.0));
             }
         }
 
         if let Some(Some(resolution)) = keyword_height {
-            return OptFloat::some(match resolution {
+            return OptF32::some(match resolution {
                 SizingKeywordResolution::Exact(height) => height,
                 SizingKeywordResolution::Measure(available_height) => {
                     keyword_measured_size.height.unwrap_or_else(|| {
                         tree.measure_child_size(
                             node,
-                            Size { width, height: OptFloat::NONE },
-                            grid_area_size.map(OptFloat::some),
+                            Size { width, height: OptF32::NONE },
+                            grid_area_size.map(OptF32::some),
                             Size {
                                 width: width.map_or(
                                     AvailableSpace::Definite(grid_area_minus_item_margins_size.width),
@@ -320,10 +320,10 @@ pub(super) fn align_and_position_item(
             && alignment_styles.vertical == AlignSelf::STRETCH
             && position != Position::Absolute
         {
-            return OptFloat::some(grid_area_minus_item_margins_size.height);
+            return OptF32::some(grid_area_minus_item_margins_size.height);
         }
 
-        OptFloat::NONE
+        OptF32::NONE
     });
     // Reapply aspect ratio after stretch and absolute position height adjustments
     let Size { width, height } = Size { width, height }.maybe_apply_aspect_ratio(aspect_ratio);
@@ -336,12 +336,12 @@ pub(super) fn align_and_position_item(
         tree.measure_child_size_both(
             node,
             Size { width, height },
-            grid_area_size.map(OptFloat::some),
+            grid_area_size.map(OptF32::some),
             grid_area_minus_item_margins_size.map(AvailableSpace::Definite),
             SizingMode::InherentSize,
             Line::FALSE,
         )
-        .map(OptFloat::some)
+        .map(OptF32::some)
     } else {
         Size { width, height }
     };
@@ -432,8 +432,8 @@ pub(super) fn align_item_within_area(
     alignment_style: AlignSelf,
     resolved_size: f32,
     position: Position,
-    inset: Line<OptFloat>,
-    margin: Line<OptFloat>,
+    inset: Line<OptF32>,
+    margin: Line<OptF32>,
     baseline_shim: f32,
     direction: Direction,
 ) -> (f32, Line<f32>) {

--- a/src/compute/grid/explicit_grid.rs
+++ b/src/compute/grid/explicit_grid.rs
@@ -6,6 +6,7 @@ use crate::style::{LengthPercentage, RepetitionCount, TrackSizingFunction};
 use crate::style_helpers::TaffyAuto;
 use crate::util::sys::{ceil, floor, Vec};
 use crate::util::MaybeMath;
+use crate::util::OptFloat;
 use crate::util::ResolveOrZero;
 use core::cmp::min;
 
@@ -26,7 +27,7 @@ pub(crate) enum AutoRepeatStrategy {
 /// Compute the number of rows and columns in the explicit grid
 pub(crate) fn compute_explicit_grid_size_in_axis(
     style: &impl GridContainerStyle,
-    auto_fit_container_size: Option<f32>,
+    auto_fit_container_size: OptFloat,
     auto_fit_strategy: AutoRepeatStrategy,
     resolve_calc_value: impl Fn(*const (), f32) -> f32,
     axis: AbsoluteAxis,
@@ -116,16 +117,16 @@ pub(crate) fn compute_explicit_grid_size_in_axis(
     let repetition_track_count = repetition_definition_iter.len().min(u16::MAX as usize) as u16;
 
     // Determine the number of repetitions
-    let num_repetitions: u32 = match auto_fit_container_size {
+    let num_repetitions: u32 = match auto_fit_container_size.into_option() {
         None => 1,
         Some(inner_container_size) => {
-            let parent_size = Some(inner_container_size);
+            let parent_size = OptFloat::some(inner_container_size);
 
             /// ...treating each track as its max track sizing function if that is definite or as its minimum track sizing function
             /// otherwise, flooring the max track sizing function by the min track sizing function if both are definite
             fn track_definite_value(
                 sizing_function: TrackSizingFunction,
-                parent_size: Option<f32>,
+                parent_size: OptFloat,
                 calc_resolver: impl Fn(*const (), f32) -> f32,
             ) -> f32 {
                 let max_size = sizing_function.max.definite_value(parent_size, &calc_resolver);
@@ -153,7 +154,8 @@ pub(crate) fn compute_explicit_grid_size_in_axis(
                     },
                 })
                 .sum();
-            let gap_size = style.gap().get_abs(axis).resolve_or_zero(Some(inner_container_size), &resolve_calc_value);
+            let gap_size =
+                style.gap().get_abs(axis).resolve_or_zero(OptFloat::some(inner_container_size), &resolve_calc_value);
 
             // Compute the amount of space that a single repetition of the repeated track list takes
             let per_repetition_track_used_space: f32 = repetition_definition_iter
@@ -392,6 +394,7 @@ mod test {
     use crate::geometry::AbsoluteAxis;
     use crate::prelude::*;
     use crate::sys::DefaultCheapStr;
+    use crate::util::OptFloat;
 
     #[test]
     fn explicit_grid_sizing_no_repeats() {
@@ -489,7 +492,7 @@ mod test {
             grid_template_rows: vec![repeat(AutoFill, vec![length(20.0)])],
             ..Default::default()
         };
-        let inner_container_size = Size { width: Some(120.0), height: Some(80.0) };
+        let inner_container_size = Size { width: OptFloat::some(120.0), height: OptFloat::some(80.0) };
         let (auto_col_reps, col_count) = compute_explicit_grid_size_in_axis(
             &grid_style,
             inner_container_size.get_abs(AbsoluteAxis::Horizontal),
@@ -520,7 +523,7 @@ mod test {
             grid_template_rows: vec![repeat(AutoFill, vec![length(20.0)])],
             ..Default::default()
         };
-        let inner_container_size = Size { width: Some(140.0), height: Some(90.0) };
+        let inner_container_size = Size { width: OptFloat::some(140.0), height: OptFloat::some(90.0) };
         let (auto_col_reps, col_count) = compute_explicit_grid_size_in_axis(
             &grid_style,
             inner_container_size.get_abs(AbsoluteAxis::Horizontal),
@@ -678,7 +681,7 @@ mod test {
             grid_template_rows: vec![repeat(AutoFill, vec![length(20.0)])],
             ..Default::default()
         };
-        let inner_container_size = Size { width: Some(100.0), height: Some(80.0) };
+        let inner_container_size = Size { width: OptFloat::some(100.0), height: OptFloat::some(80.0) };
         let (auto_col_reps, col_count) = compute_explicit_grid_size_in_axis(
             &grid_style,
             inner_container_size.get_abs(AbsoluteAxis::Horizontal),
@@ -710,7 +713,7 @@ mod test {
         };
         let (repetitions, track_count) = compute_explicit_grid_size_in_axis(
             &auto_repeat_first,
-            None,
+            OptFloat::NONE,
             AutoRepeatStrategy::MaxRepetitionsThatDoNotOverflow,
             |_, _| 42.42,
             AbsoluteAxis::Horizontal,
@@ -735,7 +738,7 @@ mod test {
         };
         let (repetitions, track_count) = compute_explicit_grid_size_in_axis(
             &auto_repeat_last,
-            None,
+            OptFloat::NONE,
             AutoRepeatStrategy::MaxRepetitionsThatDoNotOverflow,
             |_, _| 42.42,
             AbsoluteAxis::Horizontal,
@@ -759,7 +762,7 @@ mod test {
         };
         let result = compute_explicit_grid_size_in_axis(
             &grid_style,
-            None,
+            OptFloat::NONE,
             AutoRepeatStrategy::MaxRepetitionsThatDoNotOverflow,
             |_, _| 42.42,
             AbsoluteAxis::Horizontal,

--- a/src/compute/grid/explicit_grid.rs
+++ b/src/compute/grid/explicit_grid.rs
@@ -6,7 +6,7 @@ use crate::style::{LengthPercentage, RepetitionCount, TrackSizingFunction};
 use crate::style_helpers::TaffyAuto;
 use crate::util::sys::{ceil, floor, Vec};
 use crate::util::MaybeMath;
-use crate::util::OptFloat;
+use crate::util::OptF32;
 use crate::util::ResolveOrZero;
 use core::cmp::min;
 
@@ -27,7 +27,7 @@ pub(crate) enum AutoRepeatStrategy {
 /// Compute the number of rows and columns in the explicit grid
 pub(crate) fn compute_explicit_grid_size_in_axis(
     style: &impl GridContainerStyle,
-    auto_fit_container_size: OptFloat,
+    auto_fit_container_size: OptF32,
     auto_fit_strategy: AutoRepeatStrategy,
     resolve_calc_value: impl Fn(*const (), f32) -> f32,
     axis: AbsoluteAxis,
@@ -120,13 +120,13 @@ pub(crate) fn compute_explicit_grid_size_in_axis(
     let num_repetitions: u32 = match auto_fit_container_size.into_option() {
         None => 1,
         Some(inner_container_size) => {
-            let parent_size = OptFloat::some(inner_container_size);
+            let parent_size = OptF32::some(inner_container_size);
 
             /// ...treating each track as its max track sizing function if that is definite or as its minimum track sizing function
             /// otherwise, flooring the max track sizing function by the min track sizing function if both are definite
             fn track_definite_value(
                 sizing_function: TrackSizingFunction,
-                parent_size: OptFloat,
+                parent_size: OptF32,
                 calc_resolver: impl Fn(*const (), f32) -> f32,
             ) -> f32 {
                 let max_size = sizing_function.max.definite_value(parent_size, &calc_resolver);
@@ -155,7 +155,7 @@ pub(crate) fn compute_explicit_grid_size_in_axis(
                 })
                 .sum();
             let gap_size =
-                style.gap().get_abs(axis).resolve_or_zero(OptFloat::some(inner_container_size), &resolve_calc_value);
+                style.gap().get_abs(axis).resolve_or_zero(OptF32::some(inner_container_size), &resolve_calc_value);
 
             // Compute the amount of space that a single repetition of the repeated track list takes
             let per_repetition_track_used_space: f32 = repetition_definition_iter
@@ -394,7 +394,7 @@ mod test {
     use crate::geometry::AbsoluteAxis;
     use crate::prelude::*;
     use crate::sys::DefaultCheapStr;
-    use crate::util::OptFloat;
+    use crate::util::OptF32;
 
     #[test]
     fn explicit_grid_sizing_no_repeats() {
@@ -492,7 +492,7 @@ mod test {
             grid_template_rows: vec![repeat(AutoFill, vec![length(20.0)])],
             ..Default::default()
         };
-        let inner_container_size = Size { width: OptFloat::some(120.0), height: OptFloat::some(80.0) };
+        let inner_container_size = Size { width: OptF32::some(120.0), height: OptF32::some(80.0) };
         let (auto_col_reps, col_count) = compute_explicit_grid_size_in_axis(
             &grid_style,
             inner_container_size.get_abs(AbsoluteAxis::Horizontal),
@@ -523,7 +523,7 @@ mod test {
             grid_template_rows: vec![repeat(AutoFill, vec![length(20.0)])],
             ..Default::default()
         };
-        let inner_container_size = Size { width: OptFloat::some(140.0), height: OptFloat::some(90.0) };
+        let inner_container_size = Size { width: OptF32::some(140.0), height: OptF32::some(90.0) };
         let (auto_col_reps, col_count) = compute_explicit_grid_size_in_axis(
             &grid_style,
             inner_container_size.get_abs(AbsoluteAxis::Horizontal),
@@ -681,7 +681,7 @@ mod test {
             grid_template_rows: vec![repeat(AutoFill, vec![length(20.0)])],
             ..Default::default()
         };
-        let inner_container_size = Size { width: OptFloat::some(100.0), height: OptFloat::some(80.0) };
+        let inner_container_size = Size { width: OptF32::some(100.0), height: OptF32::some(80.0) };
         let (auto_col_reps, col_count) = compute_explicit_grid_size_in_axis(
             &grid_style,
             inner_container_size.get_abs(AbsoluteAxis::Horizontal),
@@ -713,7 +713,7 @@ mod test {
         };
         let (repetitions, track_count) = compute_explicit_grid_size_in_axis(
             &auto_repeat_first,
-            OptFloat::NONE,
+            OptF32::NONE,
             AutoRepeatStrategy::MaxRepetitionsThatDoNotOverflow,
             |_, _| 42.42,
             AbsoluteAxis::Horizontal,
@@ -738,7 +738,7 @@ mod test {
         };
         let (repetitions, track_count) = compute_explicit_grid_size_in_axis(
             &auto_repeat_last,
-            OptFloat::NONE,
+            OptF32::NONE,
             AutoRepeatStrategy::MaxRepetitionsThatDoNotOverflow,
             |_, _| 42.42,
             AbsoluteAxis::Horizontal,
@@ -762,7 +762,7 @@ mod test {
         };
         let result = compute_explicit_grid_size_in_axis(
             &grid_style,
-            OptFloat::NONE,
+            OptF32::NONE,
             AutoRepeatStrategy::MaxRepetitionsThatDoNotOverflow,
             |_, _| 42.42,
             AbsoluteAxis::Horizontal,

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -7,7 +7,7 @@ use crate::tree::{Baselines, Layout, LayoutInput, LayoutOutput, LayoutPartialTre
 use crate::util::debug::debug_log;
 use crate::util::sys::{f32_max, f32_min, GridTrackVec, Vec};
 use crate::util::MaybeMath;
-use crate::util::OptFloat;
+use crate::util::OptF32;
 use crate::util::{MaybeResolve, ResolveOrZero};
 use crate::{
     style_helpers::*, AlignContent, BoxGenerationMode, BoxSizing, CoreStyle, Direction, GridContainerStyle,
@@ -321,7 +321,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
         &mut columns,
         &mut rows,
         &mut items,
-        |track: &GridTrack, parent_size: OptFloat, tree: &Tree| {
+        |track: &GridTrack, parent_size: OptF32, tree: &Tree| {
             track.max_track_sizing_function.definite_value(parent_size, |val, basis| tree.calc(val, basis))
         },
         has_baseline_aligned_item,
@@ -344,7 +344,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
         &mut rows,
         &mut columns,
         &mut items,
-        |track: &GridTrack, _, _| OptFloat::some(track.base_size),
+        |track: &GridTrack, _, _| OptF32::some(track.base_size),
         false, // TODO: Support baseline alignment in the vertical axis
     );
     let initial_row_sum = rows.iter().map(|track| track.base_size).sum::<f32>();
@@ -384,10 +384,10 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
     // and therefore need to be re-resolved here based on the content-sized content box of the container
     if !available_grid_space.width.is_definite() {
         for column in &mut columns {
-            let min: OptFloat = column
+            let min: OptF32 = column
                 .min_track_sizing_function
                 .resolved_percentage_size(container_content_box.width, |val, basis| tree.calc(val, basis));
-            let max: OptFloat = column
+            let max: OptF32 = column
                 .max_track_sizing_function
                 .resolved_percentage_size(container_content_box.width, |val, basis| tree.calc(val, basis));
             column.base_size = column.base_size.maybe_clamp(min, max);
@@ -395,10 +395,10 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
     }
     if !available_grid_space.height.is_definite() {
         for row in &mut rows {
-            let min: OptFloat = row
+            let min: OptF32 = row
                 .min_track_sizing_function
                 .resolved_percentage_size(container_content_box.height, |val, basis| tree.calc(val, basis));
-            let max: OptFloat = row
+            let max: OptF32 = row
                 .max_track_sizing_function
                 .resolved_percentage_size(container_content_box.height, |val, basis| tree.calc(val, basis));
             row.base_size = row.base_size.maybe_clamp(min, max);
@@ -425,10 +425,10 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
                     &columns,
                     &rows,
                     inner_node_size,
-                    |track: &GridTrack, _| OptFloat::some(track.base_size),
+                    |track: &GridTrack, _| OptF32::some(track.base_size),
                     &|val, basis| tree.calc(val, basis),
                 );
-                let available_space = grid_area_size.with(AbstractAxis::Inline, OptFloat::NONE);
+                let available_space = grid_area_size.with(AbstractAxis::Inline, OptF32::NONE);
                 let new_min_content_contribution =
                     item.min_content_contribution(AbstractAxis::Inline, tree, grid_area_size, available_space);
 
@@ -436,9 +436,9 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
                     Some(new_min_content_contribution) != item.min_content_contribution_cache.width.into();
 
                 item.grid_area_size_cache = Some(grid_area_size);
-                item.min_content_contribution_cache.width = OptFloat::some(new_min_content_contribution);
-                item.max_content_contribution_cache.width = OptFloat::NONE;
-                item.minimum_contribution_cache.width = OptFloat::NONE;
+                item.min_content_contribution_cache.width = OptF32::some(new_min_content_contribution);
+                item.max_content_contribution_cache.width = OptF32::NONE;
+                item.minimum_contribution_cache.width = OptF32::NONE;
 
                 has_changed
             });
@@ -447,9 +447,9 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
         // Clear intrinsic width caches
         items.iter_mut().for_each(|item| {
             item.grid_area_size_cache = None;
-            item.min_content_contribution_cache.width = OptFloat::NONE;
-            item.max_content_contribution_cache.width = OptFloat::NONE;
-            item.minimum_contribution_cache.width = OptFloat::NONE;
+            item.min_content_contribution_cache.width = OptF32::NONE;
+            item.max_content_contribution_cache.width = OptF32::NONE;
+            item.minimum_contribution_cache.width = OptF32::NONE;
         });
     }
 
@@ -469,7 +469,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
             &mut columns,
             &mut rows,
             &mut items,
-            |track: &GridTrack, _, _| OptFloat::some(track.base_size),
+            |track: &GridTrack, _, _| OptF32::some(track.base_size),
             has_baseline_aligned_item,
         );
 
@@ -490,10 +490,10 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
                         &rows,
                         &columns,
                         inner_node_size,
-                        |track: &GridTrack, _| OptFloat::some(track.base_size),
+                        |track: &GridTrack, _| OptF32::some(track.base_size),
                         &|val, basis| tree.calc(val, basis),
                     );
-                    let available_space = grid_area_size.with(AbstractAxis::Block, OptFloat::NONE);
+                    let available_space = grid_area_size.with(AbstractAxis::Block, OptF32::NONE);
                     let new_min_content_contribution =
                         item.min_content_contribution(AbstractAxis::Block, tree, grid_area_size, available_space);
 
@@ -501,9 +501,9 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
                         Some(new_min_content_contribution) != item.min_content_contribution_cache.height.into();
 
                     item.grid_area_size_cache = Some(grid_area_size);
-                    item.min_content_contribution_cache.height = OptFloat::some(new_min_content_contribution);
-                    item.max_content_contribution_cache.height = OptFloat::NONE;
-                    item.minimum_contribution_cache.height = OptFloat::NONE;
+                    item.min_content_contribution_cache.height = OptF32::some(new_min_content_contribution);
+                    item.max_content_contribution_cache.height = OptF32::NONE;
+                    item.minimum_contribution_cache.height = OptF32::NONE;
 
                     has_changed
                 });
@@ -512,9 +512,9 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
             items.iter_mut().for_each(|item| {
                 // Clear intrinsic height caches
                 item.grid_area_size_cache = None;
-                item.min_content_contribution_cache.height = OptFloat::NONE;
-                item.max_content_contribution_cache.height = OptFloat::NONE;
-                item.minimum_contribution_cache.height = OptFloat::NONE;
+                item.min_content_contribution_cache.height = OptF32::NONE;
+                item.max_content_contribution_cache.height = OptF32::NONE;
+                item.minimum_contribution_cache.height = OptF32::NONE;
             });
         }
 
@@ -532,7 +532,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
                 &mut rows,
                 &mut columns,
                 &mut items,
-                |track: &GridTrack, _, _| OptFloat::some(track.base_size),
+                |track: &GridTrack, _, _| OptF32::some(track.base_size),
                 false, // TODO: Support baseline alignment in the vertical axis
             );
         }
@@ -836,8 +836,8 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
 
     // Determine the grid container baseline(s) (currently we only compute the first baseline)
     // Layout containment suppresses the box's baseline for baseline-alignment purposes
-    let grid_container_baseline: OptFloat = if contain.suppresses_baseline() {
-        OptFloat::NONE
+    let grid_container_baseline: OptF32 = if contain.suppresses_baseline() {
+        OptF32::NONE
     } else {
         // Sort items by row start position so that we can iterate items in groups which are in the same row
         items.sort_by_key(|item| item.row_indexes.start);
@@ -855,7 +855,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
             .find(|item| item.participates_in_baseline_alignment())
             .unwrap_or(&first_row_items[0]);
 
-        OptFloat::some(item.y_position + item.baseline.unwrap_or(item.height))
+        OptF32::some(item.y_position + item.baseline.unwrap_or(item.height))
     };
 
     // A scroll container's own padding at the end of the content is part of its scrollable

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -7,6 +7,7 @@ use crate::tree::{Baselines, Layout, LayoutInput, LayoutOutput, LayoutPartialTre
 use crate::util::debug::debug_log;
 use crate::util::sys::{f32_max, f32_min, GridTrackVec, Vec};
 use crate::util::MaybeMath;
+use crate::util::OptFloat;
 use crate::util::{MaybeResolve, ResolveOrZero};
 use crate::{
     style_helpers::*, AlignContent, BoxGenerationMode, BoxSizing, CoreStyle, Direction, GridContainerStyle,
@@ -122,8 +123,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
 
     let constrained_available_space = known_dimensions
         .or(preferred_size)
-        .map(|size| size.map(AvailableSpace::Definite))
-        .unwrap_or(available_space)
+        .zip_map(available_space, |opt, avs| opt.map_or(avs, AvailableSpace::Definite))
         .maybe_clamp(min_size, max_size)
         .maybe_max(padding_border_size);
 
@@ -155,13 +155,13 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
     // Short-circuit layout if the container's size is fully determined by the container's size and the run mode
     // is ComputeSize (and thus the container's size is all that we're interested in)
     if run_mode == RunMode::ComputeSize {
-        if let Size { width: Some(width), height: Some(height) } = outer_node_size {
+        if let Size { width: Some(width), height: Some(height) } = outer_node_size.into_options() {
             return LayoutOutput::from_outer_size(Size { width, height });
         }
 
         // We can also short-circuit if the width is known and only the width has been requested.
         if inputs.axis == RequestedAxis::Horizontal {
-            if let Some(width) = outer_node_size.width {
+            if let Some(width) = outer_node_size.width.into_option() {
                 return LayoutOutput::from_outer_size(Size { width, height: 0.0 });
             }
         }
@@ -193,9 +193,12 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
     // Otherwise, if the grid container has a definite min size in the relevant axis:
     //   - then the number of repetitions is the smallest possible positive integer that fulfills that minimum requirement
     // Otherwise, the specified track list repeats only once.
-    let auto_repeat_fit_strategy = outer_node_size.or(max_size).map(|val| match val {
-        Some(_) => AutoRepeatStrategy::MaxRepetitionsThatDoNotOverflow,
-        None => AutoRepeatStrategy::MinRepetitionsThatDoOverflow,
+    let auto_repeat_fit_strategy = outer_node_size.or(max_size).map(|val| {
+        if val.is_some() {
+            AutoRepeatStrategy::MaxRepetitionsThatDoNotOverflow
+        } else {
+            AutoRepeatStrategy::MinRepetitionsThatDoOverflow
+        }
     });
 
     // Compute the number of rows and columns in the explicit grid *template*
@@ -318,7 +321,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
         &mut columns,
         &mut rows,
         &mut items,
-        |track: &GridTrack, parent_size: Option<f32>, tree: &Tree| {
+        |track: &GridTrack, parent_size: OptFloat, tree: &Tree| {
             track.max_track_sizing_function.definite_value(parent_size, |val, basis| tree.calc(val, basis))
         },
         has_baseline_aligned_item,
@@ -341,7 +344,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
         &mut rows,
         &mut columns,
         &mut items,
-        |track: &GridTrack, _, _| Some(track.base_size),
+        |track: &GridTrack, _, _| OptFloat::some(track.base_size),
         false, // TODO: Support baseline alignment in the vertical axis
     );
     let initial_row_sum = rows.iter().map(|track| track.base_size).sum::<f32>();
@@ -381,10 +384,10 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
     // and therefore need to be re-resolved here based on the content-sized content box of the container
     if !available_grid_space.width.is_definite() {
         for column in &mut columns {
-            let min: Option<f32> = column
+            let min: OptFloat = column
                 .min_track_sizing_function
                 .resolved_percentage_size(container_content_box.width, |val, basis| tree.calc(val, basis));
-            let max: Option<f32> = column
+            let max: OptFloat = column
                 .max_track_sizing_function
                 .resolved_percentage_size(container_content_box.width, |val, basis| tree.calc(val, basis));
             column.base_size = column.base_size.maybe_clamp(min, max);
@@ -392,10 +395,10 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
     }
     if !available_grid_space.height.is_definite() {
         for row in &mut rows {
-            let min: Option<f32> = row
+            let min: OptFloat = row
                 .min_track_sizing_function
                 .resolved_percentage_size(container_content_box.height, |val, basis| tree.calc(val, basis));
-            let max: Option<f32> = row
+            let max: OptFloat = row
                 .max_track_sizing_function
                 .resolved_percentage_size(container_content_box.height, |val, basis| tree.calc(val, basis));
             row.base_size = row.base_size.maybe_clamp(min, max);
@@ -422,19 +425,20 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
                     &columns,
                     &rows,
                     inner_node_size,
-                    |track: &GridTrack, _| Some(track.base_size),
+                    |track: &GridTrack, _| OptFloat::some(track.base_size),
                     &|val, basis| tree.calc(val, basis),
                 );
-                let available_space = grid_area_size.with(AbstractAxis::Inline, None);
+                let available_space = grid_area_size.with(AbstractAxis::Inline, OptFloat::NONE);
                 let new_min_content_contribution =
                     item.min_content_contribution(AbstractAxis::Inline, tree, grid_area_size, available_space);
 
-                let has_changed = Some(new_min_content_contribution) != item.min_content_contribution_cache.width;
+                let has_changed =
+                    Some(new_min_content_contribution) != item.min_content_contribution_cache.width.into();
 
                 item.grid_area_size_cache = Some(grid_area_size);
-                item.min_content_contribution_cache.width = Some(new_min_content_contribution);
-                item.max_content_contribution_cache.width = None;
-                item.minimum_contribution_cache.width = None;
+                item.min_content_contribution_cache.width = OptFloat::some(new_min_content_contribution);
+                item.max_content_contribution_cache.width = OptFloat::NONE;
+                item.minimum_contribution_cache.width = OptFloat::NONE;
 
                 has_changed
             });
@@ -443,9 +447,9 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
         // Clear intrinsic width caches
         items.iter_mut().for_each(|item| {
             item.grid_area_size_cache = None;
-            item.min_content_contribution_cache.width = None;
-            item.max_content_contribution_cache.width = None;
-            item.minimum_contribution_cache.width = None;
+            item.min_content_contribution_cache.width = OptFloat::NONE;
+            item.max_content_contribution_cache.width = OptFloat::NONE;
+            item.minimum_contribution_cache.width = OptFloat::NONE;
         });
     }
 
@@ -465,7 +469,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
             &mut columns,
             &mut rows,
             &mut items,
-            |track: &GridTrack, _, _| Some(track.base_size),
+            |track: &GridTrack, _, _| OptFloat::some(track.base_size),
             has_baseline_aligned_item,
         );
 
@@ -486,19 +490,20 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
                         &rows,
                         &columns,
                         inner_node_size,
-                        |track: &GridTrack, _| Some(track.base_size),
+                        |track: &GridTrack, _| OptFloat::some(track.base_size),
                         &|val, basis| tree.calc(val, basis),
                     );
-                    let available_space = grid_area_size.with(AbstractAxis::Block, None);
+                    let available_space = grid_area_size.with(AbstractAxis::Block, OptFloat::NONE);
                     let new_min_content_contribution =
                         item.min_content_contribution(AbstractAxis::Block, tree, grid_area_size, available_space);
 
-                    let has_changed = Some(new_min_content_contribution) != item.min_content_contribution_cache.height;
+                    let has_changed =
+                        Some(new_min_content_contribution) != item.min_content_contribution_cache.height.into();
 
                     item.grid_area_size_cache = Some(grid_area_size);
-                    item.min_content_contribution_cache.height = Some(new_min_content_contribution);
-                    item.max_content_contribution_cache.height = None;
-                    item.minimum_contribution_cache.height = None;
+                    item.min_content_contribution_cache.height = OptFloat::some(new_min_content_contribution);
+                    item.max_content_contribution_cache.height = OptFloat::NONE;
+                    item.minimum_contribution_cache.height = OptFloat::NONE;
 
                     has_changed
                 });
@@ -507,9 +512,9 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
             items.iter_mut().for_each(|item| {
                 // Clear intrinsic height caches
                 item.grid_area_size_cache = None;
-                item.min_content_contribution_cache.height = None;
-                item.max_content_contribution_cache.height = None;
-                item.minimum_contribution_cache.height = None;
+                item.min_content_contribution_cache.height = OptFloat::NONE;
+                item.max_content_contribution_cache.height = OptFloat::NONE;
+                item.minimum_contribution_cache.height = OptFloat::NONE;
             });
         }
 
@@ -527,7 +532,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
                 &mut rows,
                 &mut columns,
                 &mut items,
-                |track: &GridTrack, _, _| Some(track.base_size),
+                |track: &GridTrack, _, _| OptFloat::some(track.base_size),
                 false, // TODO: Support baseline alignment in the vertical axis
             );
         }
@@ -831,8 +836,8 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
 
     // Determine the grid container baseline(s) (currently we only compute the first baseline)
     // Layout containment suppresses the box's baseline for baseline-alignment purposes
-    let grid_container_baseline: Option<f32> = if contain.suppresses_baseline() {
-        None
+    let grid_container_baseline: OptFloat = if contain.suppresses_baseline() {
+        OptFloat::NONE
     } else {
         // Sort items by row start position so that we can iterate items in groups which are in the same row
         items.sort_by_key(|item| item.row_indexes.start);
@@ -850,7 +855,7 @@ pub fn compute_grid_layout<Tree: LayoutGridContainer>(
             .find(|item| item.participates_in_baseline_alignment())
             .unwrap_or(&first_row_items[0]);
 
-        Some(item.y_position + item.baseline.unwrap_or(item.height))
+        OptFloat::some(item.y_position + item.baseline.unwrap_or(item.height))
     };
 
     // A scroll container's own padding at the end of the content is part of its scrollable

--- a/src/compute/grid/track_sizing.rs
+++ b/src/compute/grid/track_sizing.rs
@@ -6,6 +6,7 @@ use crate::style::{AlignContent, AlignContentKeyword, AvailableSpace};
 use crate::style_helpers::TaffyMinContent;
 use crate::tree::{LayoutPartialTree, LayoutPartialTreeExt, SizingMode};
 use crate::util::sys::{f32_max, f32_min, Vec};
+use crate::util::OptFloat;
 use crate::util::{MaybeMath, ResolveOrZero};
 use crate::CompactLength;
 use core::cmp::Ordering;
@@ -67,7 +68,7 @@ impl ItemBatcher {
 struct IntrinsicSizeMeasurer<'tree, 'oat, Tree, EstimateFunction>
 where
     Tree: LayoutPartialTree,
-    EstimateFunction: Fn(&GridTrack, Option<f32>, &Tree) -> Option<f32>,
+    EstimateFunction: Fn(&GridTrack, OptFloat, &Tree) -> OptFloat,
 {
     /// The layout tree
     tree: &'tree mut Tree,
@@ -79,20 +80,20 @@ where
     /// The axis we are currently sizing
     axis: AbstractAxis,
     /// The available grid space
-    inner_node_size: Size<Option<f32>>,
+    inner_node_size: Size<OptFloat>,
 }
 
 impl<Tree, EstimateFunction> IntrinsicSizeMeasurer<'_, '_, Tree, EstimateFunction>
 where
     Tree: LayoutPartialTree,
-    EstimateFunction: Fn(&GridTrack, Option<f32>, &Tree) -> Option<f32>,
+    EstimateFunction: Fn(&GridTrack, OptFloat, &Tree) -> OptFloat,
 {
     /// Compute the available_space to be passed to the child sizing functions
     /// These are estimates based on either the max track sizing function or the provisional base size in the opposite
     /// axis to the one currently being sized.
     /// https://www.w3.org/TR/css-grid-1/#algo-overview
     #[inline(always)]
-    fn grid_area_size(&self, item: &mut GridItem, axis_tracks: &[GridTrack]) -> Size<Option<f32>> {
+    fn grid_area_size(&self, item: &mut GridItem, axis_tracks: &[GridTrack]) -> Size<OptFloat> {
         item.grid_area_size_cached(
             self.axis,
             axis_tracks,
@@ -106,7 +107,7 @@ where
     /// Compute the item's resolved margins for size contributions. Horizontal percentage margins always resolve
     /// to zero if the container size is indefinite as otherwise this would introduce a cyclic dependency.
     #[inline(always)]
-    fn margins_axis_sums_with_baseline_shims(&self, item: &GridItem, percentage_basis: Option<f32>) -> Size<f32> {
+    fn margins_axis_sums_with_baseline_shims(&self, item: &GridItem, percentage_basis: OptFloat) -> Size<f32> {
         item.margins_axis_sums_with_baseline_shims(percentage_basis, self.tree)
     }
 
@@ -120,7 +121,7 @@ where
     #[inline(always)]
     fn min_content_contribution(&mut self, item: &mut GridItem, axis_tracks: &[GridTrack]) -> f32 {
         let grid_area_size = self.grid_area_size(item, axis_tracks);
-        let available_space = grid_area_size.with(self.axis, None);
+        let available_space = grid_area_size.with(self.axis, OptFloat::NONE);
         let margin_axis_sums = self.margins_axis_sums_with_baseline_shims(item, available_space.width);
         let contribution = item.min_content_contribution_cached(self.axis, self.tree, grid_area_size, available_space);
         contribution + margin_axis_sums.get(self.axis)
@@ -130,7 +131,7 @@ where
     #[inline(always)]
     fn max_content_contribution(&mut self, item: &mut GridItem, axis_tracks: &[GridTrack]) -> f32 {
         let grid_area_size = self.grid_area_size(item, axis_tracks);
-        let available_space = grid_area_size.with(self.axis, None);
+        let available_space = grid_area_size.with(self.axis, OptFloat::NONE);
         let margin_axis_sums = self.margins_axis_sums_with_baseline_shims(item, available_space.width);
         let contribution = item.max_content_contribution_cached(self.axis, self.tree, grid_area_size, available_space);
         contribution + margin_axis_sums.get(self.axis)
@@ -146,7 +147,7 @@ where
     #[inline(always)]
     fn minimum_contribution(&mut self, item: &mut GridItem, axis_tracks: &[GridTrack]) -> f32 {
         let grid_area_size = self.grid_area_size(item, axis_tracks);
-        let available_space = grid_area_size.with(self.axis, None);
+        let available_space = grid_area_size.with(self.axis, OptFloat::NONE);
         let margin_axis_sums = self.margins_axis_sums_with_baseline_shims(item, available_space.width);
         let contribution =
             item.minimum_contribution_cached(self.tree, self.axis, axis_tracks, grid_area_size, self.inner_node_size);
@@ -183,8 +184,8 @@ pub(super) fn cmp_by_cross_flex_then_span_then_start(
 #[inline(always)]
 pub(super) fn compute_alignment_gutter_adjustment(
     alignment: AlignContent,
-    axis_inner_node_size: Option<f32>,
-    get_track_size_estimate: impl Fn(&GridTrack, Option<f32>) -> Option<f32>,
+    axis_inner_node_size: OptFloat,
+    get_track_size_estimate: impl Fn(&GridTrack, OptFloat) -> OptFloat,
     tracks: &[GridTrack],
 ) -> f32 {
     if tracks.len() <= 1 {
@@ -222,11 +223,11 @@ pub(super) fn compute_alignment_gutter_adjustment(
         return 0.0;
     }
 
-    if let Some(axis_inner_node_size) = axis_inner_node_size {
+    if let Some(axis_inner_node_size) = axis_inner_node_size.into_option() {
         let free_space = tracks
             .iter()
-            .map(|track| get_track_size_estimate(track, Some(axis_inner_node_size)))
-            .sum::<Option<f32>>()
+            .map(|track| get_track_size_estimate(track, OptFloat::some(axis_inner_node_size)))
+            .sum::<OptFloat>()
             .map(|track_size_sum| f32_max(0.0, axis_inner_node_size - track_size_sum))
             .unwrap_or(0.0);
 
@@ -273,16 +274,16 @@ pub(super) fn determine_if_item_crosses_flexible_or_intrinsic_tracks(
 pub(super) fn track_sizing_algorithm<Tree: LayoutPartialTree>(
     tree: &mut Tree,
     axis: AbstractAxis,
-    axis_min_size: Option<f32>,
-    axis_max_size: Option<f32>,
+    axis_min_size: OptFloat,
+    axis_max_size: OptFloat,
     axis_alignment: AlignContent,
     other_axis_alignment: AlignContent,
     available_grid_space: Size<AvailableSpace>,
-    inner_node_size: Size<Option<f32>>,
+    inner_node_size: Size<OptFloat>,
     axis_tracks: &mut [GridTrack],
     other_axis_tracks: &mut [GridTrack],
     items: &mut [GridItem],
-    get_track_size_estimate: fn(&GridTrack, Option<f32>, &Tree) -> Option<f32>,
+    get_track_size_estimate: fn(&GridTrack, OptFloat, &Tree) -> OptFloat,
     has_baseline_aligned_item: bool,
 ) {
     // 11.4 Initialise Track sizes
@@ -347,7 +348,7 @@ pub(super) fn track_sizing_algorithm<Tree: LayoutPartialTree>(
     // into space generated by the grid container's size (as defined by either it's preferred size style or by it's parent node through
     // something like stretch alignment), not just any available space. To do this we map definite available space to AvailableSpace::MaxContent
     // in the case that inner_node_size is None
-    let axis_available_space_for_expansion = if let Some(available_space) = inner_node_size.get(axis) {
+    let axis_available_space_for_expansion = if let Some(available_space) = inner_node_size.get(axis).into_option() {
         AvailableSpace::Definite(available_space)
     } else {
         match available_grid_space.get(axis) {
@@ -421,7 +422,7 @@ fn flush_planned_growth_limit_increases(tracks: &mut [GridTrack], set_infinitely
 fn initialize_track_sizes(
     tree: &impl LayoutPartialTree,
     axis_tracks: &mut [GridTrack],
-    axis_inner_node_size: Option<f32>,
+    axis_inner_node_size: OptFloat,
 ) {
     for track in axis_tracks.iter_mut() {
         // For each track, if the track’s min track sizing function is:
@@ -459,7 +460,7 @@ fn resolve_item_baselines(
     tree: &mut impl LayoutPartialTree,
     axis: AbstractAxis,
     items: &mut [GridItem],
-    inner_node_size: Size<Option<f32>>,
+    inner_node_size: Size<OptFloat>,
 ) {
     // Sort items by track in the other axis (row) start position so that we can iterate items in groups which
     // are in the same track in the other axis (row)
@@ -525,7 +526,7 @@ fn resolve_item_baselines(
                 baseline.unwrap_or(height)
             };
 
-            item.baseline = Some(
+            item.baseline = OptFloat::some(
                 baseline + item.margin.top.resolve_or_zero(inner_node_size.width, |val, basis| tree.calc(val, basis)),
             );
         }
@@ -556,8 +557,8 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
     other_axis_tracks: &[GridTrack],
     items: &mut [GridItem],
     axis_available_grid_space: AvailableSpace,
-    inner_node_size: Size<Option<f32>>,
-    get_track_size_estimate: impl Fn(&GridTrack, Option<f32>, &Tree) -> Option<f32>,
+    inner_node_size: Size<OptFloat>,
+    get_track_size_estimate: impl Fn(&GridTrack, OptFloat, &Tree) -> OptFloat,
 ) {
     // Step 1. Shim baseline-aligned items so their intrinsic size contributions reflect their baseline alignment.
 
@@ -1015,7 +1016,7 @@ fn distribute_item_space_to_base_size(
     track_is_affected: impl Fn(&GridTrack) -> bool,
     track_limit: impl Fn(&GridTrack) -> f32,
     intrinsic_contribution_type: IntrinsicContributionType,
-    axis_inner_node_size: Option<f32>,
+    axis_inner_node_size: OptFloat,
 ) {
     if is_flex {
         let filter = |track: &GridTrack| track.is_flexible() && track_is_affected(track);
@@ -1070,7 +1071,7 @@ fn distribute_item_space_to_base_size(
         track_distribution_proportion: impl Fn(&GridTrack) -> f32,
         track_limit: impl Fn(&GridTrack) -> f32,
         intrinsic_contribution_type: IntrinsicContributionType,
-        axis_inner_node_size: Option<f32>,
+        axis_inner_node_size: OptFloat,
     ) {
         // Skip this distribution if there is either
         //   - no space to distribute
@@ -1160,7 +1161,7 @@ fn distribute_item_space_to_growth_limit(
     space: f32,
     tracks: &mut [GridTrack],
     track_is_affected: impl Fn(&GridTrack) -> bool,
-    axis_inner_node_size: Option<f32>,
+    axis_inner_node_size: OptFloat,
 ) {
     // Skip this distribution if there is either
     //   - no space to distribute
@@ -1225,7 +1226,7 @@ fn distribute_item_space_to_growth_limit(
 #[inline(always)]
 fn maximise_tracks(
     axis_tracks: &mut [GridTrack],
-    axis_inner_node_size: Option<f32>,
+    axis_inner_node_size: OptFloat,
     axis_available_grid_space: AvailableSpace,
 ) {
     let used_space: f32 = axis_tracks.iter().map(|track| track.base_size).sum();
@@ -1257,8 +1258,8 @@ fn expand_flexible_tracks(
     axis: AbstractAxis,
     axis_tracks: &mut [GridTrack],
     items: &mut [GridItem],
-    axis_min_size: Option<f32>,
-    axis_max_size: Option<f32>,
+    axis_min_size: OptFloat,
+    axis_max_size: OptFloat,
     axis_available_space_for_expansion: AvailableSpace,
 ) {
     // First, find the grid’s used flex fraction:
@@ -1420,7 +1421,7 @@ fn find_size_of_fr(tracks: &[GridTrack], space_to_fill: f32) -> f32 {
 #[inline(always)]
 fn stretch_auto_tracks(
     axis_tracks: &mut [GridTrack],
-    axis_min_size: Option<f32>,
+    axis_min_size: OptFloat,
     axis_available_space_for_expansion: AvailableSpace,
 ) {
     let num_auto_tracks = axis_tracks.iter().filter(|track| track.max_track_sizing_function.is_auto()).count();
@@ -1432,7 +1433,7 @@ fn stretch_auto_tracks(
         let free_space = if axis_available_space_for_expansion.is_definite() {
             axis_available_space_for_expansion.compute_free_space(used_space)
         } else {
-            match axis_min_size {
+            match axis_min_size.into_option() {
                 Some(size) => size - used_space,
                 None => 0.0,
             }

--- a/src/compute/grid/track_sizing.rs
+++ b/src/compute/grid/track_sizing.rs
@@ -6,7 +6,7 @@ use crate::style::{AlignContent, AlignContentKeyword, AvailableSpace};
 use crate::style_helpers::TaffyMinContent;
 use crate::tree::{LayoutPartialTree, LayoutPartialTreeExt, SizingMode};
 use crate::util::sys::{f32_max, f32_min, Vec};
-use crate::util::OptFloat;
+use crate::util::OptF32;
 use crate::util::{MaybeMath, ResolveOrZero};
 use crate::CompactLength;
 use core::cmp::Ordering;
@@ -68,7 +68,7 @@ impl ItemBatcher {
 struct IntrinsicSizeMeasurer<'tree, 'oat, Tree, EstimateFunction>
 where
     Tree: LayoutPartialTree,
-    EstimateFunction: Fn(&GridTrack, OptFloat, &Tree) -> OptFloat,
+    EstimateFunction: Fn(&GridTrack, OptF32, &Tree) -> OptF32,
 {
     /// The layout tree
     tree: &'tree mut Tree,
@@ -80,20 +80,20 @@ where
     /// The axis we are currently sizing
     axis: AbstractAxis,
     /// The available grid space
-    inner_node_size: Size<OptFloat>,
+    inner_node_size: Size<OptF32>,
 }
 
 impl<Tree, EstimateFunction> IntrinsicSizeMeasurer<'_, '_, Tree, EstimateFunction>
 where
     Tree: LayoutPartialTree,
-    EstimateFunction: Fn(&GridTrack, OptFloat, &Tree) -> OptFloat,
+    EstimateFunction: Fn(&GridTrack, OptF32, &Tree) -> OptF32,
 {
     /// Compute the available_space to be passed to the child sizing functions
     /// These are estimates based on either the max track sizing function or the provisional base size in the opposite
     /// axis to the one currently being sized.
     /// https://www.w3.org/TR/css-grid-1/#algo-overview
     #[inline(always)]
-    fn grid_area_size(&self, item: &mut GridItem, axis_tracks: &[GridTrack]) -> Size<OptFloat> {
+    fn grid_area_size(&self, item: &mut GridItem, axis_tracks: &[GridTrack]) -> Size<OptF32> {
         item.grid_area_size_cached(
             self.axis,
             axis_tracks,
@@ -107,7 +107,7 @@ where
     /// Compute the item's resolved margins for size contributions. Horizontal percentage margins always resolve
     /// to zero if the container size is indefinite as otherwise this would introduce a cyclic dependency.
     #[inline(always)]
-    fn margins_axis_sums_with_baseline_shims(&self, item: &GridItem, percentage_basis: OptFloat) -> Size<f32> {
+    fn margins_axis_sums_with_baseline_shims(&self, item: &GridItem, percentage_basis: OptF32) -> Size<f32> {
         item.margins_axis_sums_with_baseline_shims(percentage_basis, self.tree)
     }
 
@@ -121,7 +121,7 @@ where
     #[inline(always)]
     fn min_content_contribution(&mut self, item: &mut GridItem, axis_tracks: &[GridTrack]) -> f32 {
         let grid_area_size = self.grid_area_size(item, axis_tracks);
-        let available_space = grid_area_size.with(self.axis, OptFloat::NONE);
+        let available_space = grid_area_size.with(self.axis, OptF32::NONE);
         let margin_axis_sums = self.margins_axis_sums_with_baseline_shims(item, available_space.width);
         let contribution = item.min_content_contribution_cached(self.axis, self.tree, grid_area_size, available_space);
         contribution + margin_axis_sums.get(self.axis)
@@ -131,7 +131,7 @@ where
     #[inline(always)]
     fn max_content_contribution(&mut self, item: &mut GridItem, axis_tracks: &[GridTrack]) -> f32 {
         let grid_area_size = self.grid_area_size(item, axis_tracks);
-        let available_space = grid_area_size.with(self.axis, OptFloat::NONE);
+        let available_space = grid_area_size.with(self.axis, OptF32::NONE);
         let margin_axis_sums = self.margins_axis_sums_with_baseline_shims(item, available_space.width);
         let contribution = item.max_content_contribution_cached(self.axis, self.tree, grid_area_size, available_space);
         contribution + margin_axis_sums.get(self.axis)
@@ -147,7 +147,7 @@ where
     #[inline(always)]
     fn minimum_contribution(&mut self, item: &mut GridItem, axis_tracks: &[GridTrack]) -> f32 {
         let grid_area_size = self.grid_area_size(item, axis_tracks);
-        let available_space = grid_area_size.with(self.axis, OptFloat::NONE);
+        let available_space = grid_area_size.with(self.axis, OptF32::NONE);
         let margin_axis_sums = self.margins_axis_sums_with_baseline_shims(item, available_space.width);
         let contribution =
             item.minimum_contribution_cached(self.tree, self.axis, axis_tracks, grid_area_size, self.inner_node_size);
@@ -184,8 +184,8 @@ pub(super) fn cmp_by_cross_flex_then_span_then_start(
 #[inline(always)]
 pub(super) fn compute_alignment_gutter_adjustment(
     alignment: AlignContent,
-    axis_inner_node_size: OptFloat,
-    get_track_size_estimate: impl Fn(&GridTrack, OptFloat) -> OptFloat,
+    axis_inner_node_size: OptF32,
+    get_track_size_estimate: impl Fn(&GridTrack, OptF32) -> OptF32,
     tracks: &[GridTrack],
 ) -> f32 {
     if tracks.len() <= 1 {
@@ -226,8 +226,8 @@ pub(super) fn compute_alignment_gutter_adjustment(
     if let Some(axis_inner_node_size) = axis_inner_node_size.into_option() {
         let free_space = tracks
             .iter()
-            .map(|track| get_track_size_estimate(track, OptFloat::some(axis_inner_node_size)))
-            .sum::<OptFloat>()
+            .map(|track| get_track_size_estimate(track, OptF32::some(axis_inner_node_size)))
+            .sum::<OptF32>()
             .map(|track_size_sum| f32_max(0.0, axis_inner_node_size - track_size_sum))
             .unwrap_or(0.0);
 
@@ -274,16 +274,16 @@ pub(super) fn determine_if_item_crosses_flexible_or_intrinsic_tracks(
 pub(super) fn track_sizing_algorithm<Tree: LayoutPartialTree>(
     tree: &mut Tree,
     axis: AbstractAxis,
-    axis_min_size: OptFloat,
-    axis_max_size: OptFloat,
+    axis_min_size: OptF32,
+    axis_max_size: OptF32,
     axis_alignment: AlignContent,
     other_axis_alignment: AlignContent,
     available_grid_space: Size<AvailableSpace>,
-    inner_node_size: Size<OptFloat>,
+    inner_node_size: Size<OptF32>,
     axis_tracks: &mut [GridTrack],
     other_axis_tracks: &mut [GridTrack],
     items: &mut [GridItem],
-    get_track_size_estimate: fn(&GridTrack, OptFloat, &Tree) -> OptFloat,
+    get_track_size_estimate: fn(&GridTrack, OptF32, &Tree) -> OptF32,
     has_baseline_aligned_item: bool,
 ) {
     // 11.4 Initialise Track sizes
@@ -419,11 +419,7 @@ fn flush_planned_growth_limit_increases(tracks: &mut [GridTrack], set_infinitely
 /// 11.4 Initialise Track sizes
 /// Initialize each track’s base size and growth limit.
 #[inline(always)]
-fn initialize_track_sizes(
-    tree: &impl LayoutPartialTree,
-    axis_tracks: &mut [GridTrack],
-    axis_inner_node_size: OptFloat,
-) {
+fn initialize_track_sizes(tree: &impl LayoutPartialTree, axis_tracks: &mut [GridTrack], axis_inner_node_size: OptF32) {
     for track in axis_tracks.iter_mut() {
         // For each track, if the track’s min track sizing function is:
         // - A fixed sizing function
@@ -460,7 +456,7 @@ fn resolve_item_baselines(
     tree: &mut impl LayoutPartialTree,
     axis: AbstractAxis,
     items: &mut [GridItem],
-    inner_node_size: Size<OptFloat>,
+    inner_node_size: Size<OptF32>,
 ) {
     // Sort items by track in the other axis (row) start position so that we can iterate items in groups which
     // are in the same track in the other axis (row)
@@ -526,7 +522,7 @@ fn resolve_item_baselines(
                 baseline.unwrap_or(height)
             };
 
-            item.baseline = OptFloat::some(
+            item.baseline = OptF32::some(
                 baseline + item.margin.top.resolve_or_zero(inner_node_size.width, |val, basis| tree.calc(val, basis)),
             );
         }
@@ -557,8 +553,8 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
     other_axis_tracks: &[GridTrack],
     items: &mut [GridItem],
     axis_available_grid_space: AvailableSpace,
-    inner_node_size: Size<OptFloat>,
-    get_track_size_estimate: impl Fn(&GridTrack, OptFloat, &Tree) -> OptFloat,
+    inner_node_size: Size<OptF32>,
+    get_track_size_estimate: impl Fn(&GridTrack, OptF32, &Tree) -> OptF32,
 ) {
     // Step 1. Shim baseline-aligned items so their intrinsic size contributions reflect their baseline alignment.
 
@@ -1016,7 +1012,7 @@ fn distribute_item_space_to_base_size(
     track_is_affected: impl Fn(&GridTrack) -> bool,
     track_limit: impl Fn(&GridTrack) -> f32,
     intrinsic_contribution_type: IntrinsicContributionType,
-    axis_inner_node_size: OptFloat,
+    axis_inner_node_size: OptF32,
 ) {
     if is_flex {
         let filter = |track: &GridTrack| track.is_flexible() && track_is_affected(track);
@@ -1071,7 +1067,7 @@ fn distribute_item_space_to_base_size(
         track_distribution_proportion: impl Fn(&GridTrack) -> f32,
         track_limit: impl Fn(&GridTrack) -> f32,
         intrinsic_contribution_type: IntrinsicContributionType,
-        axis_inner_node_size: OptFloat,
+        axis_inner_node_size: OptF32,
     ) {
         // Skip this distribution if there is either
         //   - no space to distribute
@@ -1161,7 +1157,7 @@ fn distribute_item_space_to_growth_limit(
     space: f32,
     tracks: &mut [GridTrack],
     track_is_affected: impl Fn(&GridTrack) -> bool,
-    axis_inner_node_size: OptFloat,
+    axis_inner_node_size: OptF32,
 ) {
     // Skip this distribution if there is either
     //   - no space to distribute
@@ -1226,7 +1222,7 @@ fn distribute_item_space_to_growth_limit(
 #[inline(always)]
 fn maximise_tracks(
     axis_tracks: &mut [GridTrack],
-    axis_inner_node_size: OptFloat,
+    axis_inner_node_size: OptF32,
     axis_available_grid_space: AvailableSpace,
 ) {
     let used_space: f32 = axis_tracks.iter().map(|track| track.base_size).sum();
@@ -1258,8 +1254,8 @@ fn expand_flexible_tracks(
     axis: AbstractAxis,
     axis_tracks: &mut [GridTrack],
     items: &mut [GridItem],
-    axis_min_size: OptFloat,
-    axis_max_size: OptFloat,
+    axis_min_size: OptF32,
+    axis_max_size: OptF32,
     axis_available_space_for_expansion: AvailableSpace,
 ) {
     // First, find the grid’s used flex fraction:
@@ -1421,7 +1417,7 @@ fn find_size_of_fr(tracks: &[GridTrack], space_to_fill: f32) -> f32 {
 #[inline(always)]
 fn stretch_auto_tracks(
     axis_tracks: &mut [GridTrack],
-    axis_min_size: OptFloat,
+    axis_min_size: OptF32,
     axis_available_space_for_expansion: AvailableSpace,
 ) {
     let num_auto_tracks = axis_tracks.iter().filter(|track| track.max_track_sizing_function.is_auto()).count();

--- a/src/compute/grid/types/grid_item.rs
+++ b/src/compute/grid/types/grid_item.rs
@@ -6,6 +6,7 @@ use crate::geometry::AbstractAxis;
 use crate::geometry::{Line, Point, Rect, Size};
 use crate::style::{AlignItems, AlignSelf, AvailableSpace, Dimension, LengthPercentageAuto, Overflow};
 use crate::tree::{LayoutPartialTree, LayoutPartialTreeExt, NodeId, SizingMode};
+use crate::util::OptFloat;
 use crate::util::{MaybeMath, MaybeResolve, ResolveOrZero};
 use crate::{AlignItemsKeyword, BoxSizing, GridItemStyle, LengthPercentage};
 use core::ops::Range;
@@ -55,7 +56,7 @@ pub(in super::super) struct GridItem {
     /// The item's justify_self property, or the parent's justify_items property is not set
     pub justify_self: AlignSelf,
     /// The items first baseline (horizontal)
-    pub baseline: Option<f32>,
+    pub baseline: OptFloat,
     /// Shim for baseline alignment that acts like an extra top margin
     /// TODO: Support last baseline and vertical text baselines
     pub baseline_shim: f32,
@@ -78,13 +79,13 @@ pub(in super::super) struct GridItem {
 
     // Caches for intrinsic size computation. These caches are only valid for a single run of the track-sizing algorithm.
     /// Cache for the known_dimensions input to intrinsic sizing computation
-    pub grid_area_size_cache: Option<Size<Option<f32>>>,
+    pub grid_area_size_cache: Option<Size<OptFloat>>,
     /// Cache for the min-content size
-    pub min_content_contribution_cache: Size<Option<f32>>,
+    pub min_content_contribution_cache: Size<OptFloat>,
     /// Cache for the minimum contribution
-    pub minimum_contribution_cache: Size<Option<f32>>,
+    pub minimum_contribution_cache: Size<OptFloat>,
     /// Cache for the max-content size
-    pub max_content_contribution_cache: Size<Option<f32>>,
+    pub max_content_contribution_cache: Size<OptFloat>,
 
     /// Final y position. Used to compute baseline alignment for the container.
     pub y_position: f32,
@@ -120,7 +121,7 @@ impl GridItem {
             margin: style.margin(),
             align_self: style.align_self().unwrap_or(parent_align_items),
             justify_self: style.justify_self().unwrap_or(parent_justify_items),
-            baseline: None,
+            baseline: OptFloat::NONE,
             baseline_shim: 0.0,
             row_indexes: Line { start: 0, end: 0 }, // Properly initialised later
             column_indexes: Line { start: 0, end: 0 }, // Properly initialised later
@@ -218,9 +219,9 @@ impl GridItem {
         &mut self,
         axis: AbstractAxis,
         axis_tracks: &[GridTrack],
-        axis_parent_size: Option<f32>,
+        axis_parent_size: OptFloat,
         resolve_calc_value: &dyn Fn(*const (), f32) -> f32,
-    ) -> Option<f32> {
+    ) -> OptFloat {
         let spanned_tracks = &axis_tracks[self.track_range_excluding_lines(axis)];
         let tracks_all_fixed = spanned_tracks.iter().all(|track| {
             track.max_track_sizing_function.definite_limit(axis_parent_size, resolve_calc_value).is_some()
@@ -232,9 +233,9 @@ impl GridItem {
                     track.max_track_sizing_function.definite_limit(axis_parent_size, resolve_calc_value).unwrap()
                 })
                 .sum();
-            Some(limit)
+            OptFloat::some(limit)
         } else {
-            None
+            OptFloat::NONE
         }
     }
 
@@ -244,9 +245,9 @@ impl GridItem {
         &mut self,
         axis: AbstractAxis,
         axis_tracks: &[GridTrack],
-        axis_parent_size: Option<f32>,
+        axis_parent_size: OptFloat,
         resolve_calc_value: &dyn Fn(*const (), f32) -> f32,
-    ) -> Option<f32> {
+    ) -> OptFloat {
         let spanned_tracks = &axis_tracks[self.track_range_excluding_lines(axis)];
         let tracks_all_fixed = spanned_tracks.iter().all(|track| {
             track.max_track_sizing_function.definite_value(axis_parent_size, resolve_calc_value).is_some()
@@ -258,20 +259,16 @@ impl GridItem {
                     track.max_track_sizing_function.definite_value(axis_parent_size, resolve_calc_value).unwrap()
                 })
                 .sum();
-            Some(limit)
+            OptFloat::some(limit)
         } else {
-            None
+            OptFloat::NONE
         }
     }
 
     /// Compute the known_dimensions to be passed to the child sizing functions
     /// The key thing that is being done here is applying stretch alignment, which is necessary to
     /// allow percentage sizes further down the tree to resolve properly in some cases
-    fn known_dimensions(
-        &self,
-        tree: &mut impl LayoutPartialTree,
-        grid_area_size: Size<Option<f32>>,
-    ) -> Size<Option<f32>> {
+    fn known_dimensions(&self, tree: &mut impl LayoutPartialTree, grid_area_size: Size<OptFloat>) -> Size<OptFloat> {
         let margins = self.margins_axis_sums_with_baseline_shims(grid_area_size.width, tree);
 
         let aspect_ratio = self.aspect_ratio;
@@ -315,8 +312,8 @@ impl GridItem {
                     grid_area_minus_item_margins_size.width,
                     grid_area_size.width,
                 ) {
-                    Some(SizingKeywordResolution::Exact(width)) => Some(width),
-                    _ => None,
+                    Some(SizingKeywordResolution::Exact(width)) => OptFloat::some(width),
+                    _ => OptFloat::NONE,
                 };
             }
 
@@ -328,7 +325,7 @@ impl GridItem {
                 return grid_area_minus_item_margins_size.width;
             }
 
-            None
+            OptFloat::NONE
         });
         // Reapply aspect ratio after stretch and absolute position width adjustments
         let Size { width, height } =
@@ -343,8 +340,8 @@ impl GridItem {
                     grid_area_minus_item_margins_size.height,
                     grid_area_size.height,
                 ) {
-                    Some(SizingKeywordResolution::Exact(height)) => Some(height),
-                    _ => None,
+                    Some(SizingKeywordResolution::Exact(height)) => OptFloat::some(height),
+                    _ => OptFloat::NONE,
                 };
             }
 
@@ -356,7 +353,7 @@ impl GridItem {
                 return grid_area_minus_item_margins_size.height;
             }
 
-            None
+            OptFloat::NONE
         });
         // Reapply aspect ratio after stretch and absolute position height adjustments
         let Size { width, height } = Size { width, height }.maybe_apply_aspect_ratio(aspect_ratio);
@@ -386,30 +383,27 @@ impl GridItem {
         axis: AbstractAxis,
         axis_tracks: &[GridTrack],
         other_axis_tracks: &[GridTrack],
-        available_space: Size<Option<f32>>,
-        get_track_size_estimate: impl Fn(&GridTrack, Option<f32>) -> Option<f32>,
+        available_space: Size<OptFloat>,
+        get_track_size_estimate: impl Fn(&GridTrack, OptFloat) -> OptFloat,
         resolve_calc_value: &impl Fn(*const (), f32) -> f32,
-    ) -> Size<Option<f32>> {
+    ) -> Size<OptFloat> {
         let mut size = Size::NONE;
         size.set(
             axis,
             axis_tracks[self.track_range_excluding_lines(axis)]
                 .iter()
                 .map(|track| {
-                    let min_size = track
-                        .min_track_sizing_function
-                        .definite_value(available_space.get(axis), resolve_calc_value)?;
-                    let max_size = track
-                        .max_track_sizing_function
-                        .definite_value(available_space.get(axis), resolve_calc_value)?;
+                    let min_size =
+                        track.min_track_sizing_function.definite_value(available_space.get(axis), resolve_calc_value);
+                    let max_size =
+                        track.max_track_sizing_function.definite_value(available_space.get(axis), resolve_calc_value);
 
-                    if min_size == max_size {
-                        Some(track.base_size)
-                    } else {
-                        None
+                    match (min_size.into_option(), max_size.into_option()) {
+                        (Some(min), Some(max)) if min == max => OptFloat::some(track.base_size),
+                        _ => OptFloat::NONE,
                     }
                 })
-                .sum::<Option<f32>>(),
+                .sum::<OptFloat>(),
         );
 
         size.set(
@@ -420,7 +414,7 @@ impl GridItem {
                     get_track_size_estimate(track, available_space.get(axis.other()))
                         .map(|size| size + track.content_alignment_adjustment)
                 })
-                .sum::<Option<f32>>(),
+                .sum::<OptFloat>(),
         );
 
         size
@@ -432,10 +426,10 @@ impl GridItem {
         axis: AbstractAxis,
         axis_tracks: &[GridTrack],
         other_axis_tracks: &[GridTrack],
-        available_space: Size<Option<f32>>,
-        get_track_size_estimate: impl Fn(&GridTrack, Option<f32>) -> Option<f32>,
+        available_space: Size<OptFloat>,
+        get_track_size_estimate: impl Fn(&GridTrack, OptFloat) -> OptFloat,
         resolve_calc_value: &impl Fn(*const (), f32) -> f32,
-    ) -> Size<Option<f32>> {
+    ) -> Size<OptFloat> {
         self.grid_area_size_cache.unwrap_or_else(|| {
             let grid_area_size = self.grid_area_size(
                 axis,
@@ -455,12 +449,12 @@ impl GridItem {
     #[inline(always)]
     pub fn margins_axis_sums_with_baseline_shims(
         &self,
-        inner_node_width: Option<f32>,
+        inner_node_width: OptFloat,
         tree: &impl LayoutPartialTree,
     ) -> Size<f32> {
         Rect {
-            left: self.margin.left.resolve_or_zero(Some(0.0), |val, basis| tree.calc(val, basis)),
-            right: self.margin.right.resolve_or_zero(Some(0.0), |val, basis| tree.calc(val, basis)),
+            left: self.margin.left.resolve_or_zero(OptFloat::some(0.0), |val, basis| tree.calc(val, basis)),
+            right: self.margin.right.resolve_or_zero(OptFloat::some(0.0), |val, basis| tree.calc(val, basis)),
             top: self.margin.top.resolve_or_zero(inner_node_width, |val, basis| tree.calc(val, basis))
                 + self.baseline_shim,
             bottom: self.margin.bottom.resolve_or_zero(inner_node_width, |val, basis| tree.calc(val, basis)),
@@ -473,8 +467,8 @@ impl GridItem {
         &self,
         axis: AbstractAxis,
         tree: &mut impl LayoutPartialTree,
-        grid_area_size: Size<Option<f32>>,
-        available_space: Size<Option<f32>>,
+        grid_area_size: Size<OptFloat>,
+        available_space: Size<OptFloat>,
     ) -> f32 {
         let known_dimensions = self.known_dimensions(tree, grid_area_size);
         // The child sees the grid area as its containing block during intrinsic measurement, so
@@ -488,10 +482,7 @@ impl GridItem {
             grid_area_size,
             self.keyword_adjusted_available_space(
                 grid_area_size,
-                available_space.map(|opt| match opt {
-                    Some(size) => AvailableSpace::Definite(size),
-                    None => AvailableSpace::MinContent,
-                }),
+                available_space.map(|opt| opt.map_or(AvailableSpace::MinContent, AvailableSpace::Definite)),
                 tree,
             ),
             SizingMode::InherentSize,
@@ -506,12 +497,12 @@ impl GridItem {
         &mut self,
         axis: AbstractAxis,
         tree: &mut impl LayoutPartialTree,
-        grid_area_size: Size<Option<f32>>,
-        available_space: Size<Option<f32>>,
+        grid_area_size: Size<OptFloat>,
+        available_space: Size<OptFloat>,
     ) -> f32 {
         self.min_content_contribution_cache.get(axis).unwrap_or_else(|| {
             let size = self.min_content_contribution(axis, tree, grid_area_size, available_space);
-            self.min_content_contribution_cache.set(axis, Some(size));
+            self.min_content_contribution_cache.set(axis, OptFloat::some(size));
             size
         })
     }
@@ -521,8 +512,8 @@ impl GridItem {
         &self,
         axis: AbstractAxis,
         tree: &mut impl LayoutPartialTree,
-        grid_area_size: Size<Option<f32>>,
-        available_space: Size<Option<f32>>,
+        grid_area_size: Size<OptFloat>,
+        available_space: Size<OptFloat>,
     ) -> f32 {
         let known_dimensions = self.known_dimensions(tree, grid_area_size);
         // See the min-content path above. Max-content measurement uses the same containing-block
@@ -534,10 +525,7 @@ impl GridItem {
             grid_area_size,
             self.keyword_adjusted_available_space(
                 grid_area_size,
-                available_space.map(|opt| match opt {
-                    Some(size) => AvailableSpace::Definite(size),
-                    None => AvailableSpace::MaxContent,
-                }),
+                available_space.map(|opt| opt.map_or(AvailableSpace::MaxContent, AvailableSpace::Definite)),
                 tree,
             ),
             SizingMode::InherentSize,
@@ -551,7 +539,7 @@ impl GridItem {
     /// (min-content, max-content, fit-content, fit-content(...))
     fn keyword_adjusted_available_space(
         &self,
-        grid_area_size: Size<Option<f32>>,
+        grid_area_size: Size<OptFloat>,
         available_space: Size<AvailableSpace>,
         tree: &impl LayoutPartialTree,
     ) -> Size<AvailableSpace> {
@@ -581,12 +569,12 @@ impl GridItem {
         &mut self,
         axis: AbstractAxis,
         tree: &mut impl LayoutPartialTree,
-        grid_area_size: Size<Option<f32>>,
-        available_space: Size<Option<f32>>,
+        grid_area_size: Size<OptFloat>,
+        available_space: Size<OptFloat>,
     ) -> f32 {
         self.max_content_contribution_cache.get(axis).unwrap_or_else(|| {
             let size = self.max_content_contribution(axis, tree, grid_area_size, available_space);
-            self.max_content_contribution_cache.set(axis, Some(size));
+            self.max_content_contribution_cache.set(axis, OptFloat::some(size));
             size
         })
     }
@@ -604,8 +592,8 @@ impl GridItem {
         tree: &mut impl LayoutPartialTree,
         axis: AbstractAxis,
         axis_tracks: &[GridTrack],
-        grid_area_size: Size<Option<f32>>,
-        inner_node_size: Size<Option<f32>>,
+        grid_area_size: Size<OptFloat>,
+        inner_node_size: Size<OptFloat>,
     ) -> f32 {
         let padding = self.padding.resolve_or_zero(grid_area_size.width, |val, basis| tree.calc(val, basis));
         let border = self.border.resolve_or_zero(grid_area_size.width, |val, basis| tree.calc(val, basis));
@@ -657,9 +645,12 @@ impl GridItem {
                     // relevant axis, the size suggestion is capped by those sizes; for this purpose, any indefinite percentages
                     // in these sizes are resolved against zero (and considered definite).
                     if self.is_compressible_replaced {
-                        let size = self.size.get(axis).maybe_resolve(Some(0.0), |val, basis| tree.calc(val, basis));
-                        let max_size =
-                            self.max_size.get(axis).maybe_resolve(Some(0.0), |val, basis| tree.calc(val, basis));
+                        let size =
+                            self.size.get(axis).maybe_resolve(OptFloat::some(0.0), |val, basis| tree.calc(val, basis));
+                        let max_size = self
+                            .max_size
+                            .get(axis)
+                            .maybe_resolve(OptFloat::some(0.0), |val, basis| tree.calc(val, basis));
                         minimum_contribution = minimum_contribution.maybe_min(size).maybe_min(max_size);
                     }
 
@@ -685,12 +676,12 @@ impl GridItem {
         tree: &mut impl LayoutPartialTree,
         axis: AbstractAxis,
         axis_tracks: &[GridTrack],
-        grid_area_size: Size<Option<f32>>,
-        inner_node_size: Size<Option<f32>>,
+        grid_area_size: Size<OptFloat>,
+        inner_node_size: Size<OptFloat>,
     ) -> f32 {
         self.minimum_contribution_cache.get(axis).unwrap_or_else(|| {
             let size = self.minimum_contribution(tree, axis, axis_tracks, grid_area_size, inner_node_size);
-            self.minimum_contribution_cache.set(axis, Some(size));
+            self.minimum_contribution_cache.set(axis, OptFloat::some(size));
             size
         })
     }

--- a/src/compute/grid/types/grid_item.rs
+++ b/src/compute/grid/types/grid_item.rs
@@ -6,7 +6,7 @@ use crate::geometry::AbstractAxis;
 use crate::geometry::{Line, Point, Rect, Size};
 use crate::style::{AlignItems, AlignSelf, AvailableSpace, Dimension, LengthPercentageAuto, Overflow};
 use crate::tree::{LayoutPartialTree, LayoutPartialTreeExt, NodeId, SizingMode};
-use crate::util::OptFloat;
+use crate::util::OptF32;
 use crate::util::{MaybeMath, MaybeResolve, ResolveOrZero};
 use crate::{AlignItemsKeyword, BoxSizing, GridItemStyle, LengthPercentage};
 use core::ops::Range;
@@ -56,7 +56,7 @@ pub(in super::super) struct GridItem {
     /// The item's justify_self property, or the parent's justify_items property is not set
     pub justify_self: AlignSelf,
     /// The items first baseline (horizontal)
-    pub baseline: OptFloat,
+    pub baseline: OptF32,
     /// Shim for baseline alignment that acts like an extra top margin
     /// TODO: Support last baseline and vertical text baselines
     pub baseline_shim: f32,
@@ -79,13 +79,13 @@ pub(in super::super) struct GridItem {
 
     // Caches for intrinsic size computation. These caches are only valid for a single run of the track-sizing algorithm.
     /// Cache for the known_dimensions input to intrinsic sizing computation
-    pub grid_area_size_cache: Option<Size<OptFloat>>,
+    pub grid_area_size_cache: Option<Size<OptF32>>,
     /// Cache for the min-content size
-    pub min_content_contribution_cache: Size<OptFloat>,
+    pub min_content_contribution_cache: Size<OptF32>,
     /// Cache for the minimum contribution
-    pub minimum_contribution_cache: Size<OptFloat>,
+    pub minimum_contribution_cache: Size<OptF32>,
     /// Cache for the max-content size
-    pub max_content_contribution_cache: Size<OptFloat>,
+    pub max_content_contribution_cache: Size<OptF32>,
 
     /// Final y position. Used to compute baseline alignment for the container.
     pub y_position: f32,
@@ -121,7 +121,7 @@ impl GridItem {
             margin: style.margin(),
             align_self: style.align_self().unwrap_or(parent_align_items),
             justify_self: style.justify_self().unwrap_or(parent_justify_items),
-            baseline: OptFloat::NONE,
+            baseline: OptF32::NONE,
             baseline_shim: 0.0,
             row_indexes: Line { start: 0, end: 0 }, // Properly initialised later
             column_indexes: Line { start: 0, end: 0 }, // Properly initialised later
@@ -219,9 +219,9 @@ impl GridItem {
         &mut self,
         axis: AbstractAxis,
         axis_tracks: &[GridTrack],
-        axis_parent_size: OptFloat,
+        axis_parent_size: OptF32,
         resolve_calc_value: &dyn Fn(*const (), f32) -> f32,
-    ) -> OptFloat {
+    ) -> OptF32 {
         let spanned_tracks = &axis_tracks[self.track_range_excluding_lines(axis)];
         let tracks_all_fixed = spanned_tracks.iter().all(|track| {
             track.max_track_sizing_function.definite_limit(axis_parent_size, resolve_calc_value).is_some()
@@ -233,9 +233,9 @@ impl GridItem {
                     track.max_track_sizing_function.definite_limit(axis_parent_size, resolve_calc_value).unwrap()
                 })
                 .sum();
-            OptFloat::some(limit)
+            OptF32::some(limit)
         } else {
-            OptFloat::NONE
+            OptF32::NONE
         }
     }
 
@@ -245,9 +245,9 @@ impl GridItem {
         &mut self,
         axis: AbstractAxis,
         axis_tracks: &[GridTrack],
-        axis_parent_size: OptFloat,
+        axis_parent_size: OptF32,
         resolve_calc_value: &dyn Fn(*const (), f32) -> f32,
-    ) -> OptFloat {
+    ) -> OptF32 {
         let spanned_tracks = &axis_tracks[self.track_range_excluding_lines(axis)];
         let tracks_all_fixed = spanned_tracks.iter().all(|track| {
             track.max_track_sizing_function.definite_value(axis_parent_size, resolve_calc_value).is_some()
@@ -259,16 +259,16 @@ impl GridItem {
                     track.max_track_sizing_function.definite_value(axis_parent_size, resolve_calc_value).unwrap()
                 })
                 .sum();
-            OptFloat::some(limit)
+            OptF32::some(limit)
         } else {
-            OptFloat::NONE
+            OptF32::NONE
         }
     }
 
     /// Compute the known_dimensions to be passed to the child sizing functions
     /// The key thing that is being done here is applying stretch alignment, which is necessary to
     /// allow percentage sizes further down the tree to resolve properly in some cases
-    fn known_dimensions(&self, tree: &mut impl LayoutPartialTree, grid_area_size: Size<OptFloat>) -> Size<OptFloat> {
+    fn known_dimensions(&self, tree: &mut impl LayoutPartialTree, grid_area_size: Size<OptF32>) -> Size<OptF32> {
         let margins = self.margins_axis_sums_with_baseline_shims(grid_area_size.width, tree);
 
         let aspect_ratio = self.aspect_ratio;
@@ -312,8 +312,8 @@ impl GridItem {
                     grid_area_minus_item_margins_size.width,
                     grid_area_size.width,
                 ) {
-                    Some(SizingKeywordResolution::Exact(width)) => OptFloat::some(width),
-                    _ => OptFloat::NONE,
+                    Some(SizingKeywordResolution::Exact(width)) => OptF32::some(width),
+                    _ => OptF32::NONE,
                 };
             }
 
@@ -325,7 +325,7 @@ impl GridItem {
                 return grid_area_minus_item_margins_size.width;
             }
 
-            OptFloat::NONE
+            OptF32::NONE
         });
         // Reapply aspect ratio after stretch and absolute position width adjustments
         let Size { width, height } =
@@ -340,8 +340,8 @@ impl GridItem {
                     grid_area_minus_item_margins_size.height,
                     grid_area_size.height,
                 ) {
-                    Some(SizingKeywordResolution::Exact(height)) => OptFloat::some(height),
-                    _ => OptFloat::NONE,
+                    Some(SizingKeywordResolution::Exact(height)) => OptF32::some(height),
+                    _ => OptF32::NONE,
                 };
             }
 
@@ -353,7 +353,7 @@ impl GridItem {
                 return grid_area_minus_item_margins_size.height;
             }
 
-            OptFloat::NONE
+            OptF32::NONE
         });
         // Reapply aspect ratio after stretch and absolute position height adjustments
         let Size { width, height } = Size { width, height }.maybe_apply_aspect_ratio(aspect_ratio);
@@ -383,10 +383,10 @@ impl GridItem {
         axis: AbstractAxis,
         axis_tracks: &[GridTrack],
         other_axis_tracks: &[GridTrack],
-        available_space: Size<OptFloat>,
-        get_track_size_estimate: impl Fn(&GridTrack, OptFloat) -> OptFloat,
+        available_space: Size<OptF32>,
+        get_track_size_estimate: impl Fn(&GridTrack, OptF32) -> OptF32,
         resolve_calc_value: &impl Fn(*const (), f32) -> f32,
-    ) -> Size<OptFloat> {
+    ) -> Size<OptF32> {
         let mut size = Size::NONE;
         size.set(
             axis,
@@ -399,11 +399,11 @@ impl GridItem {
                         track.max_track_sizing_function.definite_value(available_space.get(axis), resolve_calc_value);
 
                     match (min_size.into_option(), max_size.into_option()) {
-                        (Some(min), Some(max)) if min == max => OptFloat::some(track.base_size),
-                        _ => OptFloat::NONE,
+                        (Some(min), Some(max)) if min == max => OptF32::some(track.base_size),
+                        _ => OptF32::NONE,
                     }
                 })
-                .sum::<OptFloat>(),
+                .sum::<OptF32>(),
         );
 
         size.set(
@@ -414,7 +414,7 @@ impl GridItem {
                     get_track_size_estimate(track, available_space.get(axis.other()))
                         .map(|size| size + track.content_alignment_adjustment)
                 })
-                .sum::<OptFloat>(),
+                .sum::<OptF32>(),
         );
 
         size
@@ -426,10 +426,10 @@ impl GridItem {
         axis: AbstractAxis,
         axis_tracks: &[GridTrack],
         other_axis_tracks: &[GridTrack],
-        available_space: Size<OptFloat>,
-        get_track_size_estimate: impl Fn(&GridTrack, OptFloat) -> OptFloat,
+        available_space: Size<OptF32>,
+        get_track_size_estimate: impl Fn(&GridTrack, OptF32) -> OptF32,
         resolve_calc_value: &impl Fn(*const (), f32) -> f32,
-    ) -> Size<OptFloat> {
+    ) -> Size<OptF32> {
         self.grid_area_size_cache.unwrap_or_else(|| {
             let grid_area_size = self.grid_area_size(
                 axis,
@@ -449,12 +449,12 @@ impl GridItem {
     #[inline(always)]
     pub fn margins_axis_sums_with_baseline_shims(
         &self,
-        inner_node_width: OptFloat,
+        inner_node_width: OptF32,
         tree: &impl LayoutPartialTree,
     ) -> Size<f32> {
         Rect {
-            left: self.margin.left.resolve_or_zero(OptFloat::some(0.0), |val, basis| tree.calc(val, basis)),
-            right: self.margin.right.resolve_or_zero(OptFloat::some(0.0), |val, basis| tree.calc(val, basis)),
+            left: self.margin.left.resolve_or_zero(OptF32::some(0.0), |val, basis| tree.calc(val, basis)),
+            right: self.margin.right.resolve_or_zero(OptF32::some(0.0), |val, basis| tree.calc(val, basis)),
             top: self.margin.top.resolve_or_zero(inner_node_width, |val, basis| tree.calc(val, basis))
                 + self.baseline_shim,
             bottom: self.margin.bottom.resolve_or_zero(inner_node_width, |val, basis| tree.calc(val, basis)),
@@ -467,8 +467,8 @@ impl GridItem {
         &self,
         axis: AbstractAxis,
         tree: &mut impl LayoutPartialTree,
-        grid_area_size: Size<OptFloat>,
-        available_space: Size<OptFloat>,
+        grid_area_size: Size<OptF32>,
+        available_space: Size<OptF32>,
     ) -> f32 {
         let known_dimensions = self.known_dimensions(tree, grid_area_size);
         // The child sees the grid area as its containing block during intrinsic measurement, so
@@ -497,12 +497,12 @@ impl GridItem {
         &mut self,
         axis: AbstractAxis,
         tree: &mut impl LayoutPartialTree,
-        grid_area_size: Size<OptFloat>,
-        available_space: Size<OptFloat>,
+        grid_area_size: Size<OptF32>,
+        available_space: Size<OptF32>,
     ) -> f32 {
         self.min_content_contribution_cache.get(axis).unwrap_or_else(|| {
             let size = self.min_content_contribution(axis, tree, grid_area_size, available_space);
-            self.min_content_contribution_cache.set(axis, OptFloat::some(size));
+            self.min_content_contribution_cache.set(axis, OptF32::some(size));
             size
         })
     }
@@ -512,8 +512,8 @@ impl GridItem {
         &self,
         axis: AbstractAxis,
         tree: &mut impl LayoutPartialTree,
-        grid_area_size: Size<OptFloat>,
-        available_space: Size<OptFloat>,
+        grid_area_size: Size<OptF32>,
+        available_space: Size<OptF32>,
     ) -> f32 {
         let known_dimensions = self.known_dimensions(tree, grid_area_size);
         // See the min-content path above. Max-content measurement uses the same containing-block
@@ -539,7 +539,7 @@ impl GridItem {
     /// (min-content, max-content, fit-content, fit-content(...))
     fn keyword_adjusted_available_space(
         &self,
-        grid_area_size: Size<OptFloat>,
+        grid_area_size: Size<OptF32>,
         available_space: Size<AvailableSpace>,
         tree: &impl LayoutPartialTree,
     ) -> Size<AvailableSpace> {
@@ -569,12 +569,12 @@ impl GridItem {
         &mut self,
         axis: AbstractAxis,
         tree: &mut impl LayoutPartialTree,
-        grid_area_size: Size<OptFloat>,
-        available_space: Size<OptFloat>,
+        grid_area_size: Size<OptF32>,
+        available_space: Size<OptF32>,
     ) -> f32 {
         self.max_content_contribution_cache.get(axis).unwrap_or_else(|| {
             let size = self.max_content_contribution(axis, tree, grid_area_size, available_space);
-            self.max_content_contribution_cache.set(axis, OptFloat::some(size));
+            self.max_content_contribution_cache.set(axis, OptF32::some(size));
             size
         })
     }
@@ -592,8 +592,8 @@ impl GridItem {
         tree: &mut impl LayoutPartialTree,
         axis: AbstractAxis,
         axis_tracks: &[GridTrack],
-        grid_area_size: Size<OptFloat>,
-        inner_node_size: Size<OptFloat>,
+        grid_area_size: Size<OptF32>,
+        inner_node_size: Size<OptF32>,
     ) -> f32 {
         let padding = self.padding.resolve_or_zero(grid_area_size.width, |val, basis| tree.calc(val, basis));
         let border = self.border.resolve_or_zero(grid_area_size.width, |val, basis| tree.calc(val, basis));
@@ -646,11 +646,11 @@ impl GridItem {
                     // in these sizes are resolved against zero (and considered definite).
                     if self.is_compressible_replaced {
                         let size =
-                            self.size.get(axis).maybe_resolve(OptFloat::some(0.0), |val, basis| tree.calc(val, basis));
+                            self.size.get(axis).maybe_resolve(OptF32::some(0.0), |val, basis| tree.calc(val, basis));
                         let max_size = self
                             .max_size
                             .get(axis)
-                            .maybe_resolve(OptFloat::some(0.0), |val, basis| tree.calc(val, basis));
+                            .maybe_resolve(OptF32::some(0.0), |val, basis| tree.calc(val, basis));
                         minimum_contribution = minimum_contribution.maybe_min(size).maybe_min(max_size);
                     }
 
@@ -676,12 +676,12 @@ impl GridItem {
         tree: &mut impl LayoutPartialTree,
         axis: AbstractAxis,
         axis_tracks: &[GridTrack],
-        grid_area_size: Size<OptFloat>,
-        inner_node_size: Size<OptFloat>,
+        grid_area_size: Size<OptF32>,
+        inner_node_size: Size<OptF32>,
     ) -> f32 {
         self.minimum_contribution_cache.get(axis).unwrap_or_else(|| {
             let size = self.minimum_contribution(tree, axis, axis_tracks, grid_area_size, inner_node_size);
-            self.minimum_contribution_cache.set(axis, OptFloat::some(size));
+            self.minimum_contribution_cache.set(axis, OptF32::some(size));
             size
         })
     }

--- a/src/compute/grid/types/grid_track.rs
+++ b/src/compute/grid/types/grid_track.rs
@@ -1,5 +1,5 @@
 //! Contains GridTrack used to represent a single grid track (row/column) during layout
-use crate::util::OptFloat;
+use crate::util::OptF32;
 use crate::{
     prelude::TaffyZero,
     style::{LengthPercentage, MaxTrackSizingFunction, MinTrackSizingFunction},
@@ -128,7 +128,7 @@ impl GridTrack {
 
     #[inline]
     /// Returns true if the track is flexible (has a Flex MaxTrackSizingFunction), else false.
-    pub fn fit_content_limit(&self, axis_available_grid_space: OptFloat) -> f32 {
+    pub fn fit_content_limit(&self, axis_available_grid_space: OptF32) -> f32 {
         match self.max_track_sizing_function.0.tag() {
             CompactLength::FIT_CONTENT_PX_TAG => self.max_track_sizing_function.0.value(),
             CompactLength::FIT_CONTENT_PERCENT_TAG => axis_available_grid_space
@@ -139,7 +139,7 @@ impl GridTrack {
 
     #[inline]
     /// Returns true if the track is flexible (has a Flex MaxTrackSizingFunction), else false.
-    pub fn fit_content_limited_growth_limit(&self, axis_available_grid_space: OptFloat) -> f32 {
+    pub fn fit_content_limited_growth_limit(&self, axis_available_grid_space: OptF32) -> f32 {
         f32_min(self.growth_limit, self.fit_content_limit(axis_available_grid_space))
     }
 

--- a/src/compute/grid/types/grid_track.rs
+++ b/src/compute/grid/types/grid_track.rs
@@ -1,4 +1,5 @@
 //! Contains GridTrack used to represent a single grid track (row/column) during layout
+use crate::util::OptFloat;
 use crate::{
     prelude::TaffyZero,
     style::{LengthPercentage, MaxTrackSizingFunction, MinTrackSizingFunction},
@@ -127,20 +128,18 @@ impl GridTrack {
 
     #[inline]
     /// Returns true if the track is flexible (has a Flex MaxTrackSizingFunction), else false.
-    pub fn fit_content_limit(&self, axis_available_grid_space: Option<f32>) -> f32 {
+    pub fn fit_content_limit(&self, axis_available_grid_space: OptFloat) -> f32 {
         match self.max_track_sizing_function.0.tag() {
             CompactLength::FIT_CONTENT_PX_TAG => self.max_track_sizing_function.0.value(),
-            CompactLength::FIT_CONTENT_PERCENT_TAG => match axis_available_grid_space {
-                Some(space) => space * self.max_track_sizing_function.0.value(),
-                None => f32::INFINITY,
-            },
+            CompactLength::FIT_CONTENT_PERCENT_TAG => axis_available_grid_space
+                .map_or(f32::INFINITY, |space| space * self.max_track_sizing_function.0.value()),
             _ => f32::INFINITY,
         }
     }
 
     #[inline]
     /// Returns true if the track is flexible (has a Flex MaxTrackSizingFunction), else false.
-    pub fn fit_content_limited_growth_limit(&self, axis_available_grid_space: Option<f32>) -> f32 {
+    pub fn fit_content_limited_growth_limit(&self, axis_available_grid_space: OptFloat) -> f32 {
         f32_min(self.growth_limit, self.fit_content_limit(axis_available_grid_space))
     }
 

--- a/src/compute/leaf.rs
+++ b/src/compute/leaf.rs
@@ -117,8 +117,8 @@ where
             .width
             .map_or(available_space.width, AvailableSpace::from)
             .maybe_sub(margin.horizontal_axis_sum())
-            .maybe_sub(known_dimensions.width)
-            .maybe_sub(node_size.width)
+            .maybe_set(known_dimensions.width)
+            .maybe_set(node_size.width)
             .map_definite_value(|size| {
                 size.maybe_clamp(node_min_size.width, node_max_size.width) - content_box_inset.horizontal_axis_sum()
             }),
@@ -126,8 +126,8 @@ where
             .height
             .map_or(available_space.height, AvailableSpace::from)
             .maybe_sub(margin.vertical_axis_sum())
-            .maybe_sub(known_dimensions.height)
-            .maybe_sub(node_size.height)
+            .maybe_set(known_dimensions.height)
+            .maybe_set(node_size.height)
             .map_definite_value(|size| {
                 size.maybe_clamp(node_min_size.height, node_max_size.height) - content_box_inset.vertical_axis_sum()
             }),

--- a/src/compute/leaf.rs
+++ b/src/compute/leaf.rs
@@ -8,7 +8,7 @@ use crate::tree::{LayoutInput, LayoutOutput, SizingMode};
 use crate::util::debug::debug_log;
 use crate::util::sys::f32_max;
 use crate::util::MaybeMath;
-use crate::util::OptFloat;
+use crate::util::OptF32;
 use crate::util::{MaybeResolve, ResolveOrZero};
 use crate::{BoxSizing, CoreStyle};
 use core::unreachable;
@@ -21,7 +21,7 @@ pub fn compute_leaf_layout<MeasureFunction>(
     measure_function: MeasureFunction,
 ) -> LayoutOutput
 where
-    MeasureFunction: FnOnce(Size<OptFloat>, Size<AvailableSpace>) -> Size<f32>,
+    MeasureFunction: FnOnce(Size<OptF32>, Size<AvailableSpace>) -> Size<f32>,
 {
     let LayoutInput { known_dimensions, parent_size, available_space, sizing_mode, run_mode, .. } = inputs;
 
@@ -97,7 +97,7 @@ where
         if let Size { width: Some(width), height: Some(height) } = node_size.into_options() {
             let size = Size { width, height }
                 .maybe_clamp(node_min_size, node_max_size)
-                .maybe_max(padding_border.sum_axes().map(OptFloat::some));
+                .maybe_max(padding_border.sum_axes().map(OptF32::some));
             return LayoutOutput {
                 size,
                 #[cfg(feature = "content_size")]
@@ -149,7 +149,7 @@ where
         width: clamped_size.width,
         height: f32_max(clamped_size.height, aspect_ratio.map(|ratio| clamped_size.width / ratio).unwrap_or(0.0)),
     };
-    let size = size.maybe_max(padding_border.sum_axes().map(OptFloat::some));
+    let size = size.maybe_max(padding_border.sum_axes().map(OptF32::some));
 
     // A scroll container's own padding at the end of the content is part of its scrollable
     // overflow region, so it is included in the overflow rect. Boxes that are not scroll

--- a/src/compute/leaf.rs
+++ b/src/compute/leaf.rs
@@ -1,6 +1,5 @@
 //! Computes size using styles and measure functions
 
-#[cfg(feature = "content_size")]
 use crate::geometry::Rect;
 use crate::geometry::Size;
 use crate::style::{AvailableSpace, Overflow, Position};
@@ -9,6 +8,8 @@ use crate::tree::{LayoutInput, LayoutOutput, SizingMode};
 use crate::util::debug::debug_log;
 use crate::util::sys::f32_max;
 use crate::util::MaybeMath;
+#[cfg(feature = "content_size")]
+use crate::util::OptFloat;
 use crate::util::{MaybeResolve, ResolveOrZero};
 use crate::{BoxSizing, CoreStyle};
 use core::unreachable;
@@ -21,7 +22,7 @@ pub fn compute_leaf_layout<MeasureFunction>(
     measure_function: MeasureFunction,
 ) -> LayoutOutput
 where
-    MeasureFunction: FnOnce(Size<Option<f32>>, Size<AvailableSpace>) -> Size<f32>,
+    MeasureFunction: FnOnce(Size<OptFloat>, Size<AvailableSpace>) -> Size<f32>,
 {
     let LayoutInput { known_dimensions, parent_size, available_space, sizing_mode, run_mode, .. } = inputs;
 
@@ -84,8 +85,8 @@ where
         || padding.bottom > 0.0
         || border.top > 0.0
         || border.bottom > 0.0
-        || matches!(node_size.height, Some(h) if h > 0.0)
-        || matches!(node_min_size.height, Some(h) if h > 0.0);
+        || matches!(node_size.height.into_option(), Some(h) if h > 0.0)
+        || matches!(node_min_size.height.into_option(), Some(h) if h > 0.0);
 
     debug_log!("LEAF");
     debug_log!("node_size", dbg:node_size);
@@ -94,10 +95,10 @@ where
 
     // Return early if both width and height are known
     if run_mode == RunMode::ComputeSize && has_styles_preventing_being_collapsed_through {
-        if let Size { width: Some(width), height: Some(height) } = node_size {
+        if let Size { width: Some(width), height: Some(height) } = node_size.into_options() {
             let size = Size { width, height }
                 .maybe_clamp(node_min_size, node_max_size)
-                .maybe_max(padding_border.sum_axes().map(Some));
+                .maybe_max(padding_border.sum_axes().map(OptFloat::some));
             return LayoutOutput {
                 size,
                 #[cfg(feature = "content_size")]
@@ -114,21 +115,19 @@ where
     let available_space = Size {
         width: known_dimensions
             .width
-            .map(AvailableSpace::from)
-            .unwrap_or(available_space.width)
+            .map_or(available_space.width, AvailableSpace::from)
             .maybe_sub(margin.horizontal_axis_sum())
-            .maybe_set(known_dimensions.width)
-            .maybe_set(node_size.width)
+            .maybe_sub(known_dimensions.width)
+            .maybe_sub(node_size.width)
             .map_definite_value(|size| {
                 size.maybe_clamp(node_min_size.width, node_max_size.width) - content_box_inset.horizontal_axis_sum()
             }),
         height: known_dimensions
             .height
-            .map(AvailableSpace::from)
-            .unwrap_or(available_space.height)
+            .map_or(available_space.height, AvailableSpace::from)
             .maybe_sub(margin.vertical_axis_sum())
-            .maybe_set(known_dimensions.height)
-            .maybe_set(node_size.height)
+            .maybe_sub(known_dimensions.height)
+            .maybe_sub(node_size.height)
             .map_definite_value(|size| {
                 size.maybe_clamp(node_min_size.height, node_max_size.height) - content_box_inset.vertical_axis_sum()
             }),
@@ -151,7 +150,7 @@ where
         width: clamped_size.width,
         height: f32_max(clamped_size.height, aspect_ratio.map(|ratio| clamped_size.width / ratio).unwrap_or(0.0)),
     };
-    let size = size.maybe_max(padding_border.sum_axes().map(Some));
+    let size = size.maybe_max(padding_border.sum_axes().map(OptFloat::some));
 
     // A scroll container's own padding at the end of the content is part of its scrollable
     // overflow region, so it is included in the overflow rect. Boxes that are not scroll

--- a/src/compute/leaf.rs
+++ b/src/compute/leaf.rs
@@ -8,7 +8,6 @@ use crate::tree::{LayoutInput, LayoutOutput, SizingMode};
 use crate::util::debug::debug_log;
 use crate::util::sys::f32_max;
 use crate::util::MaybeMath;
-#[cfg(feature = "content_size")]
 use crate::util::OptFloat;
 use crate::util::{MaybeResolve, ResolveOrZero};
 use crate::{BoxSizing, CoreStyle};

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -57,7 +57,7 @@ use crate::tree::{
 };
 use crate::util::debug::{debug_log, debug_log_node, debug_pop_node, debug_push_node};
 use crate::util::sys::round;
-use crate::util::{OptFloat, ResolveOrZero};
+use crate::util::{OptF32, ResolveOrZero};
 use crate::{CacheTree, MaybeMath, MaybeResolve};
 
 /// Compute layout for the root node in the tree
@@ -101,14 +101,14 @@ pub fn compute_root_layout(tree: &mut impl LayoutPartialTree, root: NodeId, avai
             // If both min and max in a given axis are set and max <= min then this determines the size in that axis
             let min_max_definite_size =
                 min_size.zip_map(max_size, |min, max| match (min.into_option(), max.into_option()) {
-                    (Some(min), Some(max)) if max <= min => OptFloat::some(min),
-                    _ => OptFloat::NONE,
+                    (Some(min), Some(max)) if max <= min => OptF32::some(min),
+                    _ => OptF32::NONE,
                 });
 
             // Block nodes automatically stretch fit their width to fit available space if available space is definite
             let available_space_based_size = Size {
                 width: available_space.width.into_option().maybe_sub(margin.horizontal_axis_sum()),
-                height: OptFloat::NONE,
+                height: OptF32::NONE,
             };
 
             let styled_based_known_dimensions = known_dimensions

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -57,7 +57,7 @@ use crate::tree::{
 };
 use crate::util::debug::{debug_log, debug_log_node, debug_pop_node, debug_push_node};
 use crate::util::sys::round;
-use crate::util::ResolveOrZero;
+use crate::util::{OptFloat, ResolveOrZero};
 use crate::{CacheTree, MaybeMath, MaybeResolve};
 
 /// Compute layout for the root node in the tree
@@ -99,15 +99,16 @@ pub fn compute_root_layout(tree: &mut impl LayoutPartialTree, root: NodeId, avai
                 .maybe_clamp(min_size, max_size);
 
             // If both min and max in a given axis are set and max <= min then this determines the size in that axis
-            let min_max_definite_size = min_size.zip_map(max_size, |min, max| match (min, max) {
-                (Some(min), Some(max)) if max <= min => Some(min),
-                _ => None,
-            });
+            let min_max_definite_size =
+                min_size.zip_map(max_size, |min, max| match (min.into_option(), max.into_option()) {
+                    (Some(min), Some(max)) if max <= min => OptFloat::some(min),
+                    _ => OptFloat::NONE,
+                });
 
             // Block nodes automatically stretch fit their width to fit available space if available space is definite
             let available_space_based_size = Size {
                 width: available_space.width.into_option().maybe_sub(margin.horizontal_axis_sum()),
-                height: None,
+                height: OptFloat::NONE,
             };
 
             let styled_based_known_dimensions = known_dimensions

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -1,6 +1,7 @@
 //! Geometric primitives useful for layout
 
 use crate::util::sys::f32_max;
+use crate::util::OptFloat;
 use crate::CompactLength;
 use crate::{style::Dimension, util::sys::f32_min};
 use core::ops::{Add, Sub};
@@ -574,19 +575,19 @@ impl Size<f32> {
     }
 }
 
-impl Size<Option<f32>> {
+impl Size<OptFloat> {
     /// A [`Size`] with `None` width and height
-    pub const NONE: Size<Option<f32>> = Self { width: None, height: None };
+    pub const NONE: Size<OptFloat> = Self { width: OptFloat::NONE, height: OptFloat::NONE };
 
-    /// A [`Size<Option<f32>>`] with `Some(width)` and `Some(height)` as parameters
+    /// A [`Size<OptFloat>`] with "some" `width` and `height` as parameters
     #[must_use]
     pub const fn new(width: f32, height: f32) -> Self {
-        Size { width: Some(width), height: Some(height) }
+        Size { width: OptFloat::some(width), height: OptFloat::some(height) }
     }
 
-    /// Creates a new [`Size<Option<f32>>`] with either the width or height set based on the provided `direction`
+    /// Creates a new [`Size<OptFloat>`] with either the width or height set based on the provided `direction`
     #[cfg(feature = "flexbox")]
-    pub const fn from_cross(direction: FlexDirection, value: Option<f32>) -> Self {
+    pub const fn from_cross(direction: FlexDirection, value: OptFloat) -> Self {
         let mut new = Self::NONE;
         if direction.is_row() {
             new.height = value
@@ -597,19 +598,59 @@ impl Size<Option<f32>> {
     }
 
     /// Applies aspect_ratio (if one is supplied) to the Size:
-    ///   - If width is `Some` but height is `None`, then height is computed from width and aspect_ratio
-    ///   - If height is `Some` but width is `None`, then width is computed from height and aspect_ratio
+    ///   - If width is "some" but height is `None`, then height is computed from width and aspect_ratio
+    ///   - If height is "some" but width is `None`, then width is computed from height and aspect_ratio
     ///
     /// If aspect_ratio is `None` then this function simply returns self.
-    pub fn maybe_apply_aspect_ratio(self, aspect_ratio: Option<f32>) -> Size<Option<f32>> {
+    pub fn maybe_apply_aspect_ratio(self, aspect_ratio: Option<f32>) -> Size<OptFloat> {
         match aspect_ratio {
-            Some(ratio) => match (self.width, self.height) {
-                (Some(width), None) => Size { width: Some(width), height: Some(width / ratio) },
-                (None, Some(height)) => Size { width: Some(height * ratio), height: Some(height) },
+            Some(ratio) => match (self.width.is_some(), self.height.is_some()) {
+                (true, false) => {
+                    Size { width: self.width, height: OptFloat::some(self.width.unchecked_value() / ratio) }
+                }
+                (false, true) => {
+                    Size { width: OptFloat::some(self.height.unchecked_value() * ratio), height: self.height }
+                }
                 _ => self,
             },
             None => self,
         }
+    }
+
+    /// Performs `OptFloat::unwrap_or` on each component separately
+    pub fn unwrap_or(self, alt: Size<f32>) -> Size<f32> {
+        Size { width: self.width.unwrap_or(alt.width), height: self.height.unwrap_or(alt.height) }
+    }
+
+    /// Performs `OptFloat::or` on each component separately
+    pub fn or(self, alt: Size<OptFloat>) -> Size<OptFloat> {
+        Size { width: self.width.or(alt.width), height: self.height.or(alt.height) }
+    }
+
+    /// Return true if both components are "some", else false.
+    #[inline(always)]
+    pub fn both_axis_defined(&self) -> bool {
+        self.width.is_some() && self.height.is_some()
+    }
+
+    /// Converts to a `Size<Option<f32>>`
+    #[inline(always)]
+    pub fn into_options(self) -> Size<Option<f32>> {
+        Size { width: self.width.into_option(), height: self.height.into_option() }
+    }
+}
+
+impl From<Size<Option<f32>>> for Size<OptFloat> {
+    #[inline(always)]
+    fn from(size: Size<Option<f32>>) -> Self {
+        Size { width: size.width.into(), height: size.height.into() }
+    }
+}
+
+impl From<Size<OptFloat>> for Size<Option<f32>> {
+    #[inline(always)]
+    fn from(size: Size<OptFloat>) -> Self {
+        size.into_options()
     }
 }
 
@@ -622,12 +663,6 @@ impl<T> Size<Option<T>> {
     /// Performs Option::or on each component separately
     pub fn or(self, alt: Size<Option<T>>) -> Size<Option<T>> {
         Size { width: self.width.or(alt.width), height: self.height.or(alt.height) }
-    }
-
-    /// Return true if both components are Some, else false.
-    #[inline(always)]
-    pub fn both_axis_defined(&self) -> bool {
-        self.width.is_some() && self.height.is_some()
     }
 }
 
@@ -662,9 +697,9 @@ impl Point<f32> {
     pub const ZERO: Self = Self { x: 0.0, y: 0.0 };
 }
 
-impl Point<Option<f32>> {
+impl Point<OptFloat> {
     /// A [`Point`] with values (None, None)
-    pub const NONE: Self = Self { x: None, y: None };
+    pub const NONE: Self = Self { x: OptFloat::NONE, y: OptFloat::NONE };
 }
 
 // Generic Add impl for Point<T> + Point<U> where T + U has an Add impl

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -1,7 +1,7 @@
 //! Geometric primitives useful for layout
 
 use crate::util::sys::f32_max;
-use crate::util::OptFloat;
+use crate::util::OptF32;
 use crate::CompactLength;
 use crate::{style::Dimension, util::sys::f32_min};
 use core::ops::{Add, Sub};
@@ -575,19 +575,19 @@ impl Size<f32> {
     }
 }
 
-impl Size<OptFloat> {
+impl Size<OptF32> {
     /// A [`Size`] with `None` width and height
-    pub const NONE: Size<OptFloat> = Self { width: OptFloat::NONE, height: OptFloat::NONE };
+    pub const NONE: Size<OptF32> = Self { width: OptF32::NONE, height: OptF32::NONE };
 
-    /// A [`Size<OptFloat>`] with "some" `width` and `height` as parameters
+    /// A [`Size<OptF32>`] with "some" `width` and `height` as parameters
     #[must_use]
     pub const fn new(width: f32, height: f32) -> Self {
-        Size { width: OptFloat::some(width), height: OptFloat::some(height) }
+        Size { width: OptF32::some(width), height: OptF32::some(height) }
     }
 
-    /// Creates a new [`Size<OptFloat>`] with either the width or height set based on the provided `direction`
+    /// Creates a new [`Size<OptF32>`] with either the width or height set based on the provided `direction`
     #[cfg(feature = "flexbox")]
-    pub const fn from_cross(direction: FlexDirection, value: OptFloat) -> Self {
+    pub const fn from_cross(direction: FlexDirection, value: OptF32) -> Self {
         let mut new = Self::NONE;
         if direction.is_row() {
             new.height = value
@@ -602,14 +602,12 @@ impl Size<OptFloat> {
     ///   - If height is "some" but width is `None`, then width is computed from height and aspect_ratio
     ///
     /// If aspect_ratio is `None` then this function simply returns self.
-    pub fn maybe_apply_aspect_ratio(self, aspect_ratio: Option<f32>) -> Size<OptFloat> {
+    pub fn maybe_apply_aspect_ratio(self, aspect_ratio: Option<f32>) -> Size<OptF32> {
         match aspect_ratio {
             Some(ratio) => match (self.width.is_some(), self.height.is_some()) {
-                (true, false) => {
-                    Size { width: self.width, height: OptFloat::some(self.width.unchecked_value() / ratio) }
-                }
+                (true, false) => Size { width: self.width, height: OptF32::some(self.width.unchecked_value() / ratio) },
                 (false, true) => {
-                    Size { width: OptFloat::some(self.height.unchecked_value() * ratio), height: self.height }
+                    Size { width: OptF32::some(self.height.unchecked_value() * ratio), height: self.height }
                 }
                 _ => self,
             },
@@ -617,13 +615,13 @@ impl Size<OptFloat> {
         }
     }
 
-    /// Performs `OptFloat::unwrap_or` on each component separately
+    /// Performs `OptF32::unwrap_or` on each component separately
     pub fn unwrap_or(self, alt: Size<f32>) -> Size<f32> {
         Size { width: self.width.unwrap_or(alt.width), height: self.height.unwrap_or(alt.height) }
     }
 
-    /// Performs `OptFloat::or` on each component separately
-    pub fn or(self, alt: Size<OptFloat>) -> Size<OptFloat> {
+    /// Performs `OptF32::or` on each component separately
+    pub fn or(self, alt: Size<OptF32>) -> Size<OptF32> {
         Size { width: self.width.or(alt.width), height: self.height.or(alt.height) }
     }
 
@@ -640,16 +638,16 @@ impl Size<OptFloat> {
     }
 }
 
-impl From<Size<Option<f32>>> for Size<OptFloat> {
+impl From<Size<Option<f32>>> for Size<OptF32> {
     #[inline(always)]
     fn from(size: Size<Option<f32>>) -> Self {
         Size { width: size.width.into(), height: size.height.into() }
     }
 }
 
-impl From<Size<OptFloat>> for Size<Option<f32>> {
+impl From<Size<OptF32>> for Size<Option<f32>> {
     #[inline(always)]
-    fn from(size: Size<OptFloat>) -> Self {
+    fn from(size: Size<OptF32>) -> Self {
         size.into_options()
     }
 }
@@ -697,9 +695,9 @@ impl Point<f32> {
     pub const ZERO: Self = Self { x: 0.0, y: 0.0 };
 }
 
-impl Point<OptFloat> {
+impl Point<OptF32> {
     /// A [`Point`] with values (None, None)
-    pub const NONE: Self = Self { x: OptFloat::NONE, y: OptFloat::NONE };
+    pub const NONE: Self = Self { x: OptF32::NONE, y: OptF32::NONE };
 }
 
 // Generic Add impl for Point<T> + Point<U> where T + U has an Add impl

--- a/src/style/available_space.rs
+++ b/src/style/available_space.rs
@@ -1,4 +1,5 @@
 //! Style type for representing available space as a sizing constraint
+use crate::util::OptFloat;
 use crate::{
     prelude::{FromLength, TaffyMaxContent, TaffyMinContent, TaffyZero},
     sys::abs,
@@ -58,10 +59,10 @@ impl AvailableSpace {
 
     /// Convert to Option
     /// Definite values become Some(value). Constraints become None.
-    pub const fn into_option(self) -> Option<f32> {
+    pub const fn into_option(self) -> OptFloat {
         match self {
-            AvailableSpace::Definite(value) => Some(value),
-            _ => None,
+            AvailableSpace::Definite(value) => OptFloat::some(value),
+            _ => OptFloat::NONE,
         }
     }
 
@@ -98,10 +99,11 @@ impl AvailableSpace {
     }
 
     /// If passed value is Some then return AvailableSpace::Definite containing that value, else return self
-    pub fn maybe_set(self, value: Option<f32>) -> AvailableSpace {
-        match value {
-            Some(value) => AvailableSpace::Definite(value),
-            None => self,
+    pub fn maybe_set(self, value: OptFloat) -> AvailableSpace {
+        if value.is_none() {
+            self
+        } else {
+            AvailableSpace::Definite(value.unchecked_value())
         }
     }
 
@@ -141,23 +143,24 @@ impl From<f32> for AvailableSpace {
     }
 }
 
-impl From<Option<f32>> for AvailableSpace {
-    fn from(option: Option<f32>) -> Self {
-        match option {
-            Some(value) => Self::Definite(value),
-            None => Self::MaxContent,
+impl From<OptFloat> for AvailableSpace {
+    fn from(option: OptFloat) -> Self {
+        if option.is_none() {
+            Self::MaxContent
+        } else {
+            Self::Definite(option.unchecked_value())
         }
     }
 }
 
 impl Size<AvailableSpace> {
-    /// Convert `Size<AvailableSpace>` into `Size<Option<f32>>`
-    pub fn into_options(self) -> Size<Option<f32>> {
+    /// Convert `Size<AvailableSpace>` into `Size<OptFloat>`
+    pub fn into_options(self) -> Size<OptFloat> {
         Size { width: self.width.into_option(), height: self.height.into_option() }
     }
 
     /// If passed value is Some then return AvailableSpace::Definite containing that value, else return self
-    pub fn maybe_set(self, value: Size<Option<f32>>) -> Size<AvailableSpace> {
+    pub fn maybe_set(self, value: Size<OptFloat>) -> Size<AvailableSpace> {
         Size { width: self.width.maybe_set(value.width), height: self.height.maybe_set(value.height) }
     }
 }

--- a/src/style/available_space.rs
+++ b/src/style/available_space.rs
@@ -1,5 +1,5 @@
 //! Style type for representing available space as a sizing constraint
-use crate::util::OptFloat;
+use crate::util::OptF32;
 use crate::{
     prelude::{FromLength, TaffyMaxContent, TaffyMinContent, TaffyZero},
     sys::abs,
@@ -59,10 +59,10 @@ impl AvailableSpace {
 
     /// Convert to Option
     /// Definite values become Some(value). Constraints become None.
-    pub const fn into_option(self) -> OptFloat {
+    pub const fn into_option(self) -> OptF32 {
         match self {
-            AvailableSpace::Definite(value) => OptFloat::some(value),
-            _ => OptFloat::NONE,
+            AvailableSpace::Definite(value) => OptF32::some(value),
+            _ => OptF32::NONE,
         }
     }
 
@@ -99,7 +99,7 @@ impl AvailableSpace {
     }
 
     /// If passed value is Some then return AvailableSpace::Definite containing that value, else return self
-    pub fn maybe_set(self, value: OptFloat) -> AvailableSpace {
+    pub fn maybe_set(self, value: OptF32) -> AvailableSpace {
         if value.is_none() {
             self
         } else {
@@ -143,8 +143,8 @@ impl From<f32> for AvailableSpace {
     }
 }
 
-impl From<OptFloat> for AvailableSpace {
-    fn from(option: OptFloat) -> Self {
+impl From<OptF32> for AvailableSpace {
+    fn from(option: OptF32) -> Self {
         if option.is_none() {
             Self::MaxContent
         } else {
@@ -163,13 +163,13 @@ impl From<Option<f32>> for AvailableSpace {
 }
 
 impl Size<AvailableSpace> {
-    /// Convert `Size<AvailableSpace>` into `Size<OptFloat>`
-    pub fn into_options(self) -> Size<OptFloat> {
+    /// Convert `Size<AvailableSpace>` into `Size<OptF32>`
+    pub fn into_options(self) -> Size<OptF32> {
         Size { width: self.width.into_option(), height: self.height.into_option() }
     }
 
     /// If passed value is Some then return AvailableSpace::Definite containing that value, else return self
-    pub fn maybe_set(self, value: Size<OptFloat>) -> Size<AvailableSpace> {
+    pub fn maybe_set(self, value: Size<OptF32>) -> Size<AvailableSpace> {
         Size { width: self.width.maybe_set(value.width), height: self.height.maybe_set(value.height) }
     }
 }

--- a/src/style/available_space.rs
+++ b/src/style/available_space.rs
@@ -153,6 +153,15 @@ impl From<OptFloat> for AvailableSpace {
     }
 }
 
+impl From<Option<f32>> for AvailableSpace {
+    fn from(option: Option<f32>) -> Self {
+        match option {
+            Some(value) => Self::Definite(value),
+            None => Self::MaxContent,
+        }
+    }
+}
+
 impl Size<AvailableSpace> {
     /// Convert `Size<AvailableSpace>` into `Size<OptFloat>`
     pub fn into_options(self) -> Size<OptFloat> {

--- a/src/style/compact_length.rs
+++ b/src/style/compact_length.rs
@@ -4,7 +4,7 @@ use super::LengthPercentage;
 use crate::style_helpers::{
     FromFr, FromLength, FromPercent, TaffyAuto, TaffyFitContent, TaffyMaxContent, TaffyMinContent, TaffyZero,
 };
-use crate::util::OptFloat;
+use crate::util::OptF32;
 
 /// Note: these two functions are copied directly from the std (core) library. But by duplicating them
 /// here we can reduce MSRV from 1.84 all the way down to 1.65 while retaining const constructors and
@@ -495,12 +495,12 @@ impl CompactLength {
     /// Resolve percentage values against the passed parent_size, returning Some(value)
     /// Non-percentage values always return None.
     #[inline(always)]
-    pub fn resolved_percentage_size(self, parent_size: f32, calc_resolver: impl Fn(*const (), f32) -> f32) -> OptFloat {
+    pub fn resolved_percentage_size(self, parent_size: f32, calc_resolver: impl Fn(*const (), f32) -> f32) -> OptF32 {
         match self.tag() {
-            CompactLength::PERCENT_TAG => OptFloat::some(self.value() * parent_size),
+            CompactLength::PERCENT_TAG => OptF32::some(self.value() * parent_size),
             #[cfg(feature = "calc")]
-            _ if self.is_calc() => OptFloat::some(calc_resolver(self.0.ptr(), parent_size)),
-            _ => OptFloat::NONE,
+            _ if self.is_calc() => OptF32::some(calc_resolver(self.0.ptr(), parent_size)),
+            _ => OptF32::NONE,
         }
     }
 }

--- a/src/style/compact_length.rs
+++ b/src/style/compact_length.rs
@@ -9,7 +9,7 @@ use crate::util::OptFloat;
 /// Note: these two functions are copied directly from the std (core) library. But by duplicating them
 /// here we can reduce MSRV from 1.84 all the way down to 1.65 while retaining const constructors and
 /// strict pointer provenance
-mod compat {
+pub(crate) mod compat {
     #![allow(unsafe_code)]
     #![allow(unknown_lints)]
     #![allow(unnecessary_transmutes)]

--- a/src/style/compact_length.rs
+++ b/src/style/compact_length.rs
@@ -4,6 +4,7 @@ use super::LengthPercentage;
 use crate::style_helpers::{
     FromFr, FromLength, FromPercent, TaffyAuto, TaffyFitContent, TaffyMaxContent, TaffyMinContent, TaffyZero,
 };
+use crate::util::OptFloat;
 
 /// Note: these two functions are copied directly from the std (core) library. But by duplicating them
 /// here we can reduce MSRV from 1.84 all the way down to 1.65 while retaining const constructors and
@@ -494,16 +495,12 @@ impl CompactLength {
     /// Resolve percentage values against the passed parent_size, returning Some(value)
     /// Non-percentage values always return None.
     #[inline(always)]
-    pub fn resolved_percentage_size(
-        self,
-        parent_size: f32,
-        calc_resolver: impl Fn(*const (), f32) -> f32,
-    ) -> Option<f32> {
+    pub fn resolved_percentage_size(self, parent_size: f32, calc_resolver: impl Fn(*const (), f32) -> f32) -> OptFloat {
         match self.tag() {
-            CompactLength::PERCENT_TAG => Some(self.value() * parent_size),
+            CompactLength::PERCENT_TAG => OptFloat::some(self.value() * parent_size),
             #[cfg(feature = "calc")]
-            _ if self.is_calc() => Some(calc_resolver(self.0.ptr(), parent_size)),
-            _ => None,
+            _ if self.is_calc() => OptFloat::some(calc_resolver(self.0.ptr(), parent_size)),
+            _ => OptFloat::NONE,
         }
     }
 }

--- a/src/style/dimension.rs
+++ b/src/style/dimension.rs
@@ -4,7 +4,7 @@ use crate::geometry::Rect;
 use crate::style_helpers::{FromLength, FromPercent, TaffyAuto, TaffyZero};
 #[cfg(feature = "parse")]
 use crate::util::parse::{from_str_from_css, CssParseResult, FromCss, Parser, Token};
-use crate::util::OptFloat;
+use crate::util::OptF32;
 
 /// A unit of linear measurement
 ///
@@ -236,13 +236,13 @@ impl LengthPercentageAuto {
     ///   - Some(resolved) using the provided context for Percent variants
     ///   - None for Auto variants
     #[inline(always)]
-    pub fn resolve_to_option(self, context: f32, calc_resolver: impl Fn(*const (), f32) -> f32) -> OptFloat {
+    pub fn resolve_to_option(self, context: f32, calc_resolver: impl Fn(*const (), f32) -> f32) -> OptF32 {
         match self.0.tag() {
-            CompactLength::LENGTH_TAG => OptFloat::some(self.0.value()),
-            CompactLength::PERCENT_TAG => OptFloat::some(context * self.0.value()),
-            CompactLength::AUTO_TAG => OptFloat::NONE,
+            CompactLength::LENGTH_TAG => OptF32::some(self.0.value()),
+            CompactLength::PERCENT_TAG => OptF32::some(context * self.0.value()),
+            CompactLength::AUTO_TAG => OptF32::NONE,
             #[cfg(feature = "calc")]
-            _ if self.0.is_calc() => OptFloat::some(calc_resolver(self.0.calc_value(), context)),
+            _ if self.0.is_calc() => OptF32::some(calc_resolver(self.0.calc_value(), context)),
             _ => unreachable!("LengthPercentageAuto values cannot be constructed with other tags"),
         }
     }
@@ -489,10 +489,10 @@ impl Dimension {
 
     /// Get Length value if value is Length variant
     #[cfg(feature = "grid")]
-    pub fn into_option(self) -> OptFloat {
+    pub fn into_option(self) -> OptF32 {
         match self.0.tag() {
-            CompactLength::LENGTH_TAG => OptFloat::some(self.0.value()),
-            _ => OptFloat::NONE,
+            CompactLength::LENGTH_TAG => OptF32::some(self.0.value()),
+            _ => OptF32::NONE,
         }
     }
     /// Returns true if value is Auto

--- a/src/style/dimension.rs
+++ b/src/style/dimension.rs
@@ -4,6 +4,7 @@ use crate::geometry::Rect;
 use crate::style_helpers::{FromLength, FromPercent, TaffyAuto, TaffyZero};
 #[cfg(feature = "parse")]
 use crate::util::parse::{from_str_from_css, CssParseResult, FromCss, Parser, Token};
+use crate::util::OptFloat;
 
 /// A unit of linear measurement
 ///
@@ -235,13 +236,13 @@ impl LengthPercentageAuto {
     ///   - Some(resolved) using the provided context for Percent variants
     ///   - None for Auto variants
     #[inline(always)]
-    pub fn resolve_to_option(self, context: f32, calc_resolver: impl Fn(*const (), f32) -> f32) -> Option<f32> {
+    pub fn resolve_to_option(self, context: f32, calc_resolver: impl Fn(*const (), f32) -> f32) -> OptFloat {
         match self.0.tag() {
-            CompactLength::LENGTH_TAG => Some(self.0.value()),
-            CompactLength::PERCENT_TAG => Some(context * self.0.value()),
-            CompactLength::AUTO_TAG => None,
+            CompactLength::LENGTH_TAG => OptFloat::some(self.0.value()),
+            CompactLength::PERCENT_TAG => OptFloat::some(context * self.0.value()),
+            CompactLength::AUTO_TAG => OptFloat::NONE,
             #[cfg(feature = "calc")]
-            _ if self.0.is_calc() => Some(calc_resolver(self.0.calc_value(), context)),
+            _ if self.0.is_calc() => OptFloat::some(calc_resolver(self.0.calc_value(), context)),
             _ => unreachable!("LengthPercentageAuto values cannot be constructed with other tags"),
         }
     }
@@ -488,10 +489,10 @@ impl Dimension {
 
     /// Get Length value if value is Length variant
     #[cfg(feature = "grid")]
-    pub fn into_option(self) -> Option<f32> {
+    pub fn into_option(self) -> OptFloat {
         match self.0.tag() {
-            CompactLength::LENGTH_TAG => Some(self.0.value()),
-            _ => None,
+            CompactLength::LENGTH_TAG => OptFloat::some(self.0.value()),
+            _ => OptFloat::NONE,
         }
     }
     /// Returns true if value is Auto

--- a/src/style/grid.rs
+++ b/src/style/grid.rs
@@ -7,7 +7,7 @@ use crate::compute::grid::{GridCoordinate, GridLine, OriginZeroLine, MAX_GRID_TR
 use crate::geometry::{AbsoluteAxis, AbstractAxis, Line, MinMax, Size};
 use crate::style_helpers::*;
 use crate::sys::{DefaultCheapStr, Vec};
-use crate::util::OptFloat;
+use crate::util::OptF32;
 use core::cmp::{max, min};
 use core::fmt::Debug;
 
@@ -990,7 +990,7 @@ impl MaxTrackSizingFunction {
 
     /// Returns whether the value can be resolved using `Self::definite_value`
     #[inline(always)]
-    pub fn has_definite_value(self, parent_size: OptFloat) -> bool {
+    pub fn has_definite_value(self, parent_size: OptF32) -> bool {
         match self.0.tag() {
             CompactLength::LENGTH_TAG => true,
             CompactLength::PERCENT_TAG => parent_size.is_some(),
@@ -1004,13 +1004,13 @@ impl MaxTrackSizingFunction {
     /// the passed available_space and returns if this results in a concrete value (which it
     /// will if the available_space is `Some`). Otherwise returns None.
     #[inline(always)]
-    pub fn definite_value(self, parent_size: OptFloat, calc_resolver: impl Fn(*const (), f32) -> f32) -> OptFloat {
+    pub fn definite_value(self, parent_size: OptF32, calc_resolver: impl Fn(*const (), f32) -> f32) -> OptF32 {
         match self.0.tag() {
-            CompactLength::LENGTH_TAG => OptFloat::some(self.0.value()),
+            CompactLength::LENGTH_TAG => OptF32::some(self.0.value()),
             CompactLength::PERCENT_TAG => parent_size.map(|size| self.0.value() * size),
             #[cfg(feature = "calc")]
             _ if self.0.is_calc() => parent_size.map(|size| calc_resolver(self.0.calc_value(), size)),
-            _ => OptFloat::NONE,
+            _ => OptF32::NONE,
         }
     }
 
@@ -1021,9 +1021,9 @@ impl MaxTrackSizingFunction {
     ///     - A fit-content sizing function with percentage argument (with definite available space)
     /// All other kinds of track sizing function return None.
     #[inline(always)]
-    pub fn definite_limit(self, parent_size: OptFloat, calc_resolver: impl Fn(*const (), f32) -> f32) -> OptFloat {
+    pub fn definite_limit(self, parent_size: OptF32, calc_resolver: impl Fn(*const (), f32) -> f32) -> OptF32 {
         match self.0.tag() {
-            CompactLength::FIT_CONTENT_PX_TAG => OptFloat::some(self.0.value()),
+            CompactLength::FIT_CONTENT_PX_TAG => OptF32::some(self.0.value()),
             CompactLength::FIT_CONTENT_PERCENT_TAG => parent_size.map(|size| self.0.value() * size),
             _ => self.definite_value(parent_size, calc_resolver),
         }
@@ -1032,7 +1032,7 @@ impl MaxTrackSizingFunction {
     /// Resolve percentage values against the passed parent_size, returning Some(value)
     /// Non-percentage values always return None.
     #[inline(always)]
-    pub fn resolved_percentage_size(self, parent_size: f32, calc_resolver: impl Fn(*const (), f32) -> f32) -> OptFloat {
+    pub fn resolved_percentage_size(self, parent_size: f32, calc_resolver: impl Fn(*const (), f32) -> f32) -> OptF32 {
         self.0.resolved_percentage_size(parent_size, calc_resolver)
     }
 
@@ -1325,20 +1325,20 @@ impl MinTrackSizingFunction {
     /// the passed available_space and returns if this results in a concrete value (which it
     /// will if the available_space is `Some`). Otherwise returns `None`.
     #[inline(always)]
-    pub fn definite_value(self, parent_size: OptFloat, calc_resolver: impl Fn(*const (), f32) -> f32) -> OptFloat {
+    pub fn definite_value(self, parent_size: OptF32, calc_resolver: impl Fn(*const (), f32) -> f32) -> OptF32 {
         match self.0.tag() {
-            CompactLength::LENGTH_TAG => OptFloat::some(self.0.value()),
+            CompactLength::LENGTH_TAG => OptF32::some(self.0.value()),
             CompactLength::PERCENT_TAG => parent_size.map(|size| self.0.value() * size),
             #[cfg(feature = "calc")]
             _ if self.0.is_calc() => parent_size.map(|size| calc_resolver(self.0.calc_value(), size)),
-            _ => OptFloat::NONE,
+            _ => OptF32::NONE,
         }
     }
 
     /// Resolve percentage values against the passed parent_size, returning Some(value)
     /// Non-percentage values always return None.
     #[inline(always)]
-    pub fn resolved_percentage_size(self, parent_size: f32, calc_resolver: impl Fn(*const (), f32) -> f32) -> OptFloat {
+    pub fn resolved_percentage_size(self, parent_size: f32, calc_resolver: impl Fn(*const (), f32) -> f32) -> OptF32 {
         self.0.resolved_percentage_size(parent_size, calc_resolver)
     }
 

--- a/src/style/grid.rs
+++ b/src/style/grid.rs
@@ -7,6 +7,7 @@ use crate::compute::grid::{GridCoordinate, GridLine, OriginZeroLine, MAX_GRID_TR
 use crate::geometry::{AbsoluteAxis, AbstractAxis, Line, MinMax, Size};
 use crate::style_helpers::*;
 use crate::sys::{DefaultCheapStr, Vec};
+use crate::util::OptFloat;
 use core::cmp::{max, min};
 use core::fmt::Debug;
 
@@ -989,7 +990,7 @@ impl MaxTrackSizingFunction {
 
     /// Returns whether the value can be resolved using `Self::definite_value`
     #[inline(always)]
-    pub fn has_definite_value(self, parent_size: Option<f32>) -> bool {
+    pub fn has_definite_value(self, parent_size: OptFloat) -> bool {
         match self.0.tag() {
             CompactLength::LENGTH_TAG => true,
             CompactLength::PERCENT_TAG => parent_size.is_some(),
@@ -1003,17 +1004,13 @@ impl MaxTrackSizingFunction {
     /// the passed available_space and returns if this results in a concrete value (which it
     /// will if the available_space is `Some`). Otherwise returns None.
     #[inline(always)]
-    pub fn definite_value(
-        self,
-        parent_size: Option<f32>,
-        calc_resolver: impl Fn(*const (), f32) -> f32,
-    ) -> Option<f32> {
+    pub fn definite_value(self, parent_size: OptFloat, calc_resolver: impl Fn(*const (), f32) -> f32) -> OptFloat {
         match self.0.tag() {
-            CompactLength::LENGTH_TAG => Some(self.0.value()),
+            CompactLength::LENGTH_TAG => OptFloat::some(self.0.value()),
             CompactLength::PERCENT_TAG => parent_size.map(|size| self.0.value() * size),
             #[cfg(feature = "calc")]
             _ if self.0.is_calc() => parent_size.map(|size| calc_resolver(self.0.calc_value(), size)),
-            _ => None,
+            _ => OptFloat::NONE,
         }
     }
 
@@ -1024,13 +1021,9 @@ impl MaxTrackSizingFunction {
     ///     - A fit-content sizing function with percentage argument (with definite available space)
     /// All other kinds of track sizing function return None.
     #[inline(always)]
-    pub fn definite_limit(
-        self,
-        parent_size: Option<f32>,
-        calc_resolver: impl Fn(*const (), f32) -> f32,
-    ) -> Option<f32> {
+    pub fn definite_limit(self, parent_size: OptFloat, calc_resolver: impl Fn(*const (), f32) -> f32) -> OptFloat {
         match self.0.tag() {
-            CompactLength::FIT_CONTENT_PX_TAG => Some(self.0.value()),
+            CompactLength::FIT_CONTENT_PX_TAG => OptFloat::some(self.0.value()),
             CompactLength::FIT_CONTENT_PERCENT_TAG => parent_size.map(|size| self.0.value() * size),
             _ => self.definite_value(parent_size, calc_resolver),
         }
@@ -1039,11 +1032,7 @@ impl MaxTrackSizingFunction {
     /// Resolve percentage values against the passed parent_size, returning Some(value)
     /// Non-percentage values always return None.
     #[inline(always)]
-    pub fn resolved_percentage_size(
-        self,
-        parent_size: f32,
-        calc_resolver: impl Fn(*const (), f32) -> f32,
-    ) -> Option<f32> {
+    pub fn resolved_percentage_size(self, parent_size: f32, calc_resolver: impl Fn(*const (), f32) -> f32) -> OptFloat {
         self.0.resolved_percentage_size(parent_size, calc_resolver)
     }
 
@@ -1336,28 +1325,20 @@ impl MinTrackSizingFunction {
     /// the passed available_space and returns if this results in a concrete value (which it
     /// will if the available_space is `Some`). Otherwise returns `None`.
     #[inline(always)]
-    pub fn definite_value(
-        self,
-        parent_size: Option<f32>,
-        calc_resolver: impl Fn(*const (), f32) -> f32,
-    ) -> Option<f32> {
+    pub fn definite_value(self, parent_size: OptFloat, calc_resolver: impl Fn(*const (), f32) -> f32) -> OptFloat {
         match self.0.tag() {
-            CompactLength::LENGTH_TAG => Some(self.0.value()),
+            CompactLength::LENGTH_TAG => OptFloat::some(self.0.value()),
             CompactLength::PERCENT_TAG => parent_size.map(|size| self.0.value() * size),
             #[cfg(feature = "calc")]
             _ if self.0.is_calc() => parent_size.map(|size| calc_resolver(self.0.calc_value(), size)),
-            _ => None,
+            _ => OptFloat::NONE,
         }
     }
 
     /// Resolve percentage values against the passed parent_size, returning Some(value)
     /// Non-percentage values always return None.
     #[inline(always)]
-    pub fn resolved_percentage_size(
-        self,
-        parent_size: f32,
-        calc_resolver: impl Fn(*const (), f32) -> f32,
-    ) -> Option<f32> {
+    pub fn resolved_percentage_size(self, parent_size: f32, calc_resolver: impl Fn(*const (), f32) -> f32) -> OptFloat {
         self.0.resolved_percentage_size(parent_size, calc_resolver)
     }
 

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -1,7 +1,7 @@
 //! A typed representation of [CSS style properties](https://css-tricks.com/snippets/css/a-guide-to-flexbox/) in Rust. Used as input to layout computation.
 mod alignment;
 mod available_space;
-mod compact_length;
+pub(crate) mod compact_length;
 mod dimension;
 
 #[cfg(feature = "block_layout")]

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -24,7 +24,7 @@ pub use self::dimension::{
     LengthPercentageAuto,
 };
 use crate::sys::DefaultCheapStr;
-use crate::util::OptFloat;
+use crate::util::OptF32;
 
 #[cfg(feature = "block_layout")]
 pub use self::block::{BlockContainerStyle, BlockItemStyle, TextAlign};
@@ -393,10 +393,10 @@ impl Overflow {
     /// Returns `Some(0.0)` if the overflow mode would cause the automatic minimum size of a Flexbox or CSS Grid item
     /// to be `0`. Else returns None.
     #[inline(always)]
-    pub(crate) fn maybe_into_automatic_min_size(self) -> OptFloat {
+    pub(crate) fn maybe_into_automatic_min_size(self) -> OptF32 {
         match self.is_scroll_container() {
-            true => OptFloat::some(0.0),
-            false => OptFloat::NONE,
+            true => OptF32::some(0.0),
+            false => OptF32::NONE,
         }
     }
 }

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -24,6 +24,7 @@ pub use self::dimension::{
     LengthPercentageAuto,
 };
 use crate::sys::DefaultCheapStr;
+use crate::util::OptFloat;
 
 #[cfg(feature = "block_layout")]
 pub use self::block::{BlockContainerStyle, BlockItemStyle, TextAlign};
@@ -392,10 +393,10 @@ impl Overflow {
     /// Returns `Some(0.0)` if the overflow mode would cause the automatic minimum size of a Flexbox or CSS Grid item
     /// to be `0`. Else returns None.
     #[inline(always)]
-    pub(crate) fn maybe_into_automatic_min_size(self) -> Option<f32> {
+    pub(crate) fn maybe_into_automatic_min_size(self) -> OptFloat {
         match self.is_scroll_container() {
-            true => Some(0.0),
-            false => None,
+            true => OptFloat::some(0.0),
+            false => OptFloat::NONE,
         }
     }
 }

--- a/src/style_helpers.rs
+++ b/src/style_helpers.rs
@@ -1,5 +1,5 @@
 //! Helper functions which it make it easier to create instances of types in the `style` and `geometry` modules.
-use crate::util::OptFloat;
+use crate::util::OptF32;
 use crate::{
     geometry::{Line, Point, Rect, Size},
     style::LengthPercentage,
@@ -108,8 +108,8 @@ impl TaffyZero for f32 {
 impl<T: TaffyZero> TaffyZero for Option<T> {
     const ZERO: Option<T> = Some(T::ZERO);
 }
-impl TaffyZero for crate::util::OptFloat {
-    const ZERO: crate::util::OptFloat = crate::util::OptFloat::some(0.0);
+impl TaffyZero for crate::util::OptF32 {
+    const ZERO: crate::util::OptF32 = crate::util::OptF32::some(0.0);
 }
 impl<T: TaffyZero> TaffyZero for Point<T> {
     const ZERO: Point<T> = Point { x: T::ZERO, y: T::ZERO };
@@ -426,10 +426,10 @@ impl FromLength for f32 {
         value.into() as f32
     }
 }
-impl FromLength for OptFloat {
+impl FromLength for OptF32 {
     #[inline(always)]
     fn from_length<Input: Into<f64> + Copy>(value: Input) -> Self {
-        OptFloat::some(value.into() as f32)
+        OptF32::some(value.into() as f32)
     }
 }
 impl<T: FromLength> FromLength for Point<T> {
@@ -507,10 +507,10 @@ impl FromPercent for f32 {
         percent.into() as f32
     }
 }
-impl FromPercent for OptFloat {
+impl FromPercent for OptF32 {
     #[inline(always)]
     fn from_percent<Input: Into<f64> + Copy>(percent: Input) -> Self {
-        OptFloat::some(percent.into() as f32)
+        OptF32::some(percent.into() as f32)
     }
 }
 impl<T: FromPercent> FromPercent for Point<T> {

--- a/src/style_helpers.rs
+++ b/src/style_helpers.rs
@@ -1,4 +1,5 @@
 //! Helper functions which it make it easier to create instances of types in the `style` and `geometry` modules.
+use crate::util::OptFloat;
 use crate::{
     geometry::{Line, Point, Rect, Size},
     style::LengthPercentage,
@@ -106,6 +107,9 @@ impl TaffyZero for f32 {
 }
 impl<T: TaffyZero> TaffyZero for Option<T> {
     const ZERO: Option<T> = Some(T::ZERO);
+}
+impl TaffyZero for crate::util::OptFloat {
+    const ZERO: crate::util::OptFloat = crate::util::OptFloat::some(0.0);
 }
 impl<T: TaffyZero> TaffyZero for Point<T> {
     const ZERO: Point<T> = Point { x: T::ZERO, y: T::ZERO };
@@ -422,10 +426,10 @@ impl FromLength for f32 {
         value.into() as f32
     }
 }
-impl FromLength for Option<f32> {
+impl FromLength for OptFloat {
     #[inline(always)]
     fn from_length<Input: Into<f64> + Copy>(value: Input) -> Self {
-        Some(value.into() as f32)
+        OptFloat::some(value.into() as f32)
     }
 }
 impl<T: FromLength> FromLength for Point<T> {
@@ -503,10 +507,10 @@ impl FromPercent for f32 {
         percent.into() as f32
     }
 }
-impl FromPercent for Option<f32> {
+impl FromPercent for OptFloat {
     #[inline(always)]
     fn from_percent<Input: Into<f64> + Copy>(percent: Input) -> Self {
-        Some(percent.into() as f32)
+        OptFloat::some(percent.into() as f32)
     }
 }
 impl<T: FromPercent> FromPercent for Point<T> {

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use crate::util::OptFloat;
+use crate::util::OptF32;
 use taffy::{AvailableSpace, NodeId, Size, Style};
 
 /// A shared measure function for tests which means that tests compiled with separate crates
@@ -58,7 +58,7 @@ pub enum TestMeasureData {
 
 /// A measure function for tests that works with `TestNodeContext`
 pub fn test_measure_function(
-    known_dimensions: Size<OptFloat>,
+    known_dimensions: Size<OptF32>,
     available_space: Size<AvailableSpace>,
     _node_id: NodeId,
     context: Option<&mut TestNodeContext>,
@@ -93,7 +93,7 @@ pub struct AspectRatioMeasureData {
     height_ratio: f32,
 }
 impl AspectRatioMeasureData {
-    fn measure(&self, known_dimensions: Size<OptFloat>) -> Size<f32> {
+    fn measure(&self, known_dimensions: Size<OptF32>) -> Size<f32> {
         let width = known_dimensions.width.unwrap_or(self.width);
         let height = known_dimensions.height.unwrap_or(width * self.height_ratio);
         Size { width, height }
@@ -119,7 +119,7 @@ pub struct AhemTextMeasureData {
 impl AhemTextMeasureData {
     fn measure(
         &self,
-        known_dimensions: taffy::Size<OptFloat>,
+        known_dimensions: taffy::Size<OptF32>,
         available_space: taffy::Size<taffy::AvailableSpace>,
     ) -> taffy::Size<f32> {
         use taffy::prelude::*;

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+use crate::util::OptFloat;
 use taffy::{AvailableSpace, NodeId, Size, Style};
 
 /// A shared measure function for tests which means that tests compiled with separate crates
@@ -57,7 +58,7 @@ pub enum TestMeasureData {
 
 /// A measure function for tests that works with `TestNodeContext`
 pub fn test_measure_function(
-    known_dimensions: Size<Option<f32>>,
+    known_dimensions: Size<OptFloat>,
     available_space: Size<AvailableSpace>,
     _node_id: NodeId,
     context: Option<&mut TestNodeContext>,
@@ -92,7 +93,7 @@ pub struct AspectRatioMeasureData {
     height_ratio: f32,
 }
 impl AspectRatioMeasureData {
-    fn measure(&self, known_dimensions: Size<Option<f32>>) -> Size<f32> {
+    fn measure(&self, known_dimensions: Size<OptFloat>) -> Size<f32> {
         let width = known_dimensions.width.unwrap_or(self.width);
         let height = known_dimensions.height.unwrap_or(width * self.height_ratio);
         Size { width, height }
@@ -118,7 +119,7 @@ pub struct AhemTextMeasureData {
 impl AhemTextMeasureData {
     fn measure(
         &self,
-        known_dimensions: taffy::Size<Option<f32>>,
+        known_dimensions: taffy::Size<OptFloat>,
         available_space: taffy::Size<taffy::AvailableSpace>,
     ) -> taffy::Size<f32> {
         use taffy::prelude::*;

--- a/src/tree/cache.rs
+++ b/src/tree/cache.rs
@@ -5,6 +5,7 @@
 use crate::geometry::Size;
 use crate::style::AvailableSpace;
 use crate::tree::{CollapsibleMarginSet, LayoutInput, LayoutOutput, RunMode};
+use crate::util::OptFloat;
 use crate::RequestedAxis;
 
 /// The number of cache entries for each node in the tree
@@ -35,18 +36,19 @@ const NON_SIGN_BITS_MASK: u64 = !BOTH_SIGN_BITS_MASK;
 /// y-axis value when comparing a cache key.
 const X_AXIS_VALUE_MASK: u64 = (u32::MAX as u64) << 32;
 
-/// Pack `Option<f32>` into `u32`
+/// Pack `OptFloat` into `u32`
 #[inline(always)]
-fn option_cache_key(input: Option<f32>) -> u32 {
-    match input {
-        Some(value) => value.to_bits(),
-        None => INFINITY_BITS,
+fn option_cache_key(input: OptFloat) -> u32 {
+    if input.is_none() {
+        INFINITY_BITS
+    } else {
+        input.to_bits()
     }
 }
 
-/// Pack `Size<Option<f32>>` into `u64`
+/// Pack `Size<OptFloat>` into `u64`
 #[inline(always)]
-fn size_option_cache_key(input: Size<Option<f32>>) -> u64 {
+fn size_option_cache_key(input: Size<OptFloat>) -> u64 {
     (option_cache_key(input.width) as u64) << 32 | option_cache_key(input.height) as u64
 }
 
@@ -67,17 +69,21 @@ fn size_available_space_cache_key(input: Size<AvailableSpace>) -> u64 {
     (available_space_cache_key(input.width) as u64) << 32 | available_space_cache_key(input.height) as u64
 }
 
-/// Encodes combination of a `known_dimension` (Option<f32>) and `AvailableSpace` in
+/// Encodes combination of a `known_dimension` (OptFloat) and `AvailableSpace` in
 /// a single dimension into a cache key in a single dimension.
 #[inline(always)]
-fn mixed_cache_key(kd: Option<f32>, avs: AvailableSpace) -> u32 {
-    kd.map(|kd| kd.to_bits()).unwrap_or_else(|| available_space_cache_key(avs))
+fn mixed_cache_key(kd: OptFloat, avs: AvailableSpace) -> u32 {
+    if kd.is_none() {
+        available_space_cache_key(avs)
+    } else {
+        kd.to_bits()
+    }
 }
 
-/// Encodes combination of a `known_dimension` (Option<f32>) and `AvailableSpace` in
+/// Encodes combination of a `known_dimension` (OptFloat) and `AvailableSpace` in
 /// two dimensions into a cache key in a single dimension.
 #[inline(always)]
-fn size_mixed_cache_key(kd: Size<Option<f32>>, avs: Size<AvailableSpace>) -> u64 {
+fn size_mixed_cache_key(kd: Size<OptFloat>, avs: Size<AvailableSpace>) -> u64 {
     (mixed_cache_key(kd.width, avs.width) as u64) << 32 | mixed_cache_key(kd.height, avs.height) as u64
 }
 
@@ -294,7 +300,7 @@ mod tests {
             run_mode: RunMode::ComputeSize,
             sizing_mode: SizingMode::InherentSize,
             axis: RequestedAxis::Both,
-            known_dimensions: Size { width: Some(width), height: None },
+            known_dimensions: Size { width: OptFloat::some(width), height: OptFloat::NONE },
             known_dimensions_are_definite: Size { width: true, height: true },
             parent_size: Size::NONE,
             available_space: Size { width: AvailableSpace::MaxContent, height: AvailableSpace::MaxContent },

--- a/src/tree/cache.rs
+++ b/src/tree/cache.rs
@@ -5,7 +5,7 @@
 use crate::geometry::Size;
 use crate::style::AvailableSpace;
 use crate::tree::{CollapsibleMarginSet, LayoutInput, LayoutOutput, RunMode};
-use crate::util::OptFloat;
+use crate::util::OptF32;
 use crate::RequestedAxis;
 
 /// The number of cache entries for each node in the tree
@@ -36,9 +36,9 @@ const NON_SIGN_BITS_MASK: u64 = !BOTH_SIGN_BITS_MASK;
 /// y-axis value when comparing a cache key.
 const X_AXIS_VALUE_MASK: u64 = (u32::MAX as u64) << 32;
 
-/// Pack `OptFloat` into `u32`
+/// Pack `OptF32` into `u32`
 #[inline(always)]
-fn option_cache_key(input: OptFloat) -> u32 {
+fn option_cache_key(input: OptF32) -> u32 {
     if input.is_none() {
         INFINITY_BITS
     } else {
@@ -46,9 +46,9 @@ fn option_cache_key(input: OptFloat) -> u32 {
     }
 }
 
-/// Pack `Size<OptFloat>` into `u64`
+/// Pack `Size<OptF32>` into `u64`
 #[inline(always)]
-fn size_option_cache_key(input: Size<OptFloat>) -> u64 {
+fn size_option_cache_key(input: Size<OptF32>) -> u64 {
     (option_cache_key(input.width) as u64) << 32 | option_cache_key(input.height) as u64
 }
 
@@ -69,10 +69,10 @@ fn size_available_space_cache_key(input: Size<AvailableSpace>) -> u64 {
     (available_space_cache_key(input.width) as u64) << 32 | available_space_cache_key(input.height) as u64
 }
 
-/// Encodes combination of a `known_dimension` (OptFloat) and `AvailableSpace` in
+/// Encodes combination of a `known_dimension` (OptF32) and `AvailableSpace` in
 /// a single dimension into a cache key in a single dimension.
 #[inline(always)]
-fn mixed_cache_key(kd: OptFloat, avs: AvailableSpace) -> u32 {
+fn mixed_cache_key(kd: OptF32, avs: AvailableSpace) -> u32 {
     if kd.is_none() {
         available_space_cache_key(avs)
     } else {
@@ -80,10 +80,10 @@ fn mixed_cache_key(kd: OptFloat, avs: AvailableSpace) -> u32 {
     }
 }
 
-/// Encodes combination of a `known_dimension` (OptFloat) and `AvailableSpace` in
+/// Encodes combination of a `known_dimension` (OptF32) and `AvailableSpace` in
 /// two dimensions into a cache key in a single dimension.
 #[inline(always)]
-fn size_mixed_cache_key(kd: Size<OptFloat>, avs: Size<AvailableSpace>) -> u64 {
+fn size_mixed_cache_key(kd: Size<OptF32>, avs: Size<AvailableSpace>) -> u64 {
     (mixed_cache_key(kd.width, avs.width) as u64) << 32 | mixed_cache_key(kd.height, avs.height) as u64
 }
 
@@ -300,7 +300,7 @@ mod tests {
             run_mode: RunMode::ComputeSize,
             sizing_mode: SizingMode::InherentSize,
             axis: RequestedAxis::Both,
-            known_dimensions: Size { width: OptFloat::some(width), height: OptFloat::NONE },
+            known_dimensions: Size { width: OptF32::some(width), height: OptF32::NONE },
             known_dimensions_are_definite: Size { width: true, height: true },
             parent_size: Size::NONE,
             available_space: Size { width: AvailableSpace::MaxContent, height: AvailableSpace::MaxContent },

--- a/src/tree/layout.rs
+++ b/src/tree/layout.rs
@@ -3,7 +3,7 @@ use crate::geometry::{AbsoluteAxis, Line, Point, Rect, Size};
 use crate::style::AvailableSpace;
 use crate::style_helpers::TaffyMaxContent;
 use crate::util::sys::{f32_max, f32_min};
-use crate::util::OptFloat;
+use crate::util::OptF32;
 
 /// Whether we are performing a full layout, or we merely need to size the node
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -126,7 +126,7 @@ pub struct LayoutInput {
     ///
     ///   "The exact size of this node is WIDTHxHEIGHT. Please lay out your children"
     ///
-    pub known_dimensions: Size<OptFloat>,
+    pub known_dimensions: Size<OptF32>,
     /// Whether each known dimension should be treated as a *definite* size when laying out the node's
     /// own content (resolving percentage sizes of children, and collecting flex items into flex lines).
     ///
@@ -139,7 +139,7 @@ pub struct LayoutInput {
     /// This flag is ignored (treated as `true`) for axes where the corresponding known dimension is `None`.
     pub known_dimensions_are_definite: Size<bool>,
     /// Parent size dimensions are intended to be used for percentage resolution.
-    pub parent_size: Size<OptFloat>,
+    pub parent_size: Size<OptF32>,
     /// Available space represents an amount of space to layout into, and is used as a soft constraint
     /// for the purpose of wrapping.
     pub available_space: Size<AvailableSpace>,
@@ -172,18 +172,18 @@ impl LayoutInput {
 #[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct Baselines {
     /// The first baseline of the node, if any
-    pub first: OptFloat,
+    pub first: OptF32,
     /// The last baseline of the node, if any
-    pub last: OptFloat,
+    pub last: OptF32,
 }
 
 impl Baselines {
     /// A `Baselines` with neither a first nor a last baseline
-    pub const NONE: Self = Self { first: OptFloat::NONE, last: OptFloat::NONE };
+    pub const NONE: Self = Self { first: OptF32::NONE, last: OptF32::NONE };
 
     /// Create a `Baselines` from just a first baseline
-    pub const fn from_first(first: OptFloat) -> Self {
-        Self { first, last: OptFloat::NONE }
+    pub const fn from_first(first: OptF32) -> Self {
+        Self { first, last: OptF32::NONE }
     }
 }
 

--- a/src/tree/layout.rs
+++ b/src/tree/layout.rs
@@ -3,6 +3,7 @@ use crate::geometry::{AbsoluteAxis, Line, Point, Rect, Size};
 use crate::style::AvailableSpace;
 use crate::style_helpers::TaffyMaxContent;
 use crate::util::sys::{f32_max, f32_min};
+use crate::util::OptFloat;
 
 /// Whether we are performing a full layout, or we merely need to size the node
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -125,7 +126,7 @@ pub struct LayoutInput {
     ///
     ///   "The exact size of this node is WIDTHxHEIGHT. Please lay out your children"
     ///
-    pub known_dimensions: Size<Option<f32>>,
+    pub known_dimensions: Size<OptFloat>,
     /// Whether each known dimension should be treated as a *definite* size when laying out the node's
     /// own content (resolving percentage sizes of children, and collecting flex items into flex lines).
     ///
@@ -138,7 +139,7 @@ pub struct LayoutInput {
     /// This flag is ignored (treated as `true`) for axes where the corresponding known dimension is `None`.
     pub known_dimensions_are_definite: Size<bool>,
     /// Parent size dimensions are intended to be used for percentage resolution.
-    pub parent_size: Size<Option<f32>>,
+    pub parent_size: Size<OptFloat>,
     /// Available space represents an amount of space to layout into, and is used as a soft constraint
     /// for the purpose of wrapping.
     pub available_space: Size<AvailableSpace>,
@@ -171,18 +172,18 @@ impl LayoutInput {
 #[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct Baselines {
     /// The first baseline of the node, if any
-    pub first: Option<f32>,
+    pub first: OptFloat,
     /// The last baseline of the node, if any
-    pub last: Option<f32>,
+    pub last: OptFloat,
 }
 
 impl Baselines {
     /// A `Baselines` with neither a first nor a last baseline
-    pub const NONE: Self = Self { first: None, last: None };
+    pub const NONE: Self = Self { first: OptFloat::NONE, last: OptFloat::NONE };
 
     /// Create a `Baselines` from just a first baseline
-    pub const fn from_first(first: Option<f32>) -> Self {
-        Self { first, last: None }
+    pub const fn from_first(first: OptFloat) -> Self {
+        Self { first, last: OptFloat::NONE }
     }
 }
 

--- a/src/tree/traits.rs
+++ b/src/tree/traits.rs
@@ -135,7 +135,7 @@ use crate::style::{AvailableSpace, CoreStyle};
 use crate::style::{FlexboxContainerStyle, FlexboxItemStyle};
 #[cfg(feature = "grid")]
 use crate::style::{GridContainerStyle, GridItemStyle};
-use crate::util::OptFloat;
+use crate::util::OptF32;
 use crate::CheapCloneStr;
 #[cfg(feature = "block_layout")]
 use crate::{BlockContainerStyle, BlockContext, BlockItemStyle};
@@ -326,8 +326,8 @@ pub(crate) trait LayoutPartialTreeExt: LayoutPartialTree {
     fn measure_child_size(
         &mut self,
         node_id: NodeId,
-        known_dimensions: Size<OptFloat>,
-        parent_size: Size<OptFloat>,
+        known_dimensions: Size<OptF32>,
+        parent_size: Size<OptF32>,
         available_space: Size<AvailableSpace>,
         sizing_mode: SizingMode,
         axis: AbsoluteAxis,
@@ -356,8 +356,8 @@ pub(crate) trait LayoutPartialTreeExt: LayoutPartialTree {
     fn measure_child_size_both(
         &mut self,
         node_id: NodeId,
-        known_dimensions: Size<OptFloat>,
-        parent_size: Size<OptFloat>,
+        known_dimensions: Size<OptF32>,
+        parent_size: Size<OptF32>,
         available_space: Size<AvailableSpace>,
         sizing_mode: SizingMode,
         vertical_margins_are_collapsible: Line<bool>,
@@ -383,8 +383,8 @@ pub(crate) trait LayoutPartialTreeExt: LayoutPartialTree {
     fn perform_child_layout(
         &mut self,
         node_id: NodeId,
-        known_dimensions: Size<OptFloat>,
-        parent_size: Size<OptFloat>,
+        known_dimensions: Size<OptF32>,
+        parent_size: Size<OptF32>,
         available_space: Size<AvailableSpace>,
         sizing_mode: SizingMode,
         vertical_margins_are_collapsible: Line<bool>,

--- a/src/tree/traits.rs
+++ b/src/tree/traits.rs
@@ -135,6 +135,7 @@ use crate::style::{AvailableSpace, CoreStyle};
 use crate::style::{FlexboxContainerStyle, FlexboxItemStyle};
 #[cfg(feature = "grid")]
 use crate::style::{GridContainerStyle, GridItemStyle};
+use crate::util::OptFloat;
 use crate::CheapCloneStr;
 #[cfg(feature = "block_layout")]
 use crate::{BlockContainerStyle, BlockContext, BlockItemStyle};
@@ -325,8 +326,8 @@ pub(crate) trait LayoutPartialTreeExt: LayoutPartialTree {
     fn measure_child_size(
         &mut self,
         node_id: NodeId,
-        known_dimensions: Size<Option<f32>>,
-        parent_size: Size<Option<f32>>,
+        known_dimensions: Size<OptFloat>,
+        parent_size: Size<OptFloat>,
         available_space: Size<AvailableSpace>,
         sizing_mode: SizingMode,
         axis: AbsoluteAxis,
@@ -355,8 +356,8 @@ pub(crate) trait LayoutPartialTreeExt: LayoutPartialTree {
     fn measure_child_size_both(
         &mut self,
         node_id: NodeId,
-        known_dimensions: Size<Option<f32>>,
-        parent_size: Size<Option<f32>>,
+        known_dimensions: Size<OptFloat>,
+        parent_size: Size<OptFloat>,
         available_space: Size<AvailableSpace>,
         sizing_mode: SizingMode,
         vertical_margins_are_collapsible: Line<bool>,
@@ -382,8 +383,8 @@ pub(crate) trait LayoutPartialTreeExt: LayoutPartialTree {
     fn perform_child_layout(
         &mut self,
         node_id: NodeId,
-        known_dimensions: Size<Option<f32>>,
-        parent_size: Size<Option<f32>>,
+        known_dimensions: Size<OptFloat>,
+        parent_size: Size<OptFloat>,
         available_space: Size<AvailableSpace>,
         sizing_mode: SizingMode,
         vertical_margins_are_collapsible: Line<bool>,

--- a/src/util/math.rs
+++ b/src/util/math.rs
@@ -3,6 +3,7 @@
 
 use crate::geometry::Size;
 use crate::style::AvailableSpace;
+use crate::util::OptFloat;
 
 /// A trait to conveniently calculate minimums and maximums when some data may not be defined
 ///
@@ -25,111 +26,115 @@ pub trait MaybeMath<In, Out> {
     fn maybe_sub(self, rhs: In) -> Out;
 }
 
-impl MaybeMath<Option<f32>, Option<f32>> for Option<f32> {
-    fn maybe_min(self, rhs: Option<f32>) -> Option<f32> {
-        match (self, rhs) {
-            (Some(l), Some(r)) => Some(l.min(r)),
-            (Some(_l), None) => self,
-            (None, Some(_r)) => None,
-            (None, None) => None,
+impl MaybeMath<OptFloat, OptFloat> for OptFloat {
+    #[inline(always)]
+    fn maybe_min(self, rhs: OptFloat) -> OptFloat {
+        if self.is_none() || rhs.is_none() {
+            self
+        } else {
+            OptFloat::some(self.unchecked_value().min(rhs.unchecked_value()))
         }
     }
 
-    fn maybe_max(self, rhs: Option<f32>) -> Option<f32> {
-        match (self, rhs) {
-            (Some(l), Some(r)) => Some(l.max(r)),
-            (Some(_l), None) => self,
-            (None, Some(_r)) => None,
-            (None, None) => None,
+    #[inline(always)]
+    fn maybe_max(self, rhs: OptFloat) -> OptFloat {
+        if self.is_none() || rhs.is_none() {
+            self
+        } else {
+            OptFloat::some(self.unchecked_value().max(rhs.unchecked_value()))
         }
     }
 
-    fn maybe_clamp(self, min: Option<f32>, max: Option<f32>) -> Option<f32> {
-        match (self, min, max) {
-            (Some(base), Some(min), Some(max)) => Some(base.min(max).max(min)),
-            (Some(base), None, Some(max)) => Some(base.min(max)),
-            (Some(base), Some(min), None) => Some(base.max(min)),
-            (Some(_), None, None) => self,
-            (None, _, _) => None,
+    #[inline(always)]
+    fn maybe_clamp(self, min: OptFloat, max: OptFloat) -> OptFloat {
+        self.maybe_min(max).maybe_max(min)
+    }
+
+    #[inline(always)]
+    fn maybe_add(self, rhs: OptFloat) -> OptFloat {
+        if self.is_none() || rhs.is_none() {
+            self
+        } else {
+            OptFloat::some(self.unchecked_value() + rhs.unchecked_value())
         }
     }
 
-    fn maybe_add(self, rhs: Option<f32>) -> Option<f32> {
-        match (self, rhs) {
-            (Some(l), Some(r)) => Some(l + r),
-            (Some(_l), None) => self,
-            (None, Some(_r)) => None,
-            (None, None) => None,
-        }
-    }
-
-    fn maybe_sub(self, rhs: Option<f32>) -> Option<f32> {
-        match (self, rhs) {
-            (Some(l), Some(r)) => Some(l - r),
-            (Some(_l), None) => self,
-            (None, Some(_r)) => None,
-            (None, None) => None,
+    #[inline(always)]
+    fn maybe_sub(self, rhs: OptFloat) -> OptFloat {
+        if self.is_none() || rhs.is_none() {
+            self
+        } else {
+            OptFloat::some(self.unchecked_value() - rhs.unchecked_value())
         }
     }
 }
 
-impl MaybeMath<f32, Option<f32>> for Option<f32> {
-    fn maybe_min(self, rhs: f32) -> Option<f32> {
+impl MaybeMath<f32, OptFloat> for OptFloat {
+    #[inline(always)]
+    fn maybe_min(self, rhs: f32) -> OptFloat {
         self.map(|val| val.min(rhs))
     }
 
-    fn maybe_max(self, rhs: f32) -> Option<f32> {
+    #[inline(always)]
+    fn maybe_max(self, rhs: f32) -> OptFloat {
         self.map(|val| val.max(rhs))
     }
 
-    fn maybe_clamp(self, min: f32, max: f32) -> Option<f32> {
+    #[inline(always)]
+    fn maybe_clamp(self, min: f32, max: f32) -> OptFloat {
         self.map(|val| val.min(max).max(min))
     }
 
-    fn maybe_add(self, rhs: f32) -> Option<f32> {
+    #[inline(always)]
+    fn maybe_add(self, rhs: f32) -> OptFloat {
         self.map(|val| val + rhs)
     }
 
-    fn maybe_sub(self, rhs: f32) -> Option<f32> {
+    #[inline(always)]
+    fn maybe_sub(self, rhs: f32) -> OptFloat {
         self.map(|val| val - rhs)
     }
 }
 
-impl MaybeMath<Option<f32>, f32> for f32 {
-    fn maybe_min(self, rhs: Option<f32>) -> f32 {
-        match rhs {
-            Some(val) => self.min(val),
-            None => self,
+impl MaybeMath<OptFloat, f32> for f32 {
+    #[inline(always)]
+    fn maybe_min(self, rhs: OptFloat) -> f32 {
+        if rhs.is_none() {
+            self
+        } else {
+            self.min(rhs.unchecked_value())
         }
     }
 
-    fn maybe_max(self, rhs: Option<f32>) -> f32 {
-        match rhs {
-            Some(val) => self.max(val),
-            None => self,
+    #[inline(always)]
+    fn maybe_max(self, rhs: OptFloat) -> f32 {
+        if rhs.is_none() {
+            self
+        } else {
+            self.max(rhs.unchecked_value())
         }
     }
 
-    fn maybe_clamp(self, min: Option<f32>, max: Option<f32>) -> f32 {
-        match (min, max) {
-            (Some(min), Some(max)) => self.min(max).max(min),
-            (None, Some(max)) => self.min(max),
-            (Some(min), None) => self.max(min),
-            (None, None) => self,
+    #[inline(always)]
+    fn maybe_clamp(self, min: OptFloat, max: OptFloat) -> f32 {
+        self.maybe_min(max).maybe_max(min)
+    }
+
+    #[inline(always)]
+    fn maybe_add(self, rhs: OptFloat) -> f32 {
+        if rhs.is_none() {
+            self
+        } else {
+            self + rhs.unchecked_value()
         }
     }
 
-    fn maybe_add(self, rhs: Option<f32>) -> f32 {
-        match rhs {
-            Some(val) => self + val,
-            None => self,
-        }
-    }
-
-    fn maybe_sub(self, rhs: Option<f32>) -> f32 {
-        match rhs {
-            Some(val) => self - val,
-            None => self,
+    #[inline(always)]
+    fn maybe_sub(self, rhs: OptFloat) -> f32 {
+        if rhs.is_none() {
+            self
+        } else {
+            self - rhs.unchecked_value()
         }
     }
 }
@@ -174,9 +179,9 @@ impl MaybeMath<f32, AvailableSpace> for AvailableSpace {
     }
 }
 
-impl MaybeMath<Option<f32>, AvailableSpace> for AvailableSpace {
-    fn maybe_min(self, rhs: Option<f32>) -> AvailableSpace {
-        match (self, rhs) {
+impl MaybeMath<OptFloat, AvailableSpace> for AvailableSpace {
+    fn maybe_min(self, rhs: OptFloat) -> AvailableSpace {
+        match (self, rhs.into_option()) {
             (AvailableSpace::Definite(val), Some(rhs)) => AvailableSpace::Definite(val.min(rhs)),
             (AvailableSpace::Definite(val), None) => AvailableSpace::Definite(val),
             (AvailableSpace::MinContent, Some(rhs)) => AvailableSpace::Definite(rhs),
@@ -185,8 +190,8 @@ impl MaybeMath<Option<f32>, AvailableSpace> for AvailableSpace {
             (AvailableSpace::MaxContent, None) => AvailableSpace::MaxContent,
         }
     }
-    fn maybe_max(self, rhs: Option<f32>) -> AvailableSpace {
-        match (self, rhs) {
+    fn maybe_max(self, rhs: OptFloat) -> AvailableSpace {
+        match (self, rhs.into_option()) {
             (AvailableSpace::Definite(val), Some(rhs)) => AvailableSpace::Definite(val.max(rhs)),
             (AvailableSpace::Definite(val), None) => AvailableSpace::Definite(val),
             (AvailableSpace::MinContent, _) => AvailableSpace::MinContent,
@@ -194,8 +199,8 @@ impl MaybeMath<Option<f32>, AvailableSpace> for AvailableSpace {
         }
     }
 
-    fn maybe_clamp(self, min: Option<f32>, max: Option<f32>) -> AvailableSpace {
-        match (self, min, max) {
+    fn maybe_clamp(self, min: OptFloat, max: OptFloat) -> AvailableSpace {
+        match (self, min.into_option(), max.into_option()) {
             (AvailableSpace::Definite(val), Some(min), Some(max)) => AvailableSpace::Definite(val.min(max).max(min)),
             (AvailableSpace::Definite(val), None, Some(max)) => AvailableSpace::Definite(val.min(max)),
             (AvailableSpace::Definite(val), Some(min), None) => AvailableSpace::Definite(val.max(min)),
@@ -205,16 +210,16 @@ impl MaybeMath<Option<f32>, AvailableSpace> for AvailableSpace {
         }
     }
 
-    fn maybe_add(self, rhs: Option<f32>) -> AvailableSpace {
-        match (self, rhs) {
+    fn maybe_add(self, rhs: OptFloat) -> AvailableSpace {
+        match (self, rhs.into_option()) {
             (AvailableSpace::Definite(val), Some(rhs)) => AvailableSpace::Definite(val + rhs),
             (AvailableSpace::Definite(val), None) => AvailableSpace::Definite(val),
             (AvailableSpace::MinContent, _) => AvailableSpace::MinContent,
             (AvailableSpace::MaxContent, _) => AvailableSpace::MaxContent,
         }
     }
-    fn maybe_sub(self, rhs: Option<f32>) -> AvailableSpace {
-        match (self, rhs) {
+    fn maybe_sub(self, rhs: OptFloat) -> AvailableSpace {
+        match (self, rhs.into_option()) {
             (AvailableSpace::Definite(val), Some(rhs)) => AvailableSpace::Definite(val - rhs),
             (AvailableSpace::Definite(val), None) => AvailableSpace::Definite(val),
             (AvailableSpace::MinContent, _) => AvailableSpace::MinContent,
@@ -251,106 +256,106 @@ impl<In, Out, T: MaybeMath<In, Out>> MaybeMath<Size<In>, Size<Out>> for Size<T> 
 #[cfg(test)]
 mod tests {
     mod lhs_option_f32_rhs_option_f32 {
-        use crate::util::MaybeMath;
+        use crate::util::{MaybeMath, OptFloat};
 
         #[test]
         fn test_maybe_min() {
-            assert_eq!(Some(3.0).maybe_min(Some(5.0)), Some(3.0));
-            assert_eq!(Some(5.0).maybe_min(Some(3.0)), Some(3.0));
-            assert_eq!(Some(3.0).maybe_min(None), Some(3.0));
-            assert_eq!(None.maybe_min(Some(3.0)), None);
-            assert_eq!(None.maybe_min(None), None);
+            assert_eq!(OptFloat::some(3.0).maybe_min(OptFloat::some(5.0)), OptFloat::some(3.0));
+            assert_eq!(OptFloat::some(5.0).maybe_min(OptFloat::some(3.0)), OptFloat::some(3.0));
+            assert_eq!(OptFloat::some(3.0).maybe_min(OptFloat::NONE), OptFloat::some(3.0));
+            assert_eq!(OptFloat::NONE.maybe_min(OptFloat::some(3.0)), OptFloat::NONE);
+            assert_eq!(OptFloat::NONE.maybe_min(OptFloat::NONE), OptFloat::NONE);
         }
 
         #[test]
         fn test_maybe_max() {
-            assert_eq!(Some(3.0).maybe_max(Some(5.0)), Some(5.0));
-            assert_eq!(Some(5.0).maybe_max(Some(3.0)), Some(5.0));
-            assert_eq!(Some(3.0).maybe_max(None), Some(3.0));
-            assert_eq!(None.maybe_max(Some(3.0)), None);
-            assert_eq!(None.maybe_max(None), None);
+            assert_eq!(OptFloat::some(3.0).maybe_max(OptFloat::some(5.0)), OptFloat::some(5.0));
+            assert_eq!(OptFloat::some(5.0).maybe_max(OptFloat::some(3.0)), OptFloat::some(5.0));
+            assert_eq!(OptFloat::some(3.0).maybe_max(OptFloat::NONE), OptFloat::some(3.0));
+            assert_eq!(OptFloat::NONE.maybe_max(OptFloat::some(3.0)), OptFloat::NONE);
+            assert_eq!(OptFloat::NONE.maybe_max(OptFloat::NONE), OptFloat::NONE);
         }
 
         #[test]
         fn test_maybe_add() {
-            assert_eq!(Some(3.0).maybe_add(Some(5.0)), Some(8.0));
-            assert_eq!(Some(5.0).maybe_add(Some(3.0)), Some(8.0));
-            assert_eq!(Some(3.0).maybe_add(None), Some(3.0));
-            assert_eq!(None.maybe_add(Some(3.0)), None);
-            assert_eq!(None.maybe_add(None), None);
+            assert_eq!(OptFloat::some(3.0).maybe_add(OptFloat::some(5.0)), OptFloat::some(8.0));
+            assert_eq!(OptFloat::some(5.0).maybe_add(OptFloat::some(3.0)), OptFloat::some(8.0));
+            assert_eq!(OptFloat::some(3.0).maybe_add(OptFloat::NONE), OptFloat::some(3.0));
+            assert_eq!(OptFloat::NONE.maybe_add(OptFloat::some(3.0)), OptFloat::NONE);
+            assert_eq!(OptFloat::NONE.maybe_add(OptFloat::NONE), OptFloat::NONE);
         }
 
         #[test]
         fn test_maybe_sub() {
-            assert_eq!(Some(3.0).maybe_sub(Some(5.0)), Some(-2.0));
-            assert_eq!(Some(5.0).maybe_sub(Some(3.0)), Some(2.0));
-            assert_eq!(Some(3.0).maybe_sub(None), Some(3.0));
-            assert_eq!(None.maybe_sub(Some(3.0)), None);
-            assert_eq!(None.maybe_sub(None), None);
+            assert_eq!(OptFloat::some(3.0).maybe_sub(OptFloat::some(5.0)), OptFloat::some(-2.0));
+            assert_eq!(OptFloat::some(5.0).maybe_sub(OptFloat::some(3.0)), OptFloat::some(2.0));
+            assert_eq!(OptFloat::some(3.0).maybe_sub(OptFloat::NONE), OptFloat::some(3.0));
+            assert_eq!(OptFloat::NONE.maybe_sub(OptFloat::some(3.0)), OptFloat::NONE);
+            assert_eq!(OptFloat::NONE.maybe_sub(OptFloat::NONE), OptFloat::NONE);
         }
     }
 
     mod lhs_option_f32_rhs_f32 {
-        use crate::util::MaybeMath;
+        use crate::util::{MaybeMath, OptFloat};
 
         #[test]
         fn test_maybe_min() {
-            assert_eq!(Some(3.0).maybe_min(5.0), Some(3.0));
-            assert_eq!(Some(5.0).maybe_min(3.0), Some(3.0));
-            assert_eq!(None.maybe_min(3.0), None);
+            assert_eq!(OptFloat::some(3.0).maybe_min(5.0), OptFloat::some(3.0));
+            assert_eq!(OptFloat::some(5.0).maybe_min(3.0), OptFloat::some(3.0));
+            assert_eq!(OptFloat::NONE.maybe_min(3.0), OptFloat::NONE);
         }
 
         #[test]
         fn test_maybe_max() {
-            assert_eq!(Some(3.0).maybe_max(5.0), Some(5.0));
-            assert_eq!(Some(5.0).maybe_max(3.0), Some(5.0));
-            assert_eq!(None.maybe_max(3.0), None);
+            assert_eq!(OptFloat::some(3.0).maybe_max(5.0), OptFloat::some(5.0));
+            assert_eq!(OptFloat::some(5.0).maybe_max(3.0), OptFloat::some(5.0));
+            assert_eq!(OptFloat::NONE.maybe_max(3.0), OptFloat::NONE);
         }
 
         #[test]
         fn test_maybe_add() {
-            assert_eq!(Some(3.0).maybe_add(5.0), Some(8.0));
-            assert_eq!(Some(5.0).maybe_add(3.0), Some(8.0));
-            assert_eq!(None.maybe_add(3.0), None);
+            assert_eq!(OptFloat::some(3.0).maybe_add(5.0), OptFloat::some(8.0));
+            assert_eq!(OptFloat::some(5.0).maybe_add(3.0), OptFloat::some(8.0));
+            assert_eq!(OptFloat::NONE.maybe_add(3.0), OptFloat::NONE);
         }
 
         #[test]
         fn test_maybe_sub() {
-            assert_eq!(Some(3.0).maybe_sub(5.0), Some(-2.0));
-            assert_eq!(Some(5.0).maybe_sub(3.0), Some(2.0));
-            assert_eq!(None.maybe_sub(3.0), None);
+            assert_eq!(OptFloat::some(3.0).maybe_sub(5.0), OptFloat::some(-2.0));
+            assert_eq!(OptFloat::some(5.0).maybe_sub(3.0), OptFloat::some(2.0));
+            assert_eq!(OptFloat::NONE.maybe_sub(3.0), OptFloat::NONE);
         }
     }
 
     mod lhs_f32_rhs_option_f32 {
-        use crate::util::MaybeMath;
+        use crate::util::{MaybeMath, OptFloat};
 
         #[test]
         fn test_maybe_min() {
-            assert_eq!(3.0.maybe_min(Some(5.0)), 3.0);
-            assert_eq!(5.0.maybe_min(Some(3.0)), 3.0);
-            assert_eq!(3.0.maybe_min(None), 3.0);
+            assert_eq!(3.0.maybe_min(OptFloat::some(5.0)), 3.0);
+            assert_eq!(5.0.maybe_min(OptFloat::some(3.0)), 3.0);
+            assert_eq!(3.0.maybe_min(OptFloat::NONE), 3.0);
         }
 
         #[test]
         fn test_maybe_max() {
-            assert_eq!(3.0.maybe_max(Some(5.0)), 5.0);
-            assert_eq!(5.0.maybe_max(Some(3.0)), 5.0);
-            assert_eq!(3.0.maybe_max(None), 3.0);
+            assert_eq!(3.0.maybe_max(OptFloat::some(5.0)), 5.0);
+            assert_eq!(5.0.maybe_max(OptFloat::some(3.0)), 5.0);
+            assert_eq!(3.0.maybe_max(OptFloat::NONE), 3.0);
         }
 
         #[test]
         fn test_maybe_add() {
-            assert_eq!(3.0.maybe_add(Some(5.0)), 8.0);
-            assert_eq!(5.0.maybe_add(Some(3.0)), 8.0);
-            assert_eq!(3.0.maybe_add(None), 3.0);
+            assert_eq!(3.0.maybe_add(OptFloat::some(5.0)), 8.0);
+            assert_eq!(5.0.maybe_add(OptFloat::some(3.0)), 8.0);
+            assert_eq!(3.0.maybe_add(OptFloat::NONE), 3.0);
         }
 
         #[test]
         fn test_maybe_sub() {
-            assert_eq!(3.0.maybe_sub(Some(5.0)), -2.0);
-            assert_eq!(5.0.maybe_sub(Some(3.0)), 2.0);
-            assert_eq!(3.0.maybe_sub(None), 3.0);
+            assert_eq!(3.0.maybe_sub(OptFloat::some(5.0)), -2.0);
+            assert_eq!(5.0.maybe_sub(OptFloat::some(3.0)), 2.0);
+            assert_eq!(3.0.maybe_sub(OptFloat::NONE), 3.0);
         }
     }
 }

--- a/src/util/math.rs
+++ b/src/util/math.rs
@@ -3,7 +3,7 @@
 
 use crate::geometry::Size;
 use crate::style::AvailableSpace;
-use crate::util::OptFloat;
+use crate::util::OptF32;
 
 /// A trait to conveniently calculate minimums and maximums when some data may not be defined
 ///
@@ -26,79 +26,79 @@ pub trait MaybeMath<In, Out> {
     fn maybe_sub(self, rhs: In) -> Out;
 }
 
-impl MaybeMath<OptFloat, OptFloat> for OptFloat {
+impl MaybeMath<OptF32, OptF32> for OptF32 {
     #[inline(always)]
-    fn maybe_min(self, rhs: OptFloat) -> OptFloat {
+    fn maybe_min(self, rhs: OptF32) -> OptF32 {
         if self.is_none() || rhs.is_none() {
             self
         } else {
-            OptFloat::some(self.unchecked_value().min(rhs.unchecked_value()))
+            OptF32::some(self.unchecked_value().min(rhs.unchecked_value()))
         }
     }
 
     #[inline(always)]
-    fn maybe_max(self, rhs: OptFloat) -> OptFloat {
+    fn maybe_max(self, rhs: OptF32) -> OptF32 {
         if self.is_none() || rhs.is_none() {
             self
         } else {
-            OptFloat::some(self.unchecked_value().max(rhs.unchecked_value()))
+            OptF32::some(self.unchecked_value().max(rhs.unchecked_value()))
         }
     }
 
     #[inline(always)]
-    fn maybe_clamp(self, min: OptFloat, max: OptFloat) -> OptFloat {
+    fn maybe_clamp(self, min: OptF32, max: OptF32) -> OptF32 {
         self.maybe_min(max).maybe_max(min)
     }
 
     #[inline(always)]
-    fn maybe_add(self, rhs: OptFloat) -> OptFloat {
+    fn maybe_add(self, rhs: OptF32) -> OptF32 {
         if self.is_none() || rhs.is_none() {
             self
         } else {
-            OptFloat::some(self.unchecked_value() + rhs.unchecked_value())
+            OptF32::some(self.unchecked_value() + rhs.unchecked_value())
         }
     }
 
     #[inline(always)]
-    fn maybe_sub(self, rhs: OptFloat) -> OptFloat {
+    fn maybe_sub(self, rhs: OptF32) -> OptF32 {
         if self.is_none() || rhs.is_none() {
             self
         } else {
-            OptFloat::some(self.unchecked_value() - rhs.unchecked_value())
+            OptF32::some(self.unchecked_value() - rhs.unchecked_value())
         }
     }
 }
 
-impl MaybeMath<f32, OptFloat> for OptFloat {
+impl MaybeMath<f32, OptF32> for OptF32 {
     #[inline(always)]
-    fn maybe_min(self, rhs: f32) -> OptFloat {
+    fn maybe_min(self, rhs: f32) -> OptF32 {
         self.map(|val| val.min(rhs))
     }
 
     #[inline(always)]
-    fn maybe_max(self, rhs: f32) -> OptFloat {
+    fn maybe_max(self, rhs: f32) -> OptF32 {
         self.map(|val| val.max(rhs))
     }
 
     #[inline(always)]
-    fn maybe_clamp(self, min: f32, max: f32) -> OptFloat {
+    fn maybe_clamp(self, min: f32, max: f32) -> OptF32 {
         self.map(|val| val.min(max).max(min))
     }
 
     #[inline(always)]
-    fn maybe_add(self, rhs: f32) -> OptFloat {
+    fn maybe_add(self, rhs: f32) -> OptF32 {
         self.map(|val| val + rhs)
     }
 
     #[inline(always)]
-    fn maybe_sub(self, rhs: f32) -> OptFloat {
+    fn maybe_sub(self, rhs: f32) -> OptF32 {
         self.map(|val| val - rhs)
     }
 }
 
-impl MaybeMath<OptFloat, f32> for f32 {
+impl MaybeMath<OptF32, f32> for f32 {
     #[inline(always)]
-    fn maybe_min(self, rhs: OptFloat) -> f32 {
+    fn maybe_min(self, rhs: OptF32) -> f32 {
         if rhs.is_none() {
             self
         } else {
@@ -107,7 +107,7 @@ impl MaybeMath<OptFloat, f32> for f32 {
     }
 
     #[inline(always)]
-    fn maybe_max(self, rhs: OptFloat) -> f32 {
+    fn maybe_max(self, rhs: OptF32) -> f32 {
         if rhs.is_none() {
             self
         } else {
@@ -116,12 +116,12 @@ impl MaybeMath<OptFloat, f32> for f32 {
     }
 
     #[inline(always)]
-    fn maybe_clamp(self, min: OptFloat, max: OptFloat) -> f32 {
+    fn maybe_clamp(self, min: OptF32, max: OptF32) -> f32 {
         self.maybe_min(max).maybe_max(min)
     }
 
     #[inline(always)]
-    fn maybe_add(self, rhs: OptFloat) -> f32 {
+    fn maybe_add(self, rhs: OptF32) -> f32 {
         if rhs.is_none() {
             self
         } else {
@@ -130,7 +130,7 @@ impl MaybeMath<OptFloat, f32> for f32 {
     }
 
     #[inline(always)]
-    fn maybe_sub(self, rhs: OptFloat) -> f32 {
+    fn maybe_sub(self, rhs: OptF32) -> f32 {
         if rhs.is_none() {
             self
         } else {
@@ -179,8 +179,8 @@ impl MaybeMath<f32, AvailableSpace> for AvailableSpace {
     }
 }
 
-impl MaybeMath<OptFloat, AvailableSpace> for AvailableSpace {
-    fn maybe_min(self, rhs: OptFloat) -> AvailableSpace {
+impl MaybeMath<OptF32, AvailableSpace> for AvailableSpace {
+    fn maybe_min(self, rhs: OptF32) -> AvailableSpace {
         match (self, rhs.into_option()) {
             (AvailableSpace::Definite(val), Some(rhs)) => AvailableSpace::Definite(val.min(rhs)),
             (AvailableSpace::Definite(val), None) => AvailableSpace::Definite(val),
@@ -190,7 +190,7 @@ impl MaybeMath<OptFloat, AvailableSpace> for AvailableSpace {
             (AvailableSpace::MaxContent, None) => AvailableSpace::MaxContent,
         }
     }
-    fn maybe_max(self, rhs: OptFloat) -> AvailableSpace {
+    fn maybe_max(self, rhs: OptF32) -> AvailableSpace {
         match (self, rhs.into_option()) {
             (AvailableSpace::Definite(val), Some(rhs)) => AvailableSpace::Definite(val.max(rhs)),
             (AvailableSpace::Definite(val), None) => AvailableSpace::Definite(val),
@@ -199,7 +199,7 @@ impl MaybeMath<OptFloat, AvailableSpace> for AvailableSpace {
         }
     }
 
-    fn maybe_clamp(self, min: OptFloat, max: OptFloat) -> AvailableSpace {
+    fn maybe_clamp(self, min: OptF32, max: OptF32) -> AvailableSpace {
         match (self, min.into_option(), max.into_option()) {
             (AvailableSpace::Definite(val), Some(min), Some(max)) => AvailableSpace::Definite(val.min(max).max(min)),
             (AvailableSpace::Definite(val), None, Some(max)) => AvailableSpace::Definite(val.min(max)),
@@ -210,7 +210,7 @@ impl MaybeMath<OptFloat, AvailableSpace> for AvailableSpace {
         }
     }
 
-    fn maybe_add(self, rhs: OptFloat) -> AvailableSpace {
+    fn maybe_add(self, rhs: OptF32) -> AvailableSpace {
         match (self, rhs.into_option()) {
             (AvailableSpace::Definite(val), Some(rhs)) => AvailableSpace::Definite(val + rhs),
             (AvailableSpace::Definite(val), None) => AvailableSpace::Definite(val),
@@ -218,7 +218,7 @@ impl MaybeMath<OptFloat, AvailableSpace> for AvailableSpace {
             (AvailableSpace::MaxContent, _) => AvailableSpace::MaxContent,
         }
     }
-    fn maybe_sub(self, rhs: OptFloat) -> AvailableSpace {
+    fn maybe_sub(self, rhs: OptF32) -> AvailableSpace {
         match (self, rhs.into_option()) {
             (AvailableSpace::Definite(val), Some(rhs)) => AvailableSpace::Definite(val - rhs),
             (AvailableSpace::Definite(val), None) => AvailableSpace::Definite(val),
@@ -256,106 +256,106 @@ impl<In, Out, T: MaybeMath<In, Out>> MaybeMath<Size<In>, Size<Out>> for Size<T> 
 #[cfg(test)]
 mod tests {
     mod lhs_option_f32_rhs_option_f32 {
-        use crate::util::{MaybeMath, OptFloat};
+        use crate::util::{MaybeMath, OptF32};
 
         #[test]
         fn test_maybe_min() {
-            assert_eq!(OptFloat::some(3.0).maybe_min(OptFloat::some(5.0)), OptFloat::some(3.0));
-            assert_eq!(OptFloat::some(5.0).maybe_min(OptFloat::some(3.0)), OptFloat::some(3.0));
-            assert_eq!(OptFloat::some(3.0).maybe_min(OptFloat::NONE), OptFloat::some(3.0));
-            assert_eq!(OptFloat::NONE.maybe_min(OptFloat::some(3.0)), OptFloat::NONE);
-            assert_eq!(OptFloat::NONE.maybe_min(OptFloat::NONE), OptFloat::NONE);
+            assert_eq!(OptF32::some(3.0).maybe_min(OptF32::some(5.0)), OptF32::some(3.0));
+            assert_eq!(OptF32::some(5.0).maybe_min(OptF32::some(3.0)), OptF32::some(3.0));
+            assert_eq!(OptF32::some(3.0).maybe_min(OptF32::NONE), OptF32::some(3.0));
+            assert_eq!(OptF32::NONE.maybe_min(OptF32::some(3.0)), OptF32::NONE);
+            assert_eq!(OptF32::NONE.maybe_min(OptF32::NONE), OptF32::NONE);
         }
 
         #[test]
         fn test_maybe_max() {
-            assert_eq!(OptFloat::some(3.0).maybe_max(OptFloat::some(5.0)), OptFloat::some(5.0));
-            assert_eq!(OptFloat::some(5.0).maybe_max(OptFloat::some(3.0)), OptFloat::some(5.0));
-            assert_eq!(OptFloat::some(3.0).maybe_max(OptFloat::NONE), OptFloat::some(3.0));
-            assert_eq!(OptFloat::NONE.maybe_max(OptFloat::some(3.0)), OptFloat::NONE);
-            assert_eq!(OptFloat::NONE.maybe_max(OptFloat::NONE), OptFloat::NONE);
+            assert_eq!(OptF32::some(3.0).maybe_max(OptF32::some(5.0)), OptF32::some(5.0));
+            assert_eq!(OptF32::some(5.0).maybe_max(OptF32::some(3.0)), OptF32::some(5.0));
+            assert_eq!(OptF32::some(3.0).maybe_max(OptF32::NONE), OptF32::some(3.0));
+            assert_eq!(OptF32::NONE.maybe_max(OptF32::some(3.0)), OptF32::NONE);
+            assert_eq!(OptF32::NONE.maybe_max(OptF32::NONE), OptF32::NONE);
         }
 
         #[test]
         fn test_maybe_add() {
-            assert_eq!(OptFloat::some(3.0).maybe_add(OptFloat::some(5.0)), OptFloat::some(8.0));
-            assert_eq!(OptFloat::some(5.0).maybe_add(OptFloat::some(3.0)), OptFloat::some(8.0));
-            assert_eq!(OptFloat::some(3.0).maybe_add(OptFloat::NONE), OptFloat::some(3.0));
-            assert_eq!(OptFloat::NONE.maybe_add(OptFloat::some(3.0)), OptFloat::NONE);
-            assert_eq!(OptFloat::NONE.maybe_add(OptFloat::NONE), OptFloat::NONE);
+            assert_eq!(OptF32::some(3.0).maybe_add(OptF32::some(5.0)), OptF32::some(8.0));
+            assert_eq!(OptF32::some(5.0).maybe_add(OptF32::some(3.0)), OptF32::some(8.0));
+            assert_eq!(OptF32::some(3.0).maybe_add(OptF32::NONE), OptF32::some(3.0));
+            assert_eq!(OptF32::NONE.maybe_add(OptF32::some(3.0)), OptF32::NONE);
+            assert_eq!(OptF32::NONE.maybe_add(OptF32::NONE), OptF32::NONE);
         }
 
         #[test]
         fn test_maybe_sub() {
-            assert_eq!(OptFloat::some(3.0).maybe_sub(OptFloat::some(5.0)), OptFloat::some(-2.0));
-            assert_eq!(OptFloat::some(5.0).maybe_sub(OptFloat::some(3.0)), OptFloat::some(2.0));
-            assert_eq!(OptFloat::some(3.0).maybe_sub(OptFloat::NONE), OptFloat::some(3.0));
-            assert_eq!(OptFloat::NONE.maybe_sub(OptFloat::some(3.0)), OptFloat::NONE);
-            assert_eq!(OptFloat::NONE.maybe_sub(OptFloat::NONE), OptFloat::NONE);
+            assert_eq!(OptF32::some(3.0).maybe_sub(OptF32::some(5.0)), OptF32::some(-2.0));
+            assert_eq!(OptF32::some(5.0).maybe_sub(OptF32::some(3.0)), OptF32::some(2.0));
+            assert_eq!(OptF32::some(3.0).maybe_sub(OptF32::NONE), OptF32::some(3.0));
+            assert_eq!(OptF32::NONE.maybe_sub(OptF32::some(3.0)), OptF32::NONE);
+            assert_eq!(OptF32::NONE.maybe_sub(OptF32::NONE), OptF32::NONE);
         }
     }
 
     mod lhs_option_f32_rhs_f32 {
-        use crate::util::{MaybeMath, OptFloat};
+        use crate::util::{MaybeMath, OptF32};
 
         #[test]
         fn test_maybe_min() {
-            assert_eq!(OptFloat::some(3.0).maybe_min(5.0), OptFloat::some(3.0));
-            assert_eq!(OptFloat::some(5.0).maybe_min(3.0), OptFloat::some(3.0));
-            assert_eq!(OptFloat::NONE.maybe_min(3.0), OptFloat::NONE);
+            assert_eq!(OptF32::some(3.0).maybe_min(5.0), OptF32::some(3.0));
+            assert_eq!(OptF32::some(5.0).maybe_min(3.0), OptF32::some(3.0));
+            assert_eq!(OptF32::NONE.maybe_min(3.0), OptF32::NONE);
         }
 
         #[test]
         fn test_maybe_max() {
-            assert_eq!(OptFloat::some(3.0).maybe_max(5.0), OptFloat::some(5.0));
-            assert_eq!(OptFloat::some(5.0).maybe_max(3.0), OptFloat::some(5.0));
-            assert_eq!(OptFloat::NONE.maybe_max(3.0), OptFloat::NONE);
+            assert_eq!(OptF32::some(3.0).maybe_max(5.0), OptF32::some(5.0));
+            assert_eq!(OptF32::some(5.0).maybe_max(3.0), OptF32::some(5.0));
+            assert_eq!(OptF32::NONE.maybe_max(3.0), OptF32::NONE);
         }
 
         #[test]
         fn test_maybe_add() {
-            assert_eq!(OptFloat::some(3.0).maybe_add(5.0), OptFloat::some(8.0));
-            assert_eq!(OptFloat::some(5.0).maybe_add(3.0), OptFloat::some(8.0));
-            assert_eq!(OptFloat::NONE.maybe_add(3.0), OptFloat::NONE);
+            assert_eq!(OptF32::some(3.0).maybe_add(5.0), OptF32::some(8.0));
+            assert_eq!(OptF32::some(5.0).maybe_add(3.0), OptF32::some(8.0));
+            assert_eq!(OptF32::NONE.maybe_add(3.0), OptF32::NONE);
         }
 
         #[test]
         fn test_maybe_sub() {
-            assert_eq!(OptFloat::some(3.0).maybe_sub(5.0), OptFloat::some(-2.0));
-            assert_eq!(OptFloat::some(5.0).maybe_sub(3.0), OptFloat::some(2.0));
-            assert_eq!(OptFloat::NONE.maybe_sub(3.0), OptFloat::NONE);
+            assert_eq!(OptF32::some(3.0).maybe_sub(5.0), OptF32::some(-2.0));
+            assert_eq!(OptF32::some(5.0).maybe_sub(3.0), OptF32::some(2.0));
+            assert_eq!(OptF32::NONE.maybe_sub(3.0), OptF32::NONE);
         }
     }
 
     mod lhs_f32_rhs_option_f32 {
-        use crate::util::{MaybeMath, OptFloat};
+        use crate::util::{MaybeMath, OptF32};
 
         #[test]
         fn test_maybe_min() {
-            assert_eq!(3.0.maybe_min(OptFloat::some(5.0)), 3.0);
-            assert_eq!(5.0.maybe_min(OptFloat::some(3.0)), 3.0);
-            assert_eq!(3.0.maybe_min(OptFloat::NONE), 3.0);
+            assert_eq!(3.0.maybe_min(OptF32::some(5.0)), 3.0);
+            assert_eq!(5.0.maybe_min(OptF32::some(3.0)), 3.0);
+            assert_eq!(3.0.maybe_min(OptF32::NONE), 3.0);
         }
 
         #[test]
         fn test_maybe_max() {
-            assert_eq!(3.0.maybe_max(OptFloat::some(5.0)), 5.0);
-            assert_eq!(5.0.maybe_max(OptFloat::some(3.0)), 5.0);
-            assert_eq!(3.0.maybe_max(OptFloat::NONE), 3.0);
+            assert_eq!(3.0.maybe_max(OptF32::some(5.0)), 5.0);
+            assert_eq!(5.0.maybe_max(OptF32::some(3.0)), 5.0);
+            assert_eq!(3.0.maybe_max(OptF32::NONE), 3.0);
         }
 
         #[test]
         fn test_maybe_add() {
-            assert_eq!(3.0.maybe_add(OptFloat::some(5.0)), 8.0);
-            assert_eq!(5.0.maybe_add(OptFloat::some(3.0)), 8.0);
-            assert_eq!(3.0.maybe_add(OptFloat::NONE), 3.0);
+            assert_eq!(3.0.maybe_add(OptF32::some(5.0)), 8.0);
+            assert_eq!(5.0.maybe_add(OptF32::some(3.0)), 8.0);
+            assert_eq!(3.0.maybe_add(OptF32::NONE), 3.0);
         }
 
         #[test]
         fn test_maybe_sub() {
-            assert_eq!(3.0.maybe_sub(OptFloat::some(5.0)), -2.0);
-            assert_eq!(5.0.maybe_sub(OptFloat::some(3.0)), 2.0);
-            assert_eq!(3.0.maybe_sub(OptFloat::NONE), 3.0);
+            assert_eq!(3.0.maybe_sub(OptF32::some(5.0)), -2.0);
+            assert_eq!(5.0.maybe_sub(OptF32::some(3.0)), 2.0);
+            assert_eq!(3.0.maybe_sub(OptF32::NONE), 3.0);
         }
     }
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,9 +1,11 @@
 //! Helpful misc. utilities such as a function to debug print a tree
 mod math;
+mod opt_float;
 mod resolve;
 pub(crate) mod sys;
 
 pub use math::MaybeMath;
+pub use opt_float::OptFloat;
 pub use resolve::{MaybeResolve, ResolveOrZero};
 
 #[doc(hidden)]

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,11 +1,11 @@
 //! Helpful misc. utilities such as a function to debug print a tree
 mod math;
-mod opt_float;
+mod opt_f32;
 mod resolve;
 pub(crate) mod sys;
 
 pub use math::MaybeMath;
-pub use opt_float::OptFloat;
+pub use opt_f32::OptF32;
 pub use resolve::{MaybeResolve, ResolveOrZero};
 
 #[doc(hidden)]

--- a/src/util/opt_f32.rs
+++ b/src/util/opt_f32.rs
@@ -9,9 +9,9 @@ use core::fmt;
 /// with a genuinely computed NaN is not a concern in practice.
 #[derive(Copy, Clone)]
 #[repr(transparent)]
-pub struct OptFloat(f32);
+pub struct OptF32(f32);
 
-impl OptFloat {
+impl OptF32 {
     /// The bit pattern used to represent `None`: a quiet NaN with a distinctive payload
     const NONE_BITS: u32 = 0x7FC0_F32A;
 
@@ -64,7 +64,7 @@ impl OptFloat {
     #[track_caller]
     pub fn unwrap(self) -> f32 {
         if self.is_none() {
-            panic!("called `OptFloat::unwrap()` on a `None` value");
+            panic!("called `OptF32::unwrap()` on a `None` value");
         }
         self.0
     }
@@ -119,7 +119,7 @@ impl OptFloat {
         }
     }
 
-    /// Sums an iterator of `OptFloat`s, returning `None` if any of the values are `None`
+    /// Sums an iterator of `OptF32`s, returning `None` if any of the values are `None`
     /// (matching the behaviour of `Option<f32>`)
     fn sum_impl(iter: impl Iterator<Item = Self>) -> Self {
         let mut total = 0.0;
@@ -163,7 +163,7 @@ impl OptFloat {
     }
 }
 
-impl core::iter::Sum for OptFloat {
+impl core::iter::Sum for OptF32 {
     /// Sums the values, returning `None` if any of the values are `None`
     /// (matching the behaviour of `Option<f32>`)
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
@@ -171,7 +171,7 @@ impl core::iter::Sum for OptFloat {
     }
 }
 
-impl From<Option<f32>> for OptFloat {
+impl From<Option<f32>> for OptF32 {
     #[inline(always)]
     fn from(value: Option<f32>) -> Self {
         match value {
@@ -181,21 +181,21 @@ impl From<Option<f32>> for OptFloat {
     }
 }
 
-impl From<OptFloat> for Option<f32> {
+impl From<OptF32> for Option<f32> {
     #[inline(always)]
-    fn from(value: OptFloat) -> Self {
+    fn from(value: OptF32) -> Self {
         value.into_option()
     }
 }
 
-impl From<f32> for OptFloat {
+impl From<f32> for OptF32 {
     #[inline(always)]
     fn from(value: f32) -> Self {
         Self::some(value)
     }
 }
 
-impl PartialEq for OptFloat {
+impl PartialEq for OptF32 {
     #[inline(always)]
     fn eq(&self, other: &Self) -> bool {
         // Values compare like f32, except that `NONE == NONE` (which the float
@@ -204,7 +204,7 @@ impl PartialEq for OptFloat {
     }
 }
 
-impl fmt::Debug for OptFloat {
+impl fmt::Debug for OptF32 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Format like Option<f32> for familiarity
         if self.is_none() {
@@ -216,14 +216,14 @@ impl fmt::Debug for OptFloat {
 }
 
 #[cfg(feature = "serde")]
-impl serde::Serialize for OptFloat {
+impl serde::Serialize for OptF32 {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         self.into_option().serialize(serializer)
     }
 }
 
 #[cfg(feature = "serde")]
-impl<'de> serde::Deserialize<'de> for OptFloat {
+impl<'de> serde::Deserialize<'de> for OptF32 {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         Option::<f32>::deserialize(deserializer).map(Self::from)
     }
@@ -231,40 +231,40 @@ impl<'de> serde::Deserialize<'de> for OptFloat {
 
 #[cfg(test)]
 mod tests {
-    use super::OptFloat;
+    use super::OptF32;
 
     #[test]
     fn size_is_4_bytes() {
-        assert_eq!(core::mem::size_of::<OptFloat>(), 4);
+        assert_eq!(core::mem::size_of::<OptF32>(), 4);
     }
 
     #[test]
     fn none_roundtrip() {
-        assert_eq!(OptFloat::NONE.into_option(), None);
-        assert!(OptFloat::NONE.is_none());
-        assert!(!OptFloat::NONE.is_some());
-        assert_eq!(OptFloat::from(None), OptFloat::NONE);
+        assert_eq!(OptF32::NONE.into_option(), None);
+        assert!(OptF32::NONE.is_none());
+        assert!(!OptF32::NONE.is_some());
+        assert_eq!(OptF32::from(None), OptF32::NONE);
     }
 
     #[test]
     fn some_roundtrip() {
-        assert_eq!(OptFloat::some(5.0).into_option(), Some(5.0));
-        assert_eq!(OptFloat::from(Some(-0.0)).into_option(), Some(-0.0));
-        assert!(OptFloat::some(0.0).is_some());
+        assert_eq!(OptF32::some(5.0).into_option(), Some(5.0));
+        assert_eq!(OptF32::from(Some(-0.0)).into_option(), Some(-0.0));
+        assert!(OptF32::some(0.0).is_some());
     }
 
     #[test]
     fn nan_is_some() {
         // A regular NaN is not the sentinel and so is a "some" value
-        assert!(OptFloat::some(f32::NAN).is_some());
+        assert!(OptF32::some(f32::NAN).is_some());
     }
 
     #[test]
     fn equality() {
-        assert_eq!(OptFloat::NONE, OptFloat::NONE);
-        assert_eq!(OptFloat::some(3.0), OptFloat::some(3.0));
-        assert_ne!(OptFloat::some(3.0), OptFloat::some(4.0));
-        assert_ne!(OptFloat::some(3.0), OptFloat::NONE);
-        assert_eq!(OptFloat::some(0.0), OptFloat::some(-0.0));
+        assert_eq!(OptF32::NONE, OptF32::NONE);
+        assert_eq!(OptF32::some(3.0), OptF32::some(3.0));
+        assert_ne!(OptF32::some(3.0), OptF32::some(4.0));
+        assert_ne!(OptF32::some(3.0), OptF32::NONE);
+        assert_eq!(OptF32::some(0.0), OptF32::some(-0.0));
     }
 }

--- a/src/util/opt_float.rs
+++ b/src/util/opt_float.rs
@@ -1,4 +1,5 @@
 //! A compact 4-byte replacement for `Option<f32>`
+use crate::style::compact_length::compat::{f32_from_bits, f32_to_bits};
 use core::fmt;
 
 /// A 4-byte equivalent of `Option<f32>` that uses a single sentinel NaN bit pattern
@@ -15,7 +16,7 @@ impl OptFloat {
     const NONE_BITS: u32 = 0x7FC0_F32A;
 
     /// The `None` value
-    pub const NONE: Self = Self(f32::from_bits(Self::NONE_BITS));
+    pub const NONE: Self = Self(f32_from_bits(Self::NONE_BITS));
 
     /// Creates a "some" value
     #[inline(always)]
@@ -26,7 +27,7 @@ impl OptFloat {
     /// Returns `true` if the value is `None`
     #[inline(always)]
     pub const fn is_none(self) -> bool {
-        self.0.to_bits() == Self::NONE_BITS
+        self.to_bits() == Self::NONE_BITS
     }
 
     /// Returns `true` if the value is not `None`
@@ -55,7 +56,7 @@ impl OptFloat {
     /// Returns the raw bit representation
     #[inline(always)]
     pub const fn to_bits(self) -> u32 {
-        self.0.to_bits()
+        f32_to_bits(self.0)
     }
 
     /// Returns the contained value, panicking if it is `None`
@@ -199,7 +200,7 @@ impl PartialEq for OptFloat {
     fn eq(&self, other: &Self) -> bool {
         // Values compare like f32, except that `NONE == NONE` (which the float
         // comparison alone would report as false as the sentinel is a NaN)
-        (self.0 == other.0) | (self.0.to_bits() == other.0.to_bits())
+        (self.0 == other.0) | (self.to_bits() == other.to_bits())
     }
 }
 

--- a/src/util/opt_float.rs
+++ b/src/util/opt_float.rs
@@ -1,0 +1,269 @@
+//! A compact 4-byte replacement for `Option<f32>`
+use core::fmt;
+
+/// A 4-byte equivalent of `Option<f32>` that uses a single sentinel NaN bit pattern
+/// to represent `None`. All other values (including other NaNs) are "some" values.
+///
+/// Taffy assumes that input lengths are non-NaN, so the sentinel pattern colliding
+/// with a genuinely computed NaN is not a concern in practice.
+#[derive(Copy, Clone)]
+#[repr(transparent)]
+pub struct OptFloat(f32);
+
+impl OptFloat {
+    /// The bit pattern used to represent `None`: a quiet NaN with a distinctive payload
+    const NONE_BITS: u32 = 0x7FC0_F32A;
+
+    /// The `None` value
+    pub const NONE: Self = Self(f32::from_bits(Self::NONE_BITS));
+
+    /// Creates a "some" value
+    #[inline(always)]
+    pub const fn some(value: f32) -> Self {
+        Self(value)
+    }
+
+    /// Returns `true` if the value is `None`
+    #[inline(always)]
+    pub const fn is_none(self) -> bool {
+        self.0.to_bits() == Self::NONE_BITS
+    }
+
+    /// Returns `true` if the value is not `None`
+    #[inline(always)]
+    pub const fn is_some(self) -> bool {
+        !self.is_none()
+    }
+
+    /// Converts to an `Option<f32>`
+    #[inline(always)]
+    pub const fn into_option(self) -> Option<f32> {
+        if self.is_none() {
+            None
+        } else {
+            Some(self.0)
+        }
+    }
+
+    /// Returns the contained value without checking whether it is `None`.
+    /// If the value is `None` then the sentinel NaN is returned.
+    #[inline(always)]
+    pub const fn unchecked_value(self) -> f32 {
+        self.0
+    }
+
+    /// Returns the raw bit representation
+    #[inline(always)]
+    pub const fn to_bits(self) -> u32 {
+        self.0.to_bits()
+    }
+
+    /// Returns the contained value, panicking if it is `None`
+    #[inline(always)]
+    #[track_caller]
+    pub fn unwrap(self) -> f32 {
+        if self.is_none() {
+            panic!("called `OptFloat::unwrap()` on a `None` value");
+        }
+        self.0
+    }
+
+    /// Returns the contained value or the provided default if `None`
+    #[inline(always)]
+    pub fn unwrap_or(self, default: f32) -> f32 {
+        if self.is_none() {
+            default
+        } else {
+            self.0
+        }
+    }
+
+    /// Returns the contained value or computes it from the closure if `None`
+    #[inline(always)]
+    pub fn unwrap_or_else(self, default: impl FnOnce() -> f32) -> f32 {
+        if self.is_none() {
+            default()
+        } else {
+            self.0
+        }
+    }
+
+    /// Returns self if it is "some", otherwise returns `other`
+    #[inline(always)]
+    pub fn or(self, other: Self) -> Self {
+        if self.is_none() {
+            other
+        } else {
+            self
+        }
+    }
+
+    /// Returns self if it is "some", otherwise computes the fallback from the closure
+    #[inline(always)]
+    pub fn or_else(self, other: impl FnOnce() -> Self) -> Self {
+        if self.is_none() {
+            other()
+        } else {
+            self
+        }
+    }
+
+    /// Applies a function to the contained value (if any)
+    #[inline(always)]
+    pub fn map(self, f: impl FnOnce(f32) -> f32) -> Self {
+        if self.is_none() {
+            self
+        } else {
+            Self(f(self.0))
+        }
+    }
+
+    /// Sums an iterator of `OptFloat`s, returning `None` if any of the values are `None`
+    /// (matching the behaviour of `Option<f32>`)
+    fn sum_impl(iter: impl Iterator<Item = Self>) -> Self {
+        let mut total = 0.0;
+        for item in iter {
+            if item.is_none() {
+                return Self::NONE;
+            }
+            total += item.0;
+        }
+        Self(total)
+    }
+
+    /// Returns `default` if the value is `None`, or applies `f` to the contained value
+    #[inline(always)]
+    pub fn map_or<U>(self, default: U, f: impl FnOnce(f32) -> U) -> U {
+        if self.is_none() {
+            default
+        } else {
+            f(self.0)
+        }
+    }
+
+    /// Returns `None` if the value is `None`, otherwise calls `f` with the value and returns the result
+    #[inline(always)]
+    pub fn and_then(self, f: impl FnOnce(f32) -> Self) -> Self {
+        if self.is_none() {
+            self
+        } else {
+            f(self.0)
+        }
+    }
+
+    /// Returns `None` if the value is `None` or the predicate returns false
+    #[inline(always)]
+    pub fn filter(self, predicate: impl FnOnce(f32) -> bool) -> Self {
+        if self.is_some() && predicate(self.0) {
+            self
+        } else {
+            Self::NONE
+        }
+    }
+}
+
+impl core::iter::Sum for OptFloat {
+    /// Sums the values, returning `None` if any of the values are `None`
+    /// (matching the behaviour of `Option<f32>`)
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        Self::sum_impl(iter)
+    }
+}
+
+impl From<Option<f32>> for OptFloat {
+    #[inline(always)]
+    fn from(value: Option<f32>) -> Self {
+        match value {
+            Some(value) => Self::some(value),
+            None => Self::NONE,
+        }
+    }
+}
+
+impl From<OptFloat> for Option<f32> {
+    #[inline(always)]
+    fn from(value: OptFloat) -> Self {
+        value.into_option()
+    }
+}
+
+impl From<f32> for OptFloat {
+    #[inline(always)]
+    fn from(value: f32) -> Self {
+        Self::some(value)
+    }
+}
+
+impl PartialEq for OptFloat {
+    #[inline(always)]
+    fn eq(&self, other: &Self) -> bool {
+        // Values compare like f32, except that `NONE == NONE` (which the float
+        // comparison alone would report as false as the sentinel is a NaN)
+        (self.0 == other.0) | (self.0.to_bits() == other.0.to_bits())
+    }
+}
+
+impl fmt::Debug for OptFloat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Format like Option<f32> for familiarity
+        if self.is_none() {
+            f.write_str("None")
+        } else {
+            f.debug_tuple("Some").field(&self.0).finish()
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for OptFloat {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.into_option().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for OptFloat {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Option::<f32>::deserialize(deserializer).map(Self::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OptFloat;
+
+    #[test]
+    fn size_is_4_bytes() {
+        assert_eq!(core::mem::size_of::<OptFloat>(), 4);
+    }
+
+    #[test]
+    fn none_roundtrip() {
+        assert_eq!(OptFloat::NONE.into_option(), None);
+        assert!(OptFloat::NONE.is_none());
+        assert!(!OptFloat::NONE.is_some());
+        assert_eq!(OptFloat::from(None), OptFloat::NONE);
+    }
+
+    #[test]
+    fn some_roundtrip() {
+        assert_eq!(OptFloat::some(5.0).into_option(), Some(5.0));
+        assert_eq!(OptFloat::from(Some(-0.0)).into_option(), Some(-0.0));
+        assert!(OptFloat::some(0.0).is_some());
+    }
+
+    #[test]
+    fn nan_is_some() {
+        // A regular NaN is not the sentinel and so is a "some" value
+        assert!(OptFloat::some(f32::NAN).is_some());
+    }
+
+    #[test]
+    fn equality() {
+        assert_eq!(OptFloat::NONE, OptFloat::NONE);
+        assert_eq!(OptFloat::some(3.0), OptFloat::some(3.0));
+        assert_ne!(OptFloat::some(3.0), OptFloat::some(4.0));
+        assert_ne!(OptFloat::some(3.0), OptFloat::NONE);
+        assert_eq!(OptFloat::some(0.0), OptFloat::some(-0.0));
+    }
+}

--- a/src/util/resolve.rs
+++ b/src/util/resolve.rs
@@ -3,6 +3,7 @@
 use crate::geometry::{Rect, Size};
 use crate::style::{Dimension, LengthPercentage, LengthPercentageAuto};
 use crate::style_helpers::TaffyZero;
+use crate::util::OptFloat;
 use crate::CompactLength;
 
 /// Trait to encapsulate behaviour where we need to resolve from a
@@ -25,12 +26,12 @@ pub trait ResolveOrZero<TContext, TOutput: TaffyZero> {
     fn resolve_or_zero(self, context: TContext, calc: impl Fn(*const (), f32) -> f32) -> TOutput;
 }
 
-impl MaybeResolve<Option<f32>, Option<f32>> for LengthPercentage {
+impl MaybeResolve<OptFloat, OptFloat> for LengthPercentage {
     /// Converts the given [`LengthPercentage`] into an absolute length
     /// Can return `None`
-    fn maybe_resolve(self, context: Option<f32>, calc: impl Fn(*const (), f32) -> f32) -> Option<f32> {
+    fn maybe_resolve(self, context: OptFloat, calc: impl Fn(*const (), f32) -> f32) -> OptFloat {
         match self.0.tag() {
-            CompactLength::LENGTH_TAG => Some(self.0.value()),
+            CompactLength::LENGTH_TAG => OptFloat::some(self.0.value()),
             CompactLength::PERCENT_TAG => context.map(|dim| dim * self.0.value()),
             #[cfg(feature = "calc")]
             _ if self.0.is_calc() => context.map(|dim| calc(self.0.calc_value(), dim)),
@@ -39,13 +40,13 @@ impl MaybeResolve<Option<f32>, Option<f32>> for LengthPercentage {
     }
 }
 
-impl MaybeResolve<Option<f32>, Option<f32>> for LengthPercentageAuto {
+impl MaybeResolve<OptFloat, OptFloat> for LengthPercentageAuto {
     /// Converts the given [`LengthPercentageAuto`] into an absolute length
     /// Can return `None`
-    fn maybe_resolve(self, context: Option<f32>, calc: impl Fn(*const (), f32) -> f32) -> Option<f32> {
+    fn maybe_resolve(self, context: OptFloat, calc: impl Fn(*const (), f32) -> f32) -> OptFloat {
         match self.0.tag() {
-            CompactLength::AUTO_TAG => None,
-            CompactLength::LENGTH_TAG => Some(self.0.value()),
+            CompactLength::AUTO_TAG => OptFloat::NONE,
+            CompactLength::LENGTH_TAG => OptFloat::some(self.0.value()),
             CompactLength::PERCENT_TAG => context.map(|dim| dim * self.0.value()),
             #[cfg(feature = "calc")]
             _ if self.0.is_calc() => context.map(|dim| calc(self.0.calc_value(), dim)),
@@ -54,34 +55,34 @@ impl MaybeResolve<Option<f32>, Option<f32>> for LengthPercentageAuto {
     }
 }
 
-impl MaybeResolve<Option<f32>, Option<f32>> for Dimension {
+impl MaybeResolve<OptFloat, OptFloat> for Dimension {
     /// Converts the given [`Dimension`] into an absolute length
     ///
     /// Can return `None`
-    fn maybe_resolve(self, context: Option<f32>, calc: impl Fn(*const (), f32) -> f32) -> Option<f32> {
+    fn maybe_resolve(self, context: OptFloat, calc: impl Fn(*const (), f32) -> f32) -> OptFloat {
         match self.0.tag() {
-            CompactLength::AUTO_TAG => None,
+            CompactLength::AUTO_TAG => OptFloat::NONE,
             // The content keyword is only valid for flex-basis. In any other context it behaves as auto.
-            CompactLength::CONTENT_TAG => None,
-            CompactLength::LENGTH_TAG => Some(self.0.value()),
+            CompactLength::CONTENT_TAG => OptFloat::NONE,
+            CompactLength::LENGTH_TAG => OptFloat::some(self.0.value()),
             CompactLength::PERCENT_TAG => context.map(|dim| dim * self.0.value()),
             #[cfg(feature = "calc")]
             _ if self.0.is_calc() => context.map(|dim| calc(self.0.calc_value(), dim)),
             // Intrinsic sizing keywords cannot be resolved to a definite size out of context.
             // Layout algorithms that support them must handle them explicitly.
-            _ if self.0.is_sizing_keyword() => None,
+            _ if self.0.is_sizing_keyword() => OptFloat::NONE,
             _ => unreachable!(),
         }
     }
 }
 
 // Generic implementation of MaybeResolve for f32 context where MaybeResolve is implemented
-// for Option<f32> context
-impl<T: MaybeResolve<Option<f32>, Option<f32>>> MaybeResolve<f32, Option<f32>> for T {
+// for OptFloat context
+impl<T: MaybeResolve<OptFloat, OptFloat>> MaybeResolve<f32, OptFloat> for T {
     /// Converts the given MaybeResolve value into an absolute length
     /// Can return `None`
-    fn maybe_resolve(self, context: f32, calc: impl Fn(*const (), f32) -> f32) -> Option<f32> {
-        self.maybe_resolve(Some(context), calc)
+    fn maybe_resolve(self, context: f32, calc: impl Fn(*const (), f32) -> f32) -> OptFloat {
+        self.maybe_resolve(OptFloat::some(context), calc)
     }
 }
 
@@ -96,23 +97,23 @@ impl<In, Out, T: MaybeResolve<In, Out>> MaybeResolve<Size<In>, Size<Out>> for Si
     }
 }
 
-impl ResolveOrZero<Option<f32>, f32> for LengthPercentage {
+impl ResolveOrZero<OptFloat, f32> for LengthPercentage {
     /// Will return a default value of result is evaluated to `None`
-    fn resolve_or_zero(self, context: Option<f32>, calc: impl Fn(*const (), f32) -> f32) -> f32 {
+    fn resolve_or_zero(self, context: OptFloat, calc: impl Fn(*const (), f32) -> f32) -> f32 {
         self.maybe_resolve(context, calc).unwrap_or(0.0)
     }
 }
 
-impl ResolveOrZero<Option<f32>, f32> for LengthPercentageAuto {
+impl ResolveOrZero<OptFloat, f32> for LengthPercentageAuto {
     /// Will return a default value of result is evaluated to `None`
-    fn resolve_or_zero(self, context: Option<f32>, calc: impl Fn(*const (), f32) -> f32) -> f32 {
+    fn resolve_or_zero(self, context: OptFloat, calc: impl Fn(*const (), f32) -> f32) -> f32 {
         self.maybe_resolve(context, calc).unwrap_or(0.0)
     }
 }
 
-impl ResolveOrZero<Option<f32>, f32> for Dimension {
+impl ResolveOrZero<OptFloat, f32> for Dimension {
     /// Will return a default value of result is evaluated to `None`
-    fn resolve_or_zero(self, context: Option<f32>, calc: impl Fn(*const (), f32) -> f32) -> f32 {
+    fn resolve_or_zero(self, context: OptFloat, calc: impl Fn(*const (), f32) -> f32) -> f32 {
         self.maybe_resolve(context, calc).unwrap_or(0.0)
     }
 }
@@ -142,9 +143,9 @@ impl<In: Copy, Out: TaffyZero, T: ResolveOrZero<In, Out>> ResolveOrZero<Size<In>
 }
 
 // Generic ResolveOrZero for resolving Rect against Option
-impl<Out: TaffyZero, T: ResolveOrZero<Option<f32>, Out>> ResolveOrZero<Option<f32>, Rect<Out>> for Rect<T> {
+impl<Out: TaffyZero, T: ResolveOrZero<OptFloat, Out>> ResolveOrZero<OptFloat, Rect<Out>> for Rect<T> {
     /// Converts any `parent`-relative values for Rect into an absolute Rect
-    fn resolve_or_zero(self, context: Option<f32>, calc: impl Fn(*const (), f32) -> f32) -> Rect<Out> {
+    fn resolve_or_zero(self, context: OptFloat, calc: impl Fn(*const (), f32) -> f32) -> Rect<Out> {
         Rect {
             left: self.left.resolve_or_zero(context, &calc),
             right: self.right.resolve_or_zero(context, &calc),
@@ -195,16 +196,17 @@ mod tests {
         use super::mr_case;
         use crate::style::Dimension;
         use crate::style_helpers::*;
+        use crate::util::OptFloat;
 
         /// `Dimension::Auto` should always return `None`
         ///
         /// The parent / context should not affect the outcome.
         #[test]
         fn resolve_auto() {
-            mr_case(Dimension::AUTO, None, None);
-            mr_case(Dimension::AUTO, Some(5.0), None);
-            mr_case(Dimension::AUTO, Some(-5.0), None);
-            mr_case(Dimension::AUTO, Some(0.), None);
+            mr_case(Dimension::AUTO, OptFloat::NONE, OptFloat::NONE);
+            mr_case(Dimension::AUTO, OptFloat::some(5.0), OptFloat::NONE);
+            mr_case(Dimension::AUTO, OptFloat::some(-5.0), OptFloat::NONE);
+            mr_case(Dimension::AUTO, OptFloat::some(0.), OptFloat::NONE);
         }
 
         /// `Dimension::Length` should always return `Some(f32)`
@@ -213,10 +215,10 @@ mod tests {
         /// The parent / context should not affect the outcome.
         #[test]
         fn resolve_length() {
-            mr_case(Dimension::from_length(1.0), None, Some(1.0));
-            mr_case(Dimension::from_length(1.0), Some(5.0), Some(1.0));
-            mr_case(Dimension::from_length(1.0), Some(-5.0), Some(1.0));
-            mr_case(Dimension::from_length(1.0), Some(0.), Some(1.0));
+            mr_case(Dimension::from_length(1.0), OptFloat::NONE, OptFloat::some(1.0));
+            mr_case(Dimension::from_length(1.0), OptFloat::some(5.0), OptFloat::some(1.0));
+            mr_case(Dimension::from_length(1.0), OptFloat::some(-5.0), OptFloat::some(1.0));
+            mr_case(Dimension::from_length(1.0), OptFloat::some(0.), OptFloat::some(1.0));
         }
 
         /// `Dimension::Percent` should return `None` if context is  `None`.
@@ -226,10 +228,10 @@ mod tests {
         /// The parent / context __should__ affect the outcome.
         #[test]
         fn resolve_percent() {
-            mr_case(Dimension::from_percent(1.0), None, None);
-            mr_case(Dimension::from_percent(1.0), Some(5.0), Some(5.0));
-            mr_case(Dimension::from_percent(1.0), Some(-5.0), Some(-5.0));
-            mr_case(Dimension::from_percent(1.0), Some(50.0), Some(50.0));
+            mr_case(Dimension::from_percent(1.0), OptFloat::NONE, OptFloat::NONE);
+            mr_case(Dimension::from_percent(1.0), OptFloat::some(5.0), OptFloat::some(5.0));
+            mr_case(Dimension::from_percent(1.0), OptFloat::some(-5.0), OptFloat::some(-5.0));
+            mr_case(Dimension::from_percent(1.0), OptFloat::some(50.0), OptFloat::some(50.0));
         }
     }
 
@@ -279,27 +281,28 @@ mod tests {
         use super::roz_case;
         use crate::style::Dimension;
         use crate::style_helpers::*;
+        use crate::util::OptFloat;
 
         #[test]
         fn resolve_or_zero_auto() {
-            roz_case(Dimension::AUTO, None, 0.0);
-            roz_case(Dimension::AUTO, Some(5.0), 0.0);
-            roz_case(Dimension::AUTO, Some(-5.0), 0.0);
-            roz_case(Dimension::AUTO, Some(0.0), 0.0);
+            roz_case(Dimension::AUTO, OptFloat::NONE, 0.0);
+            roz_case(Dimension::AUTO, OptFloat::some(5.0), 0.0);
+            roz_case(Dimension::AUTO, OptFloat::some(-5.0), 0.0);
+            roz_case(Dimension::AUTO, OptFloat::some(0.0), 0.0);
         }
         #[test]
         fn resolve_or_zero_length() {
-            roz_case(Dimension::from_length(5.0), None, 5.0);
-            roz_case(Dimension::from_length(5.0), Some(5.0), 5.0);
-            roz_case(Dimension::from_length(5.0), Some(-5.0), 5.0);
-            roz_case(Dimension::from_length(5.0), Some(0.0), 5.0);
+            roz_case(Dimension::from_length(5.0), OptFloat::NONE, 5.0);
+            roz_case(Dimension::from_length(5.0), OptFloat::some(5.0), 5.0);
+            roz_case(Dimension::from_length(5.0), OptFloat::some(-5.0), 5.0);
+            roz_case(Dimension::from_length(5.0), OptFloat::some(0.0), 5.0);
         }
         #[test]
         fn resolve_or_zero_percent() {
-            roz_case(Dimension::from_percent(5.0), None, 0.0);
-            roz_case(Dimension::from_percent(5.0), Some(5.0), 25.0);
-            roz_case(Dimension::from_percent(5.0), Some(-5.0), -25.0);
-            roz_case(Dimension::from_percent(5.0), Some(0.0), 0.0);
+            roz_case(Dimension::from_percent(5.0), OptFloat::NONE, 0.0);
+            roz_case(Dimension::from_percent(5.0), OptFloat::some(5.0), 25.0);
+            roz_case(Dimension::from_percent(5.0), OptFloat::some(-5.0), -25.0);
+            roz_case(Dimension::from_percent(5.0), OptFloat::some(0.0), 0.0);
         }
     }
 
@@ -341,29 +344,34 @@ mod tests {
         use super::roz_case;
         use crate::geometry::Rect;
         use crate::style::Dimension;
+        use crate::util::OptFloat;
 
         #[test]
         fn resolve_or_zero_auto() {
-            roz_case(Rect::<Dimension>::auto(), None, Rect::zero());
-            roz_case(Rect::<Dimension>::auto(), Some(5.0), Rect::zero());
-            roz_case(Rect::<Dimension>::auto(), Some(-5.0), Rect::zero());
-            roz_case(Rect::<Dimension>::auto(), Some(0.0), Rect::zero());
+            roz_case(Rect::<Dimension>::auto(), OptFloat::NONE, Rect::zero());
+            roz_case(Rect::<Dimension>::auto(), OptFloat::some(5.0), Rect::zero());
+            roz_case(Rect::<Dimension>::auto(), OptFloat::some(-5.0), Rect::zero());
+            roz_case(Rect::<Dimension>::auto(), OptFloat::some(0.0), Rect::zero());
         }
 
         #[test]
         fn resolve_or_zero_length() {
-            roz_case(Rect::from_length(5.0, 5.0, 5.0, 5.0), None, Rect::new(5.0, 5.0, 5.0, 5.0));
-            roz_case(Rect::from_length(5.0, 5.0, 5.0, 5.0), Some(5.0), Rect::new(5.0, 5.0, 5.0, 5.0));
-            roz_case(Rect::from_length(5.0, 5.0, 5.0, 5.0), Some(-5.0), Rect::new(5.0, 5.0, 5.0, 5.0));
-            roz_case(Rect::from_length(5.0, 5.0, 5.0, 5.0), Some(0.0), Rect::new(5.0, 5.0, 5.0, 5.0));
+            roz_case(Rect::from_length(5.0, 5.0, 5.0, 5.0), OptFloat::NONE, Rect::new(5.0, 5.0, 5.0, 5.0));
+            roz_case(Rect::from_length(5.0, 5.0, 5.0, 5.0), OptFloat::some(5.0), Rect::new(5.0, 5.0, 5.0, 5.0));
+            roz_case(Rect::from_length(5.0, 5.0, 5.0, 5.0), OptFloat::some(-5.0), Rect::new(5.0, 5.0, 5.0, 5.0));
+            roz_case(Rect::from_length(5.0, 5.0, 5.0, 5.0), OptFloat::some(0.0), Rect::new(5.0, 5.0, 5.0, 5.0));
         }
 
         #[test]
         fn resolve_or_zero_percent() {
-            roz_case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), None, Rect::zero());
-            roz_case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), Some(5.0), Rect::new(25.0, 25.0, 25.0, 25.0));
-            roz_case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), Some(-5.0), Rect::new(-25.0, -25.0, -25.0, -25.0));
-            roz_case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), Some(0.0), Rect::zero());
+            roz_case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), OptFloat::NONE, Rect::zero());
+            roz_case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), OptFloat::some(5.0), Rect::new(25.0, 25.0, 25.0, 25.0));
+            roz_case(
+                Rect::from_percent(5.0, 5.0, 5.0, 5.0),
+                OptFloat::some(-5.0),
+                Rect::new(-25.0, -25.0, -25.0, -25.0),
+            );
+            roz_case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), OptFloat::some(0.0), Rect::zero());
         }
     }
 }

--- a/src/util/resolve.rs
+++ b/src/util/resolve.rs
@@ -3,7 +3,7 @@
 use crate::geometry::{Rect, Size};
 use crate::style::{Dimension, LengthPercentage, LengthPercentageAuto};
 use crate::style_helpers::TaffyZero;
-use crate::util::OptFloat;
+use crate::util::OptF32;
 use crate::CompactLength;
 
 /// Trait to encapsulate behaviour where we need to resolve from a
@@ -26,12 +26,12 @@ pub trait ResolveOrZero<TContext, TOutput: TaffyZero> {
     fn resolve_or_zero(self, context: TContext, calc: impl Fn(*const (), f32) -> f32) -> TOutput;
 }
 
-impl MaybeResolve<OptFloat, OptFloat> for LengthPercentage {
+impl MaybeResolve<OptF32, OptF32> for LengthPercentage {
     /// Converts the given [`LengthPercentage`] into an absolute length
     /// Can return `None`
-    fn maybe_resolve(self, context: OptFloat, calc: impl Fn(*const (), f32) -> f32) -> OptFloat {
+    fn maybe_resolve(self, context: OptF32, calc: impl Fn(*const (), f32) -> f32) -> OptF32 {
         match self.0.tag() {
-            CompactLength::LENGTH_TAG => OptFloat::some(self.0.value()),
+            CompactLength::LENGTH_TAG => OptF32::some(self.0.value()),
             CompactLength::PERCENT_TAG => context.map(|dim| dim * self.0.value()),
             #[cfg(feature = "calc")]
             _ if self.0.is_calc() => context.map(|dim| calc(self.0.calc_value(), dim)),
@@ -40,13 +40,13 @@ impl MaybeResolve<OptFloat, OptFloat> for LengthPercentage {
     }
 }
 
-impl MaybeResolve<OptFloat, OptFloat> for LengthPercentageAuto {
+impl MaybeResolve<OptF32, OptF32> for LengthPercentageAuto {
     /// Converts the given [`LengthPercentageAuto`] into an absolute length
     /// Can return `None`
-    fn maybe_resolve(self, context: OptFloat, calc: impl Fn(*const (), f32) -> f32) -> OptFloat {
+    fn maybe_resolve(self, context: OptF32, calc: impl Fn(*const (), f32) -> f32) -> OptF32 {
         match self.0.tag() {
-            CompactLength::AUTO_TAG => OptFloat::NONE,
-            CompactLength::LENGTH_TAG => OptFloat::some(self.0.value()),
+            CompactLength::AUTO_TAG => OptF32::NONE,
+            CompactLength::LENGTH_TAG => OptF32::some(self.0.value()),
             CompactLength::PERCENT_TAG => context.map(|dim| dim * self.0.value()),
             #[cfg(feature = "calc")]
             _ if self.0.is_calc() => context.map(|dim| calc(self.0.calc_value(), dim)),
@@ -55,34 +55,34 @@ impl MaybeResolve<OptFloat, OptFloat> for LengthPercentageAuto {
     }
 }
 
-impl MaybeResolve<OptFloat, OptFloat> for Dimension {
+impl MaybeResolve<OptF32, OptF32> for Dimension {
     /// Converts the given [`Dimension`] into an absolute length
     ///
     /// Can return `None`
-    fn maybe_resolve(self, context: OptFloat, calc: impl Fn(*const (), f32) -> f32) -> OptFloat {
+    fn maybe_resolve(self, context: OptF32, calc: impl Fn(*const (), f32) -> f32) -> OptF32 {
         match self.0.tag() {
-            CompactLength::AUTO_TAG => OptFloat::NONE,
+            CompactLength::AUTO_TAG => OptF32::NONE,
             // The content keyword is only valid for flex-basis. In any other context it behaves as auto.
-            CompactLength::CONTENT_TAG => OptFloat::NONE,
-            CompactLength::LENGTH_TAG => OptFloat::some(self.0.value()),
+            CompactLength::CONTENT_TAG => OptF32::NONE,
+            CompactLength::LENGTH_TAG => OptF32::some(self.0.value()),
             CompactLength::PERCENT_TAG => context.map(|dim| dim * self.0.value()),
             #[cfg(feature = "calc")]
             _ if self.0.is_calc() => context.map(|dim| calc(self.0.calc_value(), dim)),
             // Intrinsic sizing keywords cannot be resolved to a definite size out of context.
             // Layout algorithms that support them must handle them explicitly.
-            _ if self.0.is_sizing_keyword() => OptFloat::NONE,
+            _ if self.0.is_sizing_keyword() => OptF32::NONE,
             _ => unreachable!(),
         }
     }
 }
 
 // Generic implementation of MaybeResolve for f32 context where MaybeResolve is implemented
-// for OptFloat context
-impl<T: MaybeResolve<OptFloat, OptFloat>> MaybeResolve<f32, OptFloat> for T {
+// for OptF32 context
+impl<T: MaybeResolve<OptF32, OptF32>> MaybeResolve<f32, OptF32> for T {
     /// Converts the given MaybeResolve value into an absolute length
     /// Can return `None`
-    fn maybe_resolve(self, context: f32, calc: impl Fn(*const (), f32) -> f32) -> OptFloat {
-        self.maybe_resolve(OptFloat::some(context), calc)
+    fn maybe_resolve(self, context: f32, calc: impl Fn(*const (), f32) -> f32) -> OptF32 {
+        self.maybe_resolve(OptF32::some(context), calc)
     }
 }
 
@@ -97,23 +97,23 @@ impl<In, Out, T: MaybeResolve<In, Out>> MaybeResolve<Size<In>, Size<Out>> for Si
     }
 }
 
-impl ResolveOrZero<OptFloat, f32> for LengthPercentage {
+impl ResolveOrZero<OptF32, f32> for LengthPercentage {
     /// Will return a default value of result is evaluated to `None`
-    fn resolve_or_zero(self, context: OptFloat, calc: impl Fn(*const (), f32) -> f32) -> f32 {
+    fn resolve_or_zero(self, context: OptF32, calc: impl Fn(*const (), f32) -> f32) -> f32 {
         self.maybe_resolve(context, calc).unwrap_or(0.0)
     }
 }
 
-impl ResolveOrZero<OptFloat, f32> for LengthPercentageAuto {
+impl ResolveOrZero<OptF32, f32> for LengthPercentageAuto {
     /// Will return a default value of result is evaluated to `None`
-    fn resolve_or_zero(self, context: OptFloat, calc: impl Fn(*const (), f32) -> f32) -> f32 {
+    fn resolve_or_zero(self, context: OptF32, calc: impl Fn(*const (), f32) -> f32) -> f32 {
         self.maybe_resolve(context, calc).unwrap_or(0.0)
     }
 }
 
-impl ResolveOrZero<OptFloat, f32> for Dimension {
+impl ResolveOrZero<OptF32, f32> for Dimension {
     /// Will return a default value of result is evaluated to `None`
-    fn resolve_or_zero(self, context: OptFloat, calc: impl Fn(*const (), f32) -> f32) -> f32 {
+    fn resolve_or_zero(self, context: OptF32, calc: impl Fn(*const (), f32) -> f32) -> f32 {
         self.maybe_resolve(context, calc).unwrap_or(0.0)
     }
 }
@@ -143,9 +143,9 @@ impl<In: Copy, Out: TaffyZero, T: ResolveOrZero<In, Out>> ResolveOrZero<Size<In>
 }
 
 // Generic ResolveOrZero for resolving Rect against Option
-impl<Out: TaffyZero, T: ResolveOrZero<OptFloat, Out>> ResolveOrZero<OptFloat, Rect<Out>> for Rect<T> {
+impl<Out: TaffyZero, T: ResolveOrZero<OptF32, Out>> ResolveOrZero<OptF32, Rect<Out>> for Rect<T> {
     /// Converts any `parent`-relative values for Rect into an absolute Rect
-    fn resolve_or_zero(self, context: OptFloat, calc: impl Fn(*const (), f32) -> f32) -> Rect<Out> {
+    fn resolve_or_zero(self, context: OptF32, calc: impl Fn(*const (), f32) -> f32) -> Rect<Out> {
         Rect {
             left: self.left.resolve_or_zero(context, &calc),
             right: self.right.resolve_or_zero(context, &calc),
@@ -196,17 +196,17 @@ mod tests {
         use super::mr_case;
         use crate::style::Dimension;
         use crate::style_helpers::*;
-        use crate::util::OptFloat;
+        use crate::util::OptF32;
 
         /// `Dimension::Auto` should always return `None`
         ///
         /// The parent / context should not affect the outcome.
         #[test]
         fn resolve_auto() {
-            mr_case(Dimension::AUTO, OptFloat::NONE, OptFloat::NONE);
-            mr_case(Dimension::AUTO, OptFloat::some(5.0), OptFloat::NONE);
-            mr_case(Dimension::AUTO, OptFloat::some(-5.0), OptFloat::NONE);
-            mr_case(Dimension::AUTO, OptFloat::some(0.), OptFloat::NONE);
+            mr_case(Dimension::AUTO, OptF32::NONE, OptF32::NONE);
+            mr_case(Dimension::AUTO, OptF32::some(5.0), OptF32::NONE);
+            mr_case(Dimension::AUTO, OptF32::some(-5.0), OptF32::NONE);
+            mr_case(Dimension::AUTO, OptF32::some(0.), OptF32::NONE);
         }
 
         /// `Dimension::Length` should always return `Some(f32)`
@@ -215,10 +215,10 @@ mod tests {
         /// The parent / context should not affect the outcome.
         #[test]
         fn resolve_length() {
-            mr_case(Dimension::from_length(1.0), OptFloat::NONE, OptFloat::some(1.0));
-            mr_case(Dimension::from_length(1.0), OptFloat::some(5.0), OptFloat::some(1.0));
-            mr_case(Dimension::from_length(1.0), OptFloat::some(-5.0), OptFloat::some(1.0));
-            mr_case(Dimension::from_length(1.0), OptFloat::some(0.), OptFloat::some(1.0));
+            mr_case(Dimension::from_length(1.0), OptF32::NONE, OptF32::some(1.0));
+            mr_case(Dimension::from_length(1.0), OptF32::some(5.0), OptF32::some(1.0));
+            mr_case(Dimension::from_length(1.0), OptF32::some(-5.0), OptF32::some(1.0));
+            mr_case(Dimension::from_length(1.0), OptF32::some(0.), OptF32::some(1.0));
         }
 
         /// `Dimension::Percent` should return `None` if context is  `None`.
@@ -228,10 +228,10 @@ mod tests {
         /// The parent / context __should__ affect the outcome.
         #[test]
         fn resolve_percent() {
-            mr_case(Dimension::from_percent(1.0), OptFloat::NONE, OptFloat::NONE);
-            mr_case(Dimension::from_percent(1.0), OptFloat::some(5.0), OptFloat::some(5.0));
-            mr_case(Dimension::from_percent(1.0), OptFloat::some(-5.0), OptFloat::some(-5.0));
-            mr_case(Dimension::from_percent(1.0), OptFloat::some(50.0), OptFloat::some(50.0));
+            mr_case(Dimension::from_percent(1.0), OptF32::NONE, OptF32::NONE);
+            mr_case(Dimension::from_percent(1.0), OptF32::some(5.0), OptF32::some(5.0));
+            mr_case(Dimension::from_percent(1.0), OptF32::some(-5.0), OptF32::some(-5.0));
+            mr_case(Dimension::from_percent(1.0), OptF32::some(50.0), OptF32::some(50.0));
         }
     }
 
@@ -281,28 +281,28 @@ mod tests {
         use super::roz_case;
         use crate::style::Dimension;
         use crate::style_helpers::*;
-        use crate::util::OptFloat;
+        use crate::util::OptF32;
 
         #[test]
         fn resolve_or_zero_auto() {
-            roz_case(Dimension::AUTO, OptFloat::NONE, 0.0);
-            roz_case(Dimension::AUTO, OptFloat::some(5.0), 0.0);
-            roz_case(Dimension::AUTO, OptFloat::some(-5.0), 0.0);
-            roz_case(Dimension::AUTO, OptFloat::some(0.0), 0.0);
+            roz_case(Dimension::AUTO, OptF32::NONE, 0.0);
+            roz_case(Dimension::AUTO, OptF32::some(5.0), 0.0);
+            roz_case(Dimension::AUTO, OptF32::some(-5.0), 0.0);
+            roz_case(Dimension::AUTO, OptF32::some(0.0), 0.0);
         }
         #[test]
         fn resolve_or_zero_length() {
-            roz_case(Dimension::from_length(5.0), OptFloat::NONE, 5.0);
-            roz_case(Dimension::from_length(5.0), OptFloat::some(5.0), 5.0);
-            roz_case(Dimension::from_length(5.0), OptFloat::some(-5.0), 5.0);
-            roz_case(Dimension::from_length(5.0), OptFloat::some(0.0), 5.0);
+            roz_case(Dimension::from_length(5.0), OptF32::NONE, 5.0);
+            roz_case(Dimension::from_length(5.0), OptF32::some(5.0), 5.0);
+            roz_case(Dimension::from_length(5.0), OptF32::some(-5.0), 5.0);
+            roz_case(Dimension::from_length(5.0), OptF32::some(0.0), 5.0);
         }
         #[test]
         fn resolve_or_zero_percent() {
-            roz_case(Dimension::from_percent(5.0), OptFloat::NONE, 0.0);
-            roz_case(Dimension::from_percent(5.0), OptFloat::some(5.0), 25.0);
-            roz_case(Dimension::from_percent(5.0), OptFloat::some(-5.0), -25.0);
-            roz_case(Dimension::from_percent(5.0), OptFloat::some(0.0), 0.0);
+            roz_case(Dimension::from_percent(5.0), OptF32::NONE, 0.0);
+            roz_case(Dimension::from_percent(5.0), OptF32::some(5.0), 25.0);
+            roz_case(Dimension::from_percent(5.0), OptF32::some(-5.0), -25.0);
+            roz_case(Dimension::from_percent(5.0), OptF32::some(0.0), 0.0);
         }
     }
 
@@ -344,34 +344,30 @@ mod tests {
         use super::roz_case;
         use crate::geometry::Rect;
         use crate::style::Dimension;
-        use crate::util::OptFloat;
+        use crate::util::OptF32;
 
         #[test]
         fn resolve_or_zero_auto() {
-            roz_case(Rect::<Dimension>::auto(), OptFloat::NONE, Rect::zero());
-            roz_case(Rect::<Dimension>::auto(), OptFloat::some(5.0), Rect::zero());
-            roz_case(Rect::<Dimension>::auto(), OptFloat::some(-5.0), Rect::zero());
-            roz_case(Rect::<Dimension>::auto(), OptFloat::some(0.0), Rect::zero());
+            roz_case(Rect::<Dimension>::auto(), OptF32::NONE, Rect::zero());
+            roz_case(Rect::<Dimension>::auto(), OptF32::some(5.0), Rect::zero());
+            roz_case(Rect::<Dimension>::auto(), OptF32::some(-5.0), Rect::zero());
+            roz_case(Rect::<Dimension>::auto(), OptF32::some(0.0), Rect::zero());
         }
 
         #[test]
         fn resolve_or_zero_length() {
-            roz_case(Rect::from_length(5.0, 5.0, 5.0, 5.0), OptFloat::NONE, Rect::new(5.0, 5.0, 5.0, 5.0));
-            roz_case(Rect::from_length(5.0, 5.0, 5.0, 5.0), OptFloat::some(5.0), Rect::new(5.0, 5.0, 5.0, 5.0));
-            roz_case(Rect::from_length(5.0, 5.0, 5.0, 5.0), OptFloat::some(-5.0), Rect::new(5.0, 5.0, 5.0, 5.0));
-            roz_case(Rect::from_length(5.0, 5.0, 5.0, 5.0), OptFloat::some(0.0), Rect::new(5.0, 5.0, 5.0, 5.0));
+            roz_case(Rect::from_length(5.0, 5.0, 5.0, 5.0), OptF32::NONE, Rect::new(5.0, 5.0, 5.0, 5.0));
+            roz_case(Rect::from_length(5.0, 5.0, 5.0, 5.0), OptF32::some(5.0), Rect::new(5.0, 5.0, 5.0, 5.0));
+            roz_case(Rect::from_length(5.0, 5.0, 5.0, 5.0), OptF32::some(-5.0), Rect::new(5.0, 5.0, 5.0, 5.0));
+            roz_case(Rect::from_length(5.0, 5.0, 5.0, 5.0), OptF32::some(0.0), Rect::new(5.0, 5.0, 5.0, 5.0));
         }
 
         #[test]
         fn resolve_or_zero_percent() {
-            roz_case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), OptFloat::NONE, Rect::zero());
-            roz_case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), OptFloat::some(5.0), Rect::new(25.0, 25.0, 25.0, 25.0));
-            roz_case(
-                Rect::from_percent(5.0, 5.0, 5.0, 5.0),
-                OptFloat::some(-5.0),
-                Rect::new(-25.0, -25.0, -25.0, -25.0),
-            );
-            roz_case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), OptFloat::some(0.0), Rect::zero());
+            roz_case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), OptF32::NONE, Rect::zero());
+            roz_case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), OptF32::some(5.0), Rect::new(25.0, 25.0, 25.0, 25.0));
+            roz_case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), OptF32::some(-5.0), Rect::new(-25.0, -25.0, -25.0, -25.0));
+            roz_case(Rect::from_percent(5.0, 5.0, 5.0, 5.0), OptF32::some(0.0), Rect::zero());
         }
     }
 }

--- a/tests/common/src/lib.rs
+++ b/tests/common/src/lib.rs
@@ -71,6 +71,7 @@ pub fn test_measure_function(
         style,
         |_, _| 0.0,
         |known_dimensions, available_space| {
+            let known_dimensions = known_dimensions.into_options();
             if let Size { width: Some(width), height: Some(height) } = known_dimensions {
                 return Size { width, height };
             }

--- a/tests/hand_written/baseline.rs
+++ b/tests/hand_written/baseline.rs
@@ -18,7 +18,11 @@ mod baseline {
         _style: &Style,
     ) -> LayoutOutput {
         let Some(context) = context else { return LayoutOutput::DEFAULT };
-        LayoutOutput::from_sizes_and_baselines(context.size, Rect::ZERO, Baselines::from_first(context.baseline_y))
+        LayoutOutput::from_sizes_and_baselines(
+            context.size,
+            Rect::ZERO,
+            Baselines::from_first(context.baseline_y.into()),
+        )
     }
 
     /// Two flex items with different intrinsic baselines are aligned along their baselines


### PR DESCRIPTION
# Objective

Implements the optimization proposed in #1142: represent optional definite lengths as a 4-byte `OptF32` (an `#[repr(transparent)]` newtype over `f32` using a single sentinel quiet-NaN bit pattern for `None`) instead of the 8-byte `Option<f32>`. This halves `Size<Option<f32>>` (16B → 8B) throughout `LayoutInput.known_dimensions`, measure-function signatures, cache keys, and compute internals.

## Context

- Sentinel: `const NONE_BITS: u32 = 0x7FC0_F32A`. Only this exact bit pattern is `None`; other NaNs behave like `Some(NaN)` does today (Taffy already assumes non-NaN inputs). Checks are simple bit comparisons; no `debug_assert`s in constructors.
- API mirrors `Option<f32>` (`some`/`NONE`/`is_some`/`is_none`/`unwrap*`/`or`/`map`/`map_or`/`and_then`/`into_option`, `From` conversions, serde as `Option<f32>`), so downstream migration is mostly mechanical. `PartialEq` matches `Option<f32>` semantics (`NONE == NONE`, `Some(0.0) == Some(-0.0)`).
- Breaking change (as discussed on the issue thread): `LayoutInput.known_dimensions`, measure-function bounds (`FnOnce(Size<OptF32>, Size<AvailableSpace>) -> Size<f32>`), `LengthPercentageAuto::resolve_to_option`, `AvailableSpace::into_option`/`maybe_set`, and the `MaybeMath`/`MaybeResolve` impls now use `OptF32`. `From<Option<f32>> for AvailableSpace` is retained for back-compat.
- `AvailableSpace` remains an enum (candidate for a separate follow-up with extra sentinels). Semantic `Option<f32>` values such as `Style::aspect_ratio` are unchanged.
- Cache-key packing in `tree/cache.rs` now uses the raw bits directly (the sentinel is already a unique bit pattern).
- Const constructors use the existing `compact_length::compat` transmute helpers to keep MSRV at 1.71 (`f32::from_bits`/`to_bits` are only const-stable since 1.83).

Benchmark comparisons vs `main` (Linux x86_64 and macOS arm64) are in PR comments below.

## Feedback wanted

- Whether `Sum for OptF32` short-circuiting on the first `None` (matching `Option<f32>` iterator sum semantics) is the desired behavior for the grid track-size estimate paths.
- Naming of `unchecked_value()` (returns the raw f32, sentinel included).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/d64dc9ef79ef464aa7e9dfe303b3fa88
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/d64dc9ef79ef464aa7e9dfe303b3fa88?variant=devin-insiders
Requested by: @nicoburns