### PR TITLE
Flexbox: transfer the aspect-ratio cross size from the used main size…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Block/float: absorb `f32` rounding errors in horizontal fit checks, preventing floats from spuriously wrapping when percentage widths and margins sum to exactly 100% of the container (#1161).
 - Flexbox: an auto-height `flex-wrap: wrap` column container no longer wraps its lines against definite available space handed down by an ancestor. A column container's automatic main size is content-based, so lines only wrap against a definite main size or a max main size (#1175)
 - Flexbox: main-axis margins are no longer dropped from an item's intrinsic main-size contribution when the contribution is floored by the item's flex basis (column containers). This fixes negative margins being ignored on flex items with `flex-grow` (#1162) and on descendants containing an `overflow: hidden` grid item (#1163).
+- Flexbox: items with `aspect-ratio` and `flex-grow`/`flex-shrink` kept the cross size of their unflexed main size (a `min-width: 64px; max-width: 128px; aspect-ratio: 1; flex-grow: 1` item ended 128×64). The cross size is now transferred from the used main size (css-flexbox-1 §9.4 step 7). Auto-width column containers still take their width from the unflexed item sizes (§9.9.2) (#804)
 
 ## 0.14.0
 

--- a/src/compute/flexbox.rs
+++ b/src/compute/flexbox.rs
@@ -1809,11 +1809,37 @@ fn determine_hypothetical_cross_size(
         let transferred_min_cross = child.min_size.maybe_apply_aspect_ratio(child.aspect_ratio).cross(constants.dir);
         let transferred_max_cross = child.max_size.maybe_apply_aspect_ratio(child.aspect_ratio).cross(constants.dir);
 
-        let child_cross = child
-            .size
-            .cross(constants.dir)
-            .maybe_clamp(transferred_min_cross, transferred_max_cross)
-            .maybe_max(padding_border_sum);
+        // A cross size transferred through the aspect ratio must follow the used (flexed) main size
+        // https://www.w3.org/TR/css-flexbox-1/#algo-cross-item
+        //
+        // Except in an auto-width column container, whose width is the largest max-content
+        // contribution of its items, measured before flexing
+        // https://www.w3.org/TR/css-flexbox-1/#intrinsic-cross-sizes
+        let transferred_cross_follows_main = constants.is_row || constants.has_definite_cross_size;
+        let cross_size = if transferred_cross_follows_main
+            && child.aspect_ratio.is_some()
+            && child.size_style.cross(constants.dir).is_auto()
+        {
+            let box_sizing_adjustment =
+                if tree.get_flexbox_child_style(child.node).box_sizing() == BoxSizing::ContentBox {
+                    (child.padding + child.border).sum_axes()
+                } else {
+                    Size::ZERO
+                };
+            Size::NONE
+                .with_main(
+                    constants.dir,
+                    Some(child.target_size.main(constants.dir) - box_sizing_adjustment.main(constants.dir)),
+                )
+                .maybe_apply_aspect_ratio(child.aspect_ratio)
+                .maybe_add(box_sizing_adjustment)
+                .cross(constants.dir)
+        } else {
+            child.size.cross(constants.dir)
+        };
+
+        let child_cross =
+            cross_size.maybe_clamp(transferred_min_cross, transferred_max_cross).maybe_max(padding_border_sum);
 
         let child_available_cross = available_space
             .cross(constants.dir)

--- a/test_fixtures/flex/aspect_ratio_flex_column_grow_transferred_width.html
+++ b/test_fixtures/flex/aspect_ratio_flex_column_grow_transferred_width.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; flex-direction: column; align-items: start; width: 300px; height: 200px;">
+  <div style="min-height: 64px; max-height: 128px; aspect-ratio: 1; flex-grow: 1; flex-shrink: 0;"></div>
+  <div style="min-height: 64px; max-height: 128px; aspect-ratio: 1; flex-grow: 1; flex-shrink: 0;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/aspect_ratio_flex_column_grow_transferred_width_stretched_container.html
+++ b/test_fixtures/flex/aspect_ratio_flex_column_grow_transferred_width_stretched_container.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 300px;">
+  <div style="display: flex; flex-direction: column; align-items: start; height: 200px;">
+    <div style="height: 50px; aspect-ratio: 1; flex-grow: 1;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/aspect_ratio_flex_row_grow_transferred_height.html
+++ b/test_fixtures/flex/aspect_ratio_flex_row_grow_transferred_height.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; justify-content: center; align-items: center; gap: 8px; width: 600px; height: 300px;">
+  <div style="min-width: 64px; max-width: 128px; aspect-ratio: 1; flex-grow: 1; flex-shrink: 0;"></div>
+  <div style="min-width: 64px; max-width: 128px; aspect-ratio: 1; flex-grow: 1; flex-shrink: 0;"></div>
+  <div style="min-width: 64px; max-width: 128px; aspect-ratio: 1; flex-grow: 1; flex-shrink: 0;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/aspect_ratio_flex_row_grow_transferred_height_auto_height_container.html
+++ b/test_fixtures/flex/aspect_ratio_flex_row_grow_transferred_height_auto_height_container.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; align-items: start; width: 200px;">
+  <div style="width: 50px; aspect-ratio: 1; flex-grow: 1;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/aspect_ratio_flex_row_grow_transferred_height_padding.html
+++ b/test_fixtures/flex/aspect_ratio_flex_row_grow_transferred_height_padding.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; align-items: start; width: 200px; height: 300px;">
+  <div style="width: 50px; padding: 10px 20px; aspect-ratio: 1; flex-grow: 1;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/aspect_ratio_flex_row_grow_transferred_height_unclamped.html
+++ b/test_fixtures/flex/aspect_ratio_flex_row_grow_transferred_height_unclamped.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; align-items: start; width: 200px; height: 300px;">
+  <div style="width: 20px; aspect-ratio: 2; flex-grow: 1;"></div>
+  <div style="width: 20px; aspect-ratio: 2; flex-grow: 1;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/aspect_ratio_flex_row_shrink_transferred_height.html
+++ b/test_fixtures/flex/aspect_ratio_flex_row_shrink_transferred_height.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; align-items: start; width: 100px; height: 300px;">
+  <div style="width: 200px; min-width: 0; aspect-ratio: 2; flex-shrink: 1;"></div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/flex/xaspect_ratio_flex_column_grow_transferred_width_auto_width_container.html
+++ b/test_fixtures/flex/xaspect_ratio_flex_column_grow_transferred_width_auto_width_container.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; flex-direction: column; align-items: start; height: 200px;">
+  <div style="height: 50px; aspect-ratio: 1; flex-grow: 1;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/flex/aspect_ratio_flex_column_grow_transferred_width__border_box_ltr.xml
+++ b/tests/xml/flex/aspect_ratio_flex_column_grow_transferred_width__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="aspect_ratio_flex_column_grow_transferred_width__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" flex-direction="column" align-items="start" width="300px" height="200px">
+      <div direction="ltr" flex-grow="1" flex-shrink="0" min-height="64px" max-height="128px" aspect-ratio="1"/>
+      <div direction="ltr" flex-grow="1" flex-shrink="0" min-height="64px" max-height="128px" aspect-ratio="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="200">
+      <node x="0" y="0" width="100" height="100"/>
+      <node x="0" y="100" width="100" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/aspect_ratio_flex_column_grow_transferred_width__border_box_rtl.xml
+++ b/tests/xml/flex/aspect_ratio_flex_column_grow_transferred_width__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="aspect_ratio_flex_column_grow_transferred_width__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" flex-direction="column" align-items="start" width="300px" height="200px">
+      <div direction="rtl" flex-grow="1" flex-shrink="0" min-height="64px" max-height="128px" aspect-ratio="1"/>
+      <div direction="rtl" flex-grow="1" flex-shrink="0" min-height="64px" max-height="128px" aspect-ratio="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="200">
+      <node x="200" y="0" width="100" height="100"/>
+      <node x="200" y="100" width="100" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/aspect_ratio_flex_column_grow_transferred_width__content_box_ltr.xml
+++ b/tests/xml/flex/aspect_ratio_flex_column_grow_transferred_width__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="aspect_ratio_flex_column_grow_transferred_width__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" flex-direction="column" align-items="start" width="300px" height="200px">
+      <div box-sizing="content-box" direction="ltr" flex-grow="1" flex-shrink="0" min-height="64px" max-height="128px" aspect-ratio="1"/>
+      <div box-sizing="content-box" direction="ltr" flex-grow="1" flex-shrink="0" min-height="64px" max-height="128px" aspect-ratio="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="200">
+      <node x="0" y="0" width="100" height="100"/>
+      <node x="0" y="100" width="100" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/aspect_ratio_flex_column_grow_transferred_width__content_box_rtl.xml
+++ b/tests/xml/flex/aspect_ratio_flex_column_grow_transferred_width__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="aspect_ratio_flex_column_grow_transferred_width__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" flex-direction="column" align-items="start" width="300px" height="200px">
+      <div box-sizing="content-box" direction="rtl" flex-grow="1" flex-shrink="0" min-height="64px" max-height="128px" aspect-ratio="1"/>
+      <div box-sizing="content-box" direction="rtl" flex-grow="1" flex-shrink="0" min-height="64px" max-height="128px" aspect-ratio="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="200">
+      <node x="200" y="0" width="100" height="100"/>
+      <node x="200" y="100" width="100" height="100"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/aspect_ratio_flex_column_grow_transferred_width_stretched_container__border_box_ltr.xml
+++ b/tests/xml/flex/aspect_ratio_flex_column_grow_transferred_width_stretched_container__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="aspect_ratio_flex_column_grow_transferred_width_stretched_container__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="300px">
+      <div display="flex" direction="ltr" flex-direction="column" align-items="start" height="200px">
+        <div direction="ltr" flex-grow="1" height="50px" aspect-ratio="1"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="200">
+      <node x="0" y="0" width="300" height="200">
+        <node x="0" y="0" width="200" height="200"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/aspect_ratio_flex_column_grow_transferred_width_stretched_container__border_box_rtl.xml
+++ b/tests/xml/flex/aspect_ratio_flex_column_grow_transferred_width_stretched_container__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="aspect_ratio_flex_column_grow_transferred_width_stretched_container__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="300px">
+      <div display="flex" direction="rtl" flex-direction="column" align-items="start" height="200px">
+        <div direction="rtl" flex-grow="1" height="50px" aspect-ratio="1"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="200">
+      <node x="0" y="0" width="300" height="200">
+        <node x="100" y="0" width="200" height="200"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/aspect_ratio_flex_column_grow_transferred_width_stretched_container__content_box_ltr.xml
+++ b/tests/xml/flex/aspect_ratio_flex_column_grow_transferred_width_stretched_container__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="aspect_ratio_flex_column_grow_transferred_width_stretched_container__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="300px">
+      <div display="flex" box-sizing="content-box" direction="ltr" flex-direction="column" align-items="start" height="200px">
+        <div box-sizing="content-box" direction="ltr" flex-grow="1" height="50px" aspect-ratio="1"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="200">
+      <node x="0" y="0" width="300" height="200">
+        <node x="0" y="0" width="200" height="200"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/aspect_ratio_flex_column_grow_transferred_width_stretched_container__content_box_rtl.xml
+++ b/tests/xml/flex/aspect_ratio_flex_column_grow_transferred_width_stretched_container__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="aspect_ratio_flex_column_grow_transferred_width_stretched_container__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="300px">
+      <div display="flex" box-sizing="content-box" direction="rtl" flex-direction="column" align-items="start" height="200px">
+        <div box-sizing="content-box" direction="rtl" flex-grow="1" height="50px" aspect-ratio="1"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="300" height="200">
+      <node x="0" y="0" width="300" height="200">
+        <node x="100" y="0" width="200" height="200"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/aspect_ratio_flex_row_grow_transferred_height__border_box_ltr.xml
+++ b/tests/xml/flex/aspect_ratio_flex_row_grow_transferred_height__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="aspect_ratio_flex_row_grow_transferred_height__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" align-items="center" justify-content="center" width="600px" height="300px" row-gap="8px" column-gap="8px">
+      <div direction="ltr" flex-grow="1" flex-shrink="0" min-width="64px" max-width="128px" aspect-ratio="1"/>
+      <div direction="ltr" flex-grow="1" flex-shrink="0" min-width="64px" max-width="128px" aspect-ratio="1"/>
+      <div direction="ltr" flex-grow="1" flex-shrink="0" min-width="64px" max-width="128px" aspect-ratio="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="600" height="300">
+      <node x="100" y="86" width="128" height="128"/>
+      <node x="236" y="86" width="128" height="128"/>
+      <node x="372" y="86" width="128" height="128"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/aspect_ratio_flex_row_grow_transferred_height__border_box_rtl.xml
+++ b/tests/xml/flex/aspect_ratio_flex_row_grow_transferred_height__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="aspect_ratio_flex_row_grow_transferred_height__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" align-items="center" justify-content="center" width="600px" height="300px" row-gap="8px" column-gap="8px">
+      <div direction="rtl" flex-grow="1" flex-shrink="0" min-width="64px" max-width="128px" aspect-ratio="1"/>
+      <div direction="rtl" flex-grow="1" flex-shrink="0" min-width="64px" max-width="128px" aspect-ratio="1"/>
+      <div direction="rtl" flex-grow="1" flex-shrink="0" min-width="64px" max-width="128px" aspect-ratio="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="600" height="300">
+      <node x="372" y="86" width="128" height="128"/>
+      <node x="236" y="86" width="128" height="128"/>
+      <node x="100" y="86" width="128" height="128"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/aspect_ratio_flex_row_grow_transferred_height__content_box_ltr.xml
+++ b/tests/xml/flex/aspect_ratio_flex_row_grow_transferred_height__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="aspect_ratio_flex_row_grow_transferred_height__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" align-items="center" justify-content="center" width="600px" height="300px" row-gap="8px" column-gap="8px">
+      <div box-sizing="content-box" direction="ltr" flex-grow="1" flex-shrink="0" min-width="64px" max-width="128px" aspect-ratio="1"/>
+      <div box-sizing="content-box" direction="ltr" flex-grow="1" flex-shrink="0" min-width="64px" max-width="128px" aspect-ratio="1"/>
+      <div box-sizing="content-box" direction="ltr" flex-grow="1" flex-shrink="0" min-width="64px" max-width="128px" aspect-ratio="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="600" height="300">
+      <node x="100" y="86" width="128" height="128"/>
+      <node x="236" y="86" width="128" height="128"/>
+      <node x="372" y="86" width="128" height="128"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/aspect_ratio_flex_row_grow_transferred_height__content_box_rtl.xml
+++ b/tests/xml/flex/aspect_ratio_flex_row_grow_transferred_height__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="aspect_ratio_flex_row_grow_transferred_height__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" align-items="center" justify-content="center" width="600px" height="300px" row-gap="8px" column-gap="8px">
+      <div box-sizing="content-box" direction="rtl" flex-grow="1" flex-shrink="0" min-width="64px" max-width="128px" aspect-ratio="1"/>
+      <div box-sizing="content-box" direction="rtl" flex-grow="1" flex-shrink="0" min-width="64px" max-width="128px" aspect-ratio="1"/>
+      <div box-sizing="content-box" direction="rtl" flex-grow="1" flex-shrink="0" min-width="64px" max-width="128px" aspect-ratio="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="600" height="300">
+      <node x="372" y="86" width="128" height="128"/>
+      <node x="236" y="86" width="128" height="128"/>
+      <node x="100" y="86" width="128" height="128"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/aspect_ratio_flex_row_grow_transferred_height_auto_height_container__border_box_ltr.xml
+++ b/tests/xml/flex/aspect_ratio_flex_row_grow_transferred_height_auto_height_container__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="aspect_ratio_flex_row_grow_transferred_height_auto_height_container__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" align-items="start" width="200px">
+      <div direction="ltr" flex-grow="1" width="50px" aspect-ratio="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="0" y="0" width="200" height="200"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/aspect_ratio_flex_row_grow_transferred_height_auto_height_container__border_box_rtl.xml
+++ b/tests/xml/flex/aspect_ratio_flex_row_grow_transferred_height_auto_height_container__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="aspect_ratio_flex_row_grow_transferred_height_auto_height_container__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" align-items="start" width="200px">
+      <div direction="rtl" flex-grow="1" width="50px" aspect-ratio="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="0" y="0" width="200" height="200"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/aspect_ratio_flex_row_grow_transferred_height_auto_height_container__content_box_ltr.xml
+++ b/tests/xml/flex/aspect_ratio_flex_row_grow_transferred_height_auto_height_container__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="aspect_ratio_flex_row_grow_transferred_height_auto_height_container__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" align-items="start" width="200px">
+      <div box-sizing="content-box" direction="ltr" flex-grow="1" width="50px" aspect-ratio="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="0" y="0" width="200" height="200"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/aspect_ratio_flex_row_grow_transferred_height_auto_height_container__content_box_rtl.xml
+++ b/tests/xml/flex/aspect_ratio_flex_row_grow_transferred_height_auto_height_container__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="aspect_ratio_flex_row_grow_transferred_height_auto_height_container__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" align-items="start" width="200px">
+      <div box-sizing="content-box" direction="rtl" flex-grow="1" width="50px" aspect-ratio="1"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="200">
+      <node x="0" y="0" width="200" height="200"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/aspect_ratio_flex_row_grow_transferred_height_padding__border_box_ltr.xml
+++ b/tests/xml/flex/aspect_ratio_flex_row_grow_transferred_height_padding__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="aspect_ratio_flex_row_grow_transferred_height_padding__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" align-items="start" width="200px" height="300px">
+      <div direction="ltr" flex-grow="1" width="50px" aspect-ratio="1" padding-top="10px" padding-left="20px" padding-bottom="10px" padding-right="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="300">
+      <node x="0" y="0" width="200" height="200"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/aspect_ratio_flex_row_grow_transferred_height_padding__border_box_rtl.xml
+++ b/tests/xml/flex/aspect_ratio_flex_row_grow_transferred_height_padding__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="aspect_ratio_flex_row_grow_transferred_height_padding__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" align-items="start" width="200px" height="300px">
+      <div direction="rtl" flex-grow="1" width="50px" aspect-ratio="1" padding-top="10px" padding-left="20px" padding-bottom="10px" padding-right="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="300">
+      <node x="0" y="0" width="200" height="200"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/aspect_ratio_flex_row_grow_transferred_height_padding__content_box_ltr.xml
+++ b/tests/xml/flex/aspect_ratio_flex_row_grow_transferred_height_padding__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="aspect_ratio_flex_row_grow_transferred_height_padding__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" align-items="start" width="200px" height="300px">
+      <div box-sizing="content-box" direction="ltr" flex-grow="1" width="50px" aspect-ratio="1" padding-top="10px" padding-left="20px" padding-bottom="10px" padding-right="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="300">
+      <node x="0" y="0" width="200" height="180"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/aspect_ratio_flex_row_grow_transferred_height_padding__content_box_rtl.xml
+++ b/tests/xml/flex/aspect_ratio_flex_row_grow_transferred_height_padding__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="aspect_ratio_flex_row_grow_transferred_height_padding__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" align-items="start" width="200px" height="300px">
+      <div box-sizing="content-box" direction="rtl" flex-grow="1" width="50px" aspect-ratio="1" padding-top="10px" padding-left="20px" padding-bottom="10px" padding-right="20px"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="300">
+      <node x="0" y="0" width="200" height="180"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/aspect_ratio_flex_row_grow_transferred_height_unclamped__border_box_ltr.xml
+++ b/tests/xml/flex/aspect_ratio_flex_row_grow_transferred_height_unclamped__border_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="aspect_ratio_flex_row_grow_transferred_height_unclamped__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" align-items="start" width="200px" height="300px">
+      <div direction="ltr" flex-grow="1" width="20px" aspect-ratio="2"/>
+      <div direction="ltr" flex-grow="1" width="20px" aspect-ratio="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="300">
+      <node x="0" y="0" width="100" height="50"/>
+      <node x="100" y="0" width="100" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/aspect_ratio_flex_row_grow_transferred_height_unclamped__border_box_rtl.xml
+++ b/tests/xml/flex/aspect_ratio_flex_row_grow_transferred_height_unclamped__border_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="aspect_ratio_flex_row_grow_transferred_height_unclamped__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" align-items="start" width="200px" height="300px">
+      <div direction="rtl" flex-grow="1" width="20px" aspect-ratio="2"/>
+      <div direction="rtl" flex-grow="1" width="20px" aspect-ratio="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="300">
+      <node x="100" y="0" width="100" height="50"/>
+      <node x="0" y="0" width="100" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/aspect_ratio_flex_row_grow_transferred_height_unclamped__content_box_ltr.xml
+++ b/tests/xml/flex/aspect_ratio_flex_row_grow_transferred_height_unclamped__content_box_ltr.xml
@@ -1,0 +1,15 @@
+<test name="aspect_ratio_flex_row_grow_transferred_height_unclamped__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" align-items="start" width="200px" height="300px">
+      <div box-sizing="content-box" direction="ltr" flex-grow="1" width="20px" aspect-ratio="2"/>
+      <div box-sizing="content-box" direction="ltr" flex-grow="1" width="20px" aspect-ratio="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="300">
+      <node x="0" y="0" width="100" height="50"/>
+      <node x="100" y="0" width="100" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/aspect_ratio_flex_row_grow_transferred_height_unclamped__content_box_rtl.xml
+++ b/tests/xml/flex/aspect_ratio_flex_row_grow_transferred_height_unclamped__content_box_rtl.xml
@@ -1,0 +1,15 @@
+<test name="aspect_ratio_flex_row_grow_transferred_height_unclamped__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" align-items="start" width="200px" height="300px">
+      <div box-sizing="content-box" direction="rtl" flex-grow="1" width="20px" aspect-ratio="2"/>
+      <div box-sizing="content-box" direction="rtl" flex-grow="1" width="20px" aspect-ratio="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="200" height="300">
+      <node x="100" y="0" width="100" height="50"/>
+      <node x="0" y="0" width="100" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/aspect_ratio_flex_row_shrink_transferred_height__border_box_ltr.xml
+++ b/tests/xml/flex/aspect_ratio_flex_row_shrink_transferred_height__border_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="aspect_ratio_flex_row_shrink_transferred_height__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="ltr" align-items="start" width="100px" height="300px">
+      <div direction="ltr" width="200px" min-width="0px" aspect-ratio="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="300">
+      <node x="0" y="0" width="100" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/aspect_ratio_flex_row_shrink_transferred_height__border_box_rtl.xml
+++ b/tests/xml/flex/aspect_ratio_flex_row_shrink_transferred_height__border_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="aspect_ratio_flex_row_shrink_transferred_height__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" direction="rtl" align-items="start" width="100px" height="300px">
+      <div direction="rtl" width="200px" min-width="0px" aspect-ratio="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="300">
+      <node x="0" y="0" width="100" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/aspect_ratio_flex_row_shrink_transferred_height__content_box_ltr.xml
+++ b/tests/xml/flex/aspect_ratio_flex_row_shrink_transferred_height__content_box_ltr.xml
@@ -1,0 +1,13 @@
+<test name="aspect_ratio_flex_row_shrink_transferred_height__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="ltr" align-items="start" width="100px" height="300px">
+      <div box-sizing="content-box" direction="ltr" width="200px" min-width="0px" aspect-ratio="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="300">
+      <node x="0" y="0" width="100" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/flex/aspect_ratio_flex_row_shrink_transferred_height__content_box_rtl.xml
+++ b/tests/xml/flex/aspect_ratio_flex_row_shrink_transferred_height__content_box_rtl.xml
@@ -1,0 +1,13 @@
+<test name="aspect_ratio_flex_row_shrink_transferred_height__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="flex" box-sizing="content-box" direction="rtl" align-items="start" width="100px" height="300px">
+      <div box-sizing="content-box" direction="rtl" width="200px" min-width="0px" aspect-ratio="2"/>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="300">
+      <node x="0" y="0" width="100" height="50"/>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -9538,6 +9538,58 @@ mod flex {
     }
 
     #[test]
+    fn aspect_ratio_flex_column_grow_transferred_width__border_box_ltr() {
+        crate::run_xml_test("flex", "aspect_ratio_flex_column_grow_transferred_width__border_box_ltr");
+    }
+
+    #[test]
+    fn aspect_ratio_flex_column_grow_transferred_width__content_box_ltr() {
+        crate::run_xml_test("flex", "aspect_ratio_flex_column_grow_transferred_width__content_box_ltr");
+    }
+
+    #[test]
+    fn aspect_ratio_flex_column_grow_transferred_width__border_box_rtl() {
+        crate::run_xml_test("flex", "aspect_ratio_flex_column_grow_transferred_width__border_box_rtl");
+    }
+
+    #[test]
+    fn aspect_ratio_flex_column_grow_transferred_width__content_box_rtl() {
+        crate::run_xml_test("flex", "aspect_ratio_flex_column_grow_transferred_width__content_box_rtl");
+    }
+
+    #[test]
+    fn aspect_ratio_flex_column_grow_transferred_width_stretched_container__border_box_ltr() {
+        crate::run_xml_test(
+            "flex",
+            "aspect_ratio_flex_column_grow_transferred_width_stretched_container__border_box_ltr",
+        );
+    }
+
+    #[test]
+    fn aspect_ratio_flex_column_grow_transferred_width_stretched_container__content_box_ltr() {
+        crate::run_xml_test(
+            "flex",
+            "aspect_ratio_flex_column_grow_transferred_width_stretched_container__content_box_ltr",
+        );
+    }
+
+    #[test]
+    fn aspect_ratio_flex_column_grow_transferred_width_stretched_container__border_box_rtl() {
+        crate::run_xml_test(
+            "flex",
+            "aspect_ratio_flex_column_grow_transferred_width_stretched_container__border_box_rtl",
+        );
+    }
+
+    #[test]
+    fn aspect_ratio_flex_column_grow_transferred_width_stretched_container__content_box_rtl() {
+        crate::run_xml_test(
+            "flex",
+            "aspect_ratio_flex_column_grow_transferred_width_stretched_container__content_box_rtl",
+        );
+    }
+
+    #[test]
     fn aspect_ratio_flex_column_stretch_fill_height__border_box_ltr() {
         crate::run_xml_test("flex", "aspect_ratio_flex_column_stretch_fill_height__border_box_ltr");
     }
@@ -9755,6 +9807,118 @@ mod flex {
     #[test]
     fn aspect_ratio_flex_row_fill_width_flex__content_box_rtl() {
         crate::run_xml_test("flex", "aspect_ratio_flex_row_fill_width_flex__content_box_rtl");
+    }
+
+    #[test]
+    fn aspect_ratio_flex_row_grow_transferred_height__border_box_ltr() {
+        crate::run_xml_test("flex", "aspect_ratio_flex_row_grow_transferred_height__border_box_ltr");
+    }
+
+    #[test]
+    fn aspect_ratio_flex_row_grow_transferred_height__content_box_ltr() {
+        crate::run_xml_test("flex", "aspect_ratio_flex_row_grow_transferred_height__content_box_ltr");
+    }
+
+    #[test]
+    fn aspect_ratio_flex_row_grow_transferred_height__border_box_rtl() {
+        crate::run_xml_test("flex", "aspect_ratio_flex_row_grow_transferred_height__border_box_rtl");
+    }
+
+    #[test]
+    fn aspect_ratio_flex_row_grow_transferred_height__content_box_rtl() {
+        crate::run_xml_test("flex", "aspect_ratio_flex_row_grow_transferred_height__content_box_rtl");
+    }
+
+    #[test]
+    fn aspect_ratio_flex_row_grow_transferred_height_auto_height_container__border_box_ltr() {
+        crate::run_xml_test(
+            "flex",
+            "aspect_ratio_flex_row_grow_transferred_height_auto_height_container__border_box_ltr",
+        );
+    }
+
+    #[test]
+    fn aspect_ratio_flex_row_grow_transferred_height_auto_height_container__content_box_ltr() {
+        crate::run_xml_test(
+            "flex",
+            "aspect_ratio_flex_row_grow_transferred_height_auto_height_container__content_box_ltr",
+        );
+    }
+
+    #[test]
+    fn aspect_ratio_flex_row_grow_transferred_height_auto_height_container__border_box_rtl() {
+        crate::run_xml_test(
+            "flex",
+            "aspect_ratio_flex_row_grow_transferred_height_auto_height_container__border_box_rtl",
+        );
+    }
+
+    #[test]
+    fn aspect_ratio_flex_row_grow_transferred_height_auto_height_container__content_box_rtl() {
+        crate::run_xml_test(
+            "flex",
+            "aspect_ratio_flex_row_grow_transferred_height_auto_height_container__content_box_rtl",
+        );
+    }
+
+    #[test]
+    fn aspect_ratio_flex_row_grow_transferred_height_padding__border_box_ltr() {
+        crate::run_xml_test("flex", "aspect_ratio_flex_row_grow_transferred_height_padding__border_box_ltr");
+    }
+
+    #[test]
+    fn aspect_ratio_flex_row_grow_transferred_height_padding__content_box_ltr() {
+        crate::run_xml_test("flex", "aspect_ratio_flex_row_grow_transferred_height_padding__content_box_ltr");
+    }
+
+    #[test]
+    fn aspect_ratio_flex_row_grow_transferred_height_padding__border_box_rtl() {
+        crate::run_xml_test("flex", "aspect_ratio_flex_row_grow_transferred_height_padding__border_box_rtl");
+    }
+
+    #[test]
+    fn aspect_ratio_flex_row_grow_transferred_height_padding__content_box_rtl() {
+        crate::run_xml_test("flex", "aspect_ratio_flex_row_grow_transferred_height_padding__content_box_rtl");
+    }
+
+    #[test]
+    fn aspect_ratio_flex_row_grow_transferred_height_unclamped__border_box_ltr() {
+        crate::run_xml_test("flex", "aspect_ratio_flex_row_grow_transferred_height_unclamped__border_box_ltr");
+    }
+
+    #[test]
+    fn aspect_ratio_flex_row_grow_transferred_height_unclamped__content_box_ltr() {
+        crate::run_xml_test("flex", "aspect_ratio_flex_row_grow_transferred_height_unclamped__content_box_ltr");
+    }
+
+    #[test]
+    fn aspect_ratio_flex_row_grow_transferred_height_unclamped__border_box_rtl() {
+        crate::run_xml_test("flex", "aspect_ratio_flex_row_grow_transferred_height_unclamped__border_box_rtl");
+    }
+
+    #[test]
+    fn aspect_ratio_flex_row_grow_transferred_height_unclamped__content_box_rtl() {
+        crate::run_xml_test("flex", "aspect_ratio_flex_row_grow_transferred_height_unclamped__content_box_rtl");
+    }
+
+    #[test]
+    fn aspect_ratio_flex_row_shrink_transferred_height__border_box_ltr() {
+        crate::run_xml_test("flex", "aspect_ratio_flex_row_shrink_transferred_height__border_box_ltr");
+    }
+
+    #[test]
+    fn aspect_ratio_flex_row_shrink_transferred_height__content_box_ltr() {
+        crate::run_xml_test("flex", "aspect_ratio_flex_row_shrink_transferred_height__content_box_ltr");
+    }
+
+    #[test]
+    fn aspect_ratio_flex_row_shrink_transferred_height__border_box_rtl() {
+        crate::run_xml_test("flex", "aspect_ratio_flex_row_shrink_transferred_height__border_box_rtl");
+    }
+
+    #[test]
+    fn aspect_ratio_flex_row_shrink_transferred_height__content_box_rtl() {
+        crate::run_xml_test("flex", "aspect_ratio_flex_row_shrink_transferred_height__content_box_rtl");
     }
 
     #[test]


### PR DESCRIPTION
# Objective

Fixes #804.

In `determine_hypothetical_cross_size`, when the item has an aspect ratio and its cross size is `auto`, transfer the cross size from `target_size.main` (the flexed main size) instead of reading the pre-flex value. `box-sizing` is handled as in `generate_anonymous_flex_items`. The min/max clamp and padding-border floor after it are unchanged.

## Context

A row flex container holds items with `min-width: 64px; max-width: 128px; aspect-ratio: 1; flex-grow: 1`.
Browsers render 128×128 squares. Taffy renders 128×64.

[The spec](https://www.w3.org/TR/css-flexbox-1/#cross-sizing) says the hypothetical cross size comes from "performing layout as if it were an in-flow block-level box with the used main size and the given available space". The used main size is the flexed one, 128. 

For a box with `aspect-ratio` the height is an [automatic size derived from the width](https://www.w3.org/TR/css-sizing-4/#aspect-ratio-automatic), so the transferred height should be 128 / 1 = 128, not 64.