### PR TITLE
Block/float: add tolerance to horizontal fit checks to absorb f32 rounding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Block/float: absorb `f32` rounding errors in horizontal fit checks, preventing floats from spuriously wrapping when percentage widths and margins sum to exactly 100% of the container (#1161).
+
 ## 0.14.0
 
 The MSRV for this release is 1.71.

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 #[cfg(feature = "float_layout")]
-use super::float::{BfcSlot, ContentSlot, FloatContext, FloatIntrinsicWidthCalculator};
+use super::float::{BfcSlot, ContentSlot, FloatContext, FloatIntrinsicWidthCalculator, FIT_TOLERANCE};
 #[cfg(feature = "float_layout")]
 use crate::{Clear, Float, FloatDirection};
 
@@ -1195,7 +1195,7 @@ fn perform_final_layout_on_in_flow_children(
                                 .width
                                 .unwrap_or(slot.stretch_width.max(min_auto_width))
                                 .maybe_clamp(item.min_size.width, item.max_size.width);
-                            if width <= slot.border_width + 0.001 {
+                            if width <= slot.border_width + FIT_TOLERANCE {
                                 break slot;
                             }
                             slot_segment = Some(segment_id);

--- a/src/compute/float.rs
+++ b/src/compute/float.rs
@@ -30,6 +30,11 @@ use core::ops::Range;
 
 use crate::{debug::debug_log, sys::Vec, AvailableSpace, Clear, Direction, FloatDirection, Point, Size};
 
+/// Tolerance used when checking whether a box fits in a horizontal space, to absorb `f32`
+/// rounding errors (e.g. percentage widths and margins that sum to exactly 100% may otherwise
+/// exceed the container width and spuriously wrap)
+pub(crate) const FIT_TOLERANCE: f32 = 0.001;
+
 /// An empty "slot" that avoids floats that is suitable for non-floated content
 /// to be laid out into
 #[derive(Debug, Clone, Copy, Default)]
@@ -136,8 +141,10 @@ fn float_fits_horizontally(
     let lead = direction as usize;
     let trail = 1 - lead;
     let x_inset = float_insets[lead].max(cb_insets[lead]);
-    let fits_opposite_floats = float_insets[trail] == 0.0 || x_inset + width <= bfc_width - float_insets[trail];
-    let fits_containing_block = float_insets[lead] == 0.0 || x_inset + width <= bfc_width - cb_insets[trail];
+    let fits_opposite_floats =
+        float_insets[trail] == 0.0 || x_inset + width <= bfc_width - float_insets[trail] + FIT_TOLERANCE;
+    let fits_containing_block =
+        float_insets[lead] == 0.0 || x_inset + width <= bfc_width - cb_insets[trail] + FIT_TOLERANCE;
     fits_opposite_floats && fits_containing_block
 }
 

--- a/test_fixtures/float/float_percentage_widths_and_margins_sum_to_container.html
+++ b/test_fixtures/float/float_percentage_widths_and_margins_sum_to_container.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Floats whose percentage widths and margins sum to exactly 100% all fit on one row
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 1628px;">
+  <div style="float: left; width: 30%; height: 50px;"></div>
+  <div style="float: left; width: 30%; height: 50px; margin-left: 5%;"></div>
+  <div style="float: left; width: 30%; height: 50px; margin-left: 5%;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/float/float_percentage_widths_and_margins_sum_to_container__border_box_ltr.xml
+++ b/tests/xml/float/float_percentage_widths_and_margins_sum_to_container__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="float_percentage_widths_and_margins_sum_to_container__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="1628px">
+      <div direction="ltr" float="left" width="30%" height="50px"/>
+      <div direction="ltr" float="left" width="30%" height="50px" margin-left="5%"/>
+      <div direction="ltr" float="left" width="30%" height="50px" margin-left="5%"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="1628" height="50">
+      <node x="0" y="0" width="488" height="50"/>
+      <node x="570" y="0" width="488" height="50"/>
+      <node x="1140" y="0" width="488" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_percentage_widths_and_margins_sum_to_container__border_box_rtl.xml
+++ b/tests/xml/float/float_percentage_widths_and_margins_sum_to_container__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="float_percentage_widths_and_margins_sum_to_container__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="1628px">
+      <div direction="rtl" float="left" width="30%" height="50px"/>
+      <div direction="rtl" float="left" width="30%" height="50px" margin-left="5%"/>
+      <div direction="rtl" float="left" width="30%" height="50px" margin-left="5%"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="1628" height="50">
+      <node x="0" y="0" width="488" height="50"/>
+      <node x="570" y="0" width="488" height="50"/>
+      <node x="1140" y="0" width="488" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_percentage_widths_and_margins_sum_to_container__content_box_ltr.xml
+++ b/tests/xml/float/float_percentage_widths_and_margins_sum_to_container__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="float_percentage_widths_and_margins_sum_to_container__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="1628px">
+      <div box-sizing="content-box" direction="ltr" float="left" width="30%" height="50px"/>
+      <div box-sizing="content-box" direction="ltr" float="left" width="30%" height="50px" margin-left="5%"/>
+      <div box-sizing="content-box" direction="ltr" float="left" width="30%" height="50px" margin-left="5%"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="1628" height="50">
+      <node x="0" y="0" width="488" height="50"/>
+      <node x="570" y="0" width="488" height="50"/>
+      <node x="1140" y="0" width="488" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/float/float_percentage_widths_and_margins_sum_to_container__content_box_rtl.xml
+++ b/tests/xml/float/float_percentage_widths_and_margins_sum_to_container__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="float_percentage_widths_and_margins_sum_to_container__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="1628px">
+      <div box-sizing="content-box" direction="rtl" float="left" width="30%" height="50px"/>
+      <div box-sizing="content-box" direction="rtl" float="left" width="30%" height="50px" margin-left="5%"/>
+      <div box-sizing="content-box" direction="rtl" float="left" width="30%" height="50px" margin-left="5%"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="1628" height="50">
+      <node x="0" y="0" width="488" height="50"/>
+      <node x="570" y="0" width="488" height="50"/>
+      <node x="1140" y="0" width="488" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -19542,6 +19542,26 @@ mod float {
     }
 
     #[test]
+    fn float_percentage_widths_and_margins_sum_to_container__border_box_ltr() {
+        crate::run_xml_test("float", "float_percentage_widths_and_margins_sum_to_container__border_box_ltr");
+    }
+
+    #[test]
+    fn float_percentage_widths_and_margins_sum_to_container__content_box_ltr() {
+        crate::run_xml_test("float", "float_percentage_widths_and_margins_sum_to_container__content_box_ltr");
+    }
+
+    #[test]
+    fn float_percentage_widths_and_margins_sum_to_container__border_box_rtl() {
+        crate::run_xml_test("float", "float_percentage_widths_and_margins_sum_to_container__border_box_rtl");
+    }
+
+    #[test]
+    fn float_percentage_widths_and_margins_sum_to_container__content_box_rtl() {
+        crate::run_xml_test("float", "float_percentage_widths_and_margins_sum_to_container__content_box_rtl");
+    }
+
+    #[test]
     fn float_shrink_to_fit_cleared_floats__border_box_ltr() {
         crate::run_xml_test("float", "float_shrink_to_fit_cleared_floats__border_box_ltr");
     }


### PR DESCRIPTION
# Objective

Fix floats spuriously wrapping when their percentage widths and margins sum to exactly 100% of the container. Observed on https://nicoburns.com at 1728px viewport width (2x scale): the three `.hero__column` floats (`width: 30%` plus two `margin-left: 5%`) wrap because with a 1628px content width, the accumulated f32 insets place the third float at `1139.60009765625 + 488.4000244140625 = 1628.0001220703125 > 1628`, failing the fit check by ~1e-4px.

Fix: introduce `FIT_TOLERANCE = 0.001` and apply it in `float_fits_horizontally`:

```rust
fits = x_inset + width <= bfc_width - trail_inset + FIT_TOLERANCE
```

The BFC-slot fit check in `block.rs` already used a `+ 0.001` tolerance for the same reason; it now shares the named constant.

## Context

Browsers avoid this class of bug by doing layout in fixed-point units (Chrome/Firefox `LayoutUnit` = 1/64px), which quantizes percentage resolution downwards so sums never exceed the container. Since Taffy uses f32 throughout, a small fit tolerance is the minimal equivalent; 0.001px is well below the 1/64px quantum so it cannot change behaviour for genuinely non-fitting boxes.

Added a gentest fixture (`float_percentage_widths_and_margins_sum_to_container`) that fails before this change and passes after.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/3eb153325a174a57ae313663cbd9cce0
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/3eb153325a174a57ae313663cbd9cce0?variant=devin-insiders
Requested by: @nicoburns