### PR TITLE
Flexbox: don't wrap auto-height column containers against ancestor-derived available space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Grid: items with an `auto` start line and a definite end line (e.g. `grid-column: auto / 1`) no longer cause a phantom zero-sized positive implicit track to be created. This previously caused `grid_template_columns()`/`grid_template_rows()` to serialize an extra `0px` track (e.g. `10px 0px` instead of `10px`)
 - Grid: fixed `DetailedGridTracksInfo::resolve_absolute_grid_area` edge cases: placements are now normalized (lines sorted, named lines resolved) *before* out-of-range lines are treated as `auto`, and axes with no tracks resolve against the axis' single content-aligned grid line instead of falling back to the padding edge
 - Block/float: absorb `f32` rounding errors in horizontal fit checks, preventing floats from spuriously wrapping when percentage widths and margins sum to exactly 100% of the container (#1161).
+- Flexbox: an auto-height `flex-wrap: wrap` column container no longer wraps its lines against definite available space handed down by an ancestor. A column container's automatic main size is content-based, so lines only wrap against a definite main size or a max main size (#1175)
 - Flexbox: main-axis margins are no longer dropped from an item's intrinsic main-size contribution when the contribution is floored by the item's flex basis (column containers). This fixes negative margins being ignored on flex items with `flex-grow` (#1162) and on descendants containing an `overflow: hidden` grid item (#1163).
 
 ## 0.14.0

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -1112,6 +1112,15 @@ fn collect_flex_lines<'a>(
                 let available = if constants.has_definite_main_size { available } else { available.min(max_size) };
                 available.maybe_max(constants.min_size.main(constants.dir))
             }),
+            // A column container's automatic main size is content-based, so definite available space
+            // handed down by an ancestor does not constrain where its lines wrap. Automatic widths
+            // resolve against available space, so rows do wrap against it.
+            None if !constants.dir.is_row()
+                && !constants.has_definite_main_size
+                && available_space.main(constants.dir).is_definite() =>
+            {
+                AvailableSpace::MaxContent
+            }
             None => available_space.main(constants.dir),
         };
 
@@ -1193,6 +1202,15 @@ fn collect_balanced_flex_lines<'a>(
                 let available = if constants.has_definite_main_size { available } else { available.min(max_size) };
                 available.maybe_max(constants.min_size.main(constants.dir))
             }),
+            // A column container's automatic main size is content-based, so definite available space
+            // handed down by an ancestor does not constrain where its lines wrap. Automatic widths
+            // resolve against available space, so rows do wrap against it.
+            None if !constants.dir.is_row()
+                && !constants.has_definite_main_size
+                && available_space.main(constants.dir).is_definite() =>
+            {
+                AvailableSpace::MaxContent
+            }
             None => available_space.main(constants.dir),
         }
     } else {

--- a/test_fixtures/flex/wrap_column_auto_height_does_not_wrap_against_available_space.html
+++ b/test_fixtures/flex/wrap_column_auto_height_does_not_wrap_against_available_space.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    An auto-height column wrap container does not wrap its lines against definite available space handed down by an ancestor
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; flex-direction: row; align-items: flex-start; width: 400px; height: 150px;">
+  <div style="display: flex; flex-direction: column; flex-wrap: wrap;">
+    <div style="width: 60px; height: 100px;"></div>
+    <div style="width: 60px; height: 100px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/flex/wrap_column_auto_height_does_not_wrap_against_available_space__border_box_ltr.xml
+++ b/tests/xml/flex/wrap_column_auto_height_does_not_wrap_against_available_space__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="wrap_column_auto_height_does_not_wrap_against_available_space__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" align-items="flex-start" width="400px" height="150px">
+      <div display="flex" direction="ltr" flex-direction="column" flex-wrap="wrap">
+        <div direction="ltr" width="60px" height="100px"/>
+        <div direction="ltr" width="60px" height="100px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="150">
+      <node x="0" y="0" width="60" height="200">
+        <node x="0" y="0" width="60" height="100"/>
+        <node x="0" y="100" width="60" height="100"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/wrap_column_auto_height_does_not_wrap_against_available_space__border_box_rtl.xml
+++ b/tests/xml/flex/wrap_column_auto_height_does_not_wrap_against_available_space__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="wrap_column_auto_height_does_not_wrap_against_available_space__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" align-items="flex-start" width="400px" height="150px">
+      <div display="flex" direction="rtl" flex-direction="column" flex-wrap="wrap">
+        <div direction="rtl" width="60px" height="100px"/>
+        <div direction="rtl" width="60px" height="100px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="150">
+      <node x="340" y="0" width="60" height="200">
+        <node x="0" y="0" width="60" height="100"/>
+        <node x="0" y="100" width="60" height="100"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/wrap_column_auto_height_does_not_wrap_against_available_space__content_box_ltr.xml
+++ b/tests/xml/flex/wrap_column_auto_height_does_not_wrap_against_available_space__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="wrap_column_auto_height_does_not_wrap_against_available_space__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" align-items="flex-start" width="400px" height="150px">
+      <div display="flex" box-sizing="content-box" direction="ltr" flex-direction="column" flex-wrap="wrap">
+        <div box-sizing="content-box" direction="ltr" width="60px" height="100px"/>
+        <div box-sizing="content-box" direction="ltr" width="60px" height="100px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="150">
+      <node x="0" y="0" width="60" height="200">
+        <node x="0" y="0" width="60" height="100"/>
+        <node x="0" y="100" width="60" height="100"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/wrap_column_auto_height_does_not_wrap_against_available_space__content_box_rtl.xml
+++ b/tests/xml/flex/wrap_column_auto_height_does_not_wrap_against_available_space__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="wrap_column_auto_height_does_not_wrap_against_available_space__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" align-items="flex-start" width="400px" height="150px">
+      <div display="flex" box-sizing="content-box" direction="rtl" flex-direction="column" flex-wrap="wrap">
+        <div box-sizing="content-box" direction="rtl" width="60px" height="100px"/>
+        <div box-sizing="content-box" direction="rtl" width="60px" height="100px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="400" height="150">
+      <node x="340" y="0" width="60" height="200">
+        <node x="0" y="0" width="60" height="100"/>
+        <node x="0" y="100" width="60" height="100"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -18760,6 +18760,26 @@ mod flex {
     }
 
     #[test]
+    fn wrap_column_auto_height_does_not_wrap_against_available_space__border_box_ltr() {
+        crate::run_xml_test("flex", "wrap_column_auto_height_does_not_wrap_against_available_space__border_box_ltr");
+    }
+
+    #[test]
+    fn wrap_column_auto_height_does_not_wrap_against_available_space__content_box_ltr() {
+        crate::run_xml_test("flex", "wrap_column_auto_height_does_not_wrap_against_available_space__content_box_ltr");
+    }
+
+    #[test]
+    fn wrap_column_auto_height_does_not_wrap_against_available_space__border_box_rtl() {
+        crate::run_xml_test("flex", "wrap_column_auto_height_does_not_wrap_against_available_space__border_box_rtl");
+    }
+
+    #[test]
+    fn wrap_column_auto_height_does_not_wrap_against_available_space__content_box_rtl() {
+        crate::run_xml_test("flex", "wrap_column_auto_height_does_not_wrap_against_available_space__content_box_rtl");
+    }
+
+    #[test]
     fn wrap_column_definite_main_size_percent_basis__border_box_ltr() {
         crate::run_xml_test("flex", "wrap_column_definite_main_size_percent_basis__border_box_ltr");
     }


### PR DESCRIPTION
# Objective

Fixes #1175.

An auto-height `flex-wrap: wrap` column container could wrap its lines against `AvailableSpace::Definite` main-axis space handed down by an ancestor (typically during a `ComputeSize`/`ContentSize` measurement round), even though its own main size is content-based. This showed up as one-frame layout flicker while animating a child's height: for the frames where the content total exceeded the ancestor-derived available height by a couple of ulps, the container split into two columns. Chrome keeps a single line for the equivalent DOM.

The wrap constraint in `collect_flex_lines` (and `collect_balanced_flex_lines`) previously fell back to `available_space.main(dir)` whenever the container had no max main size:

```rust
let main_axis_available_space = match constants.max_size.main(dir) {
    Some(max_size) => AvailableSpace::Definite(/* min(available, max) when size indefinite */),
    None => available_space.main(dir),   // <-- ancestor-derived Definite leaked in here
};
```

Now, for a **column** container with no definite main size and no max main size, definite available space is replaced with `MaxContent` (no wrapping), since an automatic block-axis size never resolves against available space:

```rust
    None if !dir.is_row() && !has_definite_main_size && available.is_definite() => AvailableSpace::MaxContent,
    None => available_space.main(dir),
```

Rows are unchanged: an automatic inline-axis size does resolve against available space (fill-available), so row containers still wrap against definite available width. Min/max-content constraints and containers with a definite main size or a max main size are also unchanged.

## Context

- Issue #1175's repro (persistent tree, per-frame `set_style` + `compute_layout_with_measure`) produced 2 anomalous frames on `main`; 0 after this change.
- PRs #1165 and #1166 do **not** fix this issue (verified by running the repro against both branches) — they change intrinsic *contribution* sizing, while this bug is in line collection. This fix also cherry-picks cleanly onto #1166 and fixes the repro there.
- New gentest fixture `wrap_column_auto_height_does_not_wrap_against_available_space`: a non-stretched auto-height column-wrap container (2×100px items) inside a 150px-tall row parent. Chrome-generated expectation is a single 60×200 column; on `main` all 4 generated variants fail (taffy wrapped into two columns), with this change all 6069 generated tests pass (default and `--all-features`).
- CHANGELOG updated.

## Feedback wanted

The fix keys on `!dir.is_row()` as a proxy for "main axis is the block axis" (taffy has no writing modes). If you'd prefer the same treatment for rows under some condition (e.g. only during `ContentSize` sizing rounds), happy to adjust — but as-is, rows keep the fill-available wrapping behavior that matches browsers for block-level row containers.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/b637316906704d10ba77a4da9f248d4e
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/b637316906704d10ba77a4da9f248d4e?variant=devin-insiders
Requested by: @nicoburns