### PR TITLE
Fix grid-area resolution edge cases in resolve_absolute_grid_area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Grid: fixed `DetailedGridTracksInfo::resolve_absolute_grid_area` edge cases: placements are now normalized (lines sorted, named lines resolved) *before* out-of-range lines are treated as `auto`, and axes with no tracks resolve against the axis' single content-aligned grid line instead of falling back to the padding edge
 - Block/float: absorb `f32` rounding errors in horizontal fit checks, preventing floats from spuriously wrapping when percentage widths and margins sum to exactly 100% of the container (#1161).
 - Flexbox: main-axis margins are no longer dropped from an item's intrinsic main-size contribution when the contribution is floored by the item's flex basis (column containers). This fixes negative margins being ignored on flex items with `flex-grow` (#1162) and on descendants containing an `overflow: hidden` grid item (#1163).
 

--- a/scripts/gentest/src/main.rs
+++ b/scripts/gentest/src/main.rs
@@ -834,6 +834,7 @@ fn serialize_grid_position(grid_position: &serde_json::Value) -> Option<Cow<'sta
                 "auto" => None, //Some(Cow::from("auto")),
                 "span" => Some(Cow::from(format!("span {}", value()))),
                 "line" => Some(Cow::from((value() as i32).to_string())),
+                "named" => Some(Cow::from(grid_position.get("value").unwrap().as_str().unwrap().to_string())),
                 _ => unreachable!(),
             },
             _ => unreachable!(),

--- a/scripts/gentest/test_helper.js
+++ b/scripts/gentest/test_helper.js
@@ -200,6 +200,7 @@ function parseGridPosition(input) {
   if (input === 'auto') return { kind: 'auto' };
   if (/^span +\d+$/.test(input)) return { kind: 'span', value: parseInt(input.replace(/[^\d]/g, ''), 10) };
   if (/^-?\d+$/.test(input)) return { kind: 'line', value: parseInt(input, 10) };
+  if (/^(-?\d+ +)?[a-zA-Z_][\w-]* *(-?\d+)?$/.test(input)) return { kind: 'named', value: input };
   return undefined;
 }
 

--- a/src/compute/grid/mod.rs
+++ b/src/compute/grid/mod.rs
@@ -24,7 +24,7 @@ use types::{CellOccupancyMatrix, GridTrack, NamedLineResolver};
 #[cfg(feature = "detailed_layout_info")]
 use crate::sys::{DefaultCheapStr, String};
 #[cfg(feature = "detailed_layout_info")]
-use crate::{CheapCloneStr, GridPlacement, OriginZeroGridPlacement};
+use crate::{CheapCloneStr, GridPlacement};
 #[cfg(feature = "detailed_layout_info")]
 use types::{GridItem, GridTrackKind, TrackCounts};
 
@@ -904,17 +904,17 @@ impl<S: CheapCloneStr> DetailedGridTracksInfo<S> {
         };
         let min_line = -(track_counts.negative_implicit as i16);
         let max_line = (track_counts.explicit + track_counts.positive_implicit) as i16;
+        // Resolve the placement to a pair of (sorted) lines first, and only then treat lines
+        // that fall outside the grid as `auto`. A placement whose lines end up swapped (e.g.
+        // `grid-column: 3 / 1`, or a non-existent named line which resolves past the end of the
+        // explicit grid) is normalized before the out-of-grid check, so e.g. `foo / 3` on a
+        // 2-column grid resolves to the area between line 3 and the end padding edge.
         let placement = self
             .line_names
             .resolve_line_names(&placement, self.explicit_tracks)
             .into_origin_zero(self.explicit_tracks)
-            .map(|placement| match placement {
-                OriginZeroGridPlacement::Line(line) if line.0 < min_line || line.0 > max_line => {
-                    OriginZeroGridPlacement::Auto
-                }
-                placement => placement,
-            })
             .resolve_absolutely_positioned_grid_tracks()
+            .map(|line| line.filter(|line| line.0 >= min_line && line.0 <= max_line))
             .map(|line| line.and_then(|line| line.try_into_track_vec_index(track_counts).map(|index| index / 2)));
         let start_position = placement
             .start
@@ -923,6 +923,7 @@ impl<S: CheapCloneStr> DetailedGridTracksInfo<S> {
                     .get(line)
                     .map(|track| if is_reversed { track.end } else { track.start })
                     .or_else(|| self.positions.last().map(|track| if is_reversed { track.start } else { track.end }))
+                    .or(self.empty_axis_line)
             })
             .unwrap_or(if is_reversed { padding_end } else { padding_start });
         let end_position = placement
@@ -932,6 +933,7 @@ impl<S: CheapCloneStr> DetailedGridTracksInfo<S> {
                     .and_then(|line| self.positions.get(line))
                     .map(|track| if is_reversed { track.start } else { track.end })
                     .or_else(|| self.positions.first().map(|track| if is_reversed { track.end } else { track.start }))
+                    .or(self.empty_axis_line)
             })
             .unwrap_or(if is_reversed { padding_start } else { padding_end });
 
@@ -1022,6 +1024,11 @@ pub struct DetailedGridTracksInfo<S: CheapCloneStr = DefaultCheapStr> {
     /// content alignment (`align-content`/`justify-content`), and collapsed tracks.
     pub positions: Vec<Line<f32>>,
 
+    /// The position of the axis' single grid line relative to the grid container's border box
+    /// when the axis has no tracks (an empty grid still contains one grid line in each axis,
+    /// positioned by content alignment). `None` when the axis has tracks.
+    pub empty_axis_line: Option<f32>,
+
     /// The names of each *explicit* grid line. Stored line `i` (0-indexed) bounds the start of
     /// explicit track `i`; use [`DetailedGridTracksInfo::names_for_line`] or
     /// [`DetailedGridTracksInfo::iter_line_names`] for indices relative to the full grid
@@ -1046,11 +1053,16 @@ impl<S: CheapCloneStr> DetailedGridTracksInfo<S> {
         grid_tracks: Vec<GridTrack>,
         line_names: GridLineNames<S>,
     ) -> Self {
+        let positions = DetailedGridTracksInfo::<S>::positions_from_grid_track_layout(&grid_tracks);
+        // An axis with no tracks consists of a single gutter whose offset is where the axis'
+        // single grid line was positioned by content alignment
+        let empty_axis_line = if positions.is_empty() { grid_tracks.first().map(|track| track.offset) } else { None };
         DetailedGridTracksInfo {
             negative_implicit_tracks: track_count.negative_implicit,
             explicit_tracks: track_count.explicit,
             positive_implicit_tracks: track_count.positive_implicit,
-            positions: DetailedGridTracksInfo::<S>::positions_from_grid_track_layout(&grid_tracks),
+            positions,
+            empty_axis_line,
             line_names,
         }
     }

--- a/test_fixtures/grid/grid_absolute_empty_grid_lines.html
+++ b/test_fixtures/grid/grid_absolute_empty_grid_lines.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Absolutely positioned children of an empty grid (no explicit or implicit tracks) with
+    grid-placement properties referencing line 1
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; position: relative; width: 100px; height: 100px; padding: 5px;">
+  <div style="position: absolute; grid-row: 1 / auto; grid-column: 1 / auto; top: 0; left: 0; right: 0; bottom: 0;"></div>
+  <div style="position: absolute; grid-row: auto / 1; grid-column: auto / 1; top: 0; left: 0; right: 0; bottom: 0;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_absolute_known_named_lines.html
+++ b/test_fixtures/grid/grid_absolute_known_named_lines.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Absolutely positioned grid children with grid-placement properties referencing named grid
+    lines that exist in the grid
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; position: relative; grid-template-columns: [a] 40px [b] 60px [c]; grid-template-rows: [a] 20px [b] 50px [c]; width: 200px; height: 150px; padding: 10px;">
+  <div style="position: absolute; grid-column: a / c; grid-row: a / c; top: 0; left: 0; right: 0; bottom: 0;"></div>
+  <div style="position: absolute; grid-column: b / auto; grid-row: auto / b; top: 0; left: 0; right: 0; bottom: 0;"></div>
+  <div style="position: absolute; grid-column: c / a; grid-row: c / a; top: 0; left: 0; right: 0; bottom: 0;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_absolute_out_of_range_lines.html
+++ b/test_fixtures/grid/grid_absolute_out_of_range_lines.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Absolutely positioned grid children with grid-placement lines outside the explicit grid
+    or span placements (both treated as auto)
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; position: relative; grid-template-columns: 40px 60px; grid-template-rows: 20px 50px; width: 200px; height: 150px; padding: 10px;">
+  <div style="position: absolute; grid-column: -5 / 1; grid-row: -5 / 1; top: 0; left: 0; right: 0; bottom: 0;"></div>
+  <div style="position: absolute; grid-column: 3 / 5; grid-row: 3 / 5; top: 0; left: 0; right: 0; bottom: 0;"></div>
+  <div style="position: absolute; grid-column: span 2 / 1; grid-row: span 2 / 1; top: 0; left: 0; right: 0; bottom: 0;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_absolute_padding_edge_lines.html
+++ b/test_fixtures/grid/grid_absolute_padding_edge_lines.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Absolutely positioned grid children whose grid area is anchored at the first or last grid
+    line with the opposite side auto (resolving to the padding edge)
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; position: relative; grid-template-columns: 40px 60px; grid-template-rows: 20px 50px; width: 200px; height: 150px; padding: 10px;">
+  <div style="position: absolute; grid-column: auto / 1; grid-row: auto / 1; top: 0; left: 0; right: 0; bottom: 0;"></div>
+  <div style="position: absolute; grid-column: 3 / auto; grid-row: 3 / auto; top: 0; left: 0; right: 0; bottom: 0;"></div>
+  <div style="position: absolute; grid-column: 1 / 2; grid-row: 3 / auto; top: 0; left: 0; right: 0; bottom: 0;"></div>
+  <div style="position: absolute; grid-column: 3 / auto; grid-row: 2 / 3; top: 0; left: 0; right: 0; bottom: 0;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_absolute_unknown_named_lines.html
+++ b/test_fixtures/grid/grid_absolute_unknown_named_lines.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Absolutely positioned grid children with grid-placement properties referencing named grid
+    lines that do not exist in the grid
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; position: relative; grid-template-columns: 40px 60px; grid-template-rows: 20px 50px; width: 200px; height: 150px; padding: 10px;">
+  <div style="position: absolute; grid-column: foo / bar; grid-row: foo / bar; top: 0; left: 0; right: 0; bottom: 0;"></div>
+  <div style="position: absolute; grid-column: 1 / foo; grid-row: 1 / bar; top: 0; left: 0; right: 0; bottom: 0;"></div>
+  <div style="position: absolute; grid-column: foo / 3; grid-row: bar / 3; top: 0; left: 0; right: 0; bottom: 0;"></div>
+  <div style="position: absolute; grid-column: foo / 1; grid-row: bar / 1; top: 0; left: 0; right: 0; bottom: 0;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/hand_written/detailed_grid_info.rs
+++ b/tests/hand_written/detailed_grid_info.rs
@@ -243,7 +243,10 @@ mod detailed_grid_info {
                 taffy::style::Direction::Ltr,
                 Rect { left: 0.0, right: 120.0, top: 0.0, bottom: 100.0 },
             ),
-            Rect { left: 0.0, right: 45.0, top: 0.0, bottom: 100.0 }
+            // An unknown named line resolves to the first implicit line past the explicit grid,
+            // which (being outside the grid) falls back to the padding edge. The resulting
+            // start/end pair is swapped, so this is equivalent to `2 / <padding-end>`.
+            Rect { left: 55.0, right: 120.0, top: 0.0, bottom: 100.0 }
         );
         assert_eq!(
             info.resolve_absolute_grid_area(

--- a/tests/xml/grid/grid_absolute_empty_grid_lines__border_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_empty_grid_lines__border_box_ltr.xml
@@ -1,7 +1,7 @@
 <test name="grid_absolute_empty_grid_lines__border_box_ltr" use-rounding="true">
   <viewport width="max-content" height="max-content"/>
   <input>
-    <div display="grid" direction="ltr" position="relative" width="100px" height="100px" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px">
+    <div display="grid" direction="ltr" width="100px" height="100px" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px">
       <div direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="1" grid-column-start="1"/>
       <div direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-end="1" grid-column-end="1"/>
     </div>

--- a/tests/xml/grid/grid_absolute_empty_grid_lines__border_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_empty_grid_lines__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_absolute_empty_grid_lines__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" position="relative" width="100px" height="100px" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px">
+      <div direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="1" grid-column-start="1"/>
+      <div direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-end="1" grid-column-end="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100" resolved-rows="none" resolved-columns="none">
+      <node x="5" y="5" width="95" height="95"/>
+      <node x="0" y="0" width="5" height="5"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_empty_grid_lines__border_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_empty_grid_lines__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_absolute_empty_grid_lines__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" position="relative" width="100px" height="100px" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px">
+      <div direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="1" grid-column-start="1"/>
+      <div direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-end="1" grid-column-end="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="100" resolved-rows="none" resolved-columns="none">
+      <node x="0" y="5" width="95" height="95"/>
+      <node x="95" y="0" width="5" height="5"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_empty_grid_lines__border_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_empty_grid_lines__border_box_rtl.xml
@@ -1,7 +1,7 @@
 <test name="grid_absolute_empty_grid_lines__border_box_rtl" use-rounding="true">
   <viewport width="max-content" height="max-content"/>
   <input>
-    <div display="grid" direction="rtl" position="relative" width="100px" height="100px" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px">
+    <div display="grid" direction="rtl" width="100px" height="100px" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px">
       <div direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="1" grid-column-start="1"/>
       <div direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-end="1" grid-column-end="1"/>
     </div>

--- a/tests/xml/grid/grid_absolute_empty_grid_lines__content_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_empty_grid_lines__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="grid_absolute_empty_grid_lines__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" position="relative" width="100px" height="100px" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px">
+      <div box-sizing="content-box" direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-end="1" grid-column-end="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="110" height="110" resolved-rows="none" resolved-columns="none">
+      <node x="5" y="5" width="105" height="105"/>
+      <node x="0" y="0" width="5" height="5"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_empty_grid_lines__content_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_empty_grid_lines__content_box_ltr.xml
@@ -1,7 +1,7 @@
 <test name="grid_absolute_empty_grid_lines__content_box_ltr" use-rounding="true">
   <viewport width="max-content" height="max-content"/>
   <input>
-    <div display="grid" box-sizing="content-box" direction="ltr" position="relative" width="100px" height="100px" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px">
+    <div display="grid" box-sizing="content-box" direction="ltr" width="100px" height="100px" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px">
       <div box-sizing="content-box" direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="1" grid-column-start="1"/>
       <div box-sizing="content-box" direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-end="1" grid-column-end="1"/>
     </div>

--- a/tests/xml/grid/grid_absolute_empty_grid_lines__content_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_empty_grid_lines__content_box_rtl.xml
@@ -1,7 +1,7 @@
 <test name="grid_absolute_empty_grid_lines__content_box_rtl" use-rounding="true">
   <viewport width="max-content" height="max-content"/>
   <input>
-    <div display="grid" box-sizing="content-box" direction="rtl" position="relative" width="100px" height="100px" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px">
+    <div display="grid" box-sizing="content-box" direction="rtl" width="100px" height="100px" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px">
       <div box-sizing="content-box" direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="1" grid-column-start="1"/>
       <div box-sizing="content-box" direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-end="1" grid-column-end="1"/>
     </div>

--- a/tests/xml/grid/grid_absolute_empty_grid_lines__content_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_empty_grid_lines__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="grid_absolute_empty_grid_lines__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" position="relative" width="100px" height="100px" padding-top="5px" padding-left="5px" padding-bottom="5px" padding-right="5px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="1" grid-column-start="1"/>
+      <div box-sizing="content-box" direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-end="1" grid-column-end="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="110" height="110" resolved-rows="none" resolved-columns="none">
+      <node x="0" y="5" width="105" height="105"/>
+      <node x="105" y="0" width="5" height="5"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_known_named_lines__border_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_known_named_lines__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_absolute_known_named_lines__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" position="relative" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="[a] 20px [b] 50px [c]" grid-template-columns="[a] 40px [b] 60px [c]">
+      <div direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="a" grid-row-end="c" grid-column-start="a" grid-column-end="c"/>
+      <div direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-end="b" grid-column-start="b"/>
+      <div direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="c" grid-row-end="a" grid-column-start="c" grid-column-end="a"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="150" resolved-rows="[a] 20px [b] 50px [c]" resolved-columns="[a] 40px [b] 60px [c]">
+      <node x="10" y="10" width="100" height="70"/>
+      <node x="50" y="0" width="150" height="30"/>
+      <node x="10" y="10" width="100" height="70"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_known_named_lines__border_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_known_named_lines__border_box_ltr.xml
@@ -1,7 +1,7 @@
 <test name="grid_absolute_known_named_lines__border_box_ltr" use-rounding="true">
   <viewport width="max-content" height="max-content"/>
   <input>
-    <div display="grid" direction="ltr" position="relative" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="[a] 20px [b] 50px [c]" grid-template-columns="[a] 40px [b] 60px [c]">
+    <div display="grid" direction="ltr" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="[a] 20px [b] 50px [c]" grid-template-columns="[a] 40px [b] 60px [c]">
       <div direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="a" grid-row-end="c" grid-column-start="a" grid-column-end="c"/>
       <div direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-end="b" grid-column-start="b"/>
       <div direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="c" grid-row-end="a" grid-column-start="c" grid-column-end="a"/>

--- a/tests/xml/grid/grid_absolute_known_named_lines__border_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_known_named_lines__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_absolute_known_named_lines__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" position="relative" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="[a] 20px [b] 50px [c]" grid-template-columns="[a] 40px [b] 60px [c]">
+      <div direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="a" grid-row-end="c" grid-column-start="a" grid-column-end="c"/>
+      <div direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-end="b" grid-column-start="b"/>
+      <div direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="c" grid-row-end="a" grid-column-start="c" grid-column-end="a"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="150" resolved-rows="[a] 20px [b] 50px [c]" resolved-columns="[a] 40px [b] 60px [c]">
+      <node x="90" y="10" width="100" height="70"/>
+      <node x="0" y="0" width="150" height="30"/>
+      <node x="90" y="10" width="100" height="70"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_known_named_lines__border_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_known_named_lines__border_box_rtl.xml
@@ -1,7 +1,7 @@
 <test name="grid_absolute_known_named_lines__border_box_rtl" use-rounding="true">
   <viewport width="max-content" height="max-content"/>
   <input>
-    <div display="grid" direction="rtl" position="relative" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="[a] 20px [b] 50px [c]" grid-template-columns="[a] 40px [b] 60px [c]">
+    <div display="grid" direction="rtl" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="[a] 20px [b] 50px [c]" grid-template-columns="[a] 40px [b] 60px [c]">
       <div direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="a" grid-row-end="c" grid-column-start="a" grid-column-end="c"/>
       <div direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-end="b" grid-column-start="b"/>
       <div direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="c" grid-row-end="a" grid-column-start="c" grid-column-end="a"/>

--- a/tests/xml/grid/grid_absolute_known_named_lines__content_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_known_named_lines__content_box_ltr.xml
@@ -1,7 +1,7 @@
 <test name="grid_absolute_known_named_lines__content_box_ltr" use-rounding="true">
   <viewport width="max-content" height="max-content"/>
   <input>
-    <div display="grid" box-sizing="content-box" direction="ltr" position="relative" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="[a] 20px [b] 50px [c]" grid-template-columns="[a] 40px [b] 60px [c]">
+    <div display="grid" box-sizing="content-box" direction="ltr" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="[a] 20px [b] 50px [c]" grid-template-columns="[a] 40px [b] 60px [c]">
       <div box-sizing="content-box" direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="a" grid-row-end="c" grid-column-start="a" grid-column-end="c"/>
       <div box-sizing="content-box" direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-end="b" grid-column-start="b"/>
       <div box-sizing="content-box" direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="c" grid-row-end="a" grid-column-start="c" grid-column-end="a"/>

--- a/tests/xml/grid/grid_absolute_known_named_lines__content_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_known_named_lines__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_absolute_known_named_lines__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" position="relative" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="[a] 20px [b] 50px [c]" grid-template-columns="[a] 40px [b] 60px [c]">
+      <div box-sizing="content-box" direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="a" grid-row-end="c" grid-column-start="a" grid-column-end="c"/>
+      <div box-sizing="content-box" direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-end="b" grid-column-start="b"/>
+      <div box-sizing="content-box" direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="c" grid-row-end="a" grid-column-start="c" grid-column-end="a"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="220" height="170" resolved-rows="[a] 20px [b] 50px [c]" resolved-columns="[a] 40px [b] 60px [c]">
+      <node x="10" y="10" width="100" height="70"/>
+      <node x="50" y="0" width="170" height="30"/>
+      <node x="10" y="10" width="100" height="70"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_known_named_lines__content_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_known_named_lines__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_absolute_known_named_lines__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" position="relative" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="[a] 20px [b] 50px [c]" grid-template-columns="[a] 40px [b] 60px [c]">
+      <div box-sizing="content-box" direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="a" grid-row-end="c" grid-column-start="a" grid-column-end="c"/>
+      <div box-sizing="content-box" direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-end="b" grid-column-start="b"/>
+      <div box-sizing="content-box" direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="c" grid-row-end="a" grid-column-start="c" grid-column-end="a"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="220" height="170" resolved-rows="[a] 20px [b] 50px [c]" resolved-columns="[a] 40px [b] 60px [c]">
+      <node x="110" y="10" width="100" height="70"/>
+      <node x="0" y="0" width="170" height="30"/>
+      <node x="110" y="10" width="100" height="70"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_known_named_lines__content_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_known_named_lines__content_box_rtl.xml
@@ -1,7 +1,7 @@
 <test name="grid_absolute_known_named_lines__content_box_rtl" use-rounding="true">
   <viewport width="max-content" height="max-content"/>
   <input>
-    <div display="grid" box-sizing="content-box" direction="rtl" position="relative" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="[a] 20px [b] 50px [c]" grid-template-columns="[a] 40px [b] 60px [c]">
+    <div display="grid" box-sizing="content-box" direction="rtl" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="[a] 20px [b] 50px [c]" grid-template-columns="[a] 40px [b] 60px [c]">
       <div box-sizing="content-box" direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="a" grid-row-end="c" grid-column-start="a" grid-column-end="c"/>
       <div box-sizing="content-box" direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-end="b" grid-column-start="b"/>
       <div box-sizing="content-box" direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="c" grid-row-end="a" grid-column-start="c" grid-column-end="a"/>

--- a/tests/xml/grid/grid_absolute_out_of_range_lines__border_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_out_of_range_lines__border_box_ltr.xml
@@ -1,7 +1,7 @@
 <test name="grid_absolute_out_of_range_lines__border_box_ltr" use-rounding="true">
   <viewport width="max-content" height="max-content"/>
   <input>
-    <div display="grid" direction="ltr" position="relative" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="20px 50px" grid-template-columns="40px 60px">
+    <div display="grid" direction="ltr" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="20px 50px" grid-template-columns="40px 60px">
       <div direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="-5" grid-row-end="1" grid-column-start="-5" grid-column-end="1"/>
       <div direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="3" grid-row-end="5" grid-column-start="3" grid-column-end="5"/>
       <div direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="span 2" grid-row-end="1" grid-column-start="span 2" grid-column-end="1"/>

--- a/tests/xml/grid/grid_absolute_out_of_range_lines__border_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_out_of_range_lines__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_absolute_out_of_range_lines__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" position="relative" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="20px 50px" grid-template-columns="40px 60px">
+      <div direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="-5" grid-row-end="1" grid-column-start="-5" grid-column-end="1"/>
+      <div direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="3" grid-row-end="5" grid-column-start="3" grid-column-end="5"/>
+      <div direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="span 2" grid-row-end="1" grid-column-start="span 2" grid-column-end="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="150" resolved-rows="20px 50px" resolved-columns="40px 60px">
+      <node x="0" y="0" width="10" height="10"/>
+      <node x="110" y="80" width="90" height="70"/>
+      <node x="0" y="0" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_out_of_range_lines__border_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_out_of_range_lines__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_absolute_out_of_range_lines__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" position="relative" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="20px 50px" grid-template-columns="40px 60px">
+      <div direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="-5" grid-row-end="1" grid-column-start="-5" grid-column-end="1"/>
+      <div direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="3" grid-row-end="5" grid-column-start="3" grid-column-end="5"/>
+      <div direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="span 2" grid-row-end="1" grid-column-start="span 2" grid-column-end="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="150" resolved-rows="20px 50px" resolved-columns="40px 60px">
+      <node x="190" y="0" width="10" height="10"/>
+      <node x="0" y="80" width="90" height="70"/>
+      <node x="190" y="0" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_out_of_range_lines__border_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_out_of_range_lines__border_box_rtl.xml
@@ -1,7 +1,7 @@
 <test name="grid_absolute_out_of_range_lines__border_box_rtl" use-rounding="true">
   <viewport width="max-content" height="max-content"/>
   <input>
-    <div display="grid" direction="rtl" position="relative" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="20px 50px" grid-template-columns="40px 60px">
+    <div display="grid" direction="rtl" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="20px 50px" grid-template-columns="40px 60px">
       <div direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="-5" grid-row-end="1" grid-column-start="-5" grid-column-end="1"/>
       <div direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="3" grid-row-end="5" grid-column-start="3" grid-column-end="5"/>
       <div direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="span 2" grid-row-end="1" grid-column-start="span 2" grid-column-end="1"/>

--- a/tests/xml/grid/grid_absolute_out_of_range_lines__content_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_out_of_range_lines__content_box_ltr.xml
@@ -1,7 +1,7 @@
 <test name="grid_absolute_out_of_range_lines__content_box_ltr" use-rounding="true">
   <viewport width="max-content" height="max-content"/>
   <input>
-    <div display="grid" box-sizing="content-box" direction="ltr" position="relative" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="20px 50px" grid-template-columns="40px 60px">
+    <div display="grid" box-sizing="content-box" direction="ltr" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="20px 50px" grid-template-columns="40px 60px">
       <div box-sizing="content-box" direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="-5" grid-row-end="1" grid-column-start="-5" grid-column-end="1"/>
       <div box-sizing="content-box" direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="3" grid-row-end="5" grid-column-start="3" grid-column-end="5"/>
       <div box-sizing="content-box" direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="span 2" grid-row-end="1" grid-column-start="span 2" grid-column-end="1"/>

--- a/tests/xml/grid/grid_absolute_out_of_range_lines__content_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_out_of_range_lines__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="grid_absolute_out_of_range_lines__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" position="relative" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="20px 50px" grid-template-columns="40px 60px">
+      <div box-sizing="content-box" direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="-5" grid-row-end="1" grid-column-start="-5" grid-column-end="1"/>
+      <div box-sizing="content-box" direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="3" grid-row-end="5" grid-column-start="3" grid-column-end="5"/>
+      <div box-sizing="content-box" direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="span 2" grid-row-end="1" grid-column-start="span 2" grid-column-end="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="220" height="170" resolved-rows="20px 50px" resolved-columns="40px 60px">
+      <node x="0" y="0" width="10" height="10"/>
+      <node x="110" y="80" width="110" height="90"/>
+      <node x="0" y="0" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_out_of_range_lines__content_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_out_of_range_lines__content_box_rtl.xml
@@ -1,7 +1,7 @@
 <test name="grid_absolute_out_of_range_lines__content_box_rtl" use-rounding="true">
   <viewport width="max-content" height="max-content"/>
   <input>
-    <div display="grid" box-sizing="content-box" direction="rtl" position="relative" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="20px 50px" grid-template-columns="40px 60px">
+    <div display="grid" box-sizing="content-box" direction="rtl" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="20px 50px" grid-template-columns="40px 60px">
       <div box-sizing="content-box" direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="-5" grid-row-end="1" grid-column-start="-5" grid-column-end="1"/>
       <div box-sizing="content-box" direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="3" grid-row-end="5" grid-column-start="3" grid-column-end="5"/>
       <div box-sizing="content-box" direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="span 2" grid-row-end="1" grid-column-start="span 2" grid-column-end="1"/>

--- a/tests/xml/grid/grid_absolute_out_of_range_lines__content_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_out_of_range_lines__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="grid_absolute_out_of_range_lines__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" position="relative" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="20px 50px" grid-template-columns="40px 60px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="-5" grid-row-end="1" grid-column-start="-5" grid-column-end="1"/>
+      <div box-sizing="content-box" direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="3" grid-row-end="5" grid-column-start="3" grid-column-end="5"/>
+      <div box-sizing="content-box" direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="span 2" grid-row-end="1" grid-column-start="span 2" grid-column-end="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="220" height="170" resolved-rows="20px 50px" resolved-columns="40px 60px">
+      <node x="210" y="0" width="10" height="10"/>
+      <node x="0" y="80" width="110" height="90"/>
+      <node x="210" y="0" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_padding_edge_lines__border_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_padding_edge_lines__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_absolute_padding_edge_lines__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" position="relative" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="20px 50px" grid-template-columns="40px 60px">
+      <div direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-end="1" grid-column-end="1"/>
+      <div direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="3" grid-column-start="3"/>
+      <div direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="3" grid-column-start="1" grid-column-end="2"/>
+      <div direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="2" grid-row-end="3" grid-column-start="3"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="150" resolved-rows="20px 50px" resolved-columns="40px 60px">
+      <node x="0" y="0" width="10" height="10"/>
+      <node x="110" y="80" width="90" height="70"/>
+      <node x="10" y="80" width="40" height="70"/>
+      <node x="110" y="30" width="90" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_padding_edge_lines__border_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_padding_edge_lines__border_box_ltr.xml
@@ -1,7 +1,7 @@
 <test name="grid_absolute_padding_edge_lines__border_box_ltr" use-rounding="true">
   <viewport width="max-content" height="max-content"/>
   <input>
-    <div display="grid" direction="ltr" position="relative" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="20px 50px" grid-template-columns="40px 60px">
+    <div display="grid" direction="ltr" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="20px 50px" grid-template-columns="40px 60px">
       <div direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-end="1" grid-column-end="1"/>
       <div direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="3" grid-column-start="3"/>
       <div direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="3" grid-column-start="1" grid-column-end="2"/>

--- a/tests/xml/grid/grid_absolute_padding_edge_lines__border_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_padding_edge_lines__border_box_rtl.xml
@@ -1,7 +1,7 @@
 <test name="grid_absolute_padding_edge_lines__border_box_rtl" use-rounding="true">
   <viewport width="max-content" height="max-content"/>
   <input>
-    <div display="grid" direction="rtl" position="relative" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="20px 50px" grid-template-columns="40px 60px">
+    <div display="grid" direction="rtl" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="20px 50px" grid-template-columns="40px 60px">
       <div direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-end="1" grid-column-end="1"/>
       <div direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="3" grid-column-start="3"/>
       <div direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="3" grid-column-start="1" grid-column-end="2"/>

--- a/tests/xml/grid/grid_absolute_padding_edge_lines__border_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_padding_edge_lines__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_absolute_padding_edge_lines__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" position="relative" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="20px 50px" grid-template-columns="40px 60px">
+      <div direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-end="1" grid-column-end="1"/>
+      <div direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="3" grid-column-start="3"/>
+      <div direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="3" grid-column-start="1" grid-column-end="2"/>
+      <div direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="2" grid-row-end="3" grid-column-start="3"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="150" resolved-rows="20px 50px" resolved-columns="40px 60px">
+      <node x="190" y="0" width="10" height="10"/>
+      <node x="0" y="80" width="90" height="70"/>
+      <node x="150" y="80" width="40" height="70"/>
+      <node x="0" y="30" width="90" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_padding_edge_lines__content_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_padding_edge_lines__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_absolute_padding_edge_lines__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" position="relative" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="20px 50px" grid-template-columns="40px 60px">
+      <div box-sizing="content-box" direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-end="1" grid-column-end="1"/>
+      <div box-sizing="content-box" direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="3" grid-column-start="3"/>
+      <div box-sizing="content-box" direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="3" grid-column-start="1" grid-column-end="2"/>
+      <div box-sizing="content-box" direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="2" grid-row-end="3" grid-column-start="3"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="220" height="170" resolved-rows="20px 50px" resolved-columns="40px 60px">
+      <node x="0" y="0" width="10" height="10"/>
+      <node x="110" y="80" width="110" height="90"/>
+      <node x="10" y="80" width="40" height="90"/>
+      <node x="110" y="30" width="110" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_padding_edge_lines__content_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_padding_edge_lines__content_box_ltr.xml
@@ -1,7 +1,7 @@
 <test name="grid_absolute_padding_edge_lines__content_box_ltr" use-rounding="true">
   <viewport width="max-content" height="max-content"/>
   <input>
-    <div display="grid" box-sizing="content-box" direction="ltr" position="relative" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="20px 50px" grid-template-columns="40px 60px">
+    <div display="grid" box-sizing="content-box" direction="ltr" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="20px 50px" grid-template-columns="40px 60px">
       <div box-sizing="content-box" direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-end="1" grid-column-end="1"/>
       <div box-sizing="content-box" direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="3" grid-column-start="3"/>
       <div box-sizing="content-box" direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="3" grid-column-start="1" grid-column-end="2"/>

--- a/tests/xml/grid/grid_absolute_padding_edge_lines__content_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_padding_edge_lines__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_absolute_padding_edge_lines__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" position="relative" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="20px 50px" grid-template-columns="40px 60px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-end="1" grid-column-end="1"/>
+      <div box-sizing="content-box" direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="3" grid-column-start="3"/>
+      <div box-sizing="content-box" direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="3" grid-column-start="1" grid-column-end="2"/>
+      <div box-sizing="content-box" direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="2" grid-row-end="3" grid-column-start="3"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="220" height="170" resolved-rows="20px 50px" resolved-columns="40px 60px">
+      <node x="210" y="0" width="10" height="10"/>
+      <node x="0" y="80" width="110" height="90"/>
+      <node x="170" y="80" width="40" height="90"/>
+      <node x="0" y="30" width="110" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_padding_edge_lines__content_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_padding_edge_lines__content_box_rtl.xml
@@ -1,7 +1,7 @@
 <test name="grid_absolute_padding_edge_lines__content_box_rtl" use-rounding="true">
   <viewport width="max-content" height="max-content"/>
   <input>
-    <div display="grid" box-sizing="content-box" direction="rtl" position="relative" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="20px 50px" grid-template-columns="40px 60px">
+    <div display="grid" box-sizing="content-box" direction="rtl" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="20px 50px" grid-template-columns="40px 60px">
       <div box-sizing="content-box" direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-end="1" grid-column-end="1"/>
       <div box-sizing="content-box" direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="3" grid-column-start="3"/>
       <div box-sizing="content-box" direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="3" grid-column-start="1" grid-column-end="2"/>

--- a/tests/xml/grid/grid_absolute_unknown_named_lines__border_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_unknown_named_lines__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_absolute_unknown_named_lines__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" position="relative" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="20px 50px" grid-template-columns="40px 60px">
+      <div direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="foo" grid-row-end="bar" grid-column-start="foo" grid-column-end="bar"/>
+      <div direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="1" grid-row-end="bar" grid-column-start="1" grid-column-end="foo"/>
+      <div direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="bar" grid-row-end="3" grid-column-start="foo" grid-column-end="3"/>
+      <div direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="bar" grid-row-end="1" grid-column-start="foo" grid-column-end="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="150" resolved-rows="20px 50px" resolved-columns="40px 60px">
+      <node x="0" y="0" width="200" height="150"/>
+      <node x="10" y="10" width="190" height="140"/>
+      <node x="110" y="80" width="90" height="70"/>
+      <node x="10" y="10" width="190" height="140"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_unknown_named_lines__border_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_unknown_named_lines__border_box_ltr.xml
@@ -1,7 +1,7 @@
 <test name="grid_absolute_unknown_named_lines__border_box_ltr" use-rounding="true">
   <viewport width="max-content" height="max-content"/>
   <input>
-    <div display="grid" direction="ltr" position="relative" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="20px 50px" grid-template-columns="40px 60px">
+    <div display="grid" direction="ltr" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="20px 50px" grid-template-columns="40px 60px">
       <div direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="foo" grid-row-end="bar" grid-column-start="foo" grid-column-end="bar"/>
       <div direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="1" grid-row-end="bar" grid-column-start="1" grid-column-end="foo"/>
       <div direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="bar" grid-row-end="3" grid-column-start="foo" grid-column-end="3"/>

--- a/tests/xml/grid/grid_absolute_unknown_named_lines__border_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_unknown_named_lines__border_box_rtl.xml
@@ -1,7 +1,7 @@
 <test name="grid_absolute_unknown_named_lines__border_box_rtl" use-rounding="true">
   <viewport width="max-content" height="max-content"/>
   <input>
-    <div display="grid" direction="rtl" position="relative" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="20px 50px" grid-template-columns="40px 60px">
+    <div display="grid" direction="rtl" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="20px 50px" grid-template-columns="40px 60px">
       <div direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="foo" grid-row-end="bar" grid-column-start="foo" grid-column-end="bar"/>
       <div direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="1" grid-row-end="bar" grid-column-start="1" grid-column-end="foo"/>
       <div direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="bar" grid-row-end="3" grid-column-start="foo" grid-column-end="3"/>

--- a/tests/xml/grid/grid_absolute_unknown_named_lines__border_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_unknown_named_lines__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_absolute_unknown_named_lines__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" position="relative" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="20px 50px" grid-template-columns="40px 60px">
+      <div direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="foo" grid-row-end="bar" grid-column-start="foo" grid-column-end="bar"/>
+      <div direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="1" grid-row-end="bar" grid-column-start="1" grid-column-end="foo"/>
+      <div direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="bar" grid-row-end="3" grid-column-start="foo" grid-column-end="3"/>
+      <div direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="bar" grid-row-end="1" grid-column-start="foo" grid-column-end="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="150" resolved-rows="20px 50px" resolved-columns="40px 60px">
+      <node x="0" y="0" width="200" height="150"/>
+      <node x="0" y="10" width="190" height="140"/>
+      <node x="0" y="80" width="90" height="70"/>
+      <node x="0" y="10" width="190" height="140"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_unknown_named_lines__content_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_unknown_named_lines__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_absolute_unknown_named_lines__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" position="relative" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="20px 50px" grid-template-columns="40px 60px">
+      <div box-sizing="content-box" direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="foo" grid-row-end="bar" grid-column-start="foo" grid-column-end="bar"/>
+      <div box-sizing="content-box" direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="1" grid-row-end="bar" grid-column-start="1" grid-column-end="foo"/>
+      <div box-sizing="content-box" direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="bar" grid-row-end="3" grid-column-start="foo" grid-column-end="3"/>
+      <div box-sizing="content-box" direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="bar" grid-row-end="1" grid-column-start="foo" grid-column-end="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="220" height="170" resolved-rows="20px 50px" resolved-columns="40px 60px">
+      <node x="0" y="0" width="220" height="170"/>
+      <node x="10" y="10" width="210" height="160"/>
+      <node x="110" y="80" width="110" height="90"/>
+      <node x="10" y="10" width="210" height="160"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_absolute_unknown_named_lines__content_box_ltr.xml
+++ b/tests/xml/grid/grid_absolute_unknown_named_lines__content_box_ltr.xml
@@ -1,7 +1,7 @@
 <test name="grid_absolute_unknown_named_lines__content_box_ltr" use-rounding="true">
   <viewport width="max-content" height="max-content"/>
   <input>
-    <div display="grid" box-sizing="content-box" direction="ltr" position="relative" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="20px 50px" grid-template-columns="40px 60px">
+    <div display="grid" box-sizing="content-box" direction="ltr" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="20px 50px" grid-template-columns="40px 60px">
       <div box-sizing="content-box" direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="foo" grid-row-end="bar" grid-column-start="foo" grid-column-end="bar"/>
       <div box-sizing="content-box" direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="1" grid-row-end="bar" grid-column-start="1" grid-column-end="foo"/>
       <div box-sizing="content-box" direction="ltr" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="bar" grid-row-end="3" grid-column-start="foo" grid-column-end="3"/>

--- a/tests/xml/grid/grid_absolute_unknown_named_lines__content_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_unknown_named_lines__content_box_rtl.xml
@@ -1,7 +1,7 @@
 <test name="grid_absolute_unknown_named_lines__content_box_rtl" use-rounding="true">
   <viewport width="max-content" height="max-content"/>
   <input>
-    <div display="grid" box-sizing="content-box" direction="rtl" position="relative" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="20px 50px" grid-template-columns="40px 60px">
+    <div display="grid" box-sizing="content-box" direction="rtl" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="20px 50px" grid-template-columns="40px 60px">
       <div box-sizing="content-box" direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="foo" grid-row-end="bar" grid-column-start="foo" grid-column-end="bar"/>
       <div box-sizing="content-box" direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="1" grid-row-end="bar" grid-column-start="1" grid-column-end="foo"/>
       <div box-sizing="content-box" direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="bar" grid-row-end="3" grid-column-start="foo" grid-column-end="3"/>

--- a/tests/xml/grid/grid_absolute_unknown_named_lines__content_box_rtl.xml
+++ b/tests/xml/grid/grid_absolute_unknown_named_lines__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_absolute_unknown_named_lines__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" position="relative" width="200px" height="150px" padding-top="10px" padding-left="10px" padding-bottom="10px" padding-right="10px" grid-template-rows="20px 50px" grid-template-columns="40px 60px">
+      <div box-sizing="content-box" direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="foo" grid-row-end="bar" grid-column-start="foo" grid-column-end="bar"/>
+      <div box-sizing="content-box" direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="1" grid-row-end="bar" grid-column-start="1" grid-column-end="foo"/>
+      <div box-sizing="content-box" direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="bar" grid-row-end="3" grid-column-start="foo" grid-column-end="3"/>
+      <div box-sizing="content-box" direction="rtl" position="absolute" top="0px" left="0px" bottom="0px" right="0px" grid-row-start="bar" grid-row-end="1" grid-column-start="foo" grid-column-end="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="220" height="170" resolved-rows="20px 50px" resolved-columns="40px 60px">
+      <node x="0" y="0" width="220" height="170"/>
+      <node x="0" y="10" width="210" height="160"/>
+      <node x="0" y="80" width="110" height="90"/>
+      <node x="0" y="10" width="210" height="160"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -20185,6 +20185,30 @@ mod grid {
 
     #[cfg(feature = "grid")]
     #[test]
+    fn grid_absolute_empty_grid_lines__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_empty_grid_lines__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_empty_grid_lines__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_empty_grid_lines__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_empty_grid_lines__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_empty_grid_lines__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_empty_grid_lines__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_empty_grid_lines__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
     fn grid_absolute_gaps_end_lines__border_box_ltr() {
         crate::run_xml_test("grid", "grid_absolute_gaps_end_lines__border_box_ltr");
     }
@@ -20425,6 +20449,30 @@ mod grid {
 
     #[cfg(feature = "grid")]
     #[test]
+    fn grid_absolute_known_named_lines__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_known_named_lines__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_known_named_lines__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_known_named_lines__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_known_named_lines__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_known_named_lines__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_known_named_lines__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_known_named_lines__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
     fn grid_absolute_layout_within_border__border_box_ltr() {
         crate::run_xml_test("grid", "grid_absolute_layout_within_border__border_box_ltr");
     }
@@ -20469,6 +20517,54 @@ mod grid {
     #[test]
     fn grid_absolute_layout_within_border_static__content_box_rtl() {
         crate::run_xml_test("grid", "grid_absolute_layout_within_border_static__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_out_of_range_lines__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_out_of_range_lines__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_out_of_range_lines__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_out_of_range_lines__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_out_of_range_lines__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_out_of_range_lines__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_out_of_range_lines__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_out_of_range_lines__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_padding_edge_lines__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_padding_edge_lines__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_padding_edge_lines__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_padding_edge_lines__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_padding_edge_lines__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_padding_edge_lines__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_padding_edge_lines__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_padding_edge_lines__content_box_rtl");
     }
 
     #[cfg(feature = "grid")]
@@ -20565,6 +20661,30 @@ mod grid {
     #[test]
     fn grid_absolute_top_overrides_bottom__content_box_rtl() {
         crate::run_xml_test("grid", "grid_absolute_top_overrides_bottom__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_unknown_named_lines__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_unknown_named_lines__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_unknown_named_lines__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_absolute_unknown_named_lines__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_unknown_named_lines__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_unknown_named_lines__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_absolute_unknown_named_lines__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_absolute_unknown_named_lines__content_box_rtl");
     }
 
     #[cfg(feature = "grid")]


### PR DESCRIPTION
# Objective

Fix edge cases in `DetailedGridTracksInfo::resolve_absolute_grid_area` where the resolved area diverged from browser behaviour (verified against Chrome via new generated fixtures):

- **Out-of-grid check ran before normalization.** Placements are now resolved to a pair of sorted lines *first*, and only then are lines falling outside the grid treated as `auto`. Pseudo-diff:
  ```diff
    placement
      .resolve_line_names(...)
      .into_origin_zero(...)
  -   .map(|p| if line out of [min_line, max_line] { Auto } else { p })
      .resolve_absolutely_positioned_grid_tracks()
  +   .map(|line| line.filter(|l| min_line <= l && l <= max_line))
  ```
  This makes e.g. `grid-column: 3 / 1` (swapped lines) and a non-existent named line like `foo / 3` (which resolves past the explicit grid end) match Chrome: on a 2-column grid, `foo / 3` resolves to the area between line 3 and the end padding edge.
- **Empty axes.** An axis with no tracks still contains one grid line, positioned by content alignment. `DetailedGridTracksInfo` gains a `pub empty_axis_line: Option<f32>` field recording that line's position, used as a fallback before the padding-edge fallback.

## Context

Extracted from the OOF-hoisting stack (#1147, originally in #1145) since it applies to `main` independently — `resolve_absolute_grid_area` already exists here. The stack will be restacked without this commit once it lands.

Also adds named-line support (`grid-template-columns/rows` line names and named placements) to the gentest fixture format, plus 5 Chrome-generated fixtures covering out-of-range lines, unknown/known named lines, padding-edge lines, and empty grids.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/65c5463061c8403bade7888271d5eeb4
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/65c5463061c8403bade7888271d5eeb4?variant=devin-insiders
Requested by: @nicoburns