### PR TITLE
Expose out-of-flow layout for explicit areas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@
   - `LayoutContainingBlock` gains a defaulted `oof_claims` method returning the new `OofClaims` struct, centralizing the policy of which out-of-flow positions a node acts as a containing block for. The default claims `position: absolute` boxes when the node's own `position` is not `static` and never claims `position: fixed` boxes; implementations may override it to make style properties such as `transform` or `filter` establish a containing block
   - The container layout algorithms no longer require the `LayoutContainingBlock` bound (only `compute_oof_layout` and `compute_root_layout` do)
 
+### Added
+
+- `compute_oof_layout_for_area` and `OofLayoutResult` allow integrations to lay out out-of-flow candidates against an explicit positioning area without immediately mutating a layout node's hoisted-child list. This supports containing blocks represented outside Taffy's layout tree.
+
 ### Fixed
 
 - Grid: items with an `auto` start line and a definite end line (e.g. `grid-column: auto / 1`) no longer cause a phantom zero-sized positive implicit track to be created. This previously caused `grid_template_columns()`/`grid_template_rows()` to serialize an extra `0px` track (e.g. `10px 0px` instead of `10px`)

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -38,7 +38,7 @@ pub(crate) mod flexbox;
 pub(crate) mod grid;
 
 pub use leaf::compute_leaf_layout;
-pub use oof::{compute_oof_layout, resolve_static_offset};
+pub use oof::{compute_oof_layout, compute_oof_layout_for_area, resolve_static_offset, OofLayoutResult};
 
 #[cfg(feature = "block_layout")]
 pub use self::block::{compute_block_layout, BlockContext, BlockFormattingContext};

--- a/src/compute/oof.rs
+++ b/src/compute/oof.rs
@@ -11,7 +11,8 @@ use crate::style::{AvailableSpace, CoreStyle, Position};
 #[cfg(feature = "grid")]
 use crate::tree::DetailedLayoutInfo;
 use crate::tree::{
-    Layout, LayoutContainingBlock, LayoutOutput, LayoutPartialTreeExt, NodeId, OofCandidate, OofCandidates, SizingMode,
+    Layout, LayoutContainingBlock, LayoutOutput, LayoutPartialTreeExt, NodeId, OofCandidate, OofCandidates, OofClaims,
+    OofPositioningArea, SizingMode,
 };
 use crate::util::sys::{f32_max, Vec};
 use crate::util::{MaybeMath, MaybeResolve, ResolveOrZero};
@@ -71,18 +72,62 @@ pub fn compute_oof_layout(tree: &mut impl LayoutContainingBlock, node_id: NodeId
 
     let style = tree.get_core_container_style(node_id);
     let direction = style.direction();
-    #[cfg(feature = "content_size")]
-    let is_scroll_container = style.overflow().x.is_scroll_container() || style.overflow().y.is_scroll_container();
     drop(style);
     let claims = tree.oof_claims(node_id);
 
     let candidates = output.oof_candidates.take();
-    let mut hoisted: Vec<NodeId> = Vec::new();
+    let result = compute_oof_layout_for_area(tree, node_id, candidates, area, direction, claims);
+    // Always record the hoisted child list (even when empty) so that lists recorded by previous
+    // layout runs do not persist
+    tree.set_hoisted_children(node_id, &result.hoisted);
+    output.oof_candidates = result.unclaimed;
+    #[cfg(feature = "content_size")]
+    {
+        output.scrollable_overflow_rect = output.scrollable_overflow_rect.union(result.scrollable_overflow_rect);
+    }
+}
+
+/// The result of laying out out-of-flow candidates against an explicit positioning area.
+pub struct OofLayoutResult {
+    /// Candidates claimed and laid out by this pass, in document order.
+    pub hoisted: Vec<NodeId>,
+    /// Candidates not claimed by this pass, which must continue bubbling.
+    pub unclaimed: OofCandidates,
+    /// Scrollable overflow contributed by the claimed candidates, relative to the positioning
+    /// area's origin.
+    pub scrollable_overflow_rect: Rect<f32>,
+}
+
+/// Lay out out-of-flow candidates against an explicit positioning area.
+///
+/// Unlike [`compute_oof_layout`], this function does not update the geometry owner's hoisted
+/// children or merge overflow into a [`LayoutOutput`]. This is useful when the CSS containing
+/// block does not have its own layout node and another node owns the resulting geometry.
+///
+/// `geometry_owner` supplies the layout tree operations, detailed layout information, and
+/// scroll-container state used by the positioning pass. `direction` and `claims` describe the
+/// actual CSS containing block.
+pub fn compute_oof_layout_for_area(
+    tree: &mut impl LayoutContainingBlock,
+    geometry_owner: NodeId,
+    candidates: OofCandidates,
+    area: OofPositioningArea,
+    direction: Direction,
+    claims: OofClaims,
+) -> OofLayoutResult {
+    #[cfg(feature = "content_size")]
+    let is_scroll_container = {
+        let style = tree.get_core_container_style(geometry_owner);
+        let is_scroll_container = style.overflow().x.is_scroll_container() || style.overflow().y.is_scroll_container();
+        drop(style);
+        is_scroll_container
+    };
+
+    let mut hoisted = Vec::new();
     let mut unclaimed = OofCandidates::new();
-    #[cfg_attr(not(feature = "content_size"), allow(unused_variables))]
-    let oof_overflow_rect = perform_oof_layout(
+    let scrollable_overflow_rect = perform_oof_layout(
         tree,
-        node_id,
+        geometry_owner,
         candidates,
         area.size,
         area.offset,
@@ -94,14 +139,8 @@ pub fn compute_oof_layout(tree: &mut impl LayoutContainingBlock, node_id: NodeId
         &mut hoisted,
         &mut unclaimed,
     );
-    // Always record the hoisted child list (even when empty) so that lists recorded by previous
-    // layout runs do not persist
-    tree.set_hoisted_children(node_id, &hoisted);
-    output.oof_candidates = unclaimed;
-    #[cfg(feature = "content_size")]
-    {
-        output.scrollable_overflow_rect = output.scrollable_overflow_rect.union(oof_overflow_rect);
-    }
+
+    OofLayoutResult { hoisted, unclaimed, scrollable_overflow_rect }
 }
 
 /// Perform final layout on the out-of-flow candidates for which the current node is the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,8 +109,8 @@ pub use crate::compute::compute_grid_layout;
 pub use crate::compute::detailed_info::*;
 #[doc(inline)]
 pub use crate::compute::{
-    compute_cached_layout, compute_hidden_layout, compute_leaf_layout, compute_oof_layout, compute_root_layout,
-    resolve_static_offset, round_layout,
+    compute_cached_layout, compute_hidden_layout, compute_leaf_layout, compute_oof_layout, compute_oof_layout_for_area,
+    compute_root_layout, resolve_static_offset, round_layout, OofLayoutResult,
 };
 #[doc(inline)]
 pub use crate::style::Style;


### PR DESCRIPTION
# Objective

Allow integrations to reuse Taffy's finalized out-of-flow sizing and positioning when the CSS containing block is represented outside Taffy's layout-node tree.

The new API separates the calculation from `LayoutOutput`/hoisted-list mutation:

```text
compute_oof_layout_for_area(tree, geometry_owner, candidates, area, direction, claims)
    -> { hoisted, unclaimed, scrollable_overflow_rect }
```

`compute_oof_layout` now delegates to this primitive and preserves its existing behavior.

## Context

Blitz represents non-atomic inline boxes as Parley spans. An inline span can establish an absolute/fixed containing block without having a Taffy layout node, so Blitz needs to provide the resolved first/last-fragment positioning area while retaining the inline formatting root as geometry owner.

The changelog documents the new public API.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/b6714d5757fa4fa7b858caed09087cdb
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/b6714d5757fa4fa7b858caed09087cdb?variant=devin-insiders
Requested by: @nicoburns