### PR TITLE
Grid: skip contribution measurement when no spanned track can receive it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Grid: intrinsic track sizing no longer measures an item's min-/max-content contribution in a step where none of the item's spanned tracks can receive that contribution (e.g. items spanning only `minmax(0, 1fr)` or fixed tracks). This matches Blink and avoids redundant, sometimes very expensive, measurement of large subtrees under a min-content constraint.
+
 ### Fixed
 
 - Grid: items with an `auto` start line and a definite end line (e.g. `grid-column: auto / 1`) no longer cause a phantom zero-sized positive implicit track to be created. This previously caused `grid_template_columns()`/`grid_template_rows()` to serialize an extra `0px` track (e.g. `10px 0px` instead of `10px`)

--- a/src/compute/grid/track_sizing.rs
+++ b/src/compute/grid/track_sizing.rs
@@ -796,6 +796,9 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
         let has_min_or_max_content_min_track_sizing_function =
             move |track: &GridTrack| track.min_track_sizing_function.is_min_or_max_content();
         for item in batch.iter_mut() {
+            if !item.spans_track_matching(axis, axis_tracks, has_min_or_max_content_min_track_sizing_function) {
+                continue;
+            }
             let space = item_sizer.min_content_contribution(item, axis_tracks);
             let tracks = &mut axis_tracks[item.track_range_excluding_lines(axis)];
             if space > 0.0 {
@@ -856,6 +859,11 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
             }
 
             for item in batch.iter_mut() {
+                if !item.spans_track_matching(axis, axis_tracks, |track| {
+                    has_auto_min_track_sizing_function(track) || has_max_content_min_track_sizing_function(track)
+                }) {
+                    continue;
+                }
                 let axis_max_content_size = item_sizer.max_content_contribution(item, axis_tracks);
                 let limit = item.spanned_track_limit(axis, axis_tracks, axis_inner_node_size, &|val, basis| {
                     item_sizer.calc(val, basis)
@@ -918,6 +926,9 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
         let has_max_content_min_track_sizing_function =
             move |track: &GridTrack| track.min_track_sizing_function.is_max_content();
         for item in batch.iter_mut() {
+            if !item.spans_track_matching(axis, axis_tracks, has_max_content_min_track_sizing_function) {
+                continue;
+            }
             let axis_max_content_size = item_sizer.max_content_contribution(item, axis_tracks);
             let space = axis_max_content_size;
             let tracks = &mut axis_tracks[item.track_range_excluding_lines(axis)];
@@ -950,6 +961,9 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
             let has_intrinsic_max_track_sizing_function =
                 move |track: &GridTrack| !track.max_track_sizing_function.has_definite_value(axis_inner_node_size);
             for item in batch.iter_mut() {
+                if !item.spans_track_matching(axis, axis_tracks, has_intrinsic_max_track_sizing_function) {
+                    continue;
+                }
                 let axis_min_content_size = item_sizer.min_content_contribution(item, axis_tracks);
                 let space = axis_min_content_size;
                 let tracks = &mut axis_tracks[item.track_range_excluding_lines(axis)];
@@ -973,6 +987,9 @@ fn resolve_intrinsic_track_sizes<Tree: LayoutPartialTree>(
                     || (track.max_track_sizing_function.uses_percentage() && axis_inner_node_size.is_none())
             };
             for item in batch.iter_mut() {
+                if !item.spans_track_matching(axis, axis_tracks, has_max_content_max_track_sizing_function) {
+                    continue;
+                }
                 let axis_max_content_size = item_sizer.max_content_contribution(item, axis_tracks);
                 let space = axis_max_content_size;
                 let tracks = &mut axis_tracks[item.track_range_excluding_lines(axis)];

--- a/src/compute/grid/track_sizing.rs
+++ b/src/compute/grid/track_sizing.rs
@@ -362,10 +362,13 @@ pub(super) fn track_sizing_algorithm<Tree: LayoutPartialTree>(
         tree,
         axis,
         axis_tracks,
+        other_axis_tracks,
         items,
         axis_min_size,
         axis_max_size,
         axis_available_space_for_expansion,
+        inner_node_size,
+        get_track_size_estimate,
     );
 
     // 11.8. Stretch auto Tracks
@@ -1269,15 +1272,21 @@ fn maximise_tracks(
 /// This step sizes flexible tracks using the largest value it can assign to an fr without exceeding the available space.
 #[allow(clippy::too_many_arguments)]
 #[inline(always)]
-fn expand_flexible_tracks(
-    tree: &mut impl LayoutPartialTree,
+fn expand_flexible_tracks<Tree: LayoutPartialTree>(
+    tree: &mut Tree,
     axis: AbstractAxis,
     axis_tracks: &mut [GridTrack],
+    other_axis_tracks: &[GridTrack],
     items: &mut [GridItem],
     axis_min_size: Option<f32>,
     axis_max_size: Option<f32>,
     axis_available_space_for_expansion: AvailableSpace,
+    inner_node_size: Size<Option<f32>>,
+    get_track_size_estimate: impl Fn(&GridTrack, Option<f32>, &Tree) -> Option<f32>,
 ) {
+    let mut item_sizer =
+        IntrinsicSizeMeasurer { tree, other_axis_tracks, axis, inner_node_size, get_track_size_estimate };
+
     // First, find the grid’s used flex fraction:
     let flex_fraction = match axis_available_space_for_expansion {
         // If the free space is zero:
@@ -1321,10 +1330,8 @@ fn expand_flexible_tracks(
                     .iter_mut()
                     .filter(|item| item.crosses_flexible_track(axis))
                     .map(|item| {
+                        let max_content_contribution = item_sizer.max_content_contribution(item, axis_tracks);
                         let tracks = &axis_tracks[item.track_range_excluding_lines(axis)];
-                        // TODO: plumb estimate of other axis size (known_dimensions) in here rather than just passing Size::NONE?
-                        let max_content_contribution =
-                            item.max_content_contribution_cached(axis, tree, Size::NONE, Size::NONE);
                         find_size_of_fr(tracks, max_content_contribution)
                     })
                     .max_by(|a, b| a.total_cmp(b))

--- a/src/compute/grid/types/grid_item.rs
+++ b/src/compute/grid/types/grid_item.rs
@@ -186,6 +186,16 @@ impl GridItem {
         (indexes.start as usize + 1)..(indexes.end as usize)
     }
 
+    /// Whether any track spanned by this item in the specified axis satisfies `predicate`
+    pub fn spans_track_matching(
+        &self,
+        axis: AbstractAxis,
+        axis_tracks: &[GridTrack],
+        predicate: impl Fn(&GridTrack) -> bool,
+    ) -> bool {
+        axis_tracks[self.track_range_excluding_lines(axis)].iter().any(predicate)
+    }
+
     /// Returns the number of tracks that this item spans in the specified axis
     pub fn span(&self, axis: AbstractAxis) -> u16 {
         match axis {

--- a/test_fixtures/grid/grid_fr_row_max_content_uses_column_width.html
+++ b/test_fixtures/grid/grid_fr_row_max_content_uses_column_width.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-columns: 50px; grid-template-rows: minmax(10px, 1fr) minmax(min-content, 50px);">
+  <div>HHHHH&ZeroWidthSpace;HHHH</div>
+  <div>HHHHH&ZeroWidthSpace;HHHH</div>
+</div>
+
+</body>
+</html>

--- a/tests/hand_written/caching.rs
+++ b/tests/hand_written/caching.rs
@@ -91,4 +91,34 @@ mod caching {
             assert_eq!(layout.location.y, 19.0 * index as f32);
         }
     }
+    /// An item whose spanned tracks cannot receive its min-/max-content contribution in any
+    /// intrinsic track sizing step (definite min, flexible max) must not be measured for it.
+    #[test]
+    #[cfg(feature = "grid")]
+    fn grid_item_spanning_only_unaffected_tracks_is_not_measured() {
+        let mut taffy = new_test_tree();
+
+        let text = TestNodeContext::ahem_text("HH HH HH HH".to_string(), taffy_test_helpers::WritingMode::Horizontal);
+        let leaf_style =
+            Style { grid_column: taffy::geometry::Line { start: line(2), end: line(3) }, ..Default::default() };
+        let leaf = taffy.new_leaf_with_context(leaf_style, text).unwrap();
+        let grid = taffy
+            .new_with_children(
+                Style {
+                    display: Display::Grid,
+                    size: Size { width: length(400.0), height: length(50.0) },
+                    grid_template_columns: vec![length(100.0), minmax(length(0.0), fr(1.0))],
+                    grid_template_rows: vec![length(50.0)],
+                    ..Default::default()
+                },
+                &[leaf],
+            )
+            .unwrap();
+
+        taffy.compute_layout_with_measure(grid, Size::MAX_CONTENT, test_measure_function).unwrap();
+
+        // Only the final layout pass measures the leaf; track sizing does not.
+        assert_eq!(taffy.layout(leaf).unwrap().size.width, 300.0);
+        assert_eq!(taffy.get_node_context_mut(leaf).unwrap().count, 1);
+    }
 }

--- a/tests/xml/grid/grid_fr_row_max_content_uses_column_width__border_box_ltr.xml
+++ b/tests/xml/grid/grid_fr_row_max_content_uses_column_width__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_fr_row_max_content_uses_column_width__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="ltr" grid-template-rows="minmax(10px, 1fr) minmax(min-content, 50px)" grid-template-columns="50px">
+      <text direction="ltr">
+        HHHHH​HHHH
+      </text>
+      <text direction="ltr">
+        HHHHH​HHHH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="50" height="70" resolved-rows="20px 50px" resolved-columns="50px">
+      <node x="0" y="0" width="50" height="20"/>
+      <node x="0" y="20" width="50" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_row_max_content_uses_column_width__border_box_rtl.xml
+++ b/tests/xml/grid/grid_fr_row_max_content_uses_column_width__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_fr_row_max_content_uses_column_width__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" direction="rtl" grid-template-rows="minmax(10px, 1fr) minmax(min-content, 50px)" grid-template-columns="50px">
+      <text direction="rtl">
+        HHHHH​HHHH
+      </text>
+      <text direction="rtl">
+        HHHHH​HHHH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="50" height="70" resolved-rows="20px 50px" resolved-columns="50px">
+      <node x="0" y="0" width="50" height="20"/>
+      <node x="0" y="20" width="50" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_row_max_content_uses_column_width__content_box_ltr.xml
+++ b/tests/xml/grid/grid_fr_row_max_content_uses_column_width__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="grid_fr_row_max_content_uses_column_width__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="ltr" grid-template-rows="minmax(10px, 1fr) minmax(min-content, 50px)" grid-template-columns="50px">
+      <text box-sizing="content-box" direction="ltr">
+        HHHHH​HHHH
+      </text>
+      <text box-sizing="content-box" direction="ltr">
+        HHHHH​HHHH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="50" height="70" resolved-rows="20px 50px" resolved-columns="50px">
+      <node x="0" y="0" width="50" height="20"/>
+      <node x="0" y="20" width="50" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/grid/grid_fr_row_max_content_uses_column_width__content_box_rtl.xml
+++ b/tests/xml/grid/grid_fr_row_max_content_uses_column_width__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="grid_fr_row_max_content_uses_column_width__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="grid" box-sizing="content-box" direction="rtl" grid-template-rows="minmax(10px, 1fr) minmax(min-content, 50px)" grid-template-columns="50px">
+      <text box-sizing="content-box" direction="rtl">
+        HHHHH​HHHH
+      </text>
+      <text box-sizing="content-box" direction="rtl">
+        HHHHH​HHHH
+      </text>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="50" height="70" resolved-rows="20px 50px" resolved-columns="50px">
+      <node x="0" y="0" width="50" height="20"/>
+      <node x="0" y="20" width="50" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -27465,6 +27465,30 @@ mod grid {
 
     #[cfg(feature = "grid")]
     #[test]
+    fn grid_fr_row_max_content_uses_column_width__border_box_ltr() {
+        crate::run_xml_test("grid", "grid_fr_row_max_content_uses_column_width__border_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_row_max_content_uses_column_width__content_box_ltr() {
+        crate::run_xml_test("grid", "grid_fr_row_max_content_uses_column_width__content_box_ltr");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_row_max_content_uses_column_width__border_box_rtl() {
+        crate::run_xml_test("grid", "grid_fr_row_max_content_uses_column_width__border_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
+    fn grid_fr_row_max_content_uses_column_width__content_box_rtl() {
+        crate::run_xml_test("grid", "grid_fr_row_max_content_uses_column_width__content_box_rtl");
+    }
+
+    #[cfg(feature = "grid")]
+    #[test]
     fn grid_fr_single_item_indefinite__border_box_ltr() {
         crate::run_xml_test("grid", "grid_fr_single_item_indefinite__border_box_ltr");
     }


### PR DESCRIPTION
# Objective

In `resolve_intrinsic_track_sizes`, the loops for "2. content-based minimums", "3. max-content minimums" (both the max-content-constraint variant and the unconditional one), "5. intrinsic maximums" and "6. max-content maximums" call `item_sizer.min_content_contribution` / `max_content_contribution` for **every** item in the batch, and only afterwards filter *tracks* via the `track_is_affected` predicate inside `distribute_item_space_to_*`. Only step 1 (`minimum_contribution`) is gated on the spanned tracks.

So an item spanning only tracks the step cannot apply to (e.g. `12.25rem minmax(0, 1fr)`) still gets measured under a min-content constraint. That measurement is a full subtree measure and is then discarded. On Wikipedia's Vector skin (`.mw-page-container-inner { grid-template-columns: 12.25rem minmax(0, 1fr) }`) this measures the entire article under `MinContent`, inside which `.mw-body`'s `minmax(0, 59.25rem)` column legitimately collapses to 0, so every inline layout in the article is line-broken at width 0 (one word per line) for nothing.

This PR moves the same predicate in front of the measurement:

```rust
for item in batch.iter_mut() {
    if !item.spans_track_matching(axis, axis_tracks, has_min_or_max_content_min_track_sizing_function) {
        continue;
    }
    let space = item_sizer.min_content_contribution(item, axis_tracks);
    ...
}
```

Track sizing results are unchanged (the distribution step would have been a no-op for these items). All generated fixtures pass. New test `grid_item_spanning_only_unaffected_tracks_is_not_measured`: 3 measurements on `main` → 1 (the final layout) with this change.

Measured on a Blitz headless load of the Barack Obama Wikipedia article: zero-width `break_lines` passes 916 → 3, first layout 845–862 ms → 592–626 ms, relayout 737–758 ms → 473–502 ms, live heap after layout 88.6 MB → 63.0 MB, layout geometry unchanged.

## Second commit: `expand_flexible_tracks` max-content measurement

Skipping the step-2/3 measurements exposed a latent bug: `expand_flexible_tracks` (11.7, indefinite free space) measured each item's max-content contribution with `Size::NONE` for both grid area and available space (there was a TODO about it). `max_content_contribution_cached` ignores the sizes passed to it, so previously the cache was always pre-filled by steps 2/3 (which measure with the real grid-area size) and the `Size::NONE` never took effect. With the skip, the flex step became the first measurer for items spanning e.g. `50px` / `minmax(10px, 1fr)`, text was measured at an unconstrained width, and `1fr` rows came out one line tall — WPT `css/css-grid/grid-definition/flex-content-resolution-rows-002.html` went 21/21 → 18/21 in Blitz.

Fix: route the flex step through `IntrinsicSizeMeasurer::max_content_contribution` like every other contribution step (this also includes the item's margins, as the other steps do). New Chrome-generated fixture `grid_fr_row_max_content_uses_column_width` (fails on `main` + first commit alone, passes now). WPT css-grid/css-flexbox/CSS2 in Blitz: no regressions vs Blitz main, +2 newly passing.

## Context

Blink does the same: `GridTrackSizingAlgorithm::IncreaseTrackSizesToAccommodateGridItems` collects `sets_to_grow` via `IsContributionAppliedToSet` and `continue`s if empty *before* calling `contribution_size(...)`; additionally `ResolveIntrinsicTrackSizes` only considers items with `IsSpanningIntrinsicTrack`. Spec: css-grid-2 §12.5 scopes each step to "items spanning tracks with a min/max track sizing function of …".

Per-step predicates used:
- step 2: min sizing fn is `min-content`/`max-content`
- step 3 (max-content constraint): min sizing fn is `auto` (and max not `min-content`) or `max-content`
- max-content minimums (all cases): min sizing fn is `max-content`
- step 5: max sizing fn has no definite value
- step 6: max sizing fn is max-content-alike (or percentage with indefinite container)

Related: DioxusLabs/blitz#835 repins Taffy to this branch and clamps negative inline available widths (a downstream symptom of the same discarded pass).


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/3a0b8cc210c041d8955c841fb2a76a8e
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/3a0b8cc210c041d8955c841fb2a76a8e?variant=devin-insiders
Requested by: @nicoburns