### PR TITLE
Flexbox: apply main-axis margin after flex-basis floor in intrinsic contributions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Block/float: absorb `f32` rounding errors in horizontal fit checks, preventing floats from spuriously wrapping when percentage widths and margins sum to exactly 100% of the container (#1161).
+- Flexbox: main-axis margins are no longer dropped from an item's intrinsic main-size contribution when the contribution is floored by the item's flex basis (column containers). This fixes negative margins being ignored on flex items with `flex-grow` (#1162) and on descendants containing an `overflow: hidden` grid item (#1163).
 
 ## 0.14.0
 

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -1405,12 +1405,13 @@ fn determine_container_main_size(
                             (_, Some(pref), _) => {
                                 let item_pb_main = item.padding.main_axis_sum(constants.dir)
                                     + item.border.main_axis_sum(constants.dir);
-                                let content_main_size =
-                                    pref.max(item_pb_main) + item.margin.main_axis_sum(constants.dir);
+                                let inner_main_size = pref.max(item_pb_main);
                                 if constants.is_row {
-                                    content_main_size.maybe_clamp(style_min, style_max)
+                                    (inner_main_size + item.margin.main_axis_sum(constants.dir))
+                                        .maybe_clamp(style_min, style_max)
                                 } else {
-                                    content_main_size.max(item.flex_basis).maybe_clamp(style_min, style_max)
+                                    (inner_main_size.max(item.flex_basis) + item.margin.main_axis_sum(constants.dir))
+                                        .maybe_clamp(style_min, style_max)
                                 }
                             }
 
@@ -1465,8 +1466,7 @@ fn determine_container_main_size(
                                     .zip(child_known_dimensions.cross(dir))
                                     .map(|(ratio, cross)| if constants.is_row { cross * ratio } else { cross / ratio });
 
-                                let content_main_size = measured_main_size.maybe_max(transferred_main_size)
-                                    + item.margin.main_axis_sum(constants.dir);
+                                let inner_main_size = measured_main_size.maybe_max(transferred_main_size);
 
                                 // This is somewhat bizarre in that it's asymmetrical depending whether the flex container is a column or a row.
                                 //
@@ -1481,9 +1481,11 @@ fn determine_container_main_size(
                                 // Ultimately, this was not found by reading the spec, but by trial and error fixing tests to align with Webkit/Firefox output.
                                 // (see the `flex_basis_unconstraint_row` and `flex_basis_uncontraint_column` generated tests which demonstrate this)
                                 if constants.is_row {
-                                    content_main_size.maybe_clamp(style_min, style_max)
+                                    (inner_main_size + item.margin.main_axis_sum(constants.dir))
+                                        .maybe_clamp(style_min, style_max)
                                 } else {
-                                    content_main_size.max(item.flex_basis).maybe_clamp(style_min, style_max)
+                                    (inner_main_size.max(item.flex_basis) + item.margin.main_axis_sum(constants.dir))
+                                        .maybe_clamp(style_min, style_max)
                                 }
                             }
                         };

--- a/test_fixtures/flex/flex_grow_flex_shrink_negative_margin_intrinsic_column.html
+++ b/test_fixtures/flex/flex_grow_flex_shrink_negative_margin_intrinsic_column.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Negative main-axis margin on a flex-grow flex-shrink item is applied when the container's main size is automatic
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; flex-direction: column; width: 300px;">
+  <div style="width: 100px; height: 100px; flex-grow: 1; flex-shrink: 1; margin-top: -24px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/flex_grow_negative_margin_intrinsic_column.html
+++ b/test_fixtures/flex/flex_grow_negative_margin_intrinsic_column.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Negative main-axis margin on a flex-grow item is applied when the container's main size is automatic
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; flex-direction: column; width: 300px;">
+  <div style="width: 100px; height: 100px; flex-grow: 1; flex-shrink: 0; margin-top: -24px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/gridflex/gridflex_negative_margin_hidden_grid_item_intrinsic_height.html
+++ b/test_fixtures/gridflex/gridflex_negative_margin_hidden_grid_item_intrinsic_height.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    A negative margin on an ancestor of a grid container is applied to the intrinsic height even when a grid item has overflow hidden
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; flex-direction: column; width: 400px;">
+  <div style="display: flex; flex-direction: column;">
+    <div style="display: flex; flex-direction: column; margin-top: -32px;">
+      <div style="display: grid; grid-template-columns: 100px;">
+        <div style="display: flex; flex-direction: column; overflow: hidden;">
+          <div style="width: 100px; height: 100px;"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/flex/flex_grow_flex_shrink_negative_margin_intrinsic_column__border_box_ltr.xml
+++ b/tests/xml/flex/flex_grow_flex_shrink_negative_margin_intrinsic_column__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="flex_grow_flex_shrink_negative_margin_intrinsic_column__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" flex-direction="column" width="300px">
+      <div direction="ltr" flex-grow="1" width="100px" height="100px" margin-top="-24px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="76">
+      <node x="0" y="-24" width="100" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_grow_flex_shrink_negative_margin_intrinsic_column__border_box_rtl.xml
+++ b/tests/xml/flex/flex_grow_flex_shrink_negative_margin_intrinsic_column__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="flex_grow_flex_shrink_negative_margin_intrinsic_column__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" flex-direction="column" width="300px">
+      <div direction="rtl" flex-grow="1" width="100px" height="100px" margin-top="-24px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="76">
+      <node x="200" y="-24" width="100" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_grow_flex_shrink_negative_margin_intrinsic_column__content_box_ltr.xml
+++ b/tests/xml/flex/flex_grow_flex_shrink_negative_margin_intrinsic_column__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="flex_grow_flex_shrink_negative_margin_intrinsic_column__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" flex-direction="column" width="300px">
+      <div box-sizing="content-box" direction="ltr" flex-grow="1" width="100px" height="100px" margin-top="-24px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="76">
+      <node x="0" y="-24" width="100" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_grow_flex_shrink_negative_margin_intrinsic_column__content_box_rtl.xml
+++ b/tests/xml/flex/flex_grow_flex_shrink_negative_margin_intrinsic_column__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="flex_grow_flex_shrink_negative_margin_intrinsic_column__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" flex-direction="column" width="300px">
+      <div box-sizing="content-box" direction="rtl" flex-grow="1" width="100px" height="100px" margin-top="-24px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="76">
+      <node x="200" y="-24" width="100" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_grow_negative_margin_intrinsic_column__border_box_ltr.xml
+++ b/tests/xml/flex/flex_grow_negative_margin_intrinsic_column__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="flex_grow_negative_margin_intrinsic_column__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" flex-direction="column" width="300px">
+      <div direction="ltr" flex-grow="1" flex-shrink="0" width="100px" height="100px" margin-top="-24px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="76">
+      <node x="0" y="-24" width="100" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_grow_negative_margin_intrinsic_column__border_box_rtl.xml
+++ b/tests/xml/flex/flex_grow_negative_margin_intrinsic_column__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="flex_grow_negative_margin_intrinsic_column__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" flex-direction="column" width="300px">
+      <div direction="rtl" flex-grow="1" flex-shrink="0" width="100px" height="100px" margin-top="-24px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="76">
+      <node x="200" y="-24" width="100" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_grow_negative_margin_intrinsic_column__content_box_ltr.xml
+++ b/tests/xml/flex/flex_grow_negative_margin_intrinsic_column__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="flex_grow_negative_margin_intrinsic_column__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" flex-direction="column" width="300px">
+      <div box-sizing="content-box" direction="ltr" flex-grow="1" flex-shrink="0" width="100px" height="100px" margin-top="-24px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="76">
+      <node x="0" y="-24" width="100" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/flex_grow_negative_margin_intrinsic_column__content_box_rtl.xml
+++ b/tests/xml/flex/flex_grow_negative_margin_intrinsic_column__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="flex_grow_negative_margin_intrinsic_column__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" flex-direction="column" width="300px">
+      <div box-sizing="content-box" direction="rtl" flex-grow="1" flex-shrink="0" width="100px" height="100px" margin-top="-24px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="76">
+      <node x="200" y="-24" width="100" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/gridflex/gridflex_negative_margin_hidden_grid_item_intrinsic_height__border_box_ltr.xml
+++ b/tests/xml/gridflex/gridflex_negative_margin_hidden_grid_item_intrinsic_height__border_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="gridflex_negative_margin_hidden_grid_item_intrinsic_height__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" flex-direction="column" width="400px">
+      <div display="flex" direction="ltr" flex-direction="column">
+        <div display="flex" direction="ltr" flex-direction="column" margin-top="-32px">
+          <div display="grid" direction="ltr" grid-template-columns="100px">
+            <div display="flex" direction="ltr" flex-direction="column" overflow-x="hidden" overflow-y="hidden" scrollbar-width="15">
+              <div direction="ltr" width="100px" height="100px"/>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="68">
+      <node x="0" y="0" width="400" height="68">
+        <node x="0" y="-32" width="400" height="100">
+          <node x="0" y="0" width="400" height="100" resolved-rows="100px" resolved-columns="100px">
+            <node x="0" y="0" width="100" height="100" scroll_width="0" scroll_height="0">
+              <node x="0" y="0" width="100" height="100"/>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/gridflex/gridflex_negative_margin_hidden_grid_item_intrinsic_height__border_box_rtl.xml
+++ b/tests/xml/gridflex/gridflex_negative_margin_hidden_grid_item_intrinsic_height__border_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="gridflex_negative_margin_hidden_grid_item_intrinsic_height__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" flex-direction="column" width="400px">
+      <div display="flex" direction="rtl" flex-direction="column">
+        <div display="flex" direction="rtl" flex-direction="column" margin-top="-32px">
+          <div display="grid" direction="rtl" grid-template-columns="100px">
+            <div display="flex" direction="rtl" flex-direction="column" overflow-x="hidden" overflow-y="hidden" scrollbar-width="15">
+              <div direction="rtl" width="100px" height="100px"/>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="68">
+      <node x="0" y="0" width="400" height="68">
+        <node x="0" y="-32" width="400" height="100">
+          <node x="0" y="0" width="400" height="100" resolved-rows="100px" resolved-columns="100px">
+            <node x="300" y="0" width="100" height="100" scroll_width="0" scroll_height="0">
+              <node x="0" y="0" width="100" height="100"/>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/gridflex/gridflex_negative_margin_hidden_grid_item_intrinsic_height__content_box_ltr.xml
+++ b/tests/xml/gridflex/gridflex_negative_margin_hidden_grid_item_intrinsic_height__content_box_ltr.xml
@@ -1,0 +1,29 @@
+<test name="gridflex_negative_margin_hidden_grid_item_intrinsic_height__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" flex-direction="column" width="400px">
+      <div display="flex" box-sizing="content-box" direction="ltr" flex-direction="column">
+        <div display="flex" box-sizing="content-box" direction="ltr" flex-direction="column" margin-top="-32px">
+          <div display="grid" box-sizing="content-box" direction="ltr" grid-template-columns="100px">
+            <div display="flex" box-sizing="content-box" direction="ltr" flex-direction="column" overflow-x="hidden" overflow-y="hidden" scrollbar-width="15">
+              <div box-sizing="content-box" direction="ltr" width="100px" height="100px"/>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="68">
+      <node x="0" y="0" width="400" height="68">
+        <node x="0" y="-32" width="400" height="100">
+          <node x="0" y="0" width="400" height="100" resolved-rows="100px" resolved-columns="100px">
+            <node x="0" y="0" width="100" height="100" scroll_width="0" scroll_height="0">
+              <node x="0" y="0" width="100" height="100"/>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/gridflex/gridflex_negative_margin_hidden_grid_item_intrinsic_height__content_box_rtl.xml
+++ b/tests/xml/gridflex/gridflex_negative_margin_hidden_grid_item_intrinsic_height__content_box_rtl.xml
@@ -1,0 +1,29 @@
+<test name="gridflex_negative_margin_hidden_grid_item_intrinsic_height__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" flex-direction="column" width="400px">
+      <div display="flex" box-sizing="content-box" direction="rtl" flex-direction="column">
+        <div display="flex" box-sizing="content-box" direction="rtl" flex-direction="column" margin-top="-32px">
+          <div display="grid" box-sizing="content-box" direction="rtl" grid-template-columns="100px">
+            <div display="flex" box-sizing="content-box" direction="rtl" flex-direction="column" overflow-x="hidden" overflow-y="hidden" scrollbar-width="15">
+              <div box-sizing="content-box" direction="rtl" width="100px" height="100px"/>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="68">
+      <node x="0" y="0" width="400" height="68">
+        <node x="0" y="-32" width="400" height="100">
+          <node x="0" y="0" width="400" height="100" resolved-rows="100px" resolved-columns="100px">
+            <node x="300" y="0" width="100" height="100" scroll_width="0" scroll_height="0">
+              <node x="0" y="0" width="100" height="100"/>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -12484,6 +12484,26 @@ mod flex {
     }
 
     #[test]
+    fn flex_grow_flex_shrink_negative_margin_intrinsic_column__border_box_ltr() {
+        crate::run_xml_test("flex", "flex_grow_flex_shrink_negative_margin_intrinsic_column__border_box_ltr");
+    }
+
+    #[test]
+    fn flex_grow_flex_shrink_negative_margin_intrinsic_column__content_box_ltr() {
+        crate::run_xml_test("flex", "flex_grow_flex_shrink_negative_margin_intrinsic_column__content_box_ltr");
+    }
+
+    #[test]
+    fn flex_grow_flex_shrink_negative_margin_intrinsic_column__border_box_rtl() {
+        crate::run_xml_test("flex", "flex_grow_flex_shrink_negative_margin_intrinsic_column__border_box_rtl");
+    }
+
+    #[test]
+    fn flex_grow_flex_shrink_negative_margin_intrinsic_column__content_box_rtl() {
+        crate::run_xml_test("flex", "flex_grow_flex_shrink_negative_margin_intrinsic_column__content_box_rtl");
+    }
+
+    #[test]
     fn flex_grow_height_maximized__border_box_ltr() {
         crate::run_xml_test("flex", "flex_grow_height_maximized__border_box_ltr");
     }
@@ -12541,6 +12561,26 @@ mod flex {
     #[test]
     fn flex_grow_less_than_factor_one__content_box_rtl() {
         crate::run_xml_test("flex", "flex_grow_less_than_factor_one__content_box_rtl");
+    }
+
+    #[test]
+    fn flex_grow_negative_margin_intrinsic_column__border_box_ltr() {
+        crate::run_xml_test("flex", "flex_grow_negative_margin_intrinsic_column__border_box_ltr");
+    }
+
+    #[test]
+    fn flex_grow_negative_margin_intrinsic_column__content_box_ltr() {
+        crate::run_xml_test("flex", "flex_grow_negative_margin_intrinsic_column__content_box_ltr");
+    }
+
+    #[test]
+    fn flex_grow_negative_margin_intrinsic_column__border_box_rtl() {
+        crate::run_xml_test("flex", "flex_grow_negative_margin_intrinsic_column__border_box_rtl");
+    }
+
+    #[test]
+    fn flex_grow_negative_margin_intrinsic_column__content_box_rtl() {
+        crate::run_xml_test("flex", "flex_grow_negative_margin_intrinsic_column__content_box_rtl");
     }
 
     #[test]
@@ -33547,6 +33587,30 @@ mod gridflex {
     #[test]
     fn gridflex_kitchen_sink_minimise3__content_box_rtl() {
         crate::run_xml_test("gridflex", "gridflex_kitchen_sink_minimise3__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn gridflex_negative_margin_hidden_grid_item_intrinsic_height__border_box_ltr() {
+        crate::run_xml_test("gridflex", "gridflex_negative_margin_hidden_grid_item_intrinsic_height__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn gridflex_negative_margin_hidden_grid_item_intrinsic_height__content_box_ltr() {
+        crate::run_xml_test("gridflex", "gridflex_negative_margin_hidden_grid_item_intrinsic_height__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn gridflex_negative_margin_hidden_grid_item_intrinsic_height__border_box_rtl() {
+        crate::run_xml_test("gridflex", "gridflex_negative_margin_hidden_grid_item_intrinsic_height__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn gridflex_negative_margin_hidden_grid_item_intrinsic_height__content_box_rtl() {
+        crate::run_xml_test("gridflex", "gridflex_negative_margin_hidden_grid_item_intrinsic_height__content_box_rtl");
     }
 
     #[cfg(feature = "grid")]


### PR DESCRIPTION
# Objective

Fixes #1162
Fixes #1163

Both issues are the same bug: in column-direction intrinsic main-size computation, an item's content contribution was computed as `(content_size + margin).max(flex_basis)`. Since `flex_basis` is a border-box size with no margin, any negative main-axis margin was silently absorbed by the floor whenever `content_size + margin < flex_basis`.

Fix: floor the *inner* size by the flex basis first, then add the margin:

```
- content_main_size = inner + margin
- if is_row { content_main_size.clamp(min, max) } else { content_main_size.max(flex_basis).clamp(min, max) }
+ if is_row { (inner + margin).clamp(min, max) } else { (inner.max(flex_basis) + margin).clamp(min, max) }
```

applied to both the definite-preferred-size fast path and the measured-content path in `determine_container_main_size`.

- #1162: a flex item with `flex-grow` and a definite height hit the fast path; `(500 - 24).max(500) = 500` dropped the margin entirely (with `flex-grow: 0` the min/max clamp short-circuit path was taken instead, which handled margins correctly — hence the asymmetry).
- #1163: the strip with `margin-top: -32px` hit the measured path; the `overflow: hidden` grid item inflated the strip's flex basis to its max-content size, so the same floor swallowed the margin.

## Context

Same family as #1151/#1152 (negative margins lost inside intrinsic sizing), but a distinct code path. Both repro programs from the issues now match Chrome on all rows; new gentest fixtures cover the three failing configurations.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/f379d8c9a11e428a92fe6198951c5e79
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/f379d8c9a11e428a92fe6198951c5e79?variant=devin-insiders
Requested by: @nicoburns