### PR TITLE
Fix phantom positive implicit track for auto-start/definite-end placements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Grid: items with an `auto` start line and a definite end line (e.g. `grid-column: auto / 1`) no longer cause a phantom zero-sized positive implicit track to be created. This previously caused `grid_template_columns()`/`grid_template_rows()` to serialize an extra `0px` track (e.g. `10px 0px` instead of `10px`)
 - Grid: fixed `DetailedGridTracksInfo::resolve_absolute_grid_area` edge cases: placements are now normalized (lines sorted, named lines resolved) *before* out-of-range lines are treated as `auto`, and axes with no tracks resolve against the axis' single content-aligned grid line instead of falling back to the padding edge
 - Block/float: absorb `f32` rounding errors in horizontal fit checks, preventing floats from spuriously wrapping when percentage widths and margins sum to exactly 100% of the container (#1161).
 - Flexbox: main-axis margins are no longer dropped from an item's intrinsic main-size contribution when the contribution is floored by the item's flex basis (column containers). This fixes negative margins being ignored on flex items with `flex-grow` (#1162) and on descendants containing an `overflow: hidden` grid item (#1163).

--- a/src/compute/grid/implicit_grid.rs
+++ b/src/compute/grid/implicit_grid.rs
@@ -127,7 +127,8 @@ fn child_min_line_max_line_span<S: CheapCloneStr>(
         (Line(track), Span(_)) => track,
 
         // End track specified
-        (Auto, Line(track)) => track,
+        // An auto start with a definite end resolves to a span of 1 ending at that line
+        (Auto, Line(track)) => track - 1,
         (Span(span), Line(track)) => track - span,
 
         // Only spans or autos

--- a/test_fixtures/grid/grid_template_serialization_negative_implicit_column.html
+++ b/test_fixtures/grid/grid_template_serialization_negative_implicit_column.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 10px; height: 10px;">
+  <div style="grid-column: auto / 1; width: 10px; height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/grid/grid_template_serialization_negative_implicit_row.html
+++ b/test_fixtures/grid/grid_template_serialization_negative_implicit_row.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; width: 10px; height: 10px;">
+  <div style="grid-row: auto / 1; width: 10px; height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/hand_written/detailed_grid_info.rs
+++ b/tests/hand_written/detailed_grid_info.rs
@@ -49,60 +49,6 @@ mod detailed_grid_info {
     }
 
     #[test]
-    fn implicit_track_before_explicit_grid() {
-        // With `grid-template-columns: none` and a child placed at `grid-column: auto / 1`,
-        // the grid has exactly one (negative) implicit column track. The resolved track list
-        // must not contain a phantom zero-sized positive implicit track.
-        // See WPT css/css-grid/parsing/grid-template-columns-computed-implicit-track.html
-        let mut tree = new_test_tree();
-        let child = tree
-            .new_leaf(Style {
-                size: Size { width: Dimension::from_length(10.0), height: Dimension::from_length(10.0) },
-                grid_column: Line { start: GridPlacement::Auto, end: GridPlacement::from_line_index(1) },
-                ..Default::default()
-            })
-            .unwrap();
-        let root = tree.new_with_children(Style { display: Display::Grid, ..Default::default() }, &[child]).unwrap();
-        tree.compute_layout(root, Size::MAX_CONTENT).unwrap();
-
-        let info = get_detailed_grid_info(&tree, root);
-        assert_eq!(info.columns.negative_implicit_tracks, 1);
-        assert_eq!(info.columns.explicit_tracks, 0);
-        assert_eq!(info.columns.positive_implicit_tracks, 0);
-        assert_eq!(info.grid_template_columns(), "10px");
-        assert_eq!(info.rows.negative_implicit_tracks, 0);
-        assert_eq!(info.rows.explicit_tracks, 0);
-        assert_eq!(info.rows.positive_implicit_tracks, 1);
-        assert_eq!(info.grid_template_rows(), "10px");
-    }
-
-    #[test]
-    fn implicit_track_before_explicit_grid_rows() {
-        // Rows analogue: child placed at `grid-row: auto / 1`
-        // See WPT css/css-grid/parsing/grid-template-rows-computed-implicit-track.html
-        let mut tree = new_test_tree();
-        let child = tree
-            .new_leaf(Style {
-                size: Size { width: Dimension::from_length(10.0), height: Dimension::from_length(10.0) },
-                grid_row: Line { start: GridPlacement::Auto, end: GridPlacement::from_line_index(1) },
-                ..Default::default()
-            })
-            .unwrap();
-        let root = tree.new_with_children(Style { display: Display::Grid, ..Default::default() }, &[child]).unwrap();
-        tree.compute_layout(root, Size::MAX_CONTENT).unwrap();
-
-        let info = get_detailed_grid_info(&tree, root);
-        assert_eq!(info.rows.negative_implicit_tracks, 1);
-        assert_eq!(info.rows.explicit_tracks, 0);
-        assert_eq!(info.rows.positive_implicit_tracks, 0);
-        assert_eq!(info.grid_template_rows(), "10px");
-        assert_eq!(info.columns.negative_implicit_tracks, 0);
-        assert_eq!(info.columns.explicit_tracks, 0);
-        assert_eq!(info.columns.positive_implicit_tracks, 1);
-        assert_eq!(info.grid_template_columns(), "10px");
-    }
-
-    #[test]
     fn template_and_area_line_names() {
         let mut tree = new_test_tree();
         let child = tree.new_leaf(Style::default()).unwrap();

--- a/tests/hand_written/detailed_grid_info.rs
+++ b/tests/hand_written/detailed_grid_info.rs
@@ -49,6 +49,60 @@ mod detailed_grid_info {
     }
 
     #[test]
+    fn implicit_track_before_explicit_grid() {
+        // With `grid-template-columns: none` and a child placed at `grid-column: auto / 1`,
+        // the grid has exactly one (negative) implicit column track. The resolved track list
+        // must not contain a phantom zero-sized positive implicit track.
+        // See WPT css/css-grid/parsing/grid-template-columns-computed-implicit-track.html
+        let mut tree = new_test_tree();
+        let child = tree
+            .new_leaf(Style {
+                size: Size { width: Dimension::from_length(10.0), height: Dimension::from_length(10.0) },
+                grid_column: Line { start: GridPlacement::Auto, end: GridPlacement::from_line_index(1) },
+                ..Default::default()
+            })
+            .unwrap();
+        let root = tree.new_with_children(Style { display: Display::Grid, ..Default::default() }, &[child]).unwrap();
+        tree.compute_layout(root, Size::MAX_CONTENT).unwrap();
+
+        let info = get_detailed_grid_info(&tree, root);
+        assert_eq!(info.columns.negative_implicit_tracks, 1);
+        assert_eq!(info.columns.explicit_tracks, 0);
+        assert_eq!(info.columns.positive_implicit_tracks, 0);
+        assert_eq!(info.grid_template_columns(), "10px");
+        assert_eq!(info.rows.negative_implicit_tracks, 0);
+        assert_eq!(info.rows.explicit_tracks, 0);
+        assert_eq!(info.rows.positive_implicit_tracks, 1);
+        assert_eq!(info.grid_template_rows(), "10px");
+    }
+
+    #[test]
+    fn implicit_track_before_explicit_grid_rows() {
+        // Rows analogue: child placed at `grid-row: auto / 1`
+        // See WPT css/css-grid/parsing/grid-template-rows-computed-implicit-track.html
+        let mut tree = new_test_tree();
+        let child = tree
+            .new_leaf(Style {
+                size: Size { width: Dimension::from_length(10.0), height: Dimension::from_length(10.0) },
+                grid_row: Line { start: GridPlacement::Auto, end: GridPlacement::from_line_index(1) },
+                ..Default::default()
+            })
+            .unwrap();
+        let root = tree.new_with_children(Style { display: Display::Grid, ..Default::default() }, &[child]).unwrap();
+        tree.compute_layout(root, Size::MAX_CONTENT).unwrap();
+
+        let info = get_detailed_grid_info(&tree, root);
+        assert_eq!(info.rows.negative_implicit_tracks, 1);
+        assert_eq!(info.rows.explicit_tracks, 0);
+        assert_eq!(info.rows.positive_implicit_tracks, 0);
+        assert_eq!(info.grid_template_rows(), "10px");
+        assert_eq!(info.columns.negative_implicit_tracks, 0);
+        assert_eq!(info.columns.explicit_tracks, 0);
+        assert_eq!(info.columns.positive_implicit_tracks, 1);
+        assert_eq!(info.grid_template_columns(), "10px");
+    }
+
+    #[test]
     fn template_and_area_line_names() {
         let mut tree = new_test_tree();
         let child = tree.new_leaf(Style::default()).unwrap();

--- a/tests/xml/grid/grid_template_serialization_negative_implicit_column__border_box_ltr.xml
+++ b/tests/xml/grid/grid_template_serialization_negative_implicit_column__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_template_serialization_negative_implicit_column__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="10px" height="10px">
+      <div direction="ltr" width="10px" height="10px" grid-column-end="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="10" height="10" resolved-rows="10px" resolved-columns="10px">
+      <node x="0" y="0" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_template_serialization_negative_implicit_column__border_box_rtl.xml
+++ b/tests/xml/grid/grid_template_serialization_negative_implicit_column__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_template_serialization_negative_implicit_column__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="10px" height="10px">
+      <div direction="rtl" width="10px" height="10px" grid-column-end="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="10" height="10" resolved-rows="10px" resolved-columns="10px">
+      <node x="0" y="0" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_template_serialization_negative_implicit_column__content_box_ltr.xml
+++ b/tests/xml/grid/grid_template_serialization_negative_implicit_column__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_template_serialization_negative_implicit_column__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="10px" height="10px">
+      <div box-sizing="content-box" direction="ltr" width="10px" height="10px" grid-column-end="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="10" height="10" resolved-rows="10px" resolved-columns="10px">
+      <node x="0" y="0" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_template_serialization_negative_implicit_column__content_box_rtl.xml
+++ b/tests/xml/grid/grid_template_serialization_negative_implicit_column__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_template_serialization_negative_implicit_column__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="10px" height="10px">
+      <div box-sizing="content-box" direction="rtl" width="10px" height="10px" grid-column-end="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="10" height="10" resolved-rows="10px" resolved-columns="10px">
+      <node x="0" y="0" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_template_serialization_negative_implicit_row__border_box_ltr.xml
+++ b/tests/xml/grid/grid_template_serialization_negative_implicit_row__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_template_serialization_negative_implicit_row__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" width="10px" height="10px">
+      <div direction="ltr" width="10px" height="10px" grid-row-end="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="10" height="10" resolved-rows="10px" resolved-columns="10px">
+      <node x="0" y="0" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_template_serialization_negative_implicit_row__border_box_rtl.xml
+++ b/tests/xml/grid/grid_template_serialization_negative_implicit_row__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_template_serialization_negative_implicit_row__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" width="10px" height="10px">
+      <div direction="rtl" width="10px" height="10px" grid-row-end="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="10" height="10" resolved-rows="10px" resolved-columns="10px">
+      <node x="0" y="0" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_template_serialization_negative_implicit_row__content_box_ltr.xml
+++ b/tests/xml/grid/grid_template_serialization_negative_implicit_row__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="grid_template_serialization_negative_implicit_row__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" width="10px" height="10px">
+      <div box-sizing="content-box" direction="ltr" width="10px" height="10px" grid-row-end="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="10" height="10" resolved-rows="10px" resolved-columns="10px">
+      <node x="0" y="0" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_template_serialization_negative_implicit_row__content_box_rtl.xml
+++ b/tests/xml/grid/grid_template_serialization_negative_implicit_row__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="grid_template_serialization_negative_implicit_row__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" width="10px" height="10px">
+      <div box-sizing="content-box" direction="rtl" width="10px" height="10px" grid-row-end="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="10" height="10" resolved-rows="10px" resolved-columns="10px">
+      <node x="0" y="0" width="10" height="10"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -33517,6 +33517,54 @@ mod grid {
 
     #[cfg(feature = "grid")]
     #[test]
+    fn grid_template_serialization_negative_implicit_column__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_template_serialization_negative_implicit_column__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_template_serialization_negative_implicit_column__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_template_serialization_negative_implicit_column__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_template_serialization_negative_implicit_column__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_template_serialization_negative_implicit_column__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_template_serialization_negative_implicit_column__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_template_serialization_negative_implicit_column__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_template_serialization_negative_implicit_row__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_template_serialization_negative_implicit_row__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_template_serialization_negative_implicit_row__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_template_serialization_negative_implicit_row__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_template_serialization_negative_implicit_row__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_template_serialization_negative_implicit_row__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_template_serialization_negative_implicit_row__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_template_serialization_negative_implicit_row__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
     fn grid_template_serialization_none__border_box_ltr() {
         crate::run_xml_test("grid", "grid_template_serialization_none__border_box_ltr");
     }


### PR DESCRIPTION
# Objective

Fix the last two failing subtests of the WPT tests `css/css-grid/parsing/grid-template-{columns,rows}-computed-implicit-track.html` in Servo: with `grid-template-columns: none` and a child at `grid-column: auto / 1`, the resolved value serialized as `10px 0px` instead of `10px` — a phantom zero-sized positive implicit track leaked into `DetailedGridTracksInfo`.

## Context

The bug is in the implicit grid size estimate, not serialization. In `child_min_line_max_line_span`, the `(Auto, Line(track))` case computed `min = track`, ignoring that an auto-start/definite-end placement resolves to a span of 1 *ending* at that line (occupying `[track - 1, track]`):

```rust
// End track specified
- (Auto, Line(track)) => track,
+ (Auto, Line(track)) => track - 1,
```

(The symmetric `(Line(track), Auto)` max case already correctly used `track + 1`.)

With `min` under-counted, the estimate reported 0 negative implicit tracks, and the "adjust positive track estimate to fit the max span" step then compensated by adding a spurious *positive* implicit track. The negative track was later added correctly during placement via `expand_to_fit_range`, leaving one real track plus a phantom 0px track at the end (`negative_implicit=1, explicit=0, positive_implicit=1`). The wrong estimate also caused the auto-placement cursor to spuriously advance in the secondary axis (via the `primary_span.start < primary_idx` check), creating an extra implicit row as well.

Both WPT subtests are ported as gentest fixtures (`grid_template_serialization_negative_implicit_{column,row}.html`) — the generated expectations from Chrome assert `resolved-columns="10px"`/`resolved-rows="10px"`, matching the WPT expectations exactly.

Verified: `cargo test --workspace --all-features` passes, `cargo fmt` / `cargo clippy` clean (one pre-existing MSRV warning unrelated to this change).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/4946c92d12ba4edc933f5a8888f5584f
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/4946c92d12ba4edc933f5a8888f5584f?variant=devin-insiders
Requested by: @nicoburns