### PR TITLE
Block: take a content-based automatic minimum in the ratio-dependent axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Block: when a block container is measured under `SizingMode::ContentSize` (e.g. for a flex item's automatic minimum size or min-/max-content contribution), its own `height`/`min-height` is no longer used as the percentage basis for its children. A `height: 100%` child previously resolved against the ignored `height`, inflating the container's content size (WPT `css-flexbox/flex-minimum-height-flex-items-025`).
 - Flexbox: in column containers an item's max-content contribution is clamped by its flex base size alone (per spec) rather than by `max(flex-basis, height)`, so an item's `height` no longer inflates the container's automatic main size past the item's `flex-basis`.
 - Flexbox: main-axis margins are no longer dropped from an item's intrinsic main-size contribution when the contribution is floored by the item's flex basis (column containers). This fixes negative margins being ignored on flex items with `flex-grow` (#1162) and on descendants containing an `overflow: hidden` grid item (#1163).
+- Block: a block box with a preferred aspect ratio and an automatic height now takes a content-based automatic minimum size in the ratio-dependent axis, so content taller than the ratio derives grows the box instead of overflowing it. The minimum is capped by `max-height`, and does not apply where `min-height` is specified, where the height is specified, or where the box is a scroll container in that axis (#1184).
 
 ## 0.14.0
 

--- a/src/compute/block.rs
+++ b/src/compute/block.rs
@@ -513,10 +513,18 @@ fn compute_inner(
     // while probing intrinsic sizes, so measure passes stay content-based. Only a
     // newly-filled axis is adopted (and clamped); an incoming known size is left
     // as the parent resolved it (re-clamping would undo padding/border overrides).
+
+    // Both are read by `ratio_content_minimum_height` below, and neither can be recovered there:
+    // an author's height and a ratio-derived one are indistinguishable once both are `Some`, and
+    // `min_size.height` may by then hold a minimum transferred from `min-width` through the ratio
+    // rather than the author's own `min-height`.
+    let min_height_is_auto = style.min_size().height.is_auto();
+    let height_was_absent = known_dimensions.height.is_none();
     let known_dimensions = {
         let derived = known_dimensions.maybe_apply_aspect_ratio(aspect_ratio).maybe_clamp(min_size, max_size);
         Size { width: known_dimensions.width.or(derived.width), height: known_dimensions.height.or(derived.height) }
     };
+    let height_is_ratio_derived = height_was_absent && known_dimensions.height.is_some();
     let percentage_basis_dimensions = Size {
         width: known_dimensions.width,
         height: known_dimensions.height.filter(|_| inputs.known_dimensions_are_definite.height),
@@ -629,8 +637,24 @@ fn compute_inner(
         intrinsic_outer_height = intrinsic_outer_height.max(block_ctx.floated_content_height_contribution());
     }
 
+    // css-sizing-4 §4.3: the automatic content-based minimum size in the ratio-dependent axis.
+    // <https://www.w3.org/TR/css-sizing-4/#aspect-ratio-minimum>
+    //
+    // > the automatic minimum size in the ratio-dependent axis of a box with a preferred aspect
+    // > ratio that is neither a replaced element, nor a scroll container in that axis, is its
+    // > min-content size capped by its maximum size.
+    //
+    // The three conditions are that sentence's: an automatic height rather than an author's
+    // override, `min-height` computing to `auto`, and not a scroll container in that axis. The
+    // minimum is raised rather than the used height maxed, so `max-height`, the clamping order
+    // and the padding-border floor keep composing as they already do.
+    let ratio_content_minimum_height =
+        (height_is_ratio_derived && min_height_is_auto && !overflow.y.is_scroll_container())
+            .then(|| intrinsic_outer_height.maybe_min(max_size.height));
+
     let container_outer_height = known_dimensions
         .height
+        .maybe_max(ratio_content_minimum_height)
         .unwrap_or(intrinsic_outer_height.maybe_clamp(min_size.height, max_size.height))
         .maybe_max(Some(padding_border_size.height));
     let final_outer_size = Size { width: container_outer_width, height: container_outer_height };

--- a/test_fixtures/block/block_aspect_ratio_content_minimum.html
+++ b/test_fixtures/block/block_aspect_ratio_content_minimum.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    A block box with a preferred aspect ratio at a definite width, whose content is taller than the ratio derives. The ratio-derived height is an automatic size, so it takes a content-based automatic minimum in the ratio-dependent axis and the box grows to its content instead of the content overflowing it.
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px;">
+  <div style="display: block; aspect-ratio: 0.85;">
+    <div style="display: block; height: 300px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/block/block_aspect_ratio_content_minimum_definite_height.html
+++ b/test_fixtures/block/block_aspect_ratio_content_minimum_definite_height.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    A specified height is an override rather than an automatic size, so no automatic minimum applies and the content overflows it. Control for the case the fix must not change.
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px;">
+  <div style="display: block; aspect-ratio: 0.85; height: 50px;">
+    <div style="display: block; height: 300px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/block/block_aspect_ratio_content_minimum_max_height.html
+++ b/test_fixtures/block/block_aspect_ratio_content_minimum_max_height.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    The content-based automatic minimum is capped by the maximum size, so a max-height below the content height binds and the content overflows after all.
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px;">
+  <div style="display: block; aspect-ratio: 0.85; max-height: 150px;">
+    <div style="display: block; height: 300px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/block/block_aspect_ratio_content_minimum_min_height.html
+++ b/test_fixtures/block/block_aspect_ratio_content_minimum_min_height.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    A specified min-height is the author's answer to the same question, so the automatic minimum does not apply and the ratio-derived height stands.
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px;">
+  <div style="display: block; aspect-ratio: 0.85; min-height: 20px;">
+    <div style="display: block; height: 300px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/block/block_aspect_ratio_content_minimum_min_width.html
+++ b/test_fixtures/block/block_aspect_ratio_content_minimum_min_width.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    A specified min-width transfers through the ratio to a minimum height (css-sizing-4 4.4), and the box also takes the content-based automatic minimum because min-height is still auto. Both are minimums; the larger governs. Boundary between the two rules.
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px;">
+  <div style="display: block; aspect-ratio: 0.85; min-width: 200px;">
+    <div style="display: block; height: 300px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/block/block_aspect_ratio_content_minimum_overflow_hidden.html
+++ b/test_fixtures/block/block_aspect_ratio_content_minimum_overflow_hidden.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    A scroll container in the ratio-dependent axis takes no content-based automatic minimum: overflow is the point of the box.
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px;">
+  <div style="display: block; aspect-ratio: 0.85; overflow-y: hidden;">
+    <div style="display: block; height: 300px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/block/block_aspect_ratio_content_minimum_percentage_child.html
+++ b/test_fixtures/block/block_aspect_ratio_content_minimum_percentage_child.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Raising the used height by the content-based automatic minimum must not change what a percentage height inside the box resolves against. The percentage resolves against the ratio-derived height, and the box then grows to contain the result, so the two sizes are deliberately different.
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px;">
+  <div style="display: block; aspect-ratio: 0.85;">
+    <div style="display: block; height: 300px;"></div>
+    <div style="display: block; height: 50%;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/test_fixtures/block/block_aspect_ratio_content_minimum_short_content.html
+++ b/test_fixtures/block/block_aspect_ratio_content_minimum_short_content.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="../../scripts/gentest/test_helper.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../scripts/gentest/test_base_style.css">
+  <title>
+    Content shorter than the ratio derives: the ratio-derived height already exceeds the content-based minimum, so the minimum is inert and the ratio governs. Control for the interior of the rule.
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px;">
+  <div style="display: block; aspect-ratio: 0.85;">
+    <div style="display: block; height: 40px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/xml/block/block_aspect_ratio_content_minimum__border_box_ltr.xml
+++ b/tests/xml/block/block_aspect_ratio_content_minimum__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_content_minimum__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px">
+      <div display="block" direction="ltr" aspect-ratio="0.85">
+        <div display="block" direction="ltr" height="300px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="300">
+      <node x="0" y="0" width="100" height="300">
+        <node x="0" y="0" width="100" height="300"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_content_minimum__border_box_rtl.xml
+++ b/tests/xml/block/block_aspect_ratio_content_minimum__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_content_minimum__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px">
+      <div display="block" direction="rtl" aspect-ratio="0.85">
+        <div display="block" direction="rtl" height="300px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="300">
+      <node x="0" y="0" width="100" height="300">
+        <node x="0" y="0" width="100" height="300"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_content_minimum__content_box_ltr.xml
+++ b/tests/xml/block/block_aspect_ratio_content_minimum__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_content_minimum__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" aspect-ratio="0.85">
+        <div display="block" box-sizing="content-box" direction="ltr" height="300px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="300">
+      <node x="0" y="0" width="100" height="300">
+        <node x="0" y="0" width="100" height="300"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_content_minimum__content_box_rtl.xml
+++ b/tests/xml/block/block_aspect_ratio_content_minimum__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_content_minimum__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" aspect-ratio="0.85">
+        <div display="block" box-sizing="content-box" direction="rtl" height="300px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="300">
+      <node x="0" y="0" width="100" height="300">
+        <node x="0" y="0" width="100" height="300"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_content_minimum_definite_height__border_box_ltr.xml
+++ b/tests/xml/block/block_aspect_ratio_content_minimum_definite_height__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_content_minimum_definite_height__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px">
+      <div display="block" direction="ltr" height="50px" aspect-ratio="0.85">
+        <div display="block" direction="ltr" height="300px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="50">
+      <node x="0" y="0" width="43" height="50">
+        <node x="0" y="0" width="43" height="300"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_content_minimum_definite_height__border_box_rtl.xml
+++ b/tests/xml/block/block_aspect_ratio_content_minimum_definite_height__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_content_minimum_definite_height__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px">
+      <div display="block" direction="rtl" height="50px" aspect-ratio="0.85">
+        <div display="block" direction="rtl" height="300px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="50">
+      <node x="58" y="0" width="42" height="50">
+        <node x="0" y="0" width="42" height="300"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_content_minimum_definite_height__content_box_ltr.xml
+++ b/tests/xml/block/block_aspect_ratio_content_minimum_definite_height__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_content_minimum_definite_height__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" height="50px" aspect-ratio="0.85">
+        <div display="block" box-sizing="content-box" direction="ltr" height="300px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="50">
+      <node x="0" y="0" width="43" height="50">
+        <node x="0" y="0" width="43" height="300"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_content_minimum_definite_height__content_box_rtl.xml
+++ b/tests/xml/block/block_aspect_ratio_content_minimum_definite_height__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_content_minimum_definite_height__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" height="50px" aspect-ratio="0.85">
+        <div display="block" box-sizing="content-box" direction="rtl" height="300px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="50">
+      <node x="58" y="0" width="42" height="50">
+        <node x="0" y="0" width="42" height="300"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_content_minimum_max_height__border_box_ltr.xml
+++ b/tests/xml/block/block_aspect_ratio_content_minimum_max_height__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_content_minimum_max_height__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px">
+      <div display="block" direction="ltr" max-height="150px" aspect-ratio="0.85">
+        <div display="block" direction="ltr" height="300px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="150">
+      <node x="0" y="0" width="100" height="150">
+        <node x="0" y="0" width="100" height="300"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_content_minimum_max_height__border_box_rtl.xml
+++ b/tests/xml/block/block_aspect_ratio_content_minimum_max_height__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_content_minimum_max_height__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px">
+      <div display="block" direction="rtl" max-height="150px" aspect-ratio="0.85">
+        <div display="block" direction="rtl" height="300px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="150">
+      <node x="0" y="0" width="100" height="150">
+        <node x="0" y="0" width="100" height="300"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_content_minimum_max_height__content_box_ltr.xml
+++ b/tests/xml/block/block_aspect_ratio_content_minimum_max_height__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_content_minimum_max_height__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" max-height="150px" aspect-ratio="0.85">
+        <div display="block" box-sizing="content-box" direction="ltr" height="300px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="150">
+      <node x="0" y="0" width="100" height="150">
+        <node x="0" y="0" width="100" height="300"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_content_minimum_max_height__content_box_rtl.xml
+++ b/tests/xml/block/block_aspect_ratio_content_minimum_max_height__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_content_minimum_max_height__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" max-height="150px" aspect-ratio="0.85">
+        <div display="block" box-sizing="content-box" direction="rtl" height="300px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="150">
+      <node x="0" y="0" width="100" height="150">
+        <node x="0" y="0" width="100" height="300"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_content_minimum_min_height__border_box_ltr.xml
+++ b/tests/xml/block/block_aspect_ratio_content_minimum_min_height__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_content_minimum_min_height__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px">
+      <div display="block" direction="ltr" min-height="20px" aspect-ratio="0.85">
+        <div display="block" direction="ltr" height="300px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="118">
+      <node x="0" y="0" width="100" height="118">
+        <node x="0" y="0" width="100" height="300"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_content_minimum_min_height__border_box_rtl.xml
+++ b/tests/xml/block/block_aspect_ratio_content_minimum_min_height__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_content_minimum_min_height__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px">
+      <div display="block" direction="rtl" min-height="20px" aspect-ratio="0.85">
+        <div display="block" direction="rtl" height="300px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="118">
+      <node x="0" y="0" width="100" height="118">
+        <node x="0" y="0" width="100" height="300"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_content_minimum_min_height__content_box_ltr.xml
+++ b/tests/xml/block/block_aspect_ratio_content_minimum_min_height__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_content_minimum_min_height__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" min-height="20px" aspect-ratio="0.85">
+        <div display="block" box-sizing="content-box" direction="ltr" height="300px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="118">
+      <node x="0" y="0" width="100" height="118">
+        <node x="0" y="0" width="100" height="300"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_content_minimum_min_height__content_box_rtl.xml
+++ b/tests/xml/block/block_aspect_ratio_content_minimum_min_height__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_content_minimum_min_height__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" min-height="20px" aspect-ratio="0.85">
+        <div display="block" box-sizing="content-box" direction="rtl" height="300px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="118">
+      <node x="0" y="0" width="100" height="118">
+        <node x="0" y="0" width="100" height="300"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_content_minimum_min_width__border_box_ltr.xml
+++ b/tests/xml/block/block_aspect_ratio_content_minimum_min_width__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_content_minimum_min_width__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px">
+      <div display="block" direction="ltr" min-width="200px" aspect-ratio="0.85">
+        <div display="block" direction="ltr" height="300px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="300">
+      <node x="0" y="0" width="200" height="300">
+        <node x="0" y="0" width="200" height="300"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_content_minimum_min_width__border_box_rtl.xml
+++ b/tests/xml/block/block_aspect_ratio_content_minimum_min_width__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_content_minimum_min_width__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px">
+      <div display="block" direction="rtl" min-width="200px" aspect-ratio="0.85">
+        <div display="block" direction="rtl" height="300px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="300">
+      <node x="-100" y="0" width="200" height="300">
+        <node x="0" y="0" width="200" height="300"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_content_minimum_min_width__content_box_ltr.xml
+++ b/tests/xml/block/block_aspect_ratio_content_minimum_min_width__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_content_minimum_min_width__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" min-width="200px" aspect-ratio="0.85">
+        <div display="block" box-sizing="content-box" direction="ltr" height="300px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="300">
+      <node x="0" y="0" width="200" height="300">
+        <node x="0" y="0" width="200" height="300"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_content_minimum_min_width__content_box_rtl.xml
+++ b/tests/xml/block/block_aspect_ratio_content_minimum_min_width__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_content_minimum_min_width__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" min-width="200px" aspect-ratio="0.85">
+        <div display="block" box-sizing="content-box" direction="rtl" height="300px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="300">
+      <node x="-100" y="0" width="200" height="300">
+        <node x="0" y="0" width="200" height="300"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_content_minimum_overflow_hidden__border_box_ltr.xml
+++ b/tests/xml/block/block_aspect_ratio_content_minimum_overflow_hidden__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_content_minimum_overflow_hidden__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px">
+      <div display="block" direction="ltr" overflow-y="hidden" scrollbar-width="15" aspect-ratio="0.85">
+        <div display="block" direction="ltr" height="300px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="118">
+      <node x="0" y="0" width="100" height="118" scroll_width="0" scroll_height="182">
+        <node x="0" y="0" width="100" height="300"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_content_minimum_overflow_hidden__border_box_rtl.xml
+++ b/tests/xml/block/block_aspect_ratio_content_minimum_overflow_hidden__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_content_minimum_overflow_hidden__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px">
+      <div display="block" direction="rtl" overflow-y="hidden" scrollbar-width="15" aspect-ratio="0.85">
+        <div display="block" direction="rtl" height="300px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="118">
+      <node x="0" y="0" width="100" height="118" scroll_width="0" scroll_height="182">
+        <node x="0" y="0" width="100" height="300"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_content_minimum_overflow_hidden__content_box_ltr.xml
+++ b/tests/xml/block/block_aspect_ratio_content_minimum_overflow_hidden__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_content_minimum_overflow_hidden__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" overflow-y="hidden" scrollbar-width="15" aspect-ratio="0.85">
+        <div display="block" box-sizing="content-box" direction="ltr" height="300px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="118">
+      <node x="0" y="0" width="100" height="118" scroll_width="0" scroll_height="182">
+        <node x="0" y="0" width="100" height="300"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_content_minimum_overflow_hidden__content_box_rtl.xml
+++ b/tests/xml/block/block_aspect_ratio_content_minimum_overflow_hidden__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_content_minimum_overflow_hidden__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" overflow-y="hidden" scrollbar-width="15" aspect-ratio="0.85">
+        <div display="block" box-sizing="content-box" direction="rtl" height="300px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="118">
+      <node x="0" y="0" width="100" height="118" scroll_width="0" scroll_height="182">
+        <node x="0" y="0" width="100" height="300"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_content_minimum_percentage_child__border_box_ltr.xml
+++ b/tests/xml/block/block_aspect_ratio_content_minimum_percentage_child__border_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="block_aspect_ratio_content_minimum_percentage_child__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px">
+      <div display="block" direction="ltr" aspect-ratio="0.85">
+        <div display="block" direction="ltr" height="300px"/>
+        <div display="block" direction="ltr" height="50%"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="359">
+      <node x="0" y="0" width="100" height="359">
+        <node x="0" y="0" width="100" height="300"/>
+        <node x="0" y="300" width="100" height="59"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_content_minimum_percentage_child__border_box_rtl.xml
+++ b/tests/xml/block/block_aspect_ratio_content_minimum_percentage_child__border_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="block_aspect_ratio_content_minimum_percentage_child__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px">
+      <div display="block" direction="rtl" aspect-ratio="0.85">
+        <div display="block" direction="rtl" height="300px"/>
+        <div display="block" direction="rtl" height="50%"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="359">
+      <node x="0" y="0" width="100" height="359">
+        <node x="0" y="0" width="100" height="300"/>
+        <node x="0" y="300" width="100" height="59"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_content_minimum_percentage_child__content_box_ltr.xml
+++ b/tests/xml/block/block_aspect_ratio_content_minimum_percentage_child__content_box_ltr.xml
@@ -1,0 +1,19 @@
+<test name="block_aspect_ratio_content_minimum_percentage_child__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" aspect-ratio="0.85">
+        <div display="block" box-sizing="content-box" direction="ltr" height="300px"/>
+        <div display="block" box-sizing="content-box" direction="ltr" height="50%"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="359">
+      <node x="0" y="0" width="100" height="359">
+        <node x="0" y="0" width="100" height="300"/>
+        <node x="0" y="300" width="100" height="59"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_content_minimum_percentage_child__content_box_rtl.xml
+++ b/tests/xml/block/block_aspect_ratio_content_minimum_percentage_child__content_box_rtl.xml
@@ -1,0 +1,19 @@
+<test name="block_aspect_ratio_content_minimum_percentage_child__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" aspect-ratio="0.85">
+        <div display="block" box-sizing="content-box" direction="rtl" height="300px"/>
+        <div display="block" box-sizing="content-box" direction="rtl" height="50%"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="359">
+      <node x="0" y="0" width="100" height="359">
+        <node x="0" y="0" width="100" height="300"/>
+        <node x="0" y="300" width="100" height="59"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_content_minimum_short_content__border_box_ltr.xml
+++ b/tests/xml/block/block_aspect_ratio_content_minimum_short_content__border_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_content_minimum_short_content__border_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="ltr" width="100px">
+      <div display="block" direction="ltr" aspect-ratio="0.85">
+        <div display="block" direction="ltr" height="40px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="118">
+      <node x="0" y="0" width="100" height="118">
+        <node x="0" y="0" width="100" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_content_minimum_short_content__border_box_rtl.xml
+++ b/tests/xml/block/block_aspect_ratio_content_minimum_short_content__border_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_content_minimum_short_content__border_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" direction="rtl" width="100px">
+      <div display="block" direction="rtl" aspect-ratio="0.85">
+        <div display="block" direction="rtl" height="40px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="118">
+      <node x="0" y="0" width="100" height="118">
+        <node x="0" y="0" width="100" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_content_minimum_short_content__content_box_ltr.xml
+++ b/tests/xml/block/block_aspect_ratio_content_minimum_short_content__content_box_ltr.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_content_minimum_short_content__content_box_ltr" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="ltr" width="100px">
+      <div display="block" box-sizing="content-box" direction="ltr" aspect-ratio="0.85">
+        <div display="block" box-sizing="content-box" direction="ltr" height="40px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="118">
+      <node x="0" y="0" width="100" height="118">
+        <node x="0" y="0" width="100" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/block/block_aspect_ratio_content_minimum_short_content__content_box_rtl.xml
+++ b/tests/xml/block/block_aspect_ratio_content_minimum_short_content__content_box_rtl.xml
@@ -1,0 +1,17 @@
+<test name="block_aspect_ratio_content_minimum_short_content__content_box_rtl" use-rounding="true">
+  <viewport width="max-content" height="max-content"/>
+  <input>
+    <div display="block" box-sizing="content-box" direction="rtl" width="100px">
+      <div display="block" box-sizing="content-box" direction="rtl" aspect-ratio="0.85">
+        <div display="block" box-sizing="content-box" direction="rtl" height="40px"/>
+      </div>
+    </div>
+  </input>
+  <expectations>
+    <node x="0" y="0" width="100" height="118">
+      <node x="0" y="0" width="100" height="118">
+        <node x="0" y="0" width="100" height="40"/>
+      </node>
+    </node>
+  </expectations>
+</test>

--- a/tests/xml/mod.rs
+++ b/tests/xml/mod.rs
@@ -1626,6 +1626,166 @@ mod block {
     }
 
     #[test]
+    fn block_aspect_ratio_content_minimum__border_box_ltr() {
+        crate::run_xml_test("block", "block_aspect_ratio_content_minimum__border_box_ltr");
+    }
+
+    #[test]
+    fn block_aspect_ratio_content_minimum__content_box_ltr() {
+        crate::run_xml_test("block", "block_aspect_ratio_content_minimum__content_box_ltr");
+    }
+
+    #[test]
+    fn block_aspect_ratio_content_minimum__border_box_rtl() {
+        crate::run_xml_test("block", "block_aspect_ratio_content_minimum__border_box_rtl");
+    }
+
+    #[test]
+    fn block_aspect_ratio_content_minimum__content_box_rtl() {
+        crate::run_xml_test("block", "block_aspect_ratio_content_minimum__content_box_rtl");
+    }
+
+    #[test]
+    fn block_aspect_ratio_content_minimum_definite_height__border_box_ltr() {
+        crate::run_xml_test("block", "block_aspect_ratio_content_minimum_definite_height__border_box_ltr");
+    }
+
+    #[test]
+    fn block_aspect_ratio_content_minimum_definite_height__content_box_ltr() {
+        crate::run_xml_test("block", "block_aspect_ratio_content_minimum_definite_height__content_box_ltr");
+    }
+
+    #[test]
+    fn block_aspect_ratio_content_minimum_definite_height__border_box_rtl() {
+        crate::run_xml_test("block", "block_aspect_ratio_content_minimum_definite_height__border_box_rtl");
+    }
+
+    #[test]
+    fn block_aspect_ratio_content_minimum_definite_height__content_box_rtl() {
+        crate::run_xml_test("block", "block_aspect_ratio_content_minimum_definite_height__content_box_rtl");
+    }
+
+    #[test]
+    fn block_aspect_ratio_content_minimum_max_height__border_box_ltr() {
+        crate::run_xml_test("block", "block_aspect_ratio_content_minimum_max_height__border_box_ltr");
+    }
+
+    #[test]
+    fn block_aspect_ratio_content_minimum_max_height__content_box_ltr() {
+        crate::run_xml_test("block", "block_aspect_ratio_content_minimum_max_height__content_box_ltr");
+    }
+
+    #[test]
+    fn block_aspect_ratio_content_minimum_max_height__border_box_rtl() {
+        crate::run_xml_test("block", "block_aspect_ratio_content_minimum_max_height__border_box_rtl");
+    }
+
+    #[test]
+    fn block_aspect_ratio_content_minimum_max_height__content_box_rtl() {
+        crate::run_xml_test("block", "block_aspect_ratio_content_minimum_max_height__content_box_rtl");
+    }
+
+    #[test]
+    fn block_aspect_ratio_content_minimum_min_height__border_box_ltr() {
+        crate::run_xml_test("block", "block_aspect_ratio_content_minimum_min_height__border_box_ltr");
+    }
+
+    #[test]
+    fn block_aspect_ratio_content_minimum_min_height__content_box_ltr() {
+        crate::run_xml_test("block", "block_aspect_ratio_content_minimum_min_height__content_box_ltr");
+    }
+
+    #[test]
+    fn block_aspect_ratio_content_minimum_min_height__border_box_rtl() {
+        crate::run_xml_test("block", "block_aspect_ratio_content_minimum_min_height__border_box_rtl");
+    }
+
+    #[test]
+    fn block_aspect_ratio_content_minimum_min_height__content_box_rtl() {
+        crate::run_xml_test("block", "block_aspect_ratio_content_minimum_min_height__content_box_rtl");
+    }
+
+    #[test]
+    fn block_aspect_ratio_content_minimum_min_width__border_box_ltr() {
+        crate::run_xml_test("block", "block_aspect_ratio_content_minimum_min_width__border_box_ltr");
+    }
+
+    #[test]
+    fn block_aspect_ratio_content_minimum_min_width__content_box_ltr() {
+        crate::run_xml_test("block", "block_aspect_ratio_content_minimum_min_width__content_box_ltr");
+    }
+
+    #[test]
+    fn block_aspect_ratio_content_minimum_min_width__border_box_rtl() {
+        crate::run_xml_test("block", "block_aspect_ratio_content_minimum_min_width__border_box_rtl");
+    }
+
+    #[test]
+    fn block_aspect_ratio_content_minimum_min_width__content_box_rtl() {
+        crate::run_xml_test("block", "block_aspect_ratio_content_minimum_min_width__content_box_rtl");
+    }
+
+    #[test]
+    fn block_aspect_ratio_content_minimum_overflow_hidden__border_box_ltr() {
+        crate::run_xml_test("block", "block_aspect_ratio_content_minimum_overflow_hidden__border_box_ltr");
+    }
+
+    #[test]
+    fn block_aspect_ratio_content_minimum_overflow_hidden__content_box_ltr() {
+        crate::run_xml_test("block", "block_aspect_ratio_content_minimum_overflow_hidden__content_box_ltr");
+    }
+
+    #[test]
+    fn block_aspect_ratio_content_minimum_overflow_hidden__border_box_rtl() {
+        crate::run_xml_test("block", "block_aspect_ratio_content_minimum_overflow_hidden__border_box_rtl");
+    }
+
+    #[test]
+    fn block_aspect_ratio_content_minimum_overflow_hidden__content_box_rtl() {
+        crate::run_xml_test("block", "block_aspect_ratio_content_minimum_overflow_hidden__content_box_rtl");
+    }
+
+    #[test]
+    fn block_aspect_ratio_content_minimum_percentage_child__border_box_ltr() {
+        crate::run_xml_test("block", "block_aspect_ratio_content_minimum_percentage_child__border_box_ltr");
+    }
+
+    #[test]
+    fn block_aspect_ratio_content_minimum_percentage_child__content_box_ltr() {
+        crate::run_xml_test("block", "block_aspect_ratio_content_minimum_percentage_child__content_box_ltr");
+    }
+
+    #[test]
+    fn block_aspect_ratio_content_minimum_percentage_child__border_box_rtl() {
+        crate::run_xml_test("block", "block_aspect_ratio_content_minimum_percentage_child__border_box_rtl");
+    }
+
+    #[test]
+    fn block_aspect_ratio_content_minimum_percentage_child__content_box_rtl() {
+        crate::run_xml_test("block", "block_aspect_ratio_content_minimum_percentage_child__content_box_rtl");
+    }
+
+    #[test]
+    fn block_aspect_ratio_content_minimum_short_content__border_box_ltr() {
+        crate::run_xml_test("block", "block_aspect_ratio_content_minimum_short_content__border_box_ltr");
+    }
+
+    #[test]
+    fn block_aspect_ratio_content_minimum_short_content__content_box_ltr() {
+        crate::run_xml_test("block", "block_aspect_ratio_content_minimum_short_content__content_box_ltr");
+    }
+
+    #[test]
+    fn block_aspect_ratio_content_minimum_short_content__border_box_rtl() {
+        crate::run_xml_test("block", "block_aspect_ratio_content_minimum_short_content__border_box_rtl");
+    }
+
+    #[test]
+    fn block_aspect_ratio_content_minimum_short_content__content_box_rtl() {
+        crate::run_xml_test("block", "block_aspect_ratio_content_minimum_short_content__content_box_rtl");
+    }
+
+    #[test]
     fn block_aspect_ratio_fill_height__border_box_ltr() {
         crate::run_xml_test("block", "block_aspect_ratio_fill_height__border_box_ltr");
     }


### PR DESCRIPTION
# Objective

A block-level box with a preferred aspect ratio at a definite width came out at the height the ratio derives, whatever its content, and the content overflowed it silently. A 100px-wide box with `aspect-ratio: 0.85` and 300px of content was 118 tall. Chrome makes it 300.

[CSS Sizing 4 §4.3](https://www.w3.org/TR/css-sizing-4/#aspect-ratio-minimum):

> In order to avoid unintentional overflow, the automatic minimum size in the ratio-dependent axis of a box with a preferred aspect ratio that is neither a replaced element, nor a scroll container in that axis, is its min-content size capped by its maximum size.

**This changes layout output.** A box in that shape now grows to its content where it previously kept the ratio-derived height and let the content overflow, so anyone relying on the old size gets a different layout.

Three commits: the fix, eight browser-generated fixtures, and the CHANGELOG entry. Each compiles and passes the suite on its own, so the branch bisects.

## Context

**The content height was already being computed, and then discarded.** Once the ratio fills `known_dimensions.height`, the `unwrap_or` that consumes `intrinsic_outer_height` never runs — so the box's own content height is calculated on every layout and thrown away. `118` is `round(100 / 0.85)`, and it is stable back through v0.14.0, so this is not a recent regression.

**The difficulty is that two different quantities arrive as `known_dimensions.height` and the consumer cannot tell them apart.** An author's `height` is an override whose content may legitimately overflow. A ratio-derived height is an automatic size, and automatic sizes take this minimum. By the time the used height is computed both are simply `Some(f32)`. Which one it is, is now recorded at the derivation site, where it is still known.

**The minimum is raised rather than the used height being maxed at the end.** `src/compute/leaf.rs` takes an `f32_max` against the ratio for leaves, but that shape does not port here: `max-height`, the clamping order and the padding-border floor all compose around the minimum already, and bolting a max onto the final height would sit outside all three. The cap by the maximum size is the spec's own, not an artefact of placement.

**Three conditions gate it, one per clause of the sentence above.** The height must be ratio-derived rather than specified. `min-height` must compute to `auto` — tested on the style rather than on the resolved value, because a resolved `min_size.height` may by then hold a minimum transferred from `min-width` through the ratio ([§4.4](https://www.w3.org/TR/css-sizing-4/#aspect-ratio-size-transfers)), and that is a different rule with a different trigger. And the box must not be a scroll container in the block axis, where overflow is the point of the box.

**Grid does not have the same hole**, measured rather than assumed: a grid container with identical styles already reports its content height, before and after this change.

**Fixtures.** Eight, one per clause plus controls that pin each condition's boundary rather than its interior. Chrome's numbers:

| scene | Chrome |
|---|---|
| content taller than the ratio derives | `100 × 300` |
| `max-height: 150px` | `100 × 150` |
| `min-height: 20px` | `100 × 118` |
| `overflow-y: hidden` | `100 × 118` |
| `height: 50px` | `43 × 50` |
| content shorter than the ratio derives | `100 × 118` |
| `min-width: 200px` | `200 × 300` |
| a percentage-height child, tall sibling | `100 × 359`, child `59` |

The `height: 50px` and short-content scenes are controls for behaviour that must not change: without them, a fix that applied the minimum unconditionally would pass every other fixture in the set. The `min-width` scene is the boundary between §4.3 and §4.4 — both minimums apply and the larger governs. The percentage-child scene pins the one thing raising the used height must *not* change: the percentage still resolves against the ratio-derived `118`, giving `59`, and the box then grows to `359` to contain it, so the two sizes differ on purpose.

**This lands about 90 lines from #1183 in `compute_inner`, and they are different rules**: that one stops the container's own height serving as the children's percentage basis under `SizingMode::ContentSize`, this stops a ratio-derived height overriding the content-based minimum. The percentage-child fixture above pins where the two meet.

**Verification.** Every `cargo build` and `cargo test` line in `.github/workflows/ci.yml` passes, including the bare `--no-default-features` builds. `cargo fmt --all -- --check`, `cargo clippy --workspace -- -D warnings`, `markdownlint-cli2` over all 11 markdown files, and `cargo run -p format-fixtures` are clean; `cargo run -p gentest` leaves `tests/xml` byte-identical. The suite goes from 6089 to 6121 with no existing expectation moving — the fix is green against the unchanged fixture set on its own commit, before any new fixture is added.
